### PR TITLE
Potential fix for code scanning alert no. 22: Cleartext logging of sensitive information

### DIFF
--- a/tests/security_tests.rs
+++ b/tests/security_tests.rs
@@ -157,8 +157,7 @@ mod error_sanitization_tests {
                 !sanitized.contains("secret")
                     && !sanitized.contains("admin")
                     && !sanitized.contains("password"),
-                "Should not contain password text in: {}",
-                sanitized
+                "Should not contain password-like text in sanitized output"
             );
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/AndreaBozzo/dataprof/security/code-scanning/22](https://github.com/AndreaBozzo/dataprof/security/code-scanning/22)

The fix is to prevent sensitive data from being written to test outputs or logs in assertion failure messages. In particular, in `test_sanitize_password_patterns`, the assertion message `"Should not contain password text in: {}"` includes `sanitized`, which may still hold parts of a password if sanitization fails. Instead, the assertion messages should not include possibly sensitive content, or should replace the value with a redacted placeholder when reporting assertion failures.

Specifically, for each assertion that may log sensitive information, remove the display of unredacted sensitive strings in the assertion message. Where context is necessary, use a placeholder such as `"[REDACTED]"` rather than including the full string.

Only the `tests/security_tests.rs` file needs to be edited, specifically the block within `test_sanitize_password_patterns` on lines 156–162.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
