### PR TITLE
ci(pages): deploy benchmark reports to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-benchmarks.yml
+++ b/.github/workflows/deploy-benchmarks.yml
@@ -1,0 +1,77 @@
+name: Deploy Benchmark Reports
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types: [completed]
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-reports
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Prepare Pages content
+        run: |
+          mkdir -p pages-content
+          if [ -d "benchmark-reports/target/criterion" ]; then
+            cp -r benchmark-reports/target/criterion/* pages-content/
+          else
+            echo "Error: Criterion reports not found"
+            exit 1
+          fi
+
+          # Create landing page that redirects to Criterion report
+          cat > pages-content/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8">
+            <title>DataProf Benchmark Reports</title>
+            <meta http-equiv="refresh" content="0; url=report/index.html">
+            <style>
+              body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; padding: 40px; }
+              a { color: #0366d6; }
+            </style>
+          </head>
+          <body>
+            <h1>DataProf Benchmark Reports</h1>
+            <p>Redirecting to <a href="report/index.html">Criterion benchmark report</a>...</p>
+          </body>
+          </html>
+          EOF
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-content
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR expose Criterion folder and its HTML reports trough Pages deploy.


- Adds new workflow `deploy-benchmarks.yml` that deploys Criterion benchmark HTML reports to GitHub Pages
- Triggers automatically after the Benchmarks workflow completes successfully on master
- Uses modern GitHub Pages deployment with `actions/deploy-pages`


## Expected Result
Benchmark reports will be available after merging at:
- https://andreabozzo.github.io/dataprof/

Closes #183