### PR TITLE
feat/fun: add one billion rows example and enhance DataFusionLoader with CSV registration options

### DIFF
--- a/examples/one_billion_rows.rs
+++ b/examples/one_billion_rows.rs
@@ -1,0 +1,100 @@
+//! One Billion Row Challenge (1BRC) solver using dataprof's DataFusion engine.
+//!
+//! This example reads a semicolon-delimited, headerless CSV file of weather
+//! station measurements and outputs the result in the canonical 1BRC format:
+//!
+//!   {station1=min/mean/max, station2=min/mean/max, ...}
+//!
+//! # Usage
+//!
+//! ```bash
+//! cargo run --release --features datafusion --example one_billion_rows -- measurements.txt
+//! ```
+//!
+//! The input file is expected to have lines like:
+//!   Hamburg;12.0
+//!   Bulawayo;8.9
+
+use anyhow::Result;
+use arrow::array::{AsArray, Float64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use dataprof::engines::{CsvReadOptions, DataFusionLoader};
+use std::env;
+use std::time::Instant;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let path = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "measurements.txt".to_string());
+
+    eprintln!("1BRC — reading {}", path);
+    let start = Instant::now();
+
+    // Initialise with a large batch size for throughput
+    let loader = DataFusionLoader::new().with_batch_size(65536);
+
+    // Register the 1BRC file: semicolon delimiter, no header, explicit schema
+    let schema = Schema::new(vec![
+        Field::new("station", DataType::Utf8, false),
+        Field::new("temperature", DataType::Float64, false),
+    ]);
+    let options = CsvReadOptions::default()
+        .delimiter(b';')
+        .has_header(false)
+        .schema(&schema);
+    loader
+        .register_csv_with_options("measurements", &path, options)
+        .await?;
+
+    // Run the aggregation — DataFusion parallelises this automatically
+    let query = "
+        SELECT
+            station,
+            MIN(temperature) AS min_temp,
+            AVG(temperature) AS mean_temp,
+            MAX(temperature) AS max_temp
+        FROM measurements
+        GROUP BY station
+        ORDER BY station
+    ";
+
+    let batches = loader.execute_sql(query).await?;
+
+    // Format output: {station=min/mean/max, ...}
+    let mut entries: Vec<String> = Vec::new();
+
+    for batch in &batches {
+        let stations = batch.column(0).as_string::<i32>();
+        let mins = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("min_temp column");
+        let means = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("mean_temp column");
+        let maxs = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("max_temp column");
+
+        for i in 0..batch.num_rows() {
+            entries.push(format!(
+                "{}={:.1}/{:.1}/{:.1}",
+                stations.value(i),
+                mins.value(i),
+                means.value(i),
+                maxs.value(i),
+            ));
+        }
+    }
+
+    println!("{{{}}}", entries.join(", "));
+
+    eprintln!("Finished in {:.2?}", start.elapsed());
+    Ok(())
+}

--- a/src/engines/datafusion_loader.rs
+++ b/src/engines/datafusion_loader.rs
@@ -7,8 +7,10 @@ use crate::engines::columnar::RecordBatchAnalyzer;
 use crate::types::{DataQualityMetrics, DataSource, QualityReport, QueryEngine, ScanInfo};
 
 use anyhow::{Context, Result};
-use datafusion::prelude::*;
+pub use arrow::record_batch::RecordBatch;
+pub use datafusion::prelude::*;
 use futures::stream::{Stream, StreamExt};
+use std::path::Path;
 use std::time::Instant;
 
 /// DataFusion loader for profiling SQL queries using Arrow integration
@@ -51,8 +53,35 @@ impl DataFusionLoader {
 
     /// Register a CSV file as a table for querying
     pub async fn register_csv(&self, table_name: &str, path: &str) -> Result<()> {
+        self.register_csv_with_options(table_name, path, CsvReadOptions::default())
+            .await
+    }
+
+    /// Register a CSV file with custom read options (delimiter, header, schema, etc.)
+    ///
+    /// # Example: semicolon-delimited file without headers (1BRC format)
+    /// ```ignore
+    /// let options = CsvReadOptions::default()
+    ///     .delimiter(b';')
+    ///     .has_header(false);
+    /// loader.register_csv_with_options("measurements", "measurements.txt", options).await?;
+    /// ```
+    pub async fn register_csv_with_options(
+        &self,
+        table_name: &str,
+        path: &str,
+        options: CsvReadOptions<'_>,
+    ) -> Result<()> {
+        // Auto-detect file extension so non-.csv files (e.g. .txt) are accepted
+        let ext = Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| format!(".{}", e))
+            .unwrap_or_else(|| ".csv".to_string());
+        let options = options.file_extension(&ext);
+
         self.ctx
-            .register_csv(table_name, path, CsvReadOptions::default())
+            .register_csv(table_name, path, options)
             .await
             .context(format!(
                 "Failed to register CSV file '{}' as '{}'",
@@ -145,6 +174,31 @@ impl DataFusionLoader {
             ScanInfo::new(total_rows, num_columns, total_rows, 1.0, scan_time_ms),
             data_quality_metrics,
         ))
+    }
+
+    /// Execute a SQL query and return raw Arrow RecordBatches.
+    ///
+    /// Unlike [`profile_query`], this returns the actual query results
+    /// rather than profiling metadata — useful when you need the data
+    /// itself (e.g., for the 1BRC output format).
+    ///
+    /// # Example
+    /// ```ignore
+    /// let batches = loader.execute_sql("SELECT station, MIN(temp) FROM data GROUP BY station").await?;
+    /// for batch in &batches {
+    ///     println!("Got {} rows", batch.num_rows());
+    /// }
+    /// ```
+    pub async fn execute_sql(&self, query: &str) -> Result<Vec<RecordBatch>> {
+        let df = self
+            .ctx
+            .sql(query)
+            .await
+            .context(format!("Failed to execute query: '{}'", query))?;
+
+        df.collect()
+            .await
+            .context("Failed to collect query results")
     }
 
     /// Profile a registered table directly

--- a/src/engines/mod.rs
+++ b/src/engines/mod.rs
@@ -11,4 +11,4 @@ pub use selection::*;
 pub use streaming::*;
 
 #[cfg(feature = "datafusion")]
-pub use datafusion_loader::DataFusionLoader;
+pub use datafusion_loader::{CsvReadOptions, DataFusionLoader, RecordBatch};


### PR DESCRIPTION
Enables 1Billion Row Challange with dataprof, leveraging datafusion and arrow directly.

script generator for txt file: https://github.com/gunnarmorling/1brc

This PR would also enable sql queries but it's not meant for merge right now, evaluating with the progress towards 0.6.0
