### PR TITLE
feat: add semantic validators for identifiers and enhance pattern detection

### DIFF
--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -77,8 +77,14 @@ def _half_up(v: float, ndigits: int) -> float:
     """
     with _decimal.localcontext() as ctx:
         ctx.rounding = _decimal.ROUND_HALF_UP
-        d = _decimal.Decimal(str(v)).quantize(_decimal.Decimal(10) ** -ndigits)
-        return float(d)
+        try:
+            d = _decimal.Decimal(str(v)).quantize(_decimal.Decimal(10) ** -ndigits)
+            return float(d)
+        except _decimal.InvalidOperation:
+            # Very large or very small numbers (e.g. variance ~1e+29) can't be
+            # quantized to N decimal places — return as-is since rounding wouldn't
+            # change the value at that magnitude anyway.
+            return v
 
 
 def _r2(v: float | None) -> float | None:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -116,10 +116,14 @@ def _column_record(col: ColumnProfile) -> dict[str, Any]:
     rq = _round_quartiles(q)
     top_pattern = None
     top_pattern_pct = None
+    top_pattern_category = None
+    top_pattern_confidence = None
     if col.patterns:
-        best = max(col.patterns, key=lambda p: p.match_count)
+        best = max(col.patterns, key=lambda p: p.confidence)
         top_pattern = best.name
         top_pattern_pct = _r2(best.match_percentage)
+        top_pattern_category = best.category
+        top_pattern_confidence = round(best.confidence, 4)
 
     return {
         "name": col.name,
@@ -152,6 +156,8 @@ def _column_record(col: ColumnProfile) -> dict[str, Any]:
         "true_ratio": _r4(col.true_ratio),
         "top_pattern": top_pattern,
         "top_pattern_pct": top_pattern_pct,
+        "top_pattern_category": top_pattern_category,
+        "top_pattern_confidence": top_pattern_confidence,
     }
 
 
@@ -172,6 +178,7 @@ def profile(
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
+    locale: str | None = None,
 ) -> ProfileReport:
     """Profile a data source and return a report.
 
@@ -202,6 +209,9 @@ def profile(
             (always included), "statistics", "patterns", "quality".
             None = all packs (default). Omitting a pack skips that
             category of computation entirely.
+        locale: ISO 3166-1 alpha-2 locale for pattern detection (e.g. "IT",
+            "US", "GB"). Boosts confidence for locale-matching patterns and
+            suppresses non-matching locale patterns. None = no preference.
 
     Returns:
         ProfileReport with analysis results and quality metrics.
@@ -222,6 +232,7 @@ def profile(
             progress_interval_ms=progress_interval_ms,
             quality_dimensions=quality_dimensions,
             metrics=metrics,
+            locale=locale,
         )
         rust_report = _analyze_file(str(source), config)
         return ProfileReport(rust_report)
@@ -391,6 +402,11 @@ class Profiler:
                 )
             condition = factory()
         self._kwargs["stop_condition"] = condition
+        return self
+
+    def locale(self, locale: str) -> Profiler:
+        """Set locale for pattern detection (e.g. "IT", "US", "GB")."""
+        self._kwargs["locale"] = locale
         return self
 
     def metrics(self, packs: list[str]) -> Profiler:
@@ -591,6 +607,8 @@ class ProfileReport:
                         "regex": p.regex,
                         "match_count": p.match_count,
                         "match_percentage": _r2(p.match_percentage),
+                        "category": p.category,
+                        "confidence": round(p.confidence, 4),
                     }
                     for p in col.patterns
                 ]
@@ -818,7 +836,7 @@ class ProfileReport:
             elif col.avg_length is not None:
                 parts.append(f"avg_len={_r4(col.avg_length)}")
             if col.patterns:
-                best = max(col.patterns, key=lambda p: p.match_count)
+                best = max(col.patterns, key=lambda p: p.confidence)
                 parts.append(f"{best.name}({_r2(best.match_percentage):.0f}%)")
             lines.append("   ".join(parts))
 
@@ -866,7 +884,7 @@ class ProfileReport:
             # Pattern cell
             pattern = ""
             if col.patterns:
-                best = max(col.patterns, key=lambda p: p.match_count)
+                best = max(col.patterns, key=lambda p: p.confidence)
                 pattern = f"{_html.escape(best.name)} ({_r2(best.match_percentage):.0f}%)"
 
             unique_str = f"{col.unique_count:,}" if col.unique_count is not None else ""

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -237,14 +237,15 @@ def profile(
         rust_report = _analyze_file(str(source), config)
         return ProfileReport(rust_report)
 
-    # DataFrame/Arrow paths — build config for metric packs + quality dims
+    # DataFrame/Arrow paths — build config for metric packs + quality dims + locale
     def _df_config() -> ProfilerConfig | None:
         """Build a ProfilerConfig if any DataFrame-relevant options are set."""
-        if any(v is not None for v in (max_rows, quality_dimensions, metrics)):
+        if any(v is not None for v in (max_rows, quality_dimensions, metrics, locale)):
             return ProfilerConfig(
                 max_rows=max_rows,
                 quality_dimensions=quality_dimensions,
                 metrics=metrics,
+                locale=locale,
             )
         return None
 

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -27,6 +27,7 @@ class ProfilerConfig:
         progress_interval_ms: int | None = None,
         quality_dimensions: list[str] | None = None,
         metrics: list[str] | None = None,
+        locale: str | None = None,
     ) -> None: ...
     @property
     def engine(self) -> str: ...
@@ -38,6 +39,8 @@ class ProfilerConfig:
     def format(self) -> str | None: ...
     @property
     def max_rows(self) -> int | None: ...
+    @property
+    def locale(self) -> str | None: ...
 
 # --- Sampling ---
 
@@ -134,6 +137,7 @@ def profile(
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
+    locale: str | None = None,
 ) -> ProfileReport:
     """Profile a data source (file path, DataFrame, or Arrow object)."""
     ...
@@ -164,6 +168,7 @@ class Profiler:
     def quality_dimensions(self, dims: list[str]) -> Profiler: ...
     def stop_when(self, condition: StopCondition | str) -> Profiler: ...
     def metrics(self, packs: list[str]) -> Profiler: ...
+    def locale(self, locale: str) -> Profiler: ...
     def profile(self, source: Any) -> ProfileReport: ...
 
 # --- Result Types ---
@@ -243,6 +248,8 @@ class Pattern:
     regex: str
     match_count: int
     match_percentage: float
+    category: str
+    confidence: float
 
 class ColumnProfile:
     """Column-level profiling statistics."""

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -381,6 +381,7 @@ class TestNamespace:
             "progress_interval_ms",
             "quality_dimensions",
             "metrics",
+            "locale",
         }
         actual_params = set(sig.parameters.keys())
         assert actual_params == expected_params, (

--- a/src/analysis/column.rs
+++ b/src/analysis/column.rs
@@ -75,7 +75,7 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
     let patterns = if fast_mode {
         Vec::new()
     } else {
-        detect_patterns(data)
+        detect_patterns(data, None)
     };
 
     let unique_count = if fast_mode {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -2,6 +2,7 @@ pub mod column;
 pub mod inference;
 pub mod metrics;
 pub mod patterns;
+pub(crate) mod validators;
 
 pub use column::{analyze_column, analyze_column_fast};
 pub use inference::infer_type;

--- a/src/analysis/patterns.rs
+++ b/src/analysis/patterns.rs
@@ -420,14 +420,14 @@ struct PatternMatch<'a> {
 
 /// Compute confidence score from pattern specificity, match rate, and validator pass rate.
 ///
-/// Formula: `(specificity / 100) × clamp(match_percentage / 50, 0.5, 1.0) × validator_pass_rate`
+/// Formula: `clamp((specificity / 100) × clamp(match_percentage / 50, 0.5, 1.0) × validator_pass_rate, 0.0, 1.0)`
 ///
 /// The validator_pass_rate penalizes patterns where the regex matches but the values
 /// fail semantic validation (e.g. 11-digit numbers that aren't valid P.IVA).
 fn compute_confidence(specificity: u8, match_percentage: f64, validator_pass_rate: f64) -> f64 {
     let base = specificity as f64 / 100.0;
     let match_factor = (match_percentage / 50.0).clamp(0.5, 1.0);
-    base * match_factor * validator_pass_rate
+    (base * match_factor * validator_pass_rate).clamp(0.0, 1.0)
 }
 
 /// Detect common data patterns in a column.

--- a/src/analysis/patterns.rs
+++ b/src/analysis/patterns.rs
@@ -1,93 +1,396 @@
-use regex::Regex;
+use regex::{Regex, RegexSet};
 use std::sync::LazyLock;
 
-use crate::types::Pattern;
+use crate::analysis::validators;
+use crate::types::{Pattern, PatternCategory};
 
-// Pre-compile pattern regexes for better performance
-// These patterns are compiled once at startup instead of on every detect_patterns call
-static PATTERN_REGEXES: LazyLock<Vec<(&'static str, Regex)>> = LazyLock::new(|| {
+/// Internal pattern definition with metadata for overlap resolution and confidence scoring.
+struct PatternDef {
+    name: &'static str,
+    regex: Regex,
+    category: PatternCategory,
+    /// 0-255: higher = more structurally specific regex (fewer false positives).
+    specificity: u8,
+    /// ISO 3166-1 alpha-2 locale, or None for universal patterns.
+    locale: Option<&'static str>,
+    /// Per-pattern minimum match percentage to report (replaces uniform 5% threshold).
+    min_threshold: f64,
+    /// Optional semantic validator run on regex-matched values.
+    /// When present, the validator pass rate feeds into the confidence formula.
+    validator: Option<fn(&str) -> bool>,
+}
+
+// Pre-compile pattern definitions with metadata for better detection accuracy.
+// Specificity values encode how structurally unique each regex is:
+//   95 = very specific (Codice Fiscale: letter/digit/letter alternation)
+//   30 = very broad (File paths, bare digit sequences)
+// Per-pattern thresholds compensate for broad regexes that produce false positives.
+static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
     vec![
-        (
-            "Email",
-            Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
-                .expect("BUG: Invalid hardcoded regex pattern for Email"),
-        ),
-        (
-            "Phone (US)",
-            Regex::new(r"^\+?1?[-.\s]?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}$")
-                .expect("BUG: Invalid hardcoded regex pattern for US Phone"),
-        ),
-        (
-            "Phone (IT)",
-            Regex::new(r"^(?:\+39|0039|39)[-.\s]?[0-9]{2,4}[-.\s]?[0-9]{5,10}$")
-                .expect("BUG: Invalid hardcoded regex pattern for IT Phone"),
-        ),
-        (
-            "URL",
-            Regex::new(r"^https?://[^\s/$.?#].[^\s]*$")
-                .expect("BUG: Invalid hardcoded regex pattern for URL"),
-        ),
-        (
-            "UUID",
-            Regex::new(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
-                .expect("BUG: Invalid hardcoded regex pattern for UUID"),
-        ),
-        (
-            "IPv4",
-            Regex::new(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
-                .expect("BUG: Invalid hardcoded regex pattern for IPv4"),
-        ),
-        (
-            "IPv6",
-            Regex::new(r"^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$")
-                .expect("BUG: Invalid hardcoded regex pattern for IPv6"),
-        ),
-        (
-            "MAC Address",
-            Regex::new(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
-                .expect("BUG: Invalid hardcoded regex pattern for MAC Address"),
-        ),
-        (
-            "Geographic Coordinates",
-            Regex::new(r"^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$")
-                .expect("BUG: Invalid hardcoded regex pattern for Geographic Coordinates"),
-        ),
-        (
-            "IBAN",
-            Regex::new(r"^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$")
-                .expect("BUG: Invalid hardcoded regex pattern for IBAN"),
-        ),
-        (
-            "Codice Fiscale (IT)",
-            Regex::new(r"^[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]$")
-                .expect("BUG: Invalid hardcoded regex pattern for Codice Fiscale"),
-        ),
-        (
-            "P.IVA (IT)",
-            Regex::new(r"^\d{11}$")
-                .expect("BUG: Invalid hardcoded regex pattern for P.IVA"),
-        ),
-        (
-            "CAP (IT)",
-            Regex::new(r"^\d{5}$")
-                .expect("BUG: Invalid hardcoded regex pattern for CAP"),
-        ),
-        (
-            "ZIP Code (US)",
-            Regex::new(r"^\d{5}(-\d{4})?$")
-                .expect("BUG: Invalid hardcoded regex pattern for ZIP Code"),
-        ),
-        (
-            "File Path (Unix)",
-            Regex::new(r"^(/[^/\x00]+)+/?$")
-                .expect("BUG: Invalid hardcoded regex pattern for Unix File Path"),
-        ),
-        (
-            "File Path (Windows)",
-            Regex::new(r##"^[A-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$"##)
-                .expect("BUG: Invalid hardcoded regex pattern for Windows File Path"),
-        ),
+        PatternDef {
+            name: "Email",
+            regex: Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
+                .expect("BUG: Invalid regex for Email"),
+            category: PatternCategory::Contact,
+            specificity: 80,
+            locale: None,
+            min_threshold: 3.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Phone (US)",
+            regex: Regex::new(r"^\+?1?[-.\s]?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}$")
+                .expect("BUG: Invalid regex for Phone (US)"),
+            category: PatternCategory::Contact,
+            specificity: 70,
+            locale: Some("US"),
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Phone (IT)",
+            regex: Regex::new(r"^(?:\+39|0039)[-.\s]?(?:0[0-9]{1,3}|3[0-9]{2})[-.\s]?[0-9]{5,8}$")
+                .expect("BUG: Invalid regex for Phone (IT)"),
+            category: PatternCategory::Contact,
+            specificity: 70,
+            locale: Some("IT"),
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "URL",
+            regex: Regex::new(r"^https?://[^\s/$.?#].[^\s]*$")
+                .expect("BUG: Invalid regex for URL"),
+            category: PatternCategory::Network,
+            specificity: 70,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "UUID",
+            regex: Regex::new(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+                .expect("BUG: Invalid regex for UUID"),
+            category: PatternCategory::Identifier,
+            specificity: 85,
+            locale: None,
+            min_threshold: 3.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "IPv4",
+            regex: Regex::new(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
+                .expect("BUG: Invalid regex for IPv4"),
+            category: PatternCategory::Network,
+            specificity: 65,
+            locale: None,
+            min_threshold: 3.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "IPv6",
+            // Pre-filter: hex groups with at least one colon, including :: compression.
+            // The validator (Ipv6Addr::from_str) does the real validation.
+            regex: Regex::new(r"^[0-9a-fA-F]*:[0-9a-fA-F:]*$")
+                .expect("BUG: Invalid regex for IPv6"),
+            category: PatternCategory::Network,
+            specificity: 75,
+            locale: None,
+            min_threshold: 3.0,
+            validator: Some(validators::validate_ipv6),
+        },
+        PatternDef {
+            name: "MAC Address",
+            regex: Regex::new(r"^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
+                .expect("BUG: Invalid regex for MAC Address"),
+            category: PatternCategory::Network,
+            specificity: 80,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Geographic Coordinates",
+            regex: Regex::new(r"^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$")
+                .expect("BUG: Invalid regex for Geographic Coordinates"),
+            category: PatternCategory::Geographic,
+            specificity: 75,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "IBAN",
+            regex: Regex::new(r"^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$")
+                .expect("BUG: Invalid regex for IBAN"),
+            category: PatternCategory::Financial,
+            specificity: 90,
+            locale: None,
+            min_threshold: 5.0,
+            validator: Some(validators::validate_iban),
+        },
+        PatternDef {
+            name: "Codice Fiscale (IT)",
+            regex: Regex::new(r"^[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]$")
+                .expect("BUG: Invalid regex for Codice Fiscale"),
+            category: PatternCategory::Identifier,
+            specificity: 95,
+            locale: Some("IT"),
+            min_threshold: 5.0,
+            validator: Some(validators::validate_codice_fiscale),
+        },
+        PatternDef {
+            name: "P.IVA (IT)",
+            regex: Regex::new(r"^\d{11}$")
+                .expect("BUG: Invalid regex for P.IVA"),
+            category: PatternCategory::Identifier,
+            specificity: 40,
+            locale: Some("IT"),
+            min_threshold: 25.0,
+            validator: Some(validators::validate_piva_it),
+        },
+        PatternDef {
+            name: "CAP (IT)",
+            regex: Regex::new(r"^\d{5}$")
+                .expect("BUG: Invalid regex for CAP"),
+            category: PatternCategory::Geographic,
+            specificity: 35,
+            locale: Some("IT"),
+            min_threshold: 20.0,
+            validator: Some(validators::validate_cap_it),
+        },
+        PatternDef {
+            name: "ZIP Code (US)",
+            regex: Regex::new(r"^\d{5}(-\d{4})?$")
+                .expect("BUG: Invalid regex for ZIP Code"),
+            category: PatternCategory::Geographic,
+            specificity: 35,
+            locale: Some("US"),
+            min_threshold: 15.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "File Path (Unix)",
+            regex: Regex::new(r"^(/[^/\x00]+)+/?$")
+                .expect("BUG: Invalid regex for Unix File Path"),
+            category: PatternCategory::FilePath,
+            specificity: 30,
+            locale: None,
+            min_threshold: 10.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "File Path (Windows)",
+            regex: Regex::new(r##"^[A-Z]:\\(?:[^\\/:*?"<>|\r\n]+\\)*[^\\/:*?"<>|\r\n]*$"##)
+                .expect("BUG: Invalid regex for Windows File Path"),
+            category: PatternCategory::FilePath,
+            specificity: 30,
+            locale: None,
+            min_threshold: 10.0,
+            validator: None,
+        },
+        // ---- Phase 3 additions ----
+        PatternDef {
+            name: "Credit Card",
+            regex: Regex::new(r"^[0-9]{4}[\s-]?[0-9]{4}[\s-]?[0-9]{4}[\s-]?[0-9]{1,4}$")
+                .expect("BUG: Invalid regex for Credit Card"),
+            category: PatternCategory::Financial,
+            specificity: 60,
+            locale: None,
+            min_threshold: 10.0,
+            validator: Some(validators::validate_credit_card),
+        },
+        PatternDef {
+            name: "SSN (US)",
+            regex: Regex::new(r"^\d{3}-?\d{2}-?\d{4}$")
+                .expect("BUG: Invalid regex for SSN (US)"),
+            category: PatternCategory::Identifier,
+            specificity: 70,
+            locale: Some("US"),
+            min_threshold: 10.0,
+            validator: Some(validators::validate_ssn_us),
+        },
+        PatternDef {
+            name: "UK Postcode",
+            regex: Regex::new(r"^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$")
+                .expect("BUG: Invalid regex for UK Postcode"),
+            category: PatternCategory::Geographic,
+            specificity: 50,
+            locale: Some("GB"),
+            min_threshold: 15.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "German PLZ",
+            regex: Regex::new(r"^\d{5}$")
+                .expect("BUG: Invalid regex for German PLZ"),
+            category: PatternCategory::Geographic,
+            specificity: 30,
+            locale: Some("DE"),
+            min_threshold: 20.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Canadian Postal Code",
+            regex: Regex::new(r"^[A-Z]\d[A-Z]\s?\d[A-Z]\d$")
+                .expect("BUG: Invalid regex for Canadian Postal Code"),
+            category: PatternCategory::Geographic,
+            specificity: 50,
+            locale: Some("CA"),
+            min_threshold: 15.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "French Code Postal",
+            regex: Regex::new(r"^\d{5}$")
+                .expect("BUG: Invalid regex for French Code Postal"),
+            category: PatternCategory::Geographic,
+            specificity: 30,
+            locale: Some("FR"),
+            min_threshold: 20.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Hex Color",
+            regex: Regex::new(r"^#[0-9a-fA-F]{6}$")
+                .expect("BUG: Invalid regex for Hex Color"),
+            category: PatternCategory::Other,
+            specificity: 60,
+            locale: None,
+            min_threshold: 10.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "SWIFT/BIC",
+            regex: Regex::new(r"^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$")
+                .expect("BUG: Invalid regex for SWIFT/BIC"),
+            category: PatternCategory::Financial,
+            specificity: 75,
+            locale: None,
+            min_threshold: 10.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Currency",
+            regex: Regex::new(r"^[$€£¥₹]\s?-?\d{1,3}([,.\s]\d{3})*([.,]\d{1,2})?$|^-?\d{1,3}([,.\s]\d{3})*([.,]\d{1,2})?\s?[$€£¥₹]$")
+                .expect("BUG: Invalid regex for Currency"),
+            category: PatternCategory::Other,
+            specificity: 40,
+            locale: None,
+            min_threshold: 15.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Percentage",
+            regex: Regex::new(r"^-?\d+([.,]\d+)?\s?%$")
+                .expect("BUG: Invalid regex for Percentage"),
+            category: PatternCategory::Other,
+            specificity: 35,
+            locale: None,
+            min_threshold: 15.0,
+            validator: None,
+        },
+        // ---- IoT / coded identifier patterns ----
+        PatternDef {
+            name: "Alphanumeric Code",
+            regex: Regex::new(r"^[A-Z]{2,}[_-]\d{2,}$")
+                .expect("BUG: Invalid regex for Alphanumeric Code"),
+            category: PatternCategory::Identifier,
+            specificity: 15,
+            locale: None,
+            min_threshold: 30.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Scientific Notation",
+            regex: Regex::new(r"^[-+]?\d+(\.\d+)?[eE][-+]?\d+$")
+                .expect("BUG: Invalid regex for Scientific Notation"),
+            category: PatternCategory::Other,
+            specificity: 20,
+            locale: None,
+            min_threshold: 20.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Labeled Identifier",
+            regex: Regex::new(r"^[A-Za-z]+[_-][A-Za-z0-9]+$")
+                .expect("BUG: Invalid regex for Labeled Identifier"),
+            category: PatternCategory::Identifier,
+            specificity: 10,
+            locale: None,
+            min_threshold: 35.0,
+            validator: None,
+        },
+        // ---- Date patterns (unified from DATE_PATTERN_REGEXES) ----
+        PatternDef {
+            name: "Date (ISO)",
+            regex: Regex::new(r"^\d{4}-\d{2}-\d{2}$")
+                .expect("BUG: Invalid regex for Date (ISO)"),
+            category: PatternCategory::Other,
+            specificity: 50,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Date (EU slash)",
+            regex: Regex::new(r"^\d{2}/\d{2}/\d{4}$")
+                .expect("BUG: Invalid regex for Date (EU slash)"),
+            category: PatternCategory::Other,
+            specificity: 50,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Date (EU dash)",
+            regex: Regex::new(r"^\d{2}-\d{2}-\d{4}$")
+                .expect("BUG: Invalid regex for Date (EU dash)"),
+            category: PatternCategory::Other,
+            specificity: 50,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Date (YYYY/MM/DD)",
+            regex: Regex::new(r"^\d{4}/\d{2}/\d{2}$")
+                .expect("BUG: Invalid regex for Date (YYYY/MM/DD)"),
+            category: PatternCategory::Other,
+            specificity: 50,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "Date (EU dot)",
+            regex: Regex::new(r"^\d{2}\.\d{2}\.\d{4}$")
+                .expect("BUG: Invalid regex for Date (EU dot)"),
+            category: PatternCategory::Other,
+            specificity: 50,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
+        PatternDef {
+            name: "DateTime (ISO)",
+            regex: Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:")
+                .expect("BUG: Invalid regex for DateTime (ISO)"),
+            category: PatternCategory::Other,
+            specificity: 55,
+            locale: None,
+            min_threshold: 5.0,
+            validator: None,
+        },
     ]
+});
+
+/// Pre-compiled RegexSet for single-pass pre-filtering.
+/// For each input value, `REGEX_SET.matches(value)` returns all pattern indices
+/// that match, avoiding redundant regex evaluation for patterns that can't match.
+static REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
+    let patterns: Vec<&str> = PATTERN_DEFS.iter().map(|d| d.regex.as_str()).collect();
+    RegexSet::new(&patterns).expect("BUG: Failed to compile RegexSet from PATTERN_DEFS")
 });
 
 // Pre-compile date pattern regexes for type inference
@@ -103,52 +406,211 @@ static DATE_PATTERN_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     ]
 });
 
-/// Detect common data patterns in a column
+/// Intermediate match result used during overlap resolution.
+struct PatternMatch<'a> {
+    def: &'a PatternDef,
+    match_count: usize,
+    match_percentage: f64,
+    /// Per-row match bitmap for overlap computation.
+    matched_rows: Vec<bool>,
+    /// Fraction of regex-matched values that also pass the semantic validator.
+    /// 1.0 when no validator is defined.
+    validator_pass_rate: f64,
+}
+
+/// Compute confidence score from pattern specificity, match rate, and validator pass rate.
 ///
-/// Analyzes string data to identify common patterns like emails, phone numbers, URLs, etc.
-/// Uses pre-compiled regex patterns for optimal performance.
+/// Formula: `(specificity / 100) × clamp(match_percentage / 50, 0.5, 1.0) × validator_pass_rate`
+///
+/// The validator_pass_rate penalizes patterns where the regex matches but the values
+/// fail semantic validation (e.g. 11-digit numbers that aren't valid P.IVA).
+fn compute_confidence(specificity: u8, match_percentage: f64, validator_pass_rate: f64) -> f64 {
+    let base = specificity as f64 / 100.0;
+    let match_factor = (match_percentage / 50.0).clamp(0.5, 1.0);
+    base * match_factor * validator_pass_rate
+}
+
+/// Detect common data patterns in a column.
+///
+/// Analyzes string data to identify common patterns like emails, phone numbers,
+/// URLs, etc. Uses pre-compiled regex patterns with per-pattern thresholds and
+/// specificity-based overlap resolution to reduce false positives.
 ///
 /// # Arguments
 /// * `data` - Slice of string values to analyze
+/// * `locale` - Optional ISO 3166-1 alpha-2 locale (e.g. "IT", "US", "GB").
+///   When set, locale-matching patterns receive a confidence boost and
+///   non-matching locale patterns are suppressed (unless match rate is very high).
 ///
 /// # Returns
-/// Vector of detected patterns with match counts and percentages
-///
-/// # Performance
-/// - Pre-compiled regexes (lazy_static) eliminate compilation overhead
-/// - Only patterns with >5% match rate are returned
-/// - Whitespace is trimmed for robust matching
-pub fn detect_patterns(data: &[String]) -> Vec<Pattern> {
-    let mut patterns = Vec::new();
-
+/// Vector of detected patterns sorted by confidence descending, after overlap
+/// suppression and locale filtering.
+pub fn detect_patterns(data: &[String], locale: Option<&str>) -> Vec<Pattern> {
     // Filter empty and whitespace-only strings for robust analysis
-    let non_empty: Vec<&String> = data.iter().filter(|s| !s.trim().is_empty()).collect();
+    let non_empty: Vec<&str> = data
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
 
     if non_empty.is_empty() {
-        return patterns;
+        return Vec::new();
     }
 
-    // Check pre-compiled patterns
-    for (name, regex) in PATTERN_REGEXES.iter() {
-        let matches = non_empty
-            .iter()
-            .filter(|s| regex.is_match(s.trim()))
-            .count();
+    let n = non_empty.len();
+    let num_patterns = PATTERN_DEFS.len();
 
-        let percentage = (matches as f64 / non_empty.len() as f64) * 100.0;
+    // Phase 1: Single-pass RegexSet pre-filter + per-row bitmaps
+    //
+    // For each value, `REGEX_SET.matches()` returns all pattern indices that
+    // match in a single pass, avoiding redundant regex evaluation. We build
+    // per-pattern match bitmaps from these results.
+    let mut match_bitmaps: Vec<Vec<bool>> = vec![vec![false; n]; num_patterns];
 
-        // Only show patterns with >5% matches to reduce noise
-        if percentage > 5.0 {
-            patterns.push(Pattern {
-                name: name.to_string(),
-                regex: regex.as_str().to_string(),
-                match_count: matches,
-                match_percentage: percentage,
+    for (row_idx, value) in non_empty.iter().enumerate() {
+        let matches = REGEX_SET.matches(value);
+        for pat_idx in matches.iter() {
+            match_bitmaps[pat_idx][row_idx] = true;
+        }
+    }
+
+    let mut candidates: Vec<PatternMatch<'_>> = Vec::new();
+
+    for (pat_idx, def) in PATTERN_DEFS.iter().enumerate() {
+        let matched_rows = &match_bitmaps[pat_idx];
+        let match_count = matched_rows.iter().filter(|&&m| m).count();
+        let match_percentage = (match_count as f64 / n as f64) * 100.0;
+
+        // Apply per-pattern threshold (replaces uniform >5% check)
+        if match_percentage > def.min_threshold {
+            // Run semantic validator on regex-matched values (if defined)
+            let validator_pass_rate = match def.validator {
+                Some(validate) => {
+                    if match_count == 0 {
+                        1.0
+                    } else {
+                        let passed = non_empty
+                            .iter()
+                            .zip(matched_rows.iter())
+                            .filter(|&(s, matched)| *matched && validate(s))
+                            .count();
+                        passed as f64 / match_count as f64
+                    }
+                }
+                None => 1.0,
+            };
+
+            candidates.push(PatternMatch {
+                def,
+                match_count,
+                match_percentage,
+                matched_rows: std::mem::take(&mut match_bitmaps[pat_idx]),
+                validator_pass_rate,
             });
         }
     }
 
-    patterns
+    // Phase 2: Specificity-based overlap suppression
+    // When a more-specific pattern explains >=80% of a less-specific pattern's
+    // matches, the less-specific one is noise and gets suppressed.
+    // Equal-specificity patterns are never suppressed (resolved by locale in Phase 4).
+    let mut suppressed = vec![false; candidates.len()];
+
+    // Sort indices by specificity descending for pairwise comparison
+    let mut indices: Vec<usize> = (0..candidates.len()).collect();
+    indices.sort_by(|&a, &b| {
+        candidates[b]
+            .def
+            .specificity
+            .cmp(&candidates[a].def.specificity)
+    });
+
+    for i in 0..indices.len() {
+        if suppressed[indices[i]] {
+            continue;
+        }
+        let a_idx = indices[i];
+        let a_spec = candidates[a_idx].def.specificity;
+
+        for &b_idx in &indices[(i + 1)..] {
+            if suppressed[b_idx] {
+                continue;
+            }
+            let b_spec = candidates[b_idx].def.specificity;
+
+            // Only suppress when specificity strictly differs
+            if a_spec <= b_spec {
+                continue;
+            }
+
+            let b_count = candidates[b_idx].match_count;
+            if b_count == 0 {
+                continue;
+            }
+
+            // Count how many of B's matches are also matched by A
+            let overlap_count = candidates[a_idx]
+                .matched_rows
+                .iter()
+                .zip(candidates[b_idx].matched_rows.iter())
+                .filter(|&(a, b)| *a && *b)
+                .count();
+
+            let overlap_ratio = overlap_count as f64 / b_count as f64;
+            if overlap_ratio >= 0.80 {
+                suppressed[b_idx] = true;
+            }
+        }
+    }
+
+    // Phase 3: Build results with locale-adjusted confidence
+    let mut results: Vec<Pattern> = candidates
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !suppressed[*i])
+        .filter_map(|(_, pm)| {
+            let mut confidence = compute_confidence(
+                pm.def.specificity,
+                pm.match_percentage,
+                pm.validator_pass_rate,
+            );
+
+            // Locale adjustments (Phase 4)
+            if let Some(configured_locale) = locale {
+                match pm.def.locale {
+                    Some(pattern_locale) if pattern_locale == configured_locale => {
+                        // Boost locale-matching patterns (cap at 1.0)
+                        confidence = (confidence * 1.2).min(1.0);
+                    }
+                    Some(_) => {
+                        // Suppress non-matching locale patterns with low confidence,
+                        // unless the match rate is very high (data speaks for itself)
+                        if confidence < 0.5 && pm.match_percentage <= 80.0 {
+                            return None;
+                        }
+                    }
+                    None => {} // Universal patterns — no adjustment
+                }
+            }
+
+            Some(Pattern {
+                name: pm.def.name.to_string(),
+                regex: pm.def.regex.as_str().to_string(),
+                match_count: pm.match_count,
+                match_percentage: pm.match_percentage,
+                category: pm.def.category.clone(),
+                confidence,
+            })
+        })
+        .collect();
+
+    results.sort_by(|a, b| {
+        b.confidence
+            .partial_cmp(&a.confidence)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    results
 }
 
 /// Check if a string value looks like a date
@@ -178,6 +640,8 @@ pub fn looks_like_date(value: &str) -> bool {
 mod tests {
     use super::*;
 
+    // ---- Pattern detection tests ----
+
     #[test]
     fn test_detect_email_pattern() {
         let data = vec![
@@ -185,12 +649,14 @@ mod tests {
             "admin@test.org".to_string(),
             "contact@company.com".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Email");
         assert_eq!(patterns[0].match_count, 3);
         assert_eq!(patterns[0].match_percentage, 100.0);
+        assert_eq!(patterns[0].category, PatternCategory::Contact);
+        assert!(patterns[0].confidence > 0.0);
     }
 
     #[test]
@@ -200,10 +666,11 @@ mod tests {
             "555-123-4567".to_string(),
             "5551234567".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Phone (US)");
+        assert_eq!(patterns[0].category, PatternCategory::Contact);
     }
 
     #[test]
@@ -213,11 +680,12 @@ mod tests {
             "http://test.org/path".to_string(),
             "https://github.com/user/repo".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "URL");
         assert_eq!(patterns[0].match_percentage, 100.0);
+        assert_eq!(patterns[0].category, PatternCategory::Network);
     }
 
     #[test]
@@ -227,10 +695,11 @@ mod tests {
             "6ba7b810-9dad-11d1-80b4-00c04fd430c8".to_string(),
             "123e4567-e89b-12d3-a456-426614174000".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "UUID");
+        assert_eq!(patterns[0].category, PatternCategory::Identifier);
     }
 
     #[test]
@@ -240,7 +709,7 @@ mod tests {
             "some string".to_string(),
             "no pattern".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 0);
     }
@@ -253,9 +722,9 @@ mod tests {
             "admin@test.org".to_string(),
             "more text".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
-        // 50% emails should be detected
+        // 50% emails should be detected (threshold 3%)
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Email");
         assert_eq!(patterns[0].match_count, 2);
@@ -263,25 +732,24 @@ mod tests {
     }
 
     #[test]
-    fn test_pattern_threshold_5_percent() {
-        // Only 1 out of 20 = 5% - should NOT be detected
+    fn test_email_threshold_at_3_percent() {
+        // 1 out of 40 = 2.5% - should NOT be detected (Email threshold = 3%)
         let mut data = vec!["user@example.com".to_string()];
-        for _ in 0..19 {
+        for _ in 0..39 {
             data.push("random text".to_string());
         }
-        let patterns = detect_patterns(&data);
-
-        assert_eq!(patterns.len(), 0); // Below threshold
+        let patterns = detect_patterns(&data, None);
+        assert_eq!(patterns.len(), 0);
     }
 
     #[test]
-    fn test_pattern_threshold_above_5_percent() {
-        // 2 out of 20 = 10% - should be detected
+    fn test_email_threshold_above_3_percent() {
+        // 2 out of 20 = 10% - should be detected (Email threshold = 3%)
         let mut data = vec!["user@example.com".to_string(), "admin@test.org".to_string()];
         for _ in 0..18 {
             data.push("random text".to_string());
         }
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].match_percentage, 10.0);
@@ -290,7 +758,7 @@ mod tests {
     #[test]
     fn test_empty_data() {
         let data: Vec<String> = vec![];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 0);
     }
@@ -298,7 +766,7 @@ mod tests {
     #[test]
     fn test_all_empty_strings() {
         let data = vec!["".to_string(), "".to_string(), "".to_string()];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 0);
     }
@@ -310,7 +778,7 @@ mod tests {
             "  admin@test.org".to_string(),
             "contact@company.com  ".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Email");
@@ -320,7 +788,7 @@ mod tests {
     #[test]
     fn test_whitespace_only_strings() {
         let data = vec!["  ".to_string(), "\t".to_string(), " \n ".to_string()];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 0);
     }
@@ -332,12 +800,13 @@ mod tests {
             "10.0.0.1".to_string(),
             "255.255.255.0".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "IPv4");
         assert_eq!(patterns[0].match_count, 3);
         assert_eq!(patterns[0].match_percentage, 100.0);
+        assert_eq!(patterns[0].category, PatternCategory::Network);
     }
 
     #[test]
@@ -347,10 +816,11 @@ mod tests {
             "fe80:0000:0000:0000:0204:61ff:fe9d:f156".to_string(),
             "2001:0db8:0001:0000:0000:0ab9:C0A8:0102".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "IPv6");
+        assert_eq!(patterns[0].category, PatternCategory::Network);
     }
 
     #[test]
@@ -360,10 +830,11 @@ mod tests {
             "A0-B1-C2-D3-E4-F5".to_string(),
             "aa:bb:cc:dd:ee:ff".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "MAC Address");
+        assert_eq!(patterns[0].category, PatternCategory::Network);
     }
 
     #[test]
@@ -373,10 +844,11 @@ mod tests {
             "40.7128, -74.0060".to_string(),  // New York
             "-33.8688, 151.2093".to_string(), // Sydney
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Geographic Coordinates");
+        assert_eq!(patterns[0].category, PatternCategory::Geographic);
     }
 
     #[test]
@@ -386,36 +858,60 @@ mod tests {
             "GB82WEST12345698765432".to_string(),
             "DE89370400440532013000".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "IBAN");
+        assert_eq!(patterns[0].category, PatternCategory::Financial);
     }
 
     #[test]
     fn test_detect_codice_fiscale_pattern() {
         let data = vec![
-            "RSSMRA85M01H501Z".to_string(),
-            "BNCGVN90A01F205X".to_string(),
-            "VRDLCU75D15L219K".to_string(),
+            "RSSMRA85M01H501Q".to_string(),
+            "BNCGVN90A01F205O".to_string(),
+            "VRDLCU75D15L219V".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Codice Fiscale (IT)");
+        assert_eq!(patterns[0].category, PatternCategory::Identifier);
     }
 
     #[test]
     fn test_detect_piva_pattern() {
+        // 100% 11-digit numbers — well above 25% threshold
         let data = vec![
             "12345678901".to_string(),
             "98765432109".to_string(),
             "11111111111".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
-        // P.IVA is 11 digits, so it should match
         assert!(!patterns.is_empty());
+        assert!(patterns.iter().any(|p| p.name == "P.IVA (IT)"));
+    }
+
+    #[test]
+    fn test_piva_below_threshold() {
+        // P.IVA threshold is 25%. 4 out of 20 = 20% — should NOT be detected.
+        let mut data: Vec<String> = (0..4).map(|i| format!("{:011}", i)).collect();
+        for _ in 0..16 {
+            data.push("random text".to_string());
+        }
+        let patterns = detect_patterns(&data, None);
+        assert!(!patterns.iter().any(|p| p.name == "P.IVA (IT)"));
+    }
+
+    #[test]
+    fn test_piva_above_threshold() {
+        // 6 out of 20 = 30% — above 25% threshold
+        let mut data: Vec<String> = (0..6).map(|i| format!("{:011}", i)).collect();
+        for _ in 0..14 {
+            data.push("random text".to_string());
+        }
+        let patterns = detect_patterns(&data, None);
         assert!(patterns.iter().any(|p| p.name == "P.IVA (IT)"));
     }
 
@@ -426,9 +922,9 @@ mod tests {
             "20121".to_string(),
             "10100".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
-        // Note: CAP might conflict with ZIP Code pattern
+        // Both CAP and ZIP have specificity 35 (equal), so neither suppresses the other
         assert!(!patterns.is_empty());
         assert!(
             patterns
@@ -444,14 +940,11 @@ mod tests {
             "90210-1234".to_string(),
             "10001".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert!(!patterns.is_empty());
-        assert!(
-            patterns
-                .iter()
-                .any(|p| p.name == "ZIP Code (US)" || p.name == "CAP (IT)")
-        );
+        // ZIP Code (US) should match — the extended format (90210-1234) only matches ZIP, not CAP
+        assert!(patterns.iter().any(|p| p.name == "ZIP Code (US)"));
     }
 
     #[test]
@@ -461,10 +954,11 @@ mod tests {
             "/var/log/system.log".to_string(),
             "/etc/config/app.conf".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "File Path (Unix)");
+        assert_eq!(patterns[0].category, PatternCategory::FilePath);
     }
 
     #[test]
@@ -474,11 +968,339 @@ mod tests {
             "D:\\Projects\\myapp\\src".to_string(),
             "E:\\Data\\file.txt".to_string(),
         ];
-        let patterns = detect_patterns(&data);
+        let patterns = detect_patterns(&data, None);
 
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "File Path (Windows)");
+        assert_eq!(patterns[0].category, PatternCategory::FilePath);
     }
+
+    // ---- Overlap suppression tests ----
+
+    #[test]
+    fn test_overlap_suppression_high_specificity_wins() {
+        // All data matches both IPv4 (specificity 65) and could match a broad
+        // pattern. The more-specific pattern should survive.
+        let data = vec![
+            "192.168.1.1".to_string(),
+            "10.0.0.1".to_string(),
+            "172.16.0.1".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].name, "IPv4");
+    }
+
+    #[test]
+    fn test_equal_specificity_no_suppression() {
+        // CAP (IT) and ZIP Code (US) both have specificity 35.
+        // Pure 5-digit data should return both (no suppression at equal specificity).
+        let data: Vec<String> = (10000..10020).map(|n| n.to_string()).collect();
+        let patterns = detect_patterns(&data, None);
+        let cap = patterns.iter().any(|p| p.name == "CAP (IT)");
+        let zip = patterns.iter().any(|p| p.name == "ZIP Code (US)");
+        assert!(
+            cap && zip,
+            "Both CAP and ZIP should survive at equal specificity"
+        );
+    }
+
+    // ---- Confidence scoring tests ----
+
+    #[test]
+    fn test_confidence_increases_with_match_rate() {
+        // Higher match rate → higher confidence for the same pattern
+        let data_low: Vec<String> = {
+            let mut d: Vec<String> = (0..3).map(|_| "user@example.com".to_string()).collect();
+            for _ in 0..27 {
+                d.push("random text".to_string());
+            }
+            d
+        };
+        let data_high = vec![
+            "user@example.com".to_string(),
+            "admin@test.org".to_string(),
+            "hello@world.com".to_string(),
+        ];
+
+        let p_low = detect_patterns(&data_low, None);
+        let p_high = detect_patterns(&data_high, None);
+
+        assert_eq!(p_low.len(), 1);
+        assert_eq!(p_high.len(), 1);
+        assert!(
+            p_high[0].confidence >= p_low[0].confidence,
+            "100% match should have >= confidence than 10% match"
+        );
+    }
+
+    #[test]
+    fn test_confidence_sorted_descending() {
+        // Mix different pattern types — results should be sorted by confidence
+        let mut data = vec![
+            "user@example.com".to_string(),
+            "admin@test.org".to_string(),
+            "/home/user/docs".to_string(),
+            "/var/log/app.log".to_string(),
+            "/etc/hosts".to_string(),
+            "random text".to_string(),
+        ];
+        // Add more file paths to ensure it passes the 10% threshold
+        for _ in 0..10 {
+            data.push("/usr/local/bin/tool".to_string());
+        }
+        let patterns = detect_patterns(&data, None);
+
+        for w in patterns.windows(2) {
+            assert!(
+                w[0].confidence >= w[1].confidence,
+                "Patterns should be sorted by confidence descending: {} ({}) vs {} ({})",
+                w[0].name,
+                w[0].confidence,
+                w[1].name,
+                w[1].confidence
+            );
+        }
+    }
+
+    #[test]
+    fn test_confidence_range() {
+        let data = vec![
+            "user@example.com".to_string(),
+            "admin@test.org".to_string(),
+            "hello@world.com".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+
+        assert_eq!(patterns.len(), 1);
+        assert!(patterns[0].confidence > 0.0 && patterns[0].confidence <= 1.0);
+    }
+
+    // ---- Validator integration tests ----
+
+    #[test]
+    fn test_validator_reduces_confidence_for_invalid_ibans() {
+        // Mix of valid and invalid IBANs — all match the regex, but validator
+        // pass rate < 1.0 should reduce confidence compared to all-valid.
+        let all_valid = vec![
+            "GB82WEST12345698765432".to_string(),
+            "DE89370400440532013000".to_string(),
+            "FR7630006000011234567890189".to_string(),
+        ];
+        let mixed = vec![
+            "GB82WEST12345698765432".to_string(),      // Valid
+            "DE89370400440532013001".to_string(),      // Invalid checksum
+            "FR7630006000011234567890180".to_string(), // Invalid checksum
+        ];
+
+        let p_valid = detect_patterns(&all_valid, None);
+        let p_mixed = detect_patterns(&mixed, None);
+
+        assert_eq!(p_valid.len(), 1);
+        assert_eq!(p_mixed.len(), 1);
+        assert_eq!(p_valid[0].name, "IBAN");
+        assert_eq!(p_mixed[0].name, "IBAN");
+        assert!(
+            p_valid[0].confidence > p_mixed[0].confidence,
+            "All-valid IBANs ({:.3}) should have higher confidence than mixed ({:.3})",
+            p_valid[0].confidence,
+            p_mixed[0].confidence,
+        );
+    }
+
+    #[test]
+    fn test_validator_cap_filters_out_of_range() {
+        // All match ^\d{5}$ but some are outside CAP range (00010-98168)
+        // This tests that the validator pass rate reduces confidence.
+        let valid_caps = vec![
+            "00118".to_string(), // Roma
+            "20121".to_string(), // Milano
+            "80100".to_string(), // Napoli
+        ];
+        let invalid_caps = vec![
+            "99999".to_string(), // Out of range
+            "99998".to_string(), // Out of range
+            "99997".to_string(), // Out of range
+        ];
+
+        let p_valid = detect_patterns(&valid_caps, None);
+        let p_invalid = detect_patterns(&invalid_caps, None);
+
+        let cap_valid = p_valid.iter().find(|p| p.name == "CAP (IT)");
+        let cap_invalid = p_invalid.iter().find(|p| p.name == "CAP (IT)");
+
+        // Valid CAPs should have higher confidence than invalid ones
+        if let (Some(v), Some(iv)) = (cap_valid, cap_invalid) {
+            assert!(
+                v.confidence > iv.confidence,
+                "Valid CAPs ({:.3}) should have higher confidence than invalid ({:.3})",
+                v.confidence,
+                iv.confidence,
+            );
+        }
+        // At minimum, valid CAPs should be detected
+        assert!(cap_valid.is_some(), "Valid CAPs should be detected");
+    }
+
+    #[test]
+    fn test_validator_piva_check_digit() {
+        // Valid P.IVA: 12345678903 (computed check digit)
+        // Invalid: 12345678901 (wrong check digit)
+        let valid = vec![
+            "12345678903".to_string(),
+            "12345678903".to_string(),
+            "12345678903".to_string(),
+            "00000000000".to_string(),
+        ];
+        let invalid = vec![
+            "12345678901".to_string(),
+            "12345678902".to_string(),
+            "99999999999".to_string(),
+            "11111111111".to_string(),
+        ];
+
+        let p_valid = detect_patterns(&valid, None);
+        let p_invalid = detect_patterns(&invalid, None);
+
+        let piva_valid = p_valid.iter().find(|p| p.name == "P.IVA (IT)");
+        let piva_invalid = p_invalid.iter().find(|p| p.name == "P.IVA (IT)");
+
+        assert!(piva_valid.is_some(), "Valid P.IVA should be detected");
+        // Both should be detected (regex matches), but valid should have higher confidence
+        if let (Some(v), Some(iv)) = (piva_valid, piva_invalid) {
+            assert!(
+                v.confidence > iv.confidence,
+                "Valid P.IVA ({:.3}) should have higher confidence than invalid ({:.3})",
+                v.confidence,
+                iv.confidence,
+            );
+        }
+    }
+
+    // ---- Phase 3 pattern tests ----
+
+    #[test]
+    fn test_detect_credit_card_pattern() {
+        let data = vec![
+            "4532015112830366".to_string(),
+            "5425233430109903".to_string(),
+            "4111111111111111".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Credit Card"));
+    }
+
+    #[test]
+    fn test_detect_ssn_pattern() {
+        let data = vec![
+            "123-45-6789".to_string(),
+            "234-56-7890".to_string(),
+            "345-67-8901".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "SSN (US)"));
+    }
+
+    #[test]
+    fn test_detect_uk_postcode_pattern() {
+        let data = vec![
+            "SW1A 1AA".to_string(),
+            "EC1A 1BB".to_string(),
+            "W1J 7NT".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "UK Postcode"));
+    }
+
+    #[test]
+    fn test_detect_canadian_postal_pattern() {
+        let data = vec![
+            "K1A 0B1".to_string(),
+            "V6B 3K9".to_string(),
+            "M5V 2T6".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Canadian Postal Code"));
+    }
+
+    #[test]
+    fn test_detect_hex_color_pattern() {
+        let data = vec![
+            "#FF5733".to_string(),
+            "#00FF00".to_string(),
+            "#0A0B0C".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Hex Color"));
+    }
+
+    #[test]
+    fn test_detect_swift_bic_pattern() {
+        let data = vec![
+            "DEUTDEFF".to_string(),
+            "BNPAFRPP".to_string(),
+            "CHASUS33XXX".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "SWIFT/BIC"));
+    }
+
+    #[test]
+    fn test_detect_percentage_pattern() {
+        let data = vec!["12.5%".to_string(), "99%".to_string(), "0.1%".to_string()];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Percentage"));
+    }
+
+    #[test]
+    fn test_detect_currency_pattern() {
+        let data = vec![
+            "$1,234.56".to_string(),
+            "$99.99".to_string(),
+            "$1,000".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Currency"));
+    }
+
+    #[test]
+    fn test_detect_scientific_notation_pattern() {
+        let data = vec![
+            "1.23e+04".to_string(),
+            "5.67E-03".to_string(),
+            "-9.81e+00".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Scientific Notation"));
+    }
+
+    #[test]
+    fn test_detect_ipv6_compressed() {
+        // Phase 3 fix: IPv6 with :: compression should now be detected
+        let data = vec![
+            "::1".to_string(),
+            "fe80::1".to_string(),
+            "2001:db8::1".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(
+            patterns.iter().any(|p| p.name == "IPv6"),
+            "Compressed IPv6 addresses should be detected"
+        );
+    }
+
+    #[test]
+    fn test_detect_date_iso_pattern() {
+        let data = vec![
+            "2024-01-15".to_string(),
+            "2023-12-25".to_string(),
+            "2022-06-01".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+        assert!(patterns.iter().any(|p| p.name == "Date (ISO)"));
+    }
+
+    // ---- Date detection tests (looks_like_date helper) ----
 
     #[test]
     fn test_looks_like_date_function() {
@@ -498,14 +1320,174 @@ mod tests {
 
     #[test]
     fn test_date_pattern_regexes_precompiled() {
-        // Validate that all date patterns compile successfully
         assert_eq!(DATE_PATTERN_REGEXES.len(), 6);
     }
 
     #[test]
-    fn test_pattern_regexes_compiled() {
-        // Validate that all hardcoded regex patterns compile successfully
-        // This test will fail at initialization if any pattern is invalid
-        assert_eq!(PATTERN_REGEXES.len(), 16);
+    fn test_pattern_defs_compiled() {
+        assert_eq!(PATTERN_DEFS.len(), 35);
+    }
+
+    // ---- RegexSet tests ----
+
+    #[test]
+    fn test_regex_set_matches_all_patterns() {
+        // Ensure the RegexSet has the same number of patterns as PATTERN_DEFS
+        assert_eq!(REGEX_SET.len(), PATTERN_DEFS.len());
+    }
+
+    #[test]
+    fn test_regex_set_prefilter_matches_individual() {
+        // Verify RegexSet matches agree with individual regex matches
+        let test_values = vec![
+            "user@example.com",
+            "192.168.1.1",
+            "2001:db8::1",
+            "IT60X0542811101000000123456",
+            "RSSMRA85M01H501Q",
+            "12345",
+            "hello world",
+            "4111111111111111",
+            "$1,234.56",
+        ];
+
+        for value in &test_values {
+            let set_matches: Vec<usize> = REGEX_SET.matches(value).iter().collect();
+            for (idx, def) in PATTERN_DEFS.iter().enumerate() {
+                let individual = def.regex.is_match(value);
+                let in_set = set_matches.contains(&idx);
+                assert_eq!(
+                    individual, in_set,
+                    "Mismatch for pattern '{}' on value '{}': individual={}, set={}",
+                    def.name, value, individual, in_set
+                );
+            }
+        }
+    }
+
+    // ---- Locale tests ----
+
+    #[test]
+    fn test_locale_it_boosts_cap_confidence() {
+        let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
+        let without_locale = detect_patterns(&data, None);
+        let with_locale = detect_patterns(&data, Some("IT"));
+
+        let cap_no_locale = without_locale.iter().find(|p| p.name == "CAP (IT)");
+        let cap_it_locale = with_locale.iter().find(|p| p.name == "CAP (IT)");
+
+        assert!(
+            cap_no_locale.is_some(),
+            "CAP should be detected without locale"
+        );
+        assert!(
+            cap_it_locale.is_some(),
+            "CAP should be detected with IT locale"
+        );
+        assert!(
+            cap_it_locale.unwrap().confidence > cap_no_locale.unwrap().confidence,
+            "IT locale should boost CAP confidence"
+        );
+    }
+
+    #[test]
+    fn test_locale_us_suppresses_non_matching_low_match_rate() {
+        // With US locale, low-confidence IT patterns should be suppressed
+        // when match rate is not overwhelmingly high
+        let mut data: Vec<String> = (20100..=20130).map(|n| format!("{:05}", n)).collect();
+        // Add non-matching rows to bring match percentage below 80%
+        for i in 0..100 {
+            data.push(format!("text_{}", i));
+        }
+        let with_us = detect_patterns(&data, Some("US"));
+
+        // CAP (IT) has low specificity (35) and locale=IT.
+        // With US locale and low match rate, it should be suppressed
+        let cap_us = with_us.iter().find(|p| p.name == "CAP (IT)");
+        assert!(
+            cap_us.is_none(),
+            "CAP (IT) should be suppressed with US locale when match rate is low"
+        );
+    }
+
+    #[test]
+    fn test_locale_high_match_rate_keeps_non_matching() {
+        // Even with non-matching locale, very high match rate (>80%) keeps the pattern
+        let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
+        let with_us = detect_patterns(&data, Some("US"));
+
+        // CAP (IT) has 100% match rate, so it survives despite US locale
+        let cap_us = with_us.iter().find(|p| p.name == "CAP (IT)");
+        assert!(
+            cap_us.is_some(),
+            "CAP (IT) should survive with US locale when match rate >80% (data speaks for itself)"
+        );
+    }
+
+    #[test]
+    fn test_locale_none_keeps_all() {
+        // Without locale, both CAP and ZIP should be present (equal specificity)
+        let data: Vec<String> = (10001..=10050).map(|n| format!("{}", n)).collect();
+        let patterns = detect_patterns(&data, None);
+
+        // At least one 5-digit pattern should survive
+        let has_five_digit = patterns.iter().any(|p| {
+            p.name == "CAP (IT)"
+                || p.name == "ZIP Code (US)"
+                || p.name == "German PLZ"
+                || p.name == "French Code Postal"
+        });
+        assert!(
+            has_five_digit,
+            "Some 5-digit pattern should be detected without locale"
+        );
+    }
+
+    // ---- End-to-end tests ----
+
+    #[test]
+    fn test_e2e_mixed_column_patterns() {
+        // Simulate a column with mostly emails and some noise
+        let mut data: Vec<String> = (0..100).map(|i| format!("user{}@example.com", i)).collect();
+        data.push("not_an_email".to_string());
+        data.push("also not".to_string());
+
+        let patterns = detect_patterns(&data, None);
+
+        assert!(!patterns.is_empty());
+        assert_eq!(patterns[0].name, "Email", "Email should be the top pattern");
+        assert!(
+            patterns[0].confidence > 0.5,
+            "Email confidence should be high"
+        );
+        assert_eq!(patterns[0].category, PatternCategory::Contact);
+    }
+
+    #[test]
+    fn test_e2e_all_pattern_categories_present() {
+        // Verify that the pattern system covers all expected categories
+        let categories: Vec<&PatternCategory> = PATTERN_DEFS.iter().map(|d| &d.category).collect();
+        assert!(categories.contains(&&PatternCategory::Contact));
+        assert!(categories.contains(&&PatternCategory::Identifier));
+        assert!(categories.contains(&&PatternCategory::Network));
+        assert!(categories.contains(&&PatternCategory::Geographic));
+        assert!(categories.contains(&&PatternCategory::Financial));
+        assert!(categories.contains(&&PatternCategory::FilePath));
+        assert!(categories.contains(&&PatternCategory::Other));
+    }
+
+    #[test]
+    fn test_e2e_confidence_never_exceeds_one() {
+        let data: Vec<String> = (0..200).map(|i| format!("user{}@example.com", i)).collect();
+        let patterns = detect_patterns(&data, Some("US"));
+
+        for p in &patterns {
+            assert!(
+                p.confidence <= 1.0,
+                "Confidence for {} should not exceed 1.0, got {}",
+                p.name,
+                p.confidence
+            );
+        }
     }
 }

--- a/src/analysis/patterns.rs
+++ b/src/analysis/patterns.rs
@@ -59,7 +59,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
         },
         PatternDef {
             name: "URL",
-            regex: Regex::new(r"^https?://[^\s/$.?#].[^\s]*$")
+            regex: Regex::new(r"^(?:https?|ftps?)://[^\s/$.?#].[^\s]*$")
                 .expect("BUG: Invalid regex for URL"),
             category: PatternCategory::Network,
             specificity: 70,
@@ -91,7 +91,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
             name: "IPv6",
             // Pre-filter: hex groups with at least one colon, including :: compression.
             // The validator (Ipv6Addr::from_str) does the real validation.
-            regex: Regex::new(r"^[0-9a-fA-F]*:[0-9a-fA-F:]*$")
+            regex: Regex::new(r"^[0-9a-fA-F]*:[0-9a-fA-F:.]*$")
                 .expect("BUG: Invalid regex for IPv6"),
             category: PatternCategory::Network,
             specificity: 75,

--- a/src/analysis/validators.rs
+++ b/src/analysis/validators.rs
@@ -7,7 +7,8 @@
 //! confidence = base(specificity) × match_factor × validator_pass_rate
 //! ```
 //!
-//! Validators are pure functions with no allocations on the hot path.
+//! Validators are pure functions; some implementations may use small temporary
+//! allocations while validating.
 
 /// Validate an Italian CAP (Codice di Avviamento Postale).
 ///

--- a/src/analysis/validators.rs
+++ b/src/analysis/validators.rs
@@ -1,0 +1,373 @@
+//! Semantic validators for pattern detection.
+//!
+//! Each validator is a `fn(&str) -> bool` that runs on values already matched by
+//! a pattern's regex. The validator pass rate feeds into the confidence formula:
+//!
+//! ```text
+//! confidence = base(specificity) × match_factor × validator_pass_rate
+//! ```
+//!
+//! Validators are pure functions with no allocations on the hot path.
+
+/// Validate an Italian CAP (Codice di Avviamento Postale).
+///
+/// Valid range: 00010–98168. The regex `^\d{5}$` matches any 5-digit string;
+/// this validator restricts to the actual Italian postal code range.
+pub fn validate_cap_it(s: &str) -> bool {
+    match s.parse::<u32>() {
+        Ok(n) => (10..=98168).contains(&n),
+        Err(_) => false,
+    }
+}
+
+/// Validate an Italian P.IVA (Partita IVA) check digit.
+///
+/// The 11th digit is computed from the first 10 using the Italian tax authority
+/// algorithm: odd-position digits are summed directly, even-position digits are
+/// doubled and digits > 9 have 9 subtracted, then `(10 - sum % 10) % 10` must
+/// equal the check digit.
+pub fn validate_piva_it(s: &str) -> bool {
+    let digits: Vec<u8> = s.bytes().map(|b| b.wrapping_sub(b'0')).collect();
+    if digits.len() != 11 || digits.iter().any(|&d| d > 9) {
+        return false;
+    }
+
+    let mut sum: u32 = 0;
+    for (i, &d) in digits[..10].iter().enumerate() {
+        if i % 2 == 0 {
+            // Odd position (1-indexed) → direct sum
+            sum += d as u32;
+        } else {
+            // Even position (1-indexed) → double, subtract 9 if >= 10
+            let doubled = (d as u32) * 2;
+            sum += if doubled > 9 { doubled - 9 } else { doubled };
+        }
+    }
+
+    let check = ((10 - (sum % 10)) % 10) as u8;
+    check == digits[10]
+}
+
+/// Validate an Italian Codice Fiscale check character.
+///
+/// Uses the official algorithm: alternating odd/even lookup tables for the first
+/// 15 characters, sum modulo 26 maps to the check letter (16th character).
+pub fn validate_codice_fiscale(s: &str) -> bool {
+    let bytes: Vec<u8> = s.bytes().collect();
+    if bytes.len() != 16 {
+        return false;
+    }
+
+    let odd_values = |c: u8| -> Option<u32> {
+        match c {
+            b'0' => Some(1),
+            b'1' => Some(0),
+            b'2' => Some(5),
+            b'3' => Some(7),
+            b'4' => Some(9),
+            b'5' => Some(13),
+            b'6' => Some(15),
+            b'7' => Some(17),
+            b'8' => Some(19),
+            b'9' => Some(21),
+            b'A' => Some(1),
+            b'B' => Some(0),
+            b'C' => Some(5),
+            b'D' => Some(7),
+            b'E' => Some(9),
+            b'F' => Some(13),
+            b'G' => Some(15),
+            b'H' => Some(17),
+            b'I' => Some(19),
+            b'J' => Some(21),
+            b'K' => Some(2),
+            b'L' => Some(4),
+            b'M' => Some(18),
+            b'N' => Some(20),
+            b'O' => Some(11),
+            b'P' => Some(3),
+            b'Q' => Some(6),
+            b'R' => Some(8),
+            b'S' => Some(12),
+            b'T' => Some(14),
+            b'U' => Some(16),
+            b'V' => Some(10),
+            b'W' => Some(22),
+            b'X' => Some(25),
+            b'Y' => Some(24),
+            b'Z' => Some(23),
+            _ => None,
+        }
+    };
+
+    let even_values = |c: u8| -> Option<u32> {
+        match c {
+            b'0'..=b'9' => Some((c - b'0') as u32),
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            _ => None,
+        }
+    };
+
+    let mut sum: u32 = 0;
+    for (i, &c) in bytes[..15].iter().enumerate() {
+        let val = if i % 2 == 0 {
+            // Odd position (1-indexed) → odd lookup
+            odd_values(c)
+        } else {
+            // Even position (1-indexed) → even lookup
+            even_values(c)
+        };
+        match val {
+            Some(v) => sum += v,
+            None => return false,
+        }
+    }
+
+    let expected = b'A' + (sum % 26) as u8;
+    bytes[15] == expected
+}
+
+/// Validate an IBAN checksum (ISO 7064 Mod 97-10).
+///
+/// Algorithm: move the first 4 characters to the end, convert letters to
+/// two-digit numbers (A=10, B=11, ..., Z=35), compute the resulting number
+/// modulo 97. Valid IBANs produce remainder 1.
+pub fn validate_iban(s: &str) -> bool {
+    let s = s.trim();
+    if s.len() < 5 || s.len() > 34 {
+        return false;
+    }
+
+    // Rearrange: move first 4 chars to end
+    let rearranged = format!("{}{}", &s[4..], &s[..4]);
+
+    // Convert to digit string (A=10, B=11, ..., Z=35)
+    let mut numeric = String::with_capacity(rearranged.len() * 2);
+    for c in rearranged.chars() {
+        match c {
+            '0'..='9' => numeric.push(c),
+            'A'..='Z' => {
+                let val = (c as u32) - ('A' as u32) + 10;
+                numeric.push_str(&val.to_string());
+            }
+            _ => return false,
+        }
+    }
+
+    // Compute mod 97 using chunked arithmetic to avoid big-integer math
+    let mut remainder: u64 = 0;
+    for chunk in numeric.as_bytes().chunks(9) {
+        let chunk_str = std::str::from_utf8(chunk).unwrap_or("0");
+        let combined = format!("{remainder}{chunk_str}");
+        remainder = combined.parse::<u64>().unwrap_or(0) % 97;
+    }
+
+    remainder == 1
+}
+
+/// Validate a credit card number using the Luhn algorithm.
+///
+/// Strips spaces/dashes, then doubles every second digit from the right,
+/// sums all digits, and checks that the total is divisible by 10.
+pub fn validate_credit_card(s: &str) -> bool {
+    let digits: Vec<u8> = s
+        .bytes()
+        .filter(|&b| b != b' ' && b != b'-')
+        .map(|b| b.wrapping_sub(b'0'))
+        .collect();
+
+    if digits.len() < 13 || digits.len() > 19 || digits.iter().any(|&d| d > 9) {
+        return false;
+    }
+
+    let mut sum: u32 = 0;
+    let parity = digits.len() % 2;
+    for (i, &d) in digits.iter().enumerate() {
+        if i % 2 == parity {
+            let doubled = (d as u32) * 2;
+            sum += if doubled > 9 { doubled - 9 } else { doubled };
+        } else {
+            sum += d as u32;
+        }
+    }
+
+    sum.is_multiple_of(10)
+}
+
+/// Validate an IPv6 address using the standard library parser.
+///
+/// The regex pre-filter is intentionally loose; this validator handles all
+/// valid representations including `::` compression and mixed IPv4 notation.
+pub fn validate_ipv6(s: &str) -> bool {
+    s.parse::<std::net::Ipv6Addr>().is_ok()
+}
+
+/// Validate a US Social Security Number.
+///
+/// Checks that the area number (first 3 digits) is not 000, 666, or 900-999.
+/// The group and serial must also be non-zero.
+pub fn validate_ssn_us(s: &str) -> bool {
+    let clean: String = s.chars().filter(|c| c.is_ascii_digit()).collect();
+    if clean.len() != 9 {
+        return false;
+    }
+    let area: u16 = clean[0..3].parse().unwrap_or(0);
+    let group: u16 = clean[3..5].parse().unwrap_or(0);
+    let serial: u16 = clean[5..9].parse().unwrap_or(0);
+
+    area != 0 && area != 666 && area < 900 && group != 0 && serial != 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- CAP (IT) validator ----
+
+    #[test]
+    fn test_cap_valid() {
+        assert!(validate_cap_it("00118")); // Roma
+        assert!(validate_cap_it("20121")); // Milano
+        assert!(validate_cap_it("10100")); // Torino
+        assert!(validate_cap_it("80100")); // Napoli
+        assert!(validate_cap_it("00010")); // Lowest valid
+        assert!(validate_cap_it("98168")); // Highest valid (Messina)
+    }
+
+    #[test]
+    fn test_cap_invalid() {
+        assert!(!validate_cap_it("00000")); // Below range
+        assert!(!validate_cap_it("00009")); // Below range
+        assert!(!validate_cap_it("99999")); // Above range
+        assert!(!validate_cap_it("98169")); // Just above range
+    }
+
+    // ---- P.IVA (IT) validator ----
+
+    #[test]
+    fn test_piva_valid() {
+        // Known valid P.IVA numbers
+        assert!(validate_piva_it("12345678903"));
+        assert!(validate_piva_it("00000000000"));
+    }
+
+    #[test]
+    fn test_piva_invalid_check_digit() {
+        assert!(!validate_piva_it("12345678901")); // Wrong check digit
+        assert!(!validate_piva_it("12345678902")); // Wrong check digit
+    }
+
+    #[test]
+    fn test_piva_invalid_length() {
+        assert!(!validate_piva_it("1234567890")); // Too short
+        assert!(!validate_piva_it("123456789012")); // Too long
+    }
+
+    #[test]
+    fn test_piva_invalid_chars() {
+        assert!(!validate_piva_it("1234567890a"));
+        assert!(!validate_piva_it("abcdefghijk"));
+    }
+
+    // ---- Codice Fiscale (IT) validator ----
+
+    #[test]
+    fn test_codice_fiscale_valid() {
+        assert!(validate_codice_fiscale("RSSMRA85M01H501Q"));
+        assert!(validate_codice_fiscale("BNCGVN90A01F205O"));
+        assert!(validate_codice_fiscale("VRDLCU75D15L219V"));
+    }
+
+    #[test]
+    fn test_codice_fiscale_invalid_check() {
+        assert!(!validate_codice_fiscale("RSSMRA85M01H501A")); // Wrong check letter
+        assert!(!validate_codice_fiscale("RSSMRA85M01H501Z")); // Wrong check letter
+    }
+
+    #[test]
+    fn test_codice_fiscale_invalid_length() {
+        assert!(!validate_codice_fiscale("RSSMRA85M01H501")); // Too short
+        assert!(!validate_codice_fiscale("RSSMRA85M01H501ZZ")); // Too long
+    }
+
+    // ---- IBAN validator ----
+
+    #[test]
+    fn test_iban_valid() {
+        assert!(validate_iban("GB82WEST12345698765432"));
+        assert!(validate_iban("DE89370400440532013000"));
+        assert!(validate_iban("FR7630006000011234567890189"));
+        assert!(validate_iban("IT60X0542811101000000123456"));
+    }
+
+    #[test]
+    fn test_iban_invalid_checksum() {
+        assert!(!validate_iban("GB82WEST12345698765431")); // Last digit changed
+        assert!(!validate_iban("DE89370400440532013001")); // Last digit changed
+    }
+
+    #[test]
+    fn test_iban_too_short() {
+        assert!(!validate_iban("GB82"));
+        assert!(!validate_iban(""));
+    }
+
+    #[test]
+    fn test_iban_invalid_chars() {
+        assert!(!validate_iban("GB82WEST1234569876543!"));
+    }
+
+    // ---- Credit Card (Luhn) validator ----
+
+    #[test]
+    fn test_credit_card_valid() {
+        assert!(validate_credit_card("4532015112830366")); // Visa
+        assert!(validate_credit_card("5425233430109903")); // Mastercard
+        assert!(validate_credit_card("4111111111111111")); // Visa test
+        assert!(validate_credit_card("4111 1111 1111 1111")); // With spaces
+        assert!(validate_credit_card("4111-1111-1111-1111")); // With dashes
+    }
+
+    #[test]
+    fn test_credit_card_invalid() {
+        assert!(!validate_credit_card("4532015112830367")); // Wrong check digit
+        assert!(!validate_credit_card("1234567890123456")); // Invalid Luhn
+        assert!(!validate_credit_card("123456789012")); // Too short
+    }
+
+    // ---- IPv6 validator ----
+
+    #[test]
+    fn test_ipv6_valid() {
+        assert!(validate_ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+        assert!(validate_ipv6("::1")); // Loopback compressed
+        assert!(validate_ipv6("fe80::1")); // Link-local compressed
+        assert!(validate_ipv6("::ffff:192.168.1.1")); // IPv4-mapped
+        assert!(validate_ipv6("::")); // All zeros
+    }
+
+    #[test]
+    fn test_ipv6_invalid() {
+        assert!(!validate_ipv6("not-an-ipv6"));
+        assert!(!validate_ipv6("192.168.1.1")); // IPv4
+        assert!(!validate_ipv6("2001:db8::g123")); // Invalid hex
+    }
+
+    // ---- SSN (US) validator ----
+
+    #[test]
+    fn test_ssn_valid() {
+        assert!(validate_ssn_us("123-45-6789"));
+        assert!(validate_ssn_us("123456789"));
+        assert!(validate_ssn_us("001-01-0001"));
+    }
+
+    #[test]
+    fn test_ssn_invalid() {
+        assert!(!validate_ssn_us("000-45-6789")); // Area 000
+        assert!(!validate_ssn_us("666-45-6789")); // Area 666
+        assert!(!validate_ssn_us("900-45-6789")); // Area 900+
+        assert!(!validate_ssn_us("123-00-6789")); // Group 00
+        assert!(!validate_ssn_us("123-45-0000")); // Serial 0000
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -52,6 +52,10 @@ pub struct ProfilerConfig {
     /// When set, locale-matching patterns get a confidence boost and non-matching
     /// locale patterns are suppressed (unless they have a very high match rate).
     /// `None` = no locale preference (default).
+    ///
+    /// Applies to file-based (CSV/Parquet) and DataFrame/Arrow profiling engines.
+    /// Database-backed (`analyze_query`) and async streaming entry points do not
+    /// currently forward this setting.
     pub locale: Option<String>,
     /// Database connection configuration. Required for `analyze_query()`.
     #[cfg(feature = "database")]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,6 +48,11 @@ pub struct ProfilerConfig {
     /// Which metric packs to compute. `None` = all (default).
     /// Controls whether statistics, patterns, and quality are included.
     pub metric_packs: Option<Vec<MetricPack>>,
+    /// ISO 3166-1 alpha-2 locale for pattern detection (e.g. "IT", "US", "GB").
+    /// When set, locale-matching patterns get a confidence boost and non-matching
+    /// locale patterns are suppressed (unless they have a very high match rate).
+    /// `None` = no locale preference (default).
+    pub locale: Option<String>,
     /// Database connection configuration. Required for `analyze_query()`.
     #[cfg(feature = "database")]
     pub database_config: Option<DatabaseConfig>,
@@ -67,6 +72,7 @@ impl Default for ProfilerConfig {
             csv_flexible: None,
             quality_dimensions: None,
             metric_packs: None,
+            locale: None,
             #[cfg(feature = "database")]
             database_config: None,
         }
@@ -200,6 +206,15 @@ impl Profiler {
     /// `Statistics`, `Patterns`, `Quality`. `None` = all (default).
     pub fn metric_packs(mut self, packs: Vec<MetricPack>) -> Self {
         self.config.metric_packs = Some(packs);
+        self
+    }
+
+    /// Set the locale for pattern detection (e.g. "IT", "US", "GB").
+    ///
+    /// Locale-matching patterns get a confidence boost; non-matching locale
+    /// patterns are suppressed unless they have a very high match rate.
+    pub fn locale(mut self, locale: impl Into<String>) -> Self {
+        self.config.locale = Some(locale.into());
         self
     }
 
@@ -387,6 +402,9 @@ impl Profiler {
                 if let Some(p) = &self.config.metric_packs {
                     profiler = profiler.metric_packs(p.clone());
                 }
+                if let Some(l) = &self.config.locale {
+                    profiler = profiler.locale(l.clone());
+                }
                 let csv_config = self.csv_config_for_file(file_path);
                 profiler = profiler.csv_config(csv_config);
                 profiler.analyze_file(file_path)
@@ -429,6 +447,9 @@ impl Profiler {
         if let Some(p) = &self.config.metric_packs {
             profiler = profiler.metric_packs(p.clone());
         }
+        if let Some(l) = &self.config.locale {
+            profiler = profiler.locale(l.clone());
+        }
         let csv_config = self.csv_config_for_file(file_path);
         profiler = profiler.csv_config(csv_config);
 
@@ -467,6 +488,9 @@ impl Profiler {
         }
         if let Some(p) = &self.config.metric_packs {
             profiler = profiler.metric_packs(p.clone());
+        }
+        if let Some(l) = &self.config.locale {
+            profiler = profiler.locale(l.clone());
         }
         let csv_config = self.csv_config_for_file(file_path);
         profiler = profiler.csv_config(csv_config);

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -33,6 +33,11 @@ pub struct AnalyzeArgs {
     #[arg(long, value_name = "PACK")]
     pub metrics: Vec<String>,
 
+    /// Locale for pattern detection (ISO 3166-1 alpha-2, e.g. "IT", "US", "GB").
+    /// Boosts confidence for locale-matching patterns and suppresses non-matching ones.
+    #[arg(long)]
+    pub locale: Option<String>,
+
     /// Common analysis options (progress, chunk-size, config)
     #[command(flatten)]
     pub common: super::CommonAnalysisOptions,
@@ -66,6 +71,7 @@ pub fn execute(args: &AnalyzeArgs) -> Result<()> {
         sample: args.sample,
         verbosity: Some(args.common.verbosity),
         metric_packs,
+        locale: args.locale.clone(),
     };
 
     // Use shared core logic that handles all improvements

--- a/src/cli/core_logic.rs
+++ b/src/cli/core_logic.rs
@@ -32,6 +32,8 @@ pub struct AnalysisOptions {
     pub verbosity: Option<u8>,
     /// Metric packs to compute (None = all)
     pub metric_packs: Option<Vec<MetricPack>>,
+    /// ISO 3166-1 alpha-2 locale for pattern detection (e.g. "IT", "US")
+    pub locale: Option<String>,
 }
 
 /// Builder for creating a properly configured profiler with all improvements
@@ -70,6 +72,11 @@ impl ProfilerBuilder {
         // Configure metric packs if specified
         if let Some(ref packs) = self.options.metric_packs {
             profiler = profiler.metric_packs(packs.clone());
+        }
+
+        // Configure locale for pattern detection
+        if let Some(ref locale) = self.options.locale {
+            profiler = profiler.locale(locale);
         }
 
         // Enable progress if requested

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,4 +22,4 @@ pub use validation::*;
 
 // Re-export pattern detection from analysis module for convenience
 pub use crate::analysis::detect_patterns;
-pub use crate::types::Pattern;
+pub use crate::types::{Pattern, PatternCategory};

--- a/src/core/profile_builder.rs
+++ b/src/core/profile_builder.rs
@@ -30,6 +30,8 @@ pub struct ColumnProfileInput<'a> {
     pub skip_statistics: bool,
     /// When true, skip pattern detection (produce empty patterns vec).
     pub skip_patterns: bool,
+    /// Optional locale for pattern detection (e.g. "IT", "US").
+    pub locale: Option<&'a str>,
 }
 
 /// Pre-computed text length stats from streaming/columnar engines.
@@ -117,7 +119,7 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
     let patterns = if input.skip_patterns {
         Vec::new()
     } else {
-        crate::detect_patterns(input.sample_values)
+        crate::detect_patterns(input.sample_values, input.locale)
     };
 
     ColumnProfile {
@@ -138,12 +140,14 @@ pub fn profiles_from_streaming(
     column_stats: &StreamingColumnCollection,
     skip_statistics: bool,
     skip_patterns: bool,
+    locale: Option<&str>,
 ) -> Vec<ColumnProfile> {
     let mut profiles = Vec::new();
 
     for column_name in column_stats.column_names() {
         if let Some(stats) = column_stats.get_column_stats(&column_name) {
-            let profile = profile_from_stats(&column_name, stats, skip_statistics, skip_patterns);
+            let profile =
+                profile_from_stats(&column_name, stats, skip_statistics, skip_patterns, locale);
             profiles.push(profile);
         }
     }
@@ -157,6 +161,7 @@ pub fn profile_from_stats(
     stats: &StreamingStatistics,
     skip_statistics: bool,
     skip_patterns: bool,
+    locale: Option<&str>,
 ) -> ColumnProfile {
     let data_type = infer_data_type_streaming(stats);
     let text_stats = stats.text_length_stats();
@@ -176,6 +181,7 @@ pub fn profile_from_stats(
         boolean_counts: None,
         skip_statistics,
         skip_patterns,
+        locale,
     })
 }
 
@@ -279,7 +285,7 @@ mod tests {
         collection.process_record(&headers, vec!["Bob".to_string(), "25".to_string()]);
         collection.process_record(&headers, vec!["Charlie".to_string(), "35".to_string()]);
 
-        let profiles = profiles_from_streaming(&collection, false, false);
+        let profiles = profiles_from_streaming(&collection, false, false, None);
         assert_eq!(profiles.len(), 2);
 
         let age = profiles.iter().find(|p| p.name == "age").unwrap();
@@ -314,6 +320,7 @@ mod tests {
             boolean_counts: Some((2, 1)),
             skip_statistics: false,
             skip_patterns: false,
+            locale: None,
         });
 
         match &profile.stats {
@@ -344,6 +351,7 @@ mod tests {
             boolean_counts: None, // forces fallback path
             skip_statistics: false,
             skip_patterns: false,
+            locale: None,
         });
 
         match &profile.stats {
@@ -370,6 +378,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: true,
             skip_patterns: false,
+            locale: None,
         });
 
         assert!(matches!(profile.stats, crate::types::ColumnStats::None));
@@ -391,6 +400,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: false,
             skip_patterns: true,
+            locale: None,
         });
 
         assert!(profile.patterns.is_empty());
@@ -412,6 +422,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: false,
             skip_patterns: false,
+            locale: None,
         });
 
         assert!(matches!(

--- a/src/engines/adaptive.rs
+++ b/src/engines/adaptive.rs
@@ -22,6 +22,7 @@ pub(crate) struct AdaptiveProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     csv_config: Option<CsvParserConfig>,
+    locale: Option<String>,
 }
 
 impl AdaptiveProfiler {
@@ -30,6 +31,7 @@ impl AdaptiveProfiler {
             quality_dimensions: None,
             metric_packs: None,
             csv_config: None,
+            locale: None,
         }
     }
 
@@ -45,6 +47,11 @@ impl AdaptiveProfiler {
 
     pub fn csv_config(mut self, config: CsvParserConfig) -> Self {
         self.csv_config = Some(config);
+        self
+    }
+
+    pub fn locale(mut self, locale: String) -> Self {
+        self.locale = Some(locale);
         self
     }
 
@@ -160,6 +167,9 @@ impl AdaptiveProfiler {
                 if let Some(ref config) = self.csv_config {
                     profiler = profiler.csv_config(config.clone());
                 }
+                if let Some(ref l) = self.locale {
+                    profiler = profiler.locale(l.clone());
+                }
                 profiler.analyze_csv_file(file_path)
             }
             InternalEngineType::Incremental => {
@@ -172,6 +182,9 @@ impl AdaptiveProfiler {
                 }
                 if let Some(ref config) = self.csv_config {
                     profiler = profiler.csv_config(config.clone());
+                }
+                if let Some(ref l) = self.locale {
+                    profiler = profiler.locale(l.clone());
                 }
                 profiler.analyze_file(file_path)
             }

--- a/src/engines/columnar/arrow_profiler.rs
+++ b/src/engines/columnar/arrow_profiler.rs
@@ -23,6 +23,7 @@ pub struct ArrowProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     csv_config: Option<CsvParserConfig>,
+    locale: Option<String>,
 }
 
 impl ArrowProfiler {
@@ -33,6 +34,7 @@ impl ArrowProfiler {
             quality_dimensions: None,
             metric_packs: None,
             csv_config: None,
+            locale: None,
         }
     }
 
@@ -58,6 +60,11 @@ impl ArrowProfiler {
 
     pub fn csv_config(mut self, config: CsvParserConfig) -> Self {
         self.csv_config = Some(config);
+        self
+    }
+
+    pub fn locale(mut self, locale: String) -> Self {
+        self.locale = Some(locale);
         self
     }
 
@@ -143,7 +150,12 @@ impl ArrowProfiler {
         for header in headers.iter() {
             let name = header.to_string();
             if let Some(analyzer) = column_analyzers.get(&name) {
-                let profile = analyzer.to_column_profile(name.clone(), skip_stats, skip_patterns);
+                let profile = analyzer.to_column_profile(
+                    name.clone(),
+                    skip_stats,
+                    skip_patterns,
+                    self.locale.as_deref(),
+                );
                 column_profiles.push(profile);
                 sample_columns.insert(name, analyzer.get_sample_values());
             }
@@ -715,6 +727,7 @@ impl ColumnAnalyzer {
         name: String,
         skip_statistics: bool,
         skip_patterns: bool,
+        locale: Option<&str>,
     ) -> ColumnProfile {
         let data_type = self.infer_data_type();
         let avg_length = if self.total_count > self.null_count {
@@ -743,6 +756,7 @@ impl ColumnAnalyzer {
                 },
                 skip_statistics,
                 skip_patterns,
+                locale,
             },
         )
     }
@@ -929,7 +943,7 @@ mod tests {
         assert_eq!(analyzer.true_count, 3);
         assert_eq!(analyzer.false_count, 2);
 
-        let profile = analyzer.to_column_profile("flag".to_string(), false, false);
+        let profile = analyzer.to_column_profile("flag".to_string(), false, false, None);
         assert_eq!(profile.data_type, DataType::Boolean);
         assert_eq!(profile.total_count, 6);
         assert_eq!(profile.null_count, 1);

--- a/src/engines/columnar/record_batch_analyzer.rs
+++ b/src/engines/columnar/record_batch_analyzer.rs
@@ -57,10 +57,16 @@ impl RecordBatchAnalyzer {
     }
 
     /// Convert the analyzers to column profiles
-    pub fn to_profiles(&self, skip_statistics: bool, skip_patterns: bool) -> Vec<ColumnProfile> {
+    pub fn to_profiles(
+        &self,
+        skip_statistics: bool,
+        skip_patterns: bool,
+        locale: Option<&str>,
+    ) -> Vec<ColumnProfile> {
         let mut profiles = Vec::new();
         for (name, analyzer) in &self.column_analyzers {
-            let profile = analyzer.to_column_profile(name.clone(), skip_statistics, skip_patterns);
+            let profile =
+                analyzer.to_column_profile(name.clone(), skip_statistics, skip_patterns, locale);
             profiles.push(profile);
         }
         profiles
@@ -901,6 +907,7 @@ impl ColumnAnalyzer {
         name: String,
         skip_statistics: bool,
         skip_patterns: bool,
+        locale: Option<&str>,
     ) -> ColumnProfile {
         let data_type = self.infer_data_type();
         let avg_length = if self.total_count > self.null_count {
@@ -929,6 +936,7 @@ impl ColumnAnalyzer {
                 },
                 skip_statistics,
                 skip_patterns,
+                locale,
             },
         )
     }
@@ -999,7 +1007,7 @@ mod tests {
         let mut analyzer = RecordBatchAnalyzer::new();
         analyzer.process_batch(&batch).unwrap();
 
-        let profiles = analyzer.to_profiles(false, false);
+        let profiles = analyzer.to_profiles(false, false, None);
         assert_eq!(profiles.len(), 3);
 
         // Check score column

--- a/src/engines/datafusion_loader.rs
+++ b/src/engines/datafusion_loader.rs
@@ -124,7 +124,7 @@ impl DataFusionLoader {
         );
 
         // Build the report
-        let column_profiles = analyzer.to_profiles(false, false);
+        let column_profiles = analyzer.to_profiles(false, false, None);
         let sample_columns = analyzer.create_sample_columns();
 
         let scan_time_ms = start.elapsed().as_millis();
@@ -204,7 +204,7 @@ impl DataFusionLoader {
                 if batch.num_rows() > 0 {
                     analyzer.process_batch(&batch)?;
                 }
-                let column_profiles = analyzer.to_profiles(false, false);
+                let column_profiles = analyzer.to_profiles(false, false, None);
                 let sample_columns = analyzer.create_sample_columns();
 
                 let total_rows = analyzer.total_rows();

--- a/src/engines/streaming/async_reader.rs
+++ b/src/engines/streaming/async_reader.rs
@@ -177,8 +177,12 @@ impl AsyncStreamingProfiler {
         let skip_stats = !MetricPack::include_statistics(packs);
         let skip_patterns = !MetricPack::include_patterns(packs);
 
-        let column_profiles =
-            profile_builder::profiles_from_streaming(&column_stats, skip_stats, skip_patterns);
+        let column_profiles = profile_builder::profiles_from_streaming(
+            &column_stats,
+            skip_stats,
+            skip_patterns,
+            None,
+        );
         let sample_columns = profile_builder::quality_check_samples(&column_stats);
         let scan_time_ms = start.elapsed().as_millis();
         let num_columns = column_profiles.len();

--- a/src/engines/streaming/incremental.rs
+++ b/src/engines/streaming/incremental.rs
@@ -28,6 +28,7 @@ pub struct IncrementalProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     csv_config: Option<CsvParserConfig>,
+    locale: Option<String>,
 }
 
 impl IncrementalProfiler {
@@ -42,6 +43,7 @@ impl IncrementalProfiler {
             quality_dimensions: None,
             metric_packs: None,
             csv_config: None,
+            locale: None,
         }
     }
 
@@ -83,6 +85,11 @@ impl IncrementalProfiler {
 
     pub fn csv_config(mut self, config: CsvParserConfig) -> Self {
         self.csv_config = Some(config);
+        self
+    }
+
+    pub fn locale(mut self, locale: String) -> Self {
+        self.locale = Some(locale);
         self
     }
 
@@ -240,8 +247,12 @@ impl IncrementalProfiler {
         let packs = self.metric_packs.as_deref();
         let skip_stats = !MetricPack::include_statistics(packs);
         let skip_patterns = !MetricPack::include_patterns(packs);
-        let column_profiles =
-            profile_builder::profiles_from_streaming(&column_stats, skip_stats, skip_patterns);
+        let column_profiles = profile_builder::profiles_from_streaming(
+            &column_stats,
+            skip_stats,
+            skip_patterns,
+            self.locale.as_deref(),
+        );
 
         // Calculate quality metrics from sample data
         let sample_columns = profile_builder::quality_check_samples(&column_stats);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,8 +95,9 @@ pub use engines::DataFusionLoader;
 pub use types::{
     AccuracyMetrics, ColumnProfile, ColumnStats, CompletenessMetrics, ConsistencyMetrics,
     DataFrameLibrary, DataSource, DataType, ExecutionMetadata, FileFormat, MetricConfidence,
-    MetricPack, OutputFormat, Pattern, ProfileReport, QualityAssessment, QualityDimension,
-    QualityMetrics, QueryEngine, TimelinessMetrics, TruncationReason, UniquenessMetrics,
+    MetricPack, OutputFormat, Pattern, PatternCategory, ProfileReport, QualityAssessment,
+    QualityDimension, QualityMetrics, QueryEngine, TimelinessMetrics, TruncationReason,
+    UniquenessMetrics,
 };
 
 // Parser API - New config-based CSV API (#181 + #218)

--- a/src/output/formatters.rs
+++ b/src/output/formatters.rs
@@ -234,6 +234,8 @@ pub struct JsonPattern {
     pub name: String,
     pub match_count: usize,
     pub match_percentage: f64,
+    pub category: String,
+    pub confidence: f64,
 }
 
 impl OutputFormatter for JsonFormatter {
@@ -342,6 +344,8 @@ impl JsonFormatter {
                     name: p.name.clone(),
                     match_count: p.match_count,
                     match_percentage: p.match_percentage,
+                    category: p.category.to_string(),
+                    confidence: p.confidence,
                 })
                 .collect(),
         }

--- a/src/parsers/csv.rs
+++ b/src/parsers/csv.rs
@@ -244,7 +244,7 @@ pub fn analyze_csv_from_reader<R: Read>(
         rows_read += 1;
     }
 
-    let profiles = profile_builder::profiles_from_streaming(&column_stats, false, false);
+    let profiles = profile_builder::profiles_from_streaming(&column_stats, false, false, None);
 
     Ok((profiles, column_stats, rows_read, header_names))
 }

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -263,7 +263,7 @@ pub fn analyze_json_from_reader<R: BufRead>(
         }
     }
 
-    let profiles = profile_builder::profiles_from_streaming(&column_stats, false, false);
+    let profiles = profile_builder::profiles_from_streaming(&column_stats, false, false, None);
 
     Ok((profiles, column_stats, rows_read, malformed_lines, format))
 }

--- a/src/parsers/parquet.rs
+++ b/src/parsers/parquet.rs
@@ -263,7 +263,7 @@ pub fn analyze_parquet_with_config_dims(
     }
 
     // Convert to column profiles
-    let column_profiles = analyzer.to_profiles(false, false);
+    let column_profiles = analyzer.to_profiles(false, false, None);
     let total_rows = analyzer.total_rows();
 
     // Calculate comprehensive quality metrics using ISO 8000/25012 standards

--- a/src/parsers/parquet_async.rs
+++ b/src/parsers/parquet_async.rs
@@ -205,7 +205,7 @@ pub async fn analyze_parquet_async_http_dims(
         analyzer.process_batch(&batch)?;
     }
 
-    let column_profiles = analyzer.to_profiles(false, false);
+    let column_profiles = analyzer.to_profiles(false, false, None);
     let total_rows = analyzer.total_rows();
 
     let sample_columns = analyzer.create_sample_columns();

--- a/src/python/arrow_export.rs
+++ b/src/python/arrow_export.rs
@@ -392,7 +392,7 @@ pub fn profile_dataframe(
         .process_batch(&batch)
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
-    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns);
+    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns, None);
     let sample_columns = if include_quality {
         analyzer.create_sample_columns()
     } else {
@@ -495,7 +495,7 @@ pub fn profile_arrow(
         .process_batch(&batch)
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
-    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns);
+    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns, None);
     let sample_columns = analyzer.create_sample_columns();
 
     let scan_time_ms = start.elapsed().as_millis();

--- a/src/python/arrow_export.rs
+++ b/src/python/arrow_export.rs
@@ -392,7 +392,8 @@ pub fn profile_dataframe(
         .process_batch(&batch)
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
-    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns, None);
+    let locale = config.and_then(|c| c.locale.as_deref());
+    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns, locale);
     let sample_columns = if include_quality {
         analyzer.create_sample_columns()
     } else {
@@ -495,7 +496,8 @@ pub fn profile_arrow(
         .process_batch(&batch)
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
-    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns, None);
+    let locale = config.and_then(|c| c.locale.as_deref());
+    let column_profiles = analyzer.to_profiles(skip_statistics, skip_patterns, locale);
     let sample_columns = analyzer.create_sample_columns();
 
     let scan_time_ms = start.elapsed().as_millis();

--- a/src/python/config.rs
+++ b/src/python/config.rs
@@ -32,6 +32,7 @@ pub struct PyProfilerConfig {
     pub(crate) progress_interval_ms: Option<u64>,
     pub(crate) quality_dimensions: Option<Vec<QualityDimension>>,
     pub(crate) metric_packs: Option<Vec<MetricPack>>,
+    pub(crate) locale: Option<String>,
 }
 
 #[pymethods]
@@ -51,6 +52,7 @@ impl PyProfilerConfig {
         progress_interval_ms = None,
         quality_dimensions = None,
         metrics = None,
+        locale = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -67,6 +69,7 @@ impl PyProfilerConfig {
         progress_interval_ms: Option<u64>,
         quality_dimensions: Option<Vec<String>>,
         metrics: Option<Vec<String>>,
+        locale: Option<String>,
     ) -> PyResult<Self> {
         let engine = parse_engine(engine)?;
         let format_override = format.map(parse_format).transpose()?;
@@ -132,6 +135,7 @@ impl PyProfilerConfig {
             progress_interval_ms,
             quality_dimensions,
             metric_packs,
+            locale,
         })
     }
 
@@ -179,6 +183,12 @@ impl PyProfilerConfig {
     #[getter]
     fn csv_flexible(&self) -> Option<bool> {
         self.csv_flexible
+    }
+
+    /// Locale for pattern detection
+    #[getter]
+    fn locale(&self) -> Option<&str> {
+        self.locale.as_deref()
     }
 
     fn __repr__(&self) -> String {
@@ -241,6 +251,9 @@ impl PyProfilerConfig {
         }
         if let Some(ref packs) = self.metric_packs {
             profiler = profiler.metric_packs(packs.clone());
+        }
+        if let Some(ref l) = self.locale {
+            profiler = profiler.locale(l);
         }
 
         profiler

--- a/src/python/types.rs
+++ b/src/python/types.rs
@@ -17,6 +17,10 @@ pub struct PyPattern {
     pub match_count: usize,
     #[pyo3(get)]
     pub match_percentage: f64,
+    #[pyo3(get)]
+    pub category: String,
+    #[pyo3(get)]
+    pub confidence: f64,
 }
 
 impl From<&Pattern> for PyPattern {
@@ -26,6 +30,8 @@ impl From<&Pattern> for PyPattern {
             regex: p.regex.clone(),
             match_count: p.match_count,
             match_percentage: p.match_percentage,
+            category: p.category.to_string(),
+            confidence: p.confidence,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1252,10 +1252,44 @@ pub enum ColumnStats {
     None,
 }
 
+/// Semantic category for a detected pattern.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PatternCategory {
+    /// Email addresses, phone numbers
+    Contact,
+    /// UUIDs, fiscal codes, tax IDs
+    Identifier,
+    /// IPv4, IPv6, MAC addresses, URLs
+    Network,
+    /// Coordinates, postal codes
+    Geographic,
+    /// IBANs, credit cards, SWIFT/BIC
+    Financial,
+    /// Unix/Windows file paths
+    FilePath,
+    /// Uncategorized patterns
+    Other,
+}
+
+impl std::fmt::Display for PatternCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Contact => write!(f, "contact"),
+            Self::Identifier => write!(f, "identifier"),
+            Self::Network => write!(f, "network"),
+            Self::Geographic => write!(f, "geographic"),
+            Self::Financial => write!(f, "financial"),
+            Self::FilePath => write!(f, "file_path"),
+            Self::Other => write!(f, "other"),
+        }
+    }
+}
+
 /// A detected value pattern within a column (e.g. email, phone, UUID).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Pattern {
-    /// Pattern name (e.g. "email", "phone", "uuid")
+    /// Pattern name (e.g. "Email", "Phone (US)", "UUID")
     pub name: String,
     /// Regex used for detection
     pub regex: String,
@@ -1263,6 +1297,10 @@ pub struct Pattern {
     pub match_count: usize,
     /// Percentage of non-null values matching (0.0--100.0)
     pub match_percentage: f64,
+    /// Semantic category (e.g. contact, network, financial)
+    pub category: PatternCategory,
+    /// Detection confidence score (0.0--1.0), derived from pattern specificity and match rate
+    pub confidence: f64,
 }
 
 /// Output format for CLI and programmatic output.


### PR DESCRIPTION
close #289, i also added patterns specific to iot/sensors such as scientific notation etc. . Worth noting that now we should be able to properly distinguish specific and majority of EU such as Italy patterns (p.iva, codice fiscale) or German PLZ etc. trough the simple validation process added in this PR.
Overall, the direction seems good, so the rusults so far :fire: 
@Cipuddra PTAL