### PR TITLE
Fix ProfileReport non-string key error

### DIFF
--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -680,6 +680,8 @@ class ProfileReport:
     # -- Mapping protocol --
 
     def __getitem__(self, key: str) -> ColumnProfile:
+        if not isinstance(key, str):
+            raise TypeError("ProfileReport keys must be strings")
         profiles = self.column_profiles
         if key not in profiles:
             raise KeyError(key)

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -556,6 +556,10 @@ class TestProfileReportMapping:
         with pytest.raises(KeyError):
             report["nonexistent_column"]
 
+    def test_getitem_non_string_raises_type_error(self, report):
+        with pytest.raises(TypeError, match="keys must be strings"):
+            report[0]  # type: ignore[index]
+
     def test_contains(self, report):
         assert "name" in report
         assert "nonexistent_column" not in report


### PR DESCRIPTION
`ProfileReport.__getitem__ `  now correctly raises `TypeError("ProfileReport keys must be strings")` , smaller qol left from 0.8 changes.

## Summary
- Raise `TypeError` for non-string `ProfileReport` keys
- Add mapping regression test

## Checks
- `make fmt`
- `make clippy`
- `uv run pytest python/tests/test_python_api.py::TestProfileReportMapping -q`