### PR TITLE
feat(python): report ergonomics — to_html, to_markdown, compare, from_dict/from_json (#316)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrow"
@@ -1878,9 +1878,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -146,9 +146,16 @@ report.to_polars()               # polars DataFrame -- all stats (requires polar
 report.to_arrow()                # PyArrow Table -- all stats (requires pyarrow)
 report.describe()                # transposed summary like pandas describe()
 report.quality_summary()         # single-row dict for quality tracking
+report.to_html()                 # standalone HTML (same as the notebook display)
+report.to_markdown()             # GitHub-flavored markdown table
+report.compare(other)            # dict of quality/schema/null deltas vs another report
 report.save("report.json")      # save to JSON
 report.save("report.csv")       # save column profiles to CSV
 report.save("report.parquet")   # save column profiles to Parquet (requires pyarrow)
+
+# Round-trip a saved report without re-profiling (read-only view)
+reloaded = dp.ProfileReport.from_json(report.to_json())
+reloaded = dp.ProfileReport.from_dict(report.to_dict())
 ```
 
 **Rounding:** All floating-point values in exported data are rounded to match the CLI
@@ -368,6 +375,53 @@ import pandas as pd
 rows = [dp.profile(f).quality_summary() for f in files]
 history = pd.DataFrame(rows)
 ```
+
+### `to_html()` / `to_markdown()`
+
+Render the report for sharing outside a notebook:
+
+```python
+html = report.to_html()          # same rich table Jupyter shows, as a string
+open("report.html", "w").write(html)
+
+md = report.to_markdown()        # GitHub-flavored markdown table
+# Paste straight into a PR comment, issue, or Slack message
+```
+
+### `from_json()` / `from_dict()`
+
+Rebuild a report from previously exported data without re-profiling. The
+reconstructed report is a **read-only view** backed by the exported values, but
+all export methods (`to_json`, `to_markdown`, `to_dataframe`, `describe`,
+`quality_summary`, mapping access, …) work as usual:
+
+```python
+report.save("report.json")
+# ...later...
+reloaded = dp.ProfileReport.from_json(open("report.json").read())
+reloaded.quality_score          # == the original report's quality_score
+reloaded["email"].null_percentage
+```
+
+### `compare()`
+
+Detect quality drift or schema changes between two profiles (e.g. the same
+dataset before and after a pipeline run):
+
+```python
+before = dp.profile("data_v1.csv")
+after = dp.profile("data_v2.csv")
+delta = before.compare(after)
+# {
+#   "quality_score": {"a": 92.3, "b": 88.1, "abs": -4.2, "rel_pct": -4.55},
+#   "dimensions": {"completeness": {...}, "consistency": {...}, ...},
+#   "columns": {"email": {"null_pct_a": 1.0, "null_pct_b": 6.5, "null_pct_delta": 5.5}, ...},
+#   "schema": {"added": ["phone"], "removed": [], "common": ["id", "email", ...]},
+# }
+```
+
+> The `compare()` result shape is provisional and will align with the Rust-side
+> `QualityDelta` type once it lands.
 
 ### `save()`
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -734,10 +734,20 @@ class _DictColumn:
         self.null_percentage = d.get("null_percentage")
         self.unique_count = d.get("unique_count")
         self.uniqueness_ratio = d.get("uniqueness_ratio")
-        for key, value in (d.get("stats") or {}).items():
-            setattr(self, key, value)
+        # Overlay only known stat attributes — never setattr arbitrary keys from
+        # (possibly malformed) input, which could inject unexpected/dunder names.
+        stats = d.get("stats")
+        if isinstance(stats, dict):
+            allowed = set(self._STAT_ATTRS)
+            for key, value in stats.items():
+                if key in allowed:
+                    setattr(self, key, value)
         patterns = d.get("patterns")
-        self.patterns = [_DictPattern(p) for p in patterns] if patterns is not None else None
+        self.patterns = (
+            [_DictPattern(p) for p in patterns if isinstance(p, dict)]
+            if isinstance(patterns, list)
+            else None
+        )
 
 
 class _DictQuality:
@@ -790,8 +800,8 @@ class _DictBackedReport:
         self.sampling_applied = bool(execution.get("sampling_applied", False))
         self.sampling_ratio = execution.get("sampling_ratio")
         quality = d.get("quality")
-        self.quality = _DictQuality(quality) if quality is not None else None
-        self.quality_score = quality.get("overall_score") if quality is not None else None
+        self.quality = _DictQuality(quality) if isinstance(quality, dict) else None
+        self.quality_score = quality.get("overall_score") if isinstance(quality, dict) else None
         self.column_profiles = [_DictColumn(c) for c in d.get("columns", [])]
 
 
@@ -1244,6 +1254,11 @@ class ProfileReport:
                 "from_dict() expects a mapping produced by ProfileReport.to_dict() "
                 "(with 'source', 'columns', and 'execution' keys)."
             )
+        if not isinstance(data["execution"], dict):
+            raise ValueError("from_dict(): 'execution' must be a mapping.")
+        columns = data["columns"]
+        if not isinstance(columns, list) or not all(isinstance(c, dict) for c in columns):
+            raise ValueError("from_dict(): 'columns' must be a list of mappings.")
         return cls(_DictBackedReport(data))
 
     @classmethod
@@ -1251,8 +1266,15 @@ class ProfileReport:
         """Rebuild a read-only ProfileReport from JSON produced by :meth:`to_json`.
 
         See :meth:`from_dict` for the reconstruction semantics.
+
+        Raises:
+            ValueError: if ``text`` is not valid JSON from ``to_json()``.
         """
-        return cls.from_dict(json.loads(text))
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"from_json() received invalid JSON: {exc}") from exc
+        return cls.from_dict(data)
 
     def __repr__(self) -> str:
         qs = self.quality_score

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -307,6 +307,35 @@ def _column_record(col: ColumnProfile) -> dict[str, Any]:
     }
 
 
+def _stats_cell(col: ColumnProfile) -> str:
+    """Compact stats summary for a column, shared by the HTML/markdown/text views.
+
+    Numeric columns show mean/std/median; boolean columns show true count and
+    ratio; text columns show average length. Returns "" when none apply.
+    """
+    parts: list[str] = []
+    if col.mean is not None:
+        parts.append(f"mean={_r4(col.mean)}")
+        if col.std_dev is not None:
+            parts.append(f"std={_r4(col.std_dev)}")
+        if col.median is not None:
+            parts.append(f"median={_r4(col.median)}")
+    elif col.true_count is not None:
+        pct = _r2(col.true_ratio * 100) if col.true_ratio is not None else 0
+        parts.append(f"true={col.true_count} ({pct:.0f}%)")
+    elif col.avg_length is not None:
+        parts.append(f"avg_len={_r4(col.avg_length)}")
+    return ", ".join(parts)
+
+
+def _pattern_cell(col: ColumnProfile) -> str:
+    """Highest-confidence detected pattern for a column, as "Name (pct%)"."""
+    if col.patterns:
+        best = max(col.patterns, key=lambda p: p.confidence)
+        return f"{best.name} ({_r2(best.match_percentage):.0f}%)"
+    return ""
+
+
 def profile(
     source: Any,
     *,
@@ -646,6 +675,126 @@ class Profiler:
         return f"Profiler({settings})"
 
 
+# ---------------------------------------------------------------------------
+# Read-only proxy backing ProfileReport.from_dict() / from_json().
+#
+# The native ProfileReport can't be constructed from Python, so these classes
+# mimic the attribute surface the export methods read (self._report.<attr> and
+# self._report.column_profiles) closely enough that every ProfileReport method
+# works unchanged on a reloaded report.
+# ---------------------------------------------------------------------------
+
+
+class _DictPattern:
+    """Read-only stand-in for a native Pattern, built from a to_dict() entry."""
+
+    def __init__(self, d: dict[str, Any]):
+        self.name = d.get("name")
+        self.regex = d.get("regex")
+        self.match_count = d.get("match_count")
+        self.match_percentage = d.get("match_percentage")
+        self.category = d.get("category")
+        self.confidence = d.get("confidence", 0.0)
+
+
+class _DictColumn:
+    """Read-only stand-in for a native ColumnProfile, built from to_dict()."""
+
+    # Optional stat attributes, all defaulting to None; a subset is overlaid
+    # from the nested "stats" dict depending on the column's data type.
+    _STAT_ATTRS = (
+        "min",
+        "max",
+        "mean",
+        "std_dev",
+        "variance",
+        "median",
+        "mode",
+        "skewness",
+        "kurtosis",
+        "coefficient_of_variation",
+        "quartiles",
+        "is_approximate",
+        "outlier_count",
+        "min_length",
+        "max_length",
+        "avg_length",
+        "true_count",
+        "false_count",
+        "true_ratio",
+    )
+
+    def __init__(self, d: dict[str, Any]):
+        for attr in self._STAT_ATTRS:
+            setattr(self, attr, None)
+        self.name = d.get("name")
+        self.data_type = d.get("data_type")
+        self.total_count = d.get("total_count")
+        self.null_count = d.get("null_count")
+        self.null_percentage = d.get("null_percentage")
+        self.unique_count = d.get("unique_count")
+        self.uniqueness_ratio = d.get("uniqueness_ratio")
+        for key, value in (d.get("stats") or {}).items():
+            setattr(self, key, value)
+        patterns = d.get("patterns")
+        self.patterns = [_DictPattern(p) for p in patterns] if patterns is not None else None
+
+
+class _DictQuality:
+    """Read-only stand-in for native DataQualityMetrics, built from to_dict()."""
+
+    def __init__(self, d: dict[str, Any]):
+        self._d = d
+        self.low_sample_warning = bool(d.get("low_sample_warning", False))
+
+    @property
+    def completeness(self) -> dict[str, Any] | None:
+        return self._d.get("completeness")
+
+    @property
+    def consistency(self) -> dict[str, Any] | None:
+        return self._d.get("consistency")
+
+    @property
+    def uniqueness(self) -> dict[str, Any] | None:
+        return self._d.get("uniqueness")
+
+    @property
+    def accuracy(self) -> dict[str, Any] | None:
+        return self._d.get("accuracy")
+
+    @property
+    def timeliness(self) -> dict[str, Any] | None:
+        return self._d.get("timeliness")
+
+    def overall_quality_score(self) -> float | None:
+        return self._d.get("overall_score")
+
+
+class _DictBackedReport:
+    """Read-only stand-in for the native ProfileReport, built from to_dict()."""
+
+    def __init__(self, d: dict[str, Any]):
+        execution = d.get("execution") or {}
+        self.source = d.get("source")
+        self.source_type = d.get("source_type")
+        self.rows_processed = execution.get("rows_processed")
+        self.columns_detected = execution.get("columns_detected")
+        self.scan_time_ms = execution.get("scan_time_ms")
+        self.source_exhausted = execution.get("source_exhausted")
+        self.truncation_reason = execution.get("truncation_reason")
+        self.bytes_consumed = execution.get("bytes_consumed")
+        self.throughput_rows_sec = execution.get("throughput_rows_sec")
+        self.memory_peak_mb = execution.get("memory_peak_mb")
+        self.error_count = execution.get("error_count")
+        self.sampling_applied = bool(execution.get("sampling_applied", False))
+        self.sampling_ratio = execution.get("sampling_ratio")
+        quality = d.get("quality")
+        self.quality = _DictQuality(quality) if quality is not None else None
+        self.quality_score = quality.get("overall_score") if quality is not None else None
+        self.column_profiles = [_DictColumn(c) for c in d.get("columns", [])]
+
+
 class ProfileReport:
     """High-level wrapper around the Rust ProfileReport with export methods.
 
@@ -967,6 +1116,144 @@ class ProfileReport:
             raise ValueError("Unsupported format. Use .json, .csv, or .parquet")
         return self
 
+    def to_html(self) -> str:
+        """Return the standalone HTML representation of the report.
+
+        Identical to Jupyter's rich display (``_repr_html_``), exposed as a
+        public method for saving standalone HTML files, embedding in CI
+        summaries, or sharing outside a notebook.
+        """
+        return self._repr_html_()
+
+    def to_markdown(self) -> str:
+        """Render the report as a GitHub-flavored markdown table.
+
+        Suitable for issue bodies, pull-request comments, Slack posts, or
+        README snippets. Uses the same per-column summary as the HTML view.
+        """
+
+        def esc(value: object) -> str:
+            return str(value).replace("|", "\\|")
+
+        qs = self.quality_score
+        qs_str = f"{qs:.1f}%" if qs is not None else "N/A"
+        lines = [
+            f"**Source:** {esc(self.source)} | **Rows:** {self.rows:,} | "
+            f"**Columns:** {self.columns} | **Quality:** {qs_str} | "
+            f"**Time:** {self.execution_time_ms}ms",
+            "",
+            "| Column | Type | Count | Null % | Unique | Stats | Pattern |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        for col in self._report.column_profiles:
+            unique_str = f"{col.unique_count:,}" if col.unique_count is not None else ""
+            row = [
+                esc(col.name),
+                esc(col.data_type),
+                f"{col.total_count:,}",
+                f"{_r2(col.null_percentage):.1f}%",
+                unique_str,
+                esc(_stats_cell(col)),
+                esc(_pattern_cell(col)),
+            ]
+            lines.append("| " + " | ".join(row) + " |")
+        return "\n".join(lines)
+
+    def compare(self, other: ProfileReport) -> dict[str, Any]:
+        """Compare this report with another and return a dict of deltas.
+
+        The result captures quality drift and schema differences between two
+        profiles (e.g. the same dataset before and after a pipeline change):
+
+        - ``quality_score``: overall score for each side plus absolute and
+          relative-percent change.
+        - ``dimensions``: the same a/b/abs/rel_pct shape per ISO 25012
+          dimension (completeness, consistency, uniqueness, accuracy,
+          timeliness), sourced from :meth:`quality_summary`.
+        - ``columns``: per-column null-percentage drift over the union of
+          column names (missing on one side → ``None``).
+        - ``schema``: column names ``added`` / ``removed`` / ``common``.
+
+        .. note::
+            The exact shape is provisional and will align with the Rust-side
+            ``QualityDelta`` type (#310) once it lands.
+        """
+
+        def _delta(a: float | None, b: float | None) -> dict[str, float | None]:
+            abs_change = None if a is None or b is None else _r2(b - a)
+            if a is None or b is None or a == 0:
+                rel_pct = None
+            else:
+                rel_pct = _r2((b - a) / abs(a) * 100.0)
+            return {"a": a, "b": b, "abs": abs_change, "rel_pct": rel_pct}
+
+        a_summary = self.quality_summary()
+        b_summary = other.quality_summary()
+
+        dimensions = {
+            dim: _delta(a_summary.get(dim), b_summary.get(dim))
+            for dim in ("completeness", "consistency", "uniqueness", "accuracy", "timeliness")
+        }
+
+        a_cols = self.column_profiles
+        b_cols = other.column_profiles
+        a_names = set(a_cols)
+        b_names = set(b_cols)
+
+        def _null_pct(cols: dict[str, ColumnProfile], name: str) -> float | None:
+            col = cols.get(name)
+            return _r2(col.null_percentage) if col is not None else None
+
+        columns: dict[str, dict[str, float | None]] = {}
+        for name in sorted(a_names | b_names):
+            null_a = _null_pct(a_cols, name)
+            null_b = _null_pct(b_cols, name)
+            null_delta = None if null_a is None or null_b is None else _r2(null_b - null_a)
+            columns[name] = {
+                "null_pct_a": null_a,
+                "null_pct_b": null_b,
+                "null_pct_delta": null_delta,
+            }
+
+        return {
+            "quality_score": _delta(self.quality_score, other.quality_score),
+            "dimensions": dimensions,
+            "columns": columns,
+            "schema": {
+                "added": sorted(b_names - a_names),
+                "removed": sorted(a_names - b_names),
+                "common": sorted(a_names & b_names),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProfileReport:
+        """Rebuild a read-only ProfileReport from a dict produced by :meth:`to_dict`.
+
+        The reconstructed report is backed by a lightweight proxy rather than
+        the native engine, so it is read-only, but all export methods
+        (``to_json``, ``to_markdown``, ``to_dataframe``, ``describe``,
+        ``quality_summary``, mapping access, …) work as usual. Useful for
+        reloading a report saved yesterday without re-profiling the data.
+
+        Raises:
+            ValueError: if ``data`` is not a mapping produced by ``to_dict()``.
+        """
+        if not isinstance(data, dict) or not {"source", "columns", "execution"} <= data.keys():
+            raise ValueError(
+                "from_dict() expects a mapping produced by ProfileReport.to_dict() "
+                "(with 'source', 'columns', and 'execution' keys)."
+            )
+        return cls(_DictBackedReport(data))
+
+    @classmethod
+    def from_json(cls, text: str) -> ProfileReport:
+        """Rebuild a read-only ProfileReport from JSON produced by :meth:`to_json`.
+
+        See :meth:`from_dict` for the reconstruction semantics.
+        """
+        return cls.from_dict(json.loads(text))
+
     def __repr__(self) -> str:
         qs = self.quality_score
         qs_str = f"{qs:.1f}%" if qs is not None else "N/A"
@@ -1025,27 +1312,8 @@ class ProfileReport:
         col_rows = ""
         for i, col in enumerate(self._report.column_profiles):
             bg = "#f9fafb" if i % 2 else "#ffffff"
-            # Stats cell
-            stats_parts: list[str] = []
-            if col.mean is not None:
-                stats_parts.append(f"mean={_r4(col.mean)}")
-                if col.std_dev is not None:
-                    stats_parts.append(f"std={_r4(col.std_dev)}")
-                if col.median is not None:
-                    stats_parts.append(f"median={_r4(col.median)}")
-            elif col.true_count is not None:
-                pct = _r2(col.true_ratio * 100) if col.true_ratio is not None else 0
-                stats_parts.append(f"true={col.true_count} ({pct:.0f}%)")
-            elif col.avg_length is not None:
-                stats_parts.append(f"avg_len={_r4(col.avg_length)}")
-            stats = ", ".join(stats_parts)
-
-            # Pattern cell
-            pattern = ""
-            if col.patterns:
-                best = max(col.patterns, key=lambda p: p.confidence)
-                pattern = f"{_html.escape(best.name)} ({_r2(best.match_percentage):.0f}%)"
-
+            stats = _stats_cell(col)
+            pattern = _html.escape(_pattern_cell(col))
             unique_str = f"{col.unique_count:,}" if col.unique_count is not None else ""
 
             col_rows += (

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -265,6 +265,23 @@ class ProfileReport:
     def save(self, path: str) -> ProfileReport:
         """Save report to file (.json, .csv, or .parquet)."""
         ...
+    def to_html(self) -> str:
+        """Standalone HTML representation (same as Jupyter's rich display)."""
+        ...
+    def to_markdown(self) -> str:
+        """GitHub-flavored markdown table of the column profiles."""
+        ...
+    def compare(self, other: ProfileReport) -> dict[str, Any]:
+        """Dict of quality/schema/null deltas versus another report."""
+        ...
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProfileReport:
+        """Rebuild a read-only ProfileReport from a to_dict() mapping."""
+        ...
+    @classmethod
+    def from_json(cls, text: str) -> ProfileReport:
+        """Rebuild a read-only ProfileReport from a to_json() string."""
+        ...
 
 class Pattern:
     """Detected pattern statistics."""

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -233,6 +233,91 @@ class TestProfileReport:
 
 
 # ─────────────────────────────────────────────────
+#  2b. Report ergonomics: to_html / to_markdown / round-trip / compare
+# ─────────────────────────────────────────────────
+
+
+class TestReportErgonomics:
+    @pytest.fixture()
+    def report(self):
+        return dataprof.profile(CSV_FILE)
+
+    def test_to_html_matches_repr_html(self, report):
+        assert report.to_html() == report._repr_html_()
+        assert "<table" in report.to_html()
+
+    def test_to_markdown_structure(self, report):
+        md = report.to_markdown()
+        lines = md.splitlines()
+        header_idx = next(i for i, line in enumerate(lines) if line.startswith("| Column |"))
+        assert lines[header_idx + 1].startswith("|---")
+        data_rows = [line for line in lines[header_idx + 2 :] if line.startswith("|")]
+        assert len(data_rows) == report.columns
+        assert "**Source:**" in lines[0]
+
+    def test_to_markdown_escapes_pipe(self):
+        pd = pytest.importorskip("pandas")
+        df = pd.DataFrame({"a|b": [1, 2, 3], "c": [4, 5, 6]})
+        md = dataprof.profile(df).to_markdown()
+        assert "a\\|b" in md
+        # No unescaped pipe leaks into a cell and breaks the table
+        assert "| a|b |" not in md
+
+    def test_from_json_round_trip_quality_score(self, report):
+        reloaded = dataprof.ProfileReport.from_json(report.to_json())
+        assert reloaded.quality_score == report.quality_score
+
+    def test_from_dict_round_trip_idempotent(self, report):
+        reloaded = dataprof.ProfileReport.from_dict(report.to_dict())
+        assert reloaded.to_dict() == report.to_dict()
+
+    def test_reloaded_report_supports_exports(self, report):
+        reloaded = dataprof.ProfileReport.from_json(report.to_json())
+        # Rendering + mapping access work on the read-only view
+        assert reloaded.to_markdown() == report.to_markdown()
+        assert "name" in reloaded
+        assert reloaded["name"].name == "name"
+        assert reloaded.columns == report.columns
+
+    def test_reloaded_report_to_dataframe(self, report):
+        pytest.importorskip("pandas")
+        reloaded = dataprof.ProfileReport.from_json(report.to_json())
+        df = reloaded.to_dataframe()
+        assert len(df) == report.columns
+
+    def test_from_dict_rejects_malformed(self):
+        with pytest.raises(ValueError, match="to_dict"):
+            dataprof.ProfileReport.from_dict({"not": "a report"})
+
+    def test_compare_identical_is_zero(self, report):
+        reloaded = dataprof.ProfileReport.from_json(report.to_json())
+        delta = report.compare(reloaded)
+        assert delta["quality_score"]["abs"] == 0
+        assert delta["schema"]["added"] == []
+        assert delta["schema"]["removed"] == []
+        assert set(delta["schema"]["common"]) == set(report.column_profiles)
+        for col in delta["columns"].values():
+            assert col["null_pct_delta"] == 0
+
+    def test_compare_schema_diff(self):
+        pd = pytest.importorskip("pandas")
+        a = dataprof.profile(pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}))
+        b = dataprof.profile(pd.DataFrame({"x": [1, 2, 3], "z": [7, 8, 9]}))
+        delta = a.compare(b)
+        assert delta["schema"]["added"] == ["z"]
+        assert delta["schema"]["removed"] == ["y"]
+        assert delta["schema"]["common"] == ["x"]
+        assert "quality_score" in delta
+        assert set(delta["dimensions"]) == {
+            "completeness",
+            "consistency",
+            "uniqueness",
+            "accuracy",
+            "timeliness",
+        }
+
+
+# ─────────────────────────────────────────────────
 #  3. Partial analysis
 # ─────────────────────────────────────────────────
 
@@ -526,6 +611,11 @@ class TestNamespace:
             "describe",
             "quality_summary",
             "save",
+            "to_html",
+            "to_markdown",
+            "compare",
+            "from_dict",
+            "from_json",
             "__getitem__",
             "__contains__",
             "__iter__",

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -289,6 +289,29 @@ class TestReportErgonomics:
         with pytest.raises(ValueError, match="to_dict"):
             dataprof.ProfileReport.from_dict({"not": "a report"})
 
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"source": "x", "columns": [], "execution": []},  # execution not a mapping
+            {"source": "x", "columns": None, "execution": {}},  # columns not a list
+            {"source": "x", "columns": [1, 2], "execution": {}},  # columns not mappings
+        ],
+    )
+    def test_from_dict_rejects_wrong_types(self, bad):
+        with pytest.raises(ValueError):
+            dataprof.ProfileReport.from_dict(bad)
+
+    def test_from_json_rejects_invalid_json(self):
+        with pytest.raises(ValueError, match="invalid JSON"):
+            dataprof.ProfileReport.from_json("{not valid json")
+
+    def test_from_dict_ignores_unknown_stat_keys(self, report):
+        d = report.to_dict()
+        d["columns"][0].setdefault("stats", {})["__evil__"] = "nope"
+        reloaded = dataprof.ProfileReport.from_dict(d)
+        col = reloaded[d["columns"][0]["name"]]
+        assert not hasattr(col, "__evil__")
+
     def test_compare_identical_is_zero(self, report):
         reloaded = dataprof.ProfileReport.from_json(report.to_json())
         delta = report.compare(reloaded)


### PR DESCRIPTION
Closes #316.

Adds four notebook-natural methods to the Python `ProfileReport`. Pure-Python change — no Rust/`_dataprof` changes, no ABI impact.

## What

- **`to_html()`** — public alias exposing the existing Jupyter `_repr_html_()` output for standalone files, CI summaries, or sharing outside a notebook.
- **`to_markdown()`** — GitHub-flavored markdown table for issue bodies, PR comments, Slack, or READMEs. Shares the per-column stats/pattern cell logic with the HTML renderer (extracted into `_stats_cell`/`_pattern_cell`; `_repr_html_` refactored onto them with identical output) and escapes `|` in cell values.
- **`from_dict()` / `from_json()`** — rebuild a **read-only** `ProfileReport` from previously exported data without re-profiling. Backed by lightweight proxy classes (`_DictColumn`, `_DictPattern`, `_DictQuality`, `_DictBackedReport`) that mimic the native report surface, so every export method (`to_json`, `to_markdown`, `to_dataframe`, `describe`, `quality_summary`, mapping access, …) works on the reloaded report.
- **`compare(other)`** — dict of quality/schema/null deltas between two reports (overall score, per-dimension, per-column null% drift, schema added/removed/common). Built on public surface so it works for any two reports. The shape is intentionally provisional and will align with the Rust-side `QualityDelta` (#310) when it lands.

## Acceptance (from the issue)

- `report.to_html()` returns the same HTML as `_repr_html_` ✅
- `report.to_markdown()` returns a GitHub-flavored markdown table ✅
- `ProfileReport.from_json(report.to_json()).quality_score == report.quality_score` ✅
- `a.compare(b)` returns a useful dict of deltas ✅

## Also updated

- `.pyi` stubs for the new methods
- `docs/python/README.md` (export list + dedicated sections)
- 11 new tests + extended `expected_methods` list

## Verification

- `maturin develop` build, then `pytest python/tests/test_python_api.py` → **139 passed**
- `ruff check` and `ruff format --check` clean across source, stub, and tests
- Manual smoke test: markdown rendering, exact JSON round-trip (reloaded `to_markdown()` byte-identical), and `compare()` output
