### PR TITLE
deps: bump arrow and parquet from 57.3.0 to 58.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrow"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -179,7 +179,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -262,15 +262,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
@@ -286,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -299,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -312,18 +313,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -335,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1318,6 +1319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,9 +1860,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -2092,14 +2099,13 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
@@ -2111,7 +2117,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 tempfile = "3.24"
 anyhow = "1.0"
 env_logger = "0.11"
-arrow = { version = "57.3.0", features = ["ffi"] }
-parquet = { version = "57.3.0", features = ["arrow"] }
+arrow = { version = "58.1.0", features = ["ffi"] }
+parquet = { version = "58.1.0", features = ["arrow"] }
 sqlx = { version = "0.8.1", features = [
     "runtime-tokio-rustls",
     "chrono",

--- a/crates/dataprof-core/Cargo.toml
+++ b/crates/dataprof-core/Cargo.toml
@@ -19,7 +19,7 @@ num_cpus = "1.16"
 rand = { version = "0.9.3", features = ["small_rng"] }
 rand_chacha = "0.9"
 sysinfo = "0.38"
-arrow = { version = "57.3.0", features = ["ffi"], optional = true }
+arrow = { version = "58.1.0", features = ["ffi"], optional = true }
 tokio = { version = "1.49", features = ["sync"], optional = true }
 
 [dev-dependencies]

--- a/crates/dataprof-parquet/Cargo.toml
+++ b/crates/dataprof-parquet/Cargo.toml
@@ -14,7 +14,7 @@ parquet-async = ["parquet", "parquet/async", "dep:bytes", "dep:futures", "dep:re
 
 [dependencies]
 anyhow = "1.0"
-arrow = { version = "57.3.0", features = ["ffi"], optional = true }
+arrow = { version = "58.1.0", features = ["ffi"], optional = true }
 bytes = { version = "1.10", optional = true }
 csv = { version = "1.4", optional = true }
 dataprof-core = { version = "0.8.1", path = "../dataprof-core" }
@@ -22,7 +22,7 @@ dataprof-csv = { version = "0.8.1", path = "../dataprof-csv", optional = true }
 dataprof-metrics = { version = "0.8.1", path = "../dataprof-metrics" }
 dataprof-runtime = { version = "0.8.1", path = "../dataprof-runtime" }
 futures = { version = "0.3.31", optional = true }
-parquet = { version = "57.3.0", features = ["arrow"], optional = true }
+parquet = { version = "58.1.0", features = ["arrow"], optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"], optional = true }
 
 [dev-dependencies]

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -182,9 +182,12 @@ impl AsyncFileReader for HttpParquetReader {
             let limit = self.content_length as u64;
             let metadata_opts = options.map(|o| o.metadata_options().clone());
             let metadata_reader = ParquetMetaDataReader::new()
-                .with_page_index_policy(PageIndexPolicy::from(
-                    options.is_some_and(|o| o.page_index()),
-                ))
+                .with_column_index_policy(
+                    options.map_or(PageIndexPolicy::Skip, |o| o.column_index_policy()),
+                )
+                .with_offset_index_policy(
+                    options.map_or(PageIndexPolicy::Skip, |o| o.offset_index_policy()),
+                )
                 .with_metadata_options(metadata_opts);
 
             let parquet_metadata = metadata_reader.load_and_finish(self, limit).await?;

--- a/crates/dataprof-partial/Cargo.toml
+++ b/crates/dataprof-partial/Cargo.toml
@@ -18,14 +18,14 @@ async-streaming = [
 ]
 
 [dependencies]
-arrow = { version = "57.3.0", features = ["ffi"], optional = true }
+arrow = { version = "58.1.0", features = ["ffi"], optional = true }
 bytes = { version = "1.10", optional = true }
 csv = "1.4"
 dataprof-core = { version = "0.8.1", path = "../dataprof-core" }
 dataprof-csv = { version = "0.8.1", path = "../dataprof-csv" }
 dataprof-json = { version = "0.8.1", path = "../dataprof-json" }
 dataprof-runtime = { version = "0.8.1", path = "../dataprof-runtime" }
-parquet = { version = "57.3.0", features = ["arrow"], optional = true }
+parquet = { version = "58.1.0", features = ["arrow"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.49", features = ["full"], optional = true }

--- a/crates/dataprof-python/Cargo.toml
+++ b/crates/dataprof-python/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-arrow = { version = "57.3.0", features = ["ffi"] }
+arrow = { version = "58.1.0", features = ["ffi"] }
 bytes = { version = "1.10", optional = true }
 dataprof = { version = "0.8.1", path = "../..", default-features = true }
 dataprof-parquet = { version = "0.8.1", path = "../dataprof-parquet", features = ["arrow"], default-features = false }


### PR DESCRIPTION
Combined upgrade of `arrow` and `parquet` from 57.3.0 to 58.x.

Supersedes the individual Dependabot PRs #287 (arrow) and #296 (parquet), which fail on their own because `arrow` and `parquet` are version-locked and must move in lockstep — bumping one leaves two arrow versions in the tree. `datafusion` (which pinned arrow to 57) has been removed from the project, which unblocks the upgrade.

## Changes
- Bump `arrow` + `parquet` pins `57.3.0` → `58.1.0` across all crates (workspace root, `dataprof-core`, `dataprof-parquet`, `dataprof-partial`, `dataprof-python`).
- `Cargo.lock` resolves to `arrow`/`parquet` **58.3.0**.
- Fix one 58.x deprecation: `ArrowReaderOptions::page_index()` → per-index `column_index_policy()` / `offset_index_policy()` in the async HTTP Parquet metadata reader (`dataprof-parquet/src/async_http.rs`). This is more precise than the previous bool round-trip — it propagates the column and offset index policies independently.

## Verification
- `cargo check` clean across core, `dataprof-python`, `dataprof-partial` (parquet), and the `parquet-async` path.
- `cargo clippy --features parquet-async -- -D warnings` clean.
- Rebuilt the Python extension at arrow 58 and ran the Python suite (exercises the arrow FFI + Parquet reader): **141 passed, 2 skipped**.
- `cargo deny check advisories bans` ok.

> Note: the full `cargo test` Rust binary could not be executed in my local Windows environment (blocked by an Application Control policy, `os error 4551`), but all crates + tests compile and CI runs the full Rust suite here.

Closes #287
Closes #296
