### PR TITLE
chore: add .mailmap to canonicalize author identity

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Canonicalize commit author identities.
+# All of these are the same person (same email); this normalizes the
+# display name so `git shortlog`/`git log` and GitHub stats show one author.
+AndreaBozzo <andreabozzo92@gmail.com> poinT92 <andreabozzo92@gmail.com>
+AndreaBozzo <andreabozzo92@gmail.com> Andrea Bozzo <andreabozzo92@gmail.com>


### PR DESCRIPTION
This consolidates my personas so commits stay united on this, noone really cares but i do lol.
Adds a `.mailmap` so `git shortlog`, `git log`, and GitHub contributor stats show a single author name.

All commits authored as `poinT92`, `Andrea Bozzo`, and `AndreaBozzo` use the same email (`andreabozzo92@gmail.com`), so they are already the same person; this just normalizes the display name.

Effect on `git shortlog -sn --all`:

- before: poinT92 (335), AndreaBozzo (186), Andrea Bozzo (104)
- after: AndreaBozzo (625)

No history rewrite, no rebase. Purely a display mapping.
