### PR TITLE
chore(python): adopt ty type checking with a compiled-core stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,11 @@ jobs:
       - name: Lint
         run: uv run ruff check python/
 
+      # Advisory: ty is pre-1.0 (Astral's type checker). Non-blocking for now.
+      - name: Type check (ty)
+        continue-on-error: true
+        run: uv run ty check python/
+
   python-tests:
     name: Python Tests
     runs-on: ubuntu-latest

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Python: type stubs for the compiled extension (`dataprof/_dataprof.pyi`), so
+  type checkers and IDEs can resolve the native core. The public stubs now
+  re-export these types instead of duplicating them.
+
+### Internal
+
+- Python: adopt [ty](https://github.com/astral-sh/ty) for static type checking,
+  wired into CI as an advisory (non-blocking) step while it is pre-1.0.
+
 ## [0.8.1] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "maturin>=1.5,<2.0",
     "pytest>=8.0",
     "ruff>=0.9",
+    "ty>=0.0.56",
     "pandas>=2.0.0",
     "polars>=1.0.0",
     "pyarrow>=14.0",
@@ -65,8 +66,17 @@ bindings = "pyo3"
 target-version = "py310"
 line-length = 100
 
+[tool.ty.environment]
+# Match requires-python floor; the extension module is stubbed in
+# python/dataprof/_dataprof.pyi so ty can resolve the compiled core.
+python-version = "3.10"
+
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP"]
+
+[tool.ruff.lint.isort]
+# Keep `from x import (a as a, b as b)` re-export blocks (e.g. __init__.pyi) combined.
+combine-as-imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["python/tests"]

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -13,12 +13,14 @@ import math
 import os
 import pathlib
 import warnings
-from typing import Any, Iterator
+from collections.abc import Callable, Iterator
+from typing import Any
 
 from ._dataprof import (
     ColumnProfile,
     DataQualityMetrics,
     ProfilerConfig,
+    ProfileReport as _RustProfileReport,
     ProgressEvent,
     RecordBatch,
     RowCountEstimate,
@@ -26,23 +28,10 @@ from ._dataprof import (
     SchemaResult,
     StopCondition,
     __version__,
-)
-from ._dataprof import (
-    ProfileReport as _RustProfileReport,
-)
-from ._dataprof import (
     analyze_file as _analyze_file,
-)
-from ._dataprof import (
     infer_schema as _infer_schema,
-)
-from ._dataprof import (
     profile_arrow as _profile_arrow,
-)
-from ._dataprof import (
     profile_dataframe as _profile_dataframe,
-)
-from ._dataprof import (
     quick_row_count as _quick_row_count,
 )
 
@@ -231,11 +220,10 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
             }
         )
     if col.true_count is not None:
-        if "stats" not in col_data:
-            col_data["stats"] = {}
-        col_data["stats"]["true_count"] = col.true_count
-        col_data["stats"]["false_count"] = col.false_count
-        col_data["stats"]["true_ratio"] = _r4(col.true_ratio)
+        bool_stats: dict[str, Any] = col_data.setdefault("stats", {})
+        bool_stats["true_count"] = col.true_count
+        bool_stats["false_count"] = col.false_count
+        bool_stats["true_ratio"] = _r4(col.true_ratio)
 
     if col.patterns is not None:
         col_data["patterns"] = [
@@ -349,7 +337,7 @@ def profile(
     csv_flexible: bool | None = None,
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
-    on_progress: object | None = None,
+    on_progress: Callable[[ProgressEvent], None] | None = None,
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
@@ -627,7 +615,9 @@ class Profiler:
                     f"Unknown stop_when shorthand: {condition!r}. "
                     f"Valid shorthands: {sorted(_STOP_SHORTHANDS)}"
                 )
-            condition = factory()
+            # factory is non-None here (guarded above); ty 0.0.x doesn't narrow
+            # the dict.get() result through the raise.
+            condition = factory()  # ty: ignore[call-non-callable]
         self._kwargs["stop_condition"] = condition
         return self
 
@@ -1259,7 +1249,9 @@ class ProfileReport:
         columns = data["columns"]
         if not isinstance(columns, list) or not all(isinstance(c, dict) for c in columns):
             raise ValueError("from_dict(): 'columns' must be a list of mappings.")
-        return cls(_DictBackedReport(data))
+        # _DictBackedReport is a read-only proxy that duck-types the raw Rust
+        # report; it intentionally isn't a nominal _RustProfileReport.
+        return cls(_DictBackedReport(data))  # ty: ignore[invalid-argument-type]
 
     @classmethod
     def from_json(cls, text: str) -> ProfileReport:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -14,7 +14,7 @@ import os
 import pathlib
 import warnings
 from collections.abc import Callable, Iterator
-from typing import Any
+from typing import Any, cast
 
 from ._dataprof import (
     ColumnProfile,
@@ -513,7 +513,7 @@ def profile(
 
 
 # Stop-when shorthand strings for the Profiler builder
-_STOP_SHORTHANDS: dict[str, object] = {
+_STOP_SHORTHANDS: dict[str, Callable[[], StopCondition]] = {
     "schema_stable": lambda: StopCondition.schema_stable(1000),
     "schema_inference": lambda: StopCondition.schema_inference(),
     "quality_sample": lambda: StopCondition.quality_sample(),
@@ -615,9 +615,7 @@ class Profiler:
                     f"Unknown stop_when shorthand: {condition!r}. "
                     f"Valid shorthands: {sorted(_STOP_SHORTHANDS)}"
                 )
-            # factory is non-None here (guarded above); ty 0.0.x doesn't narrow
-            # the dict.get() result through the raise.
-            condition = factory()  # ty: ignore[call-non-callable]
+            condition = factory()
         self._kwargs["stop_condition"] = condition
         return self
 
@@ -1251,7 +1249,7 @@ class ProfileReport:
             raise ValueError("from_dict(): 'columns' must be a list of mappings.")
         # _DictBackedReport is a read-only proxy that duck-types the raw Rust
         # report; it intentionally isn't a nominal _RustProfileReport.
-        return cls(_DictBackedReport(data))  # ty: ignore[invalid-argument-type]
+        return cls(cast("_RustProfileReport", _DictBackedReport(data)))
 
     @classmethod
     def from_json(cls, text: str) -> ProfileReport:

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -2,128 +2,24 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
 from os import PathLike
-from typing import Any, Callable, Iterator
+from typing import Any
 
-# Version
-__version__: str
-
-# --- Configuration ---
-
-class ProfilerConfig:
-    """Profiler configuration with Python-friendly kwargs."""
-
-    def __init__(
-        self,
-        engine: str = "auto",
-        chunk_size: int | None = None,
-        memory_limit_mb: int | None = None,
-        format: str | None = None,
-        max_rows: int | None = None,
-        csv_delimiter: str | None = None,
-        csv_flexible: bool | None = None,
-        sampling: SamplingStrategy | None = None,
-        stop_condition: StopCondition | None = None,
-        on_progress: Callable[[ProgressEvent], None] | None = None,
-        progress_interval_ms: int | None = None,
-        quality_dimensions: list[str] | None = None,
-        metrics: list[str] | None = None,
-        locale: str | None = None,
-        positive_columns: list[str] | None = None,
-        identifier_columns: list[str] | None = None,
-    ) -> None: ...
-    @property
-    def engine(self) -> str: ...
-    @property
-    def chunk_size(self) -> int | None: ...
-    @property
-    def memory_limit_mb(self) -> int | None: ...
-    @property
-    def format(self) -> str | None: ...
-    @property
-    def max_rows(self) -> int | None: ...
-    @property
-    def locale(self) -> str | None: ...
-    @property
-    def positive_columns(self) -> list[str]: ...
-    @property
-    def identifier_columns(self) -> list[str]: ...
-
-# --- Sampling ---
-
-class SamplingStrategy:
-    """Sampling strategy for controlling how data is sampled during profiling."""
-
-    @staticmethod
-    def none() -> SamplingStrategy: ...
-    @staticmethod
-    def random(size: int) -> SamplingStrategy: ...
-    @staticmethod
-    def reservoir(size: int) -> SamplingStrategy: ...
-    @staticmethod
-    def stratified(key_columns: list[str], samples_per_stratum: int) -> SamplingStrategy: ...
-    @staticmethod
-    def progressive(
-        initial_size: int,
-        confidence_level: float = 0.95,
-        max_size: int = 100_000,
-    ) -> SamplingStrategy: ...
-    @staticmethod
-    def systematic(interval: int) -> SamplingStrategy: ...
-    @staticmethod
-    def importance(weight_threshold: float) -> SamplingStrategy: ...
-    @staticmethod
-    def multi_stage(stages: list[SamplingStrategy]) -> SamplingStrategy: ...
-    @staticmethod
-    def adaptive(total_rows: int | None = None, file_size_mb: float = 0.0) -> SamplingStrategy: ...
-
-# --- Stop Conditions ---
-
-class StopCondition:
-    """Composable stop condition for early termination.
-
-    Combine with ``|`` (any) or ``&`` (all) operators::
-
-        stop = StopCondition.max_rows(10000) | StopCondition.max_bytes(50_000_000)
-    """
-
-    @staticmethod
-    def max_rows(n: int) -> StopCondition: ...
-    @staticmethod
-    def max_bytes(n: int) -> StopCondition: ...
-    @staticmethod
-    def schema_stable(consecutive_stable_rows: int) -> StopCondition: ...
-    @staticmethod
-    def confidence_threshold(threshold: float) -> StopCondition: ...
-    @staticmethod
-    def memory_pressure(threshold: float) -> StopCondition: ...
-    @staticmethod
-    def never() -> StopCondition: ...
-    @staticmethod
-    def schema_inference() -> StopCondition: ...
-    @staticmethod
-    def quality_sample() -> StopCondition: ...
-    def __or__(self, other: StopCondition) -> StopCondition: ...
-    def __and__(self, other: StopCondition) -> StopCondition: ...
-
-# --- Progress ---
-
-class ProgressEvent:
-    """A progress event emitted during profiling."""
-
-    kind: str
-    rows_processed: int | None
-    bytes_consumed: int | None
-    elapsed_ms: int | None
-    processing_speed: float | None
-    percentage: float | None
-    column_names: list[str] | None
-    total_rows: int | None
-    total_bytes: int | None
-    truncated: bool | None
-    message: str | None
-    estimated_total_rows: int | None
-    estimated_total_bytes: int | None
+# Raw data types are provided by the compiled extension and re-exported here.
+from ._dataprof import (
+    ColumnProfile as ColumnProfile,
+    DataQualityMetrics as DataQualityMetrics,
+    Pattern as Pattern,
+    ProfilerConfig as ProfilerConfig,
+    ProgressEvent as ProgressEvent,
+    RecordBatch as RecordBatch,
+    RowCountEstimate as RowCountEstimate,
+    SamplingStrategy as SamplingStrategy,
+    SchemaResult as SchemaResult,
+    StopCondition as StopCondition,
+    __version__ as __version__,
+)
 
 # --- Primary API ---
 
@@ -199,7 +95,8 @@ class Profiler:
 class ProfileReport:
     """High-level profiling report with export methods.
 
-    Supports dict-like column access::
+    Wraps the raw ``dataprof._dataprof.ProfileReport`` (or a dict-backed proxy
+    for reloaded reports). Supports dict-like column access::
 
         report["column_name"]          # -> ColumnProfile
         "column_name" in report        # -> bool
@@ -207,6 +104,7 @@ class ProfileReport:
         len(report)                    # number of columns
     """
 
+    def __init__(self, report: Any) -> None: ...
     @property
     def source(self) -> str: ...
     @property
@@ -282,134 +180,6 @@ class ProfileReport:
     def from_json(cls, text: str) -> ProfileReport:
         """Rebuild a read-only ProfileReport from a to_json() string."""
         ...
-
-class Pattern:
-    """Detected pattern statistics."""
-
-    name: str
-    regex: str
-    match_count: int
-    match_percentage: float
-    category: str
-    confidence: float
-
-class ColumnProfile:
-    """Column-level profiling statistics."""
-
-    name: str
-    data_type: str
-    total_count: int
-    null_count: int
-    unique_count: int | None
-    null_percentage: float
-    uniqueness_ratio: float
-    min: float | None
-    max: float | None
-    mean: float | None
-    std_dev: float | None
-    variance: float | None
-    median: float | None
-    mode: float | None
-    skewness: float | None
-    kurtosis: float | None
-    coefficient_of_variation: float | None
-    quartiles: dict[str, float] | None
-    is_approximate: bool | None
-    outlier_count: int | None
-    min_length: int | None
-    max_length: int | None
-    avg_length: float | None
-    true_count: int | None
-    false_count: int | None
-    true_ratio: float | None
-    patterns: list[Pattern] | None
-
-class DataQualityMetrics:
-    """ISO 8000/25012 data quality metrics.
-
-    Flat accessors return defaults (0.0 / 0 / [] / False) for dimensions
-    not computed. Use the nested dimension properties to check which
-    dimensions were actually evaluated.
-    """
-
-    # Flat backward-compatible accessors
-    missing_values_ratio: float
-    complete_records_ratio: float
-    null_columns: list[str]
-    data_type_consistency: float
-    format_violations: int
-    encoding_issues: int
-    duplicate_rows: int
-    key_uniqueness: float
-    high_cardinality_warning: bool
-    outlier_ratio: float
-    range_violations: int
-    negative_values_in_positive: int
-    future_dates_count: int
-    stale_data_ratio: float
-    temporal_violations: int
-    low_sample_warning: bool
-
-    # Nested dimension accessors (None when dimension was not requested)
-    @property
-    def completeness(self) -> dict[str, Any] | None: ...
-    @property
-    def consistency(self) -> dict[str, Any] | None: ...
-    @property
-    def uniqueness(self) -> dict[str, Any] | None: ...
-    @property
-    def accuracy(self) -> dict[str, Any] | None: ...
-    @property
-    def timeliness(self) -> dict[str, Any] | None: ...
-    def overall_quality_score(self) -> float: ...
-
-# --- Partial Analysis ---
-
-class SchemaResult:
-    """Result of fast schema inference."""
-
-    @property
-    def columns(self) -> list[dict[str, str]]: ...
-    @property
-    def rows_sampled(self) -> int: ...
-    @property
-    def inference_time_ms(self) -> int: ...
-    @property
-    def schema_stable(self) -> bool: ...
-    @property
-    def num_columns(self) -> int: ...
-    @property
-    def column_names(self) -> list[str]: ...
-
-class RowCountEstimate:
-    """Result of a quick row count."""
-
-    @property
-    def count(self) -> int: ...
-    @property
-    def exact(self) -> bool: ...
-    @property
-    def method(self) -> str: ...
-    @property
-    def count_time_ms(self) -> int: ...
-
-# --- Arrow Interop ---
-
-class RecordBatch:
-    """Arrow RecordBatch with PyCapsule interface for zero-copy exchange."""
-
-    @property
-    def num_rows(self) -> int: ...
-    @property
-    def num_columns(self) -> int: ...
-    @property
-    def column_names(self) -> list[str]: ...
-    def to_pandas(self) -> Any: ...
-    def to_polars(self) -> Any: ...
-    def __arrow_c_schema__(self) -> object: ...
-    def __arrow_c_array__(
-        self, requested_schema: object | None = None
-    ) -> tuple[object, object]: ...
 
 # --- Exports ---
 

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -1,0 +1,324 @@
+"""Type stubs for the compiled Rust extension module `dataprof._dataprof`.
+
+This declares the raw symbols exported by the PyO3 extension. The public
+`dataprof` package (`__init__.pyi`) re-exports the data types from here and
+wraps the module-level functions with Python-friendly APIs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+__version__: str
+
+# --- Configuration ---
+
+class ProfilerConfig:
+    """Profiler configuration with Python-friendly kwargs."""
+
+    def __init__(
+        self,
+        engine: str = "auto",
+        chunk_size: int | None = None,
+        memory_limit_mb: int | None = None,
+        format: str | None = None,
+        max_rows: int | None = None,
+        csv_delimiter: str | None = None,
+        csv_flexible: bool | None = None,
+        sampling: SamplingStrategy | None = None,
+        stop_condition: StopCondition | None = None,
+        on_progress: Callable[[ProgressEvent], None] | None = None,
+        progress_interval_ms: int | None = None,
+        quality_dimensions: list[str] | None = None,
+        metrics: list[str] | None = None,
+        locale: str | None = None,
+        positive_columns: list[str] | None = None,
+        identifier_columns: list[str] | None = None,
+    ) -> None: ...
+    @property
+    def engine(self) -> str: ...
+    @property
+    def chunk_size(self) -> int | None: ...
+    @property
+    def memory_limit_mb(self) -> int | None: ...
+    @property
+    def format(self) -> str | None: ...
+    @property
+    def max_rows(self) -> int | None: ...
+    @property
+    def locale(self) -> str | None: ...
+    @property
+    def positive_columns(self) -> list[str]: ...
+    @property
+    def identifier_columns(self) -> list[str]: ...
+
+# --- Sampling ---
+
+class SamplingStrategy:
+    """Sampling strategy for controlling how data is sampled during profiling."""
+
+    @staticmethod
+    def none() -> SamplingStrategy: ...
+    @staticmethod
+    def random(size: int) -> SamplingStrategy: ...
+    @staticmethod
+    def reservoir(size: int) -> SamplingStrategy: ...
+    @staticmethod
+    def stratified(key_columns: list[str], samples_per_stratum: int) -> SamplingStrategy: ...
+    @staticmethod
+    def progressive(
+        initial_size: int,
+        confidence_level: float = 0.95,
+        max_size: int = 100_000,
+    ) -> SamplingStrategy: ...
+    @staticmethod
+    def systematic(interval: int) -> SamplingStrategy: ...
+    @staticmethod
+    def importance(weight_threshold: float) -> SamplingStrategy: ...
+    @staticmethod
+    def multi_stage(stages: list[SamplingStrategy]) -> SamplingStrategy: ...
+    @staticmethod
+    def adaptive(total_rows: int | None = None, file_size_mb: float = 0.0) -> SamplingStrategy: ...
+
+# --- Stop Conditions ---
+
+class StopCondition:
+    """Composable stop condition for early termination."""
+
+    @staticmethod
+    def max_rows(n: int) -> StopCondition: ...
+    @staticmethod
+    def max_bytes(n: int) -> StopCondition: ...
+    @staticmethod
+    def schema_stable(consecutive_stable_rows: int) -> StopCondition: ...
+    @staticmethod
+    def confidence_threshold(threshold: float) -> StopCondition: ...
+    @staticmethod
+    def memory_pressure(threshold: float) -> StopCondition: ...
+    @staticmethod
+    def never() -> StopCondition: ...
+    @staticmethod
+    def schema_inference() -> StopCondition: ...
+    @staticmethod
+    def quality_sample() -> StopCondition: ...
+    def __or__(self, other: StopCondition) -> StopCondition: ...
+    def __and__(self, other: StopCondition) -> StopCondition: ...
+
+# --- Progress ---
+
+class ProgressEvent:
+    """A progress event emitted during profiling."""
+
+    kind: str
+    rows_processed: int | None
+    bytes_consumed: int | None
+    elapsed_ms: int | None
+    processing_speed: float | None
+    percentage: float | None
+    column_names: list[str] | None
+    total_rows: int | None
+    total_bytes: int | None
+    truncated: bool | None
+    message: str | None
+    estimated_total_rows: int | None
+    estimated_total_bytes: int | None
+
+# --- Data types ---
+
+class Pattern:
+    """Detected pattern statistics."""
+
+    name: str
+    regex: str
+    match_count: int
+    match_percentage: float
+    category: str
+    confidence: float
+
+class ColumnProfile:
+    """Column-level profiling statistics."""
+
+    name: str
+    data_type: str
+    total_count: int
+    null_count: int
+    unique_count: int | None
+    null_percentage: float
+    uniqueness_ratio: float
+    min: float | None
+    max: float | None
+    mean: float | None
+    std_dev: float | None
+    variance: float | None
+    median: float | None
+    mode: float | None
+    skewness: float | None
+    kurtosis: float | None
+    coefficient_of_variation: float | None
+    quartiles: dict[str, float] | None
+    is_approximate: bool | None
+    outlier_count: int | None
+    min_length: int | None
+    max_length: int | None
+    avg_length: float | None
+    true_count: int | None
+    false_count: int | None
+    true_ratio: float | None
+    patterns: list[Pattern] | None
+
+class DataQualityMetrics:
+    """ISO 8000/25012 data quality metrics."""
+
+    missing_values_ratio: float
+    complete_records_ratio: float
+    null_columns: list[str]
+    data_type_consistency: float
+    format_violations: int
+    encoding_issues: int
+    duplicate_rows: int
+    key_uniqueness: float
+    high_cardinality_warning: bool
+    outlier_ratio: float
+    range_violations: int
+    negative_values_in_positive: int
+    future_dates_count: int
+    stale_data_ratio: float
+    temporal_violations: int
+    low_sample_warning: bool
+
+    @property
+    def completeness(self) -> dict[str, Any] | None: ...
+    @property
+    def consistency(self) -> dict[str, Any] | None: ...
+    @property
+    def uniqueness(self) -> dict[str, Any] | None: ...
+    @property
+    def accuracy(self) -> dict[str, Any] | None: ...
+    @property
+    def timeliness(self) -> dict[str, Any] | None: ...
+    def overall_quality_score(self) -> float: ...
+
+# --- Partial analysis results ---
+
+class SchemaResult:
+    """Result of fast schema inference."""
+
+    @property
+    def columns(self) -> list[dict[str, str]]: ...
+    @property
+    def rows_sampled(self) -> int: ...
+    @property
+    def inference_time_ms(self) -> int: ...
+    @property
+    def schema_stable(self) -> bool: ...
+    @property
+    def num_columns(self) -> int: ...
+    @property
+    def column_names(self) -> list[str]: ...
+
+class RowCountEstimate:
+    """Result of a quick row count."""
+
+    @property
+    def count(self) -> int: ...
+    @property
+    def exact(self) -> bool: ...
+    @property
+    def method(self) -> str: ...
+    @property
+    def count_time_ms(self) -> int: ...
+
+# --- Arrow interop ---
+
+class RecordBatch:
+    """Arrow RecordBatch with PyCapsule interface for zero-copy exchange."""
+
+    @property
+    def num_rows(self) -> int: ...
+    @property
+    def num_columns(self) -> int: ...
+    @property
+    def column_names(self) -> list[str]: ...
+    def to_pandas(self) -> Any: ...
+    def to_polars(self) -> Any: ...
+    def __arrow_c_schema__(self) -> object: ...
+    def __arrow_c_array__(
+        self, requested_schema: object | None = None
+    ) -> tuple[object, object]: ...
+
+# --- Raw report ---
+
+class ProfileReport:
+    """Raw Rust profiling report (wrapped by the public `dataprof.ProfileReport`)."""
+
+    @property
+    def source(self) -> str: ...
+    @property
+    def source_type(self) -> str: ...
+    @property
+    def source_library(self) -> str | None: ...
+    @property
+    def memory_bytes(self) -> int | None: ...
+    @property
+    def rows_processed(self) -> int: ...
+    @property
+    def columns_detected(self) -> int: ...
+    @property
+    def scan_time_ms(self) -> int: ...
+    @property
+    def source_exhausted(self) -> bool: ...
+    @property
+    def truncation_reason(self) -> str | None: ...
+    @property
+    def bytes_consumed(self) -> int | None: ...
+    @property
+    def throughput_rows_sec(self) -> float | None: ...
+    @property
+    def memory_peak_mb(self) -> float | None: ...
+    @property
+    def error_count(self) -> int: ...
+    @property
+    def sampling_applied(self) -> bool: ...
+    @property
+    def sampling_ratio(self) -> float | None: ...
+    @property
+    def column_profiles(self) -> list[ColumnProfile]: ...
+    @property
+    def quality(self) -> DataQualityMetrics | None: ...
+    @property
+    def quality_score(self) -> float | None: ...
+    def to_json(self) -> str: ...
+
+# --- Module-level functions ---
+
+def analyze_file(path: str, config: ProfilerConfig | None) -> ProfileReport: ...
+def profile_dataframe(
+    df: Any, name: str, max_rows: int | None, config: ProfilerConfig | None
+) -> ProfileReport: ...
+def profile_arrow(
+    source: Any, name: str, max_rows: int | None, config: ProfilerConfig | None
+) -> ProfileReport: ...
+def infer_schema(path: str) -> SchemaResult: ...
+def quick_row_count(path: str) -> RowCountEstimate: ...
+def analyze_csv_to_arrow(path: str) -> RecordBatch: ...
+def analyze_parquet_to_arrow(path: str) -> RecordBatch: ...
+
+# Async functions (available only with the `python-async` feature build)
+async def profile_file_async(path: str, config: ProfilerConfig | None) -> ProfileReport: ...
+async def profile_bytes_async(
+    data: bytes, format: str, config: ProfilerConfig | None
+) -> ProfileReport: ...
+async def profile_url_async(
+    url: str, format: str | None, config: ProfilerConfig | None
+) -> ProfileReport: ...
+async def infer_schema_stream_async(data: bytes, format: str) -> SchemaResult: ...
+async def quick_row_count_stream_async(data: bytes, format: str) -> RowCountEstimate: ...
+
+# Database functions (available only with the `database` feature build)
+async def analyze_database_async(
+    connection_string: str, query: str, config: ProfilerConfig | None = None
+) -> ProfileReport: ...
+async def count_table_rows_async(connection_string: str, table: str) -> RowCountEstimate: ...
+async def get_table_schema_async(connection_string: str, table: str) -> SchemaResult: ...
+async def test_connection_async(connection_string: str) -> bool: ...

--- a/python/dataprof/asyncio.py
+++ b/python/dataprof/asyncio.py
@@ -21,16 +21,10 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from ._dataprof import (
-        infer_schema_stream_async as _infer_schema_stream_async,
-    )
     from ._dataprof import (  # type: ignore[import-not-found]
+        infer_schema_stream_async as _infer_schema_stream_async,
         profile_bytes_async as _profile_bytes_async,
-    )
-    from ._dataprof import (
         profile_file_async as _profile_file_async,
-    )
-    from ._dataprof import (
         quick_row_count_stream_async as _quick_row_count_stream_async,
     )
 

--- a/python/dataprof/asyncio.pyi
+++ b/python/dataprof/asyncio.pyi
@@ -7,6 +7,10 @@ from typing import Any
 
 from . import ProfileReport, RowCountEstimate, SchemaResult
 
+# True when the extension was built with the corresponding feature flags.
+_HAS_ASYNC: bool
+_HAS_URL: bool
+
 async def profile_bytes(
     data: bytes,
     *,

--- a/python/dataprof/interop.py
+++ b/python/dataprof/interop.py
@@ -14,17 +14,11 @@ from dataprof._dataprof import (  # type: ignore[import-not-found]
     ProfilerConfig,
     ProfileReport,
     RecordBatch,
+    analyze_csv_to_arrow as _analyze_csv_to_arrow,
+    analyze_file as _analyze_file,
+    analyze_parquet_to_arrow as _analyze_parquet_to_arrow,
     profile_arrow,
     profile_dataframe,
-)
-from dataprof._dataprof import (
-    analyze_csv_to_arrow as _analyze_csv_to_arrow,
-)
-from dataprof._dataprof import (
-    analyze_file as _analyze_file,
-)
-from dataprof._dataprof import (
-    analyze_parquet_to_arrow as _analyze_parquet_to_arrow,
 )
 
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1215,6 +1215,7 @@ class TestSemanticHints:
         path.write_text("pressure,temperature_delta\n101325,1\n-500,-2\n100900,3\n")
 
         without_hint = dataprof.profile(str(path), engine="incremental")
+        assert without_hint.quality is not None
         assert without_hint.quality.negative_values_in_positive == 0
 
         with_hint = dataprof.profile(
@@ -1222,6 +1223,7 @@ class TestSemanticHints:
             engine="incremental",
             positive_columns=["pressure"],
         )
+        assert with_hint.quality is not None
         assert with_hint.quality.negative_values_in_positive == 1
 
     def test_identifier_columns_omit_numeric_stats(self, tmp_path):
@@ -1237,6 +1239,7 @@ class TestSemanticHints:
         assert order_id.data_type == "identifier"
         assert order_id.mean is None
         assert order_id.outlier_count is None
+        assert report.quality is not None
         assert report.quality.outlier_ratio == 0.0
 
     def test_dataframe_hints(self):
@@ -1248,6 +1251,7 @@ class TestSemanticHints:
             positive_columns=["pressure"],
         )
         assert report["order_id"].data_type == "identifier"
+        assert report.quality is not None
         assert report.quality.negative_values_in_positive == 1
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,7 @@ dev = [
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -88,6 +89,7 @@ dev = [
     { name = "pyarrow", specifier = ">=14.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "ty", specifier = ">=0.0.56" },
 ]
 
 [[package]]
@@ -871,6 +873,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.56"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/07/fb29aea5235b0aa8ecfc4d1cc6ddf9fba8b863d67d96c6d345694d644c43/ty-0.0.56.tar.gz", hash = "sha256:84d114dc3796361c0fc72945016eabd74d46b9ee64f198cb0e485719704681e5", size = 6050123, upload-time = "2026-07-01T16:44:56.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/48/bce79e7ca5c1cc529d3e0d37ddd1121aea4b68a4f749974ad1cc77161871/ty-0.0.56-py3-none-linux_armv6l.whl", hash = "sha256:186d4a53e15747c947e1ec3d7eec8e345d8e40a1ca10e634c585db52497e87dd", size = 11643066, upload-time = "2026-07-01T16:44:18.374Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d1/22555d8a1d719661f10050f3865d877bbf497da908961c75fe22217dd18a/ty-0.0.56-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aae1a980fd9535da0469b7ba2b2e1b54a907743a5e0f442dd57eee9f5bfd034c", size = 11407487, upload-time = "2026-07-01T16:44:20.956Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/2d/b3b7a74ce8bc59ef48843ad80179bb0d9598bbd6cfc0d11d519bdf6b1352/ty-0.0.56-py3-none-macosx_11_0_arm64.whl", hash = "sha256:afd3058c0a6c5f241e814734f133008c93ee805f61c9cf4ce7412b8822b5d9ad", size = 10962270, upload-time = "2026-07-01T16:44:22.959Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ac/6c2fd7de0304a8a7218a756af74f7e62a5e8540fdb175e0a869e51042345/ty-0.0.56-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:058b52f7a823ac13aae3cae30809dd6b5145794b64d8478f9ef38c75d79b4483", size = 11471406, upload-time = "2026-07-01T16:44:25.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b6/11d861156861c03c7726b74558f9a0e0092661aff83a4fda1279df28c425/ty-0.0.56-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c66e00c1522add1f2bbdd2e45828c953b35c306b7bef03ec9169c75a63699a0", size = 11445612, upload-time = "2026-07-01T16:44:27.531Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ba/09df108582090f3c0770ec4bc8675affed60248f6793a78d909be16211d9/ty-0.0.56-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40903d71c669a30691b5a5d5728056c7877a1bd6be4f233a38883a8b28cf34d7", size = 12093889, upload-time = "2026-07-01T16:44:29.548Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f7/dbb4b4ccb69cd64c209ae55b1ab788ace8222c2bc1f6845be9e7cbedbf25/ty-0.0.56-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63fe3947fe0c46c69a7d950e6832ee70a9ec17321fefbff3d2e3c20baf9e5bd0", size = 12666337, upload-time = "2026-07-01T16:44:31.586Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e9/73f903fe4a3d9ea02f26f57c1eb07e3b1029ec92b0e8c2364718893440e3/ty-0.0.56-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71a0c1a72f9854532e710e119b6871ffe4542c8a65146f1f65dcd78fecd885b4", size = 12280247, upload-time = "2026-07-01T16:44:33.637Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/cebd222495832f1a00dcd321ba25f3cab804221a4991b992c2178bec68ee/ty-0.0.56-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70d1665596494e24d8ebd198438872b5a56ec3cae5f2bcf6c673be797acc4e3c", size = 11991107, upload-time = "2026-07-01T16:44:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/8f7337a07250f42d975cdb6decf47fc5b421e6c7da5e3e7be1e85f63a7e5/ty-0.0.56-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:778f99e51558afc1dbbe48ee38ab6aae7b31390ed8c1a1ef1499b295e9f1e82f", size = 12298970, upload-time = "2026-07-01T16:44:38.243Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b9/a52cd59034a48f5f18c6b155cc2cc36861d874b6d0af204b12c898024c3d/ty-0.0.56-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:867bc5708e0066bb4ff6c7db524bd5deea2676c62bfe71d3303138b3be850af0", size = 11425683, upload-time = "2026-07-01T16:44:40.473Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2e/48e42d33357d52eefb695c0c3fcfc96879b73668a7447d1d1e0ad774fedc/ty-0.0.56-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6012f4189c928edb330a37deb9930f982380bd4aa7c4b8e0428eec9651c7551", size = 11469258, upload-time = "2026-07-01T16:44:42.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/01/ad1b4138be1e3fa97863af3925aa2134f17a593240c35dc38c3429fb5ad1/ty-0.0.56-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ee83de1a7ff4cc32837ec06134ce391d441bc5b35ecd8d3cfe053f120f3e4c1", size = 11758736, upload-time = "2026-07-01T16:44:44.567Z" },
+    { url = "https://files.pythonhosted.org/packages/09/34/9d81967ff240eaa57e9249728ef7b7790747cf6d3c9a98ec86b2cfdcc8ee/ty-0.0.56-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:62619b3b0e2c6248ef30d3f0e2f2217ae9893040585be07f32324242f197cd6f", size = 12100242, upload-time = "2026-07-01T16:44:46.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/36/f51d4666d2de6cf33c1f3a1fcc4bb6b70b197dd6ceaa491eef71d78fe8e8/ty-0.0.56-py3-none-win32.whl", hash = "sha256:b30687bb5cd9729d34c889a289edf32770388d9bb05243e534e723fb45e0381b", size = 11093759, upload-time = "2026-07-01T16:44:49.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b4/8fb5d4acfa4afb152245b20fa263069a7547bd1f8e4bfca4eda280c897d7/ty-0.0.56-py3-none-win_amd64.whl", hash = "sha256:ad4c8c47b6f4e3f9ed3fc0b1a5d650088d229e17dd8f63c1826d6bbe94cc3235", size = 12100327, upload-time = "2026-07-01T16:44:51.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/6a183e71edde90d0c35c2303f23f7a45b6891d1a2c45daf7b8f869831e19/ty-0.0.56-py3-none-win_arm64.whl", hash = "sha256:57538f273d444a5f1293fa7860e967178afe3917611fc5eff16b64e1204fe0d6", size = 11538780, upload-time = "2026-07-01T16:44:53.8Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adopts [ty](https://github.com/astral-sh/ty) (Astral's type checker) for the Python package, and gives it something real to check by stubbing the compiled core.

- **New `python/dataprof/_dataprof.pyi`** — declares the raw PyO3 extension symbols. Previously `dataprof._dataprof` was unresolvable to any type checker (mypy/pyright/ty alike); now it resolves. The public `__init__.pyi` re-exports these types instead of duplicating them, and gains the missing `ProfileReport.__init__`.
- **ty wired into CI as advisory** (non-blocking, since ty is pre-1.0) in the existing `Python Lint & Format` job; added to the `dev` dependency group + a `[tool.ty]` config block.

## Real findings fixed along the way

- `_df_config()` returns `ProfilerConfig | None` — stub params made nullable to match.
- `profile(on_progress=...)` was typed `object`; now `Callable[[ProgressEvent], None] | None`.
- Tests: narrow `report.quality` (an `Optional`) with asserts before attribute access.
- Move `typing.Iterator/Callable` → `collections.abc` (UP035, newly active under the py310 target).
- ruff: enable isort `combine-as-imports` for tidy re-export blocks.

## Verification

`uv run ty check python/` → **All checks passed**; `ruff check`/`format` clean; `pytest` **139 passed**.

Net result: the compiled extension is finally typed, which improves IDE/type-checker UX for downstream users too — independent of which checker they run.