### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Fixes the `cargo deny` **advisories** CI failure: **RUSTSEC-2026-0204** — an invalid pointer dereference in the `fmt::Pointer` impl of `crossbeam-epoch 0.9.18`.

Lockfile-only bump to the fixed **0.9.20** (`cargo update -p crossbeam-epoch`).

## Scope

`crossbeam-epoch` is a purely transitive **dev/bench** dependency:

```
crossbeam-epoch -> crossbeam-deque -> rayon-core -> rayon -> criterion -> (dev) dataprof
```

Not in any shipped artifact. Patch bump within semver — API-compatible.

## Verification

- `cargo deny check advisories` → **advisories ok** (was FAILED)
- `cargo check --benches` → compiles clean