### PR TITLE
feat(python): ProfileReport.load(path) to reload a saved report (#325)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Python: `ProfileReport.load(path)` — reload a report saved with `save()` from a
+  `.json` file path (the path-based counterpart to `from_json()`/`from_dict()`).
+  `.csv`/`.parquet` paths raise a clear `ValueError` since they store column
+  profiles only. (#325)
 - Python: type stubs for the compiled extension (`dataprof/_dataprof.pyi`), so
   type checkers and IDEs can resolve the native core. The public stubs now
   re-export these types instead of duplicating them.

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -154,8 +154,9 @@ report.save("report.csv")       # save column profiles to CSV
 report.save("report.parquet")   # save column profiles to Parquet (requires pyarrow)
 
 # Round-trip a saved report without re-profiling (read-only view)
-reloaded = dp.ProfileReport.from_json(report.to_json())
-reloaded = dp.ProfileReport.from_dict(report.to_dict())
+reloaded = dp.ProfileReport.load("report.json")   # from a saved .json file
+reloaded = dp.ProfileReport.from_json(report.to_json())  # from a JSON string
+reloaded = dp.ProfileReport.from_dict(report.to_dict())  # from a dict
 ```
 
 **Rounding:** All floating-point values in exported data are rounded to match the CLI
@@ -388,19 +389,31 @@ md = report.to_markdown()        # GitHub-flavored markdown table
 # Paste straight into a PR comment, issue, or Slack message
 ```
 
-### `from_json()` / `from_dict()`
+### `load()` / `from_json()` / `from_dict()`
 
 Rebuild a report from previously exported data without re-profiling. The
 reconstructed report is a **read-only view** backed by the exported values, but
 all export methods (`to_json`, `to_markdown`, `to_dataframe`, `describe`,
-`quality_summary`, mapping access, …) work as usual:
+`quality_summary`, mapping access, …) work as usual.
+
+`load(path)` is the path-based entry point — the natural counterpart to
+`save()`. Only `.json` files carry a full report; `.csv` / `.parquet` store
+column profiles only and cannot round-trip:
 
 ```python
 report.save("report.json")
 # ...later...
-reloaded = dp.ProfileReport.from_json(open("report.json").read())
+reloaded = dp.ProfileReport.load("report.json")
 reloaded.quality_score          # == the original report's quality_score
 reloaded["email"].null_percentage
+```
+
+`from_json(text)` and `from_dict(data)` take an in-memory JSON string or dict
+instead of a file path:
+
+```python
+reloaded = dp.ProfileReport.from_json(report.to_json())
+reloaded = dp.ProfileReport.from_dict(report.to_dict())
 ```
 
 ### `compare()`

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1266,6 +1266,39 @@ class ProfileReport:
             raise ValueError(f"from_json() received invalid JSON: {exc}") from exc
         return cls.from_dict(data)
 
+    @classmethod
+    def load(cls, path: str | os.PathLike[str]) -> ProfileReport:
+        """Reload a report previously written with :meth:`save`.
+
+        This is the path-based counterpart to :meth:`from_json` (which takes a
+        JSON *string*) and :meth:`from_dict` (which takes a *dict*)::
+
+            before.save("before.json")
+            loaded = dp.ProfileReport.load("before.json")
+
+        Only ``.json`` files carry a full report and can be reloaded. The
+        ``.csv`` / ``.parquet`` outputs of :meth:`save` store only column
+        profiles, not the full report, so they cannot round-trip.
+
+        Args:
+            path: Path to a ``.json`` file produced by ``save()``.
+
+        Raises:
+            ValueError: if the file is ``.csv`` / ``.parquet`` (profiles only)
+                or has an unsupported extension.
+            FileNotFoundError: if the file does not exist.
+        """
+        path = _normalize_pathlike(path)
+        if path.endswith(".json"):
+            with open(path, encoding="utf-8") as f:
+                return cls.from_json(f.read())
+        if path.endswith((".csv", ".parquet")):
+            raise ValueError(
+                f"Cannot reload a full report from '{path}': .csv/.parquet store "
+                "only column profiles. Save and load with .json to round-trip a report."
+            )
+        raise ValueError("Unsupported format. Use .json (produced by save()).")
+
     def __repr__(self) -> str:
         qs = self.quality_score
         qs_str = f"{qs:.1f}%" if qs is not None else "N/A"

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -180,6 +180,10 @@ class ProfileReport:
     def from_json(cls, text: str) -> ProfileReport:
         """Rebuild a read-only ProfileReport from a to_json() string."""
         ...
+    @classmethod
+    def load(cls, path: str | PathLike[str]) -> ProfileReport:
+        """Reload a report from a .json file written by save()."""
+        ...
 
 # --- Exports ---
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -305,6 +305,41 @@ class TestReportErgonomics:
         with pytest.raises(ValueError, match="invalid JSON"):
             dataprof.ProfileReport.from_json("{not valid json")
 
+    def test_load_json_round_trip(self, report):
+        # The 0.9.0 acceptance snippet: save → load → same quality_score.
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            report.save(path)
+            loaded = dataprof.ProfileReport.load(path)
+            assert loaded.quality_score == report.quality_score
+            assert loaded.to_dict() == report.to_dict()
+        finally:
+            os.unlink(path)
+
+    def test_load_accepts_pathlike(self, report):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = Path(f.name)
+        try:
+            report.save(str(path))
+            loaded = dataprof.ProfileReport.load(path)
+            assert loaded.quality_score == report.quality_score
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.parametrize("suffix", [".csv", ".parquet"])
+    def test_load_profiles_only_formats_raise(self, suffix):
+        with pytest.raises(ValueError, match=r"\.json"):
+            dataprof.ProfileReport.load(f"report{suffix}")
+
+    def test_load_unsupported_ext_raises(self):
+        with pytest.raises(ValueError, match="Unsupported format"):
+            dataprof.ProfileReport.load("report.html")
+
+    def test_load_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            dataprof.ProfileReport.load("does_not_exist_12345.json")
+
     def test_from_dict_ignores_unknown_stat_keys(self, report):
         d = report.to_dict()
         d["columns"][0].setdefault("stats", {})["__evil__"] = "nope"
@@ -639,6 +674,7 @@ class TestNamespace:
             "compare",
             "from_dict",
             "from_json",
+            "load",
             "__getitem__",
             "__contains__",
             "__iter__",


### PR DESCRIPTION
Closes #325.

## What

Adds `ProfileReport.load(path)` — the path-based counterpart to `from_json()` (JSON string) and `from_dict()` (dict). Completes the 0.9.0 "export → reload → compare" story.

```python
before = dp.profile("raw.csv")
before.save("before.json")
loaded = dp.ProfileReport.load("before.json")
assert loaded.quality_score == before.quality_score
```

## Behavior

- `.json` → reads the file and rebuilds a read-only report (reuses the existing `_DictBackedReport` path via `from_json`).
- `.csv` / `.parquet` → raises a clear `ValueError` (those store column profiles only, not a full report).
- other extensions → `ValueError`; missing file → natural `FileNotFoundError`.
- Accepts `str | PathLike` via the existing `_normalize_pathlike()` helper.

## Also

Moves `typing.Iterator`/`Callable` → `collections.abc` (UP035, newly active under the py310 target).

## Verification

`pytest` **145 passed** (6 new `load` tests: json round-trip, PathLike, `.csv`/`.parquet` reject, unsupported ext, missing file); `ruff check`/`format` clean. Stub, docs (`docs/python/README.md`), and CHANGELOG updated.

> Note: overlaps with #345 (ty adoption) in `python/dataprof/__init__.pyi` / `__init__.py`; whichever merges second needs a small mechanical rebase.