### PR TITLE
Implement Python 0.9 quality metrics breaking pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,11 @@ jobs:
         with:
           cache-prefix: rust-python
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,11 @@ jobs:
         with:
           cache-prefix: rust-python-url-${{ matrix.variant }}
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -296,6 +301,11 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           cache-prefix: rust-db
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
 
       - name: Initialize test databases
         run: |

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -409,4 +409,108 @@ mod tests {
         assert_eq!(metrics.duplicate_rows(), 0);
         assert!(!metrics.high_cardinality_warning());
     }
+
+    #[test]
+    fn test_partial_dimension_flat_defaults_table() {
+        struct Case {
+            name: &'static str,
+            metrics: QualityMetrics,
+            has_completeness: bool,
+            has_uniqueness: bool,
+            has_accuracy: bool,
+            missing_values_ratio: f64,
+            key_uniqueness: f64,
+            outlier_ratio: f64,
+        }
+
+        let cases = [
+            Case {
+                name: "only completeness",
+                metrics: QualityMetrics {
+                    completeness: Some(CompletenessMetrics {
+                        missing_values_ratio: 12.5,
+                        complete_records_ratio: 87.5,
+                        null_columns: vec!["email".to_string()],
+                    }),
+                    ..QualityMetrics::default()
+                },
+                has_completeness: true,
+                has_uniqueness: false,
+                has_accuracy: false,
+                missing_values_ratio: 12.5,
+                key_uniqueness: 100.0,
+                outlier_ratio: 0.0,
+            },
+            Case {
+                name: "only uniqueness",
+                metrics: QualityMetrics {
+                    uniqueness: Some(UniquenessMetrics {
+                        duplicate_rows: 2,
+                        key_uniqueness: 92.0,
+                        high_cardinality_warning: true,
+                    }),
+                    ..QualityMetrics::default()
+                },
+                has_completeness: false,
+                has_uniqueness: true,
+                has_accuracy: false,
+                missing_values_ratio: 0.0,
+                key_uniqueness: 92.0,
+                outlier_ratio: 0.0,
+            },
+            Case {
+                name: "only accuracy",
+                metrics: QualityMetrics {
+                    accuracy: Some(AccuracyMetrics {
+                        outlier_ratio: 6.25,
+                        range_violations: 1,
+                        negative_values_in_positive: 1,
+                    }),
+                    ..QualityMetrics::default()
+                },
+                has_completeness: false,
+                has_uniqueness: false,
+                has_accuracy: true,
+                missing_values_ratio: 0.0,
+                key_uniqueness: 100.0,
+                outlier_ratio: 6.25,
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                case.metrics.completeness.is_some(),
+                case.has_completeness,
+                "{} completeness presence",
+                case.name
+            );
+            assert_eq!(
+                case.metrics.uniqueness.is_some(),
+                case.has_uniqueness,
+                "{} uniqueness presence",
+                case.name
+            );
+            assert_eq!(
+                case.metrics.accuracy.is_some(),
+                case.has_accuracy,
+                "{} accuracy presence",
+                case.name
+            );
+            assert!(
+                (case.metrics.missing_values_ratio() - case.missing_values_ratio).abs() < 0.01,
+                "{} missing_values_ratio",
+                case.name
+            );
+            assert!(
+                (case.metrics.key_uniqueness() - case.key_uniqueness).abs() < 0.01,
+                "{} key_uniqueness",
+                case.name
+            );
+            assert!(
+                (case.metrics.outlier_ratio() - case.outlier_ratio).abs() < 0.01,
+                "{} outlier_ratio",
+                case.name
+            );
+        }
+    }
 }

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -1,3 +1,7 @@
+use std::ffi::CString;
+
+use pyo3::PyErr;
+use pyo3::exceptions::PyDeprecationWarning;
 use pyo3::prelude::*;
 
 use dataprof::{
@@ -268,69 +272,94 @@ impl From<&QualityMetrics> for PyDataQualityMetrics {
     }
 }
 
+fn warn_flat_quality_accessor(py: Python<'_>, name: &str) -> PyResult<()> {
+    let message = CString::new(format!(
+        "DataQualityMetrics.{name} is deprecated; use the nested dimension properties \
+         such as completeness, consistency, uniqueness, accuracy, or timeliness instead"
+    ))
+    .expect("warning message contains no nul bytes");
+    let category = py.get_type::<PyDeprecationWarning>();
+    PyErr::warn(py, &category, message.as_c_str(), 2)
+}
+
 #[pymethods]
 impl PyDataQualityMetrics {
-    // -- Backward-compatible flat properties --
+    // -- Deprecated flat properties --
 
     #[getter]
-    fn missing_values_ratio(&self) -> f64 {
-        self.inner.missing_values_ratio()
+    fn missing_values_ratio(&self, py: Python<'_>) -> PyResult<f64> {
+        warn_flat_quality_accessor(py, "missing_values_ratio")?;
+        Ok(self.inner.missing_values_ratio())
     }
     #[getter]
-    fn complete_records_ratio(&self) -> f64 {
-        self.inner.complete_records_ratio()
+    fn complete_records_ratio(&self, py: Python<'_>) -> PyResult<f64> {
+        warn_flat_quality_accessor(py, "complete_records_ratio")?;
+        Ok(self.inner.complete_records_ratio())
     }
     #[getter]
-    fn null_columns(&self) -> Vec<String> {
-        self.inner.null_columns().to_vec()
+    fn null_columns(&self, py: Python<'_>) -> PyResult<Vec<String>> {
+        warn_flat_quality_accessor(py, "null_columns")?;
+        Ok(self.inner.null_columns().to_vec())
     }
     #[getter]
-    fn data_type_consistency(&self) -> f64 {
-        self.inner.data_type_consistency()
+    fn data_type_consistency(&self, py: Python<'_>) -> PyResult<f64> {
+        warn_flat_quality_accessor(py, "data_type_consistency")?;
+        Ok(self.inner.data_type_consistency())
     }
     #[getter]
-    fn format_violations(&self) -> usize {
-        self.inner.format_violations()
+    fn format_violations(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "format_violations")?;
+        Ok(self.inner.format_violations())
     }
     #[getter]
-    fn encoding_issues(&self) -> usize {
-        self.inner.encoding_issues()
+    fn encoding_issues(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "encoding_issues")?;
+        Ok(self.inner.encoding_issues())
     }
     #[getter]
-    fn duplicate_rows(&self) -> usize {
-        self.inner.duplicate_rows()
+    fn duplicate_rows(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "duplicate_rows")?;
+        Ok(self.inner.duplicate_rows())
     }
     #[getter]
-    fn key_uniqueness(&self) -> f64 {
-        self.inner.key_uniqueness()
+    fn key_uniqueness(&self, py: Python<'_>) -> PyResult<f64> {
+        warn_flat_quality_accessor(py, "key_uniqueness")?;
+        Ok(self.inner.key_uniqueness())
     }
     #[getter]
-    fn high_cardinality_warning(&self) -> bool {
-        self.inner.high_cardinality_warning()
+    fn high_cardinality_warning(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_flat_quality_accessor(py, "high_cardinality_warning")?;
+        Ok(self.inner.high_cardinality_warning())
     }
     #[getter]
-    fn outlier_ratio(&self) -> f64 {
-        self.inner.outlier_ratio()
+    fn outlier_ratio(&self, py: Python<'_>) -> PyResult<f64> {
+        warn_flat_quality_accessor(py, "outlier_ratio")?;
+        Ok(self.inner.outlier_ratio())
     }
     #[getter]
-    fn range_violations(&self) -> usize {
-        self.inner.range_violations()
+    fn range_violations(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "range_violations")?;
+        Ok(self.inner.range_violations())
     }
     #[getter]
-    fn negative_values_in_positive(&self) -> usize {
-        self.inner.negative_values_in_positive()
+    fn negative_values_in_positive(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "negative_values_in_positive")?;
+        Ok(self.inner.negative_values_in_positive())
     }
     #[getter]
-    fn future_dates_count(&self) -> usize {
-        self.inner.future_dates_count()
+    fn future_dates_count(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "future_dates_count")?;
+        Ok(self.inner.future_dates_count())
     }
     #[getter]
-    fn stale_data_ratio(&self) -> f64 {
-        self.inner.stale_data_ratio()
+    fn stale_data_ratio(&self, py: Python<'_>) -> PyResult<f64> {
+        warn_flat_quality_accessor(py, "stale_data_ratio")?;
+        Ok(self.inner.stale_data_ratio())
     }
     #[getter]
-    fn temporal_violations(&self) -> usize {
-        self.inner.temporal_violations()
+    fn temporal_violations(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "temporal_violations")?;
+        Ok(self.inner.temporal_violations())
     }
 
     /// True when the underlying sample was below the recommended minimum

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   type checkers and IDEs can resolve the native core. The public stubs now
   re-export these types instead of duplicating them.
 
+### Changed
+
+- Python: flat `DataQualityMetrics` accessors such as
+  `missing_values_ratio`, `key_uniqueness`, and `outlier_ratio` now emit
+  `DeprecationWarning`. Use nested dimension properties such as
+  `quality.completeness`, `quality.uniqueness`, and `quality.accuracy`, which
+  are `None` when a dimension was not computed. The flat accessors keep their
+  0.8-compatible values for the 0.9 line. (#326)
+- Python: the supported runtime floor is Python 3.10+. Project metadata,
+  tooling, and CI now exercise that minimum explicitly. (#326)
+
 ### Internal
 
 - Python: adopt [ty](https://github.com/astral-sh/ty) for static type checking,

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -324,13 +324,16 @@ score = report.quality_score or 0.0
 
 if score < 90.0:
     q = report.quality
+    completeness = q.completeness if q else None
+    uniqueness = q.uniqueness if q else None
+    accuracy = q.accuracy if q else None
     failures = []
-    if q.missing_values_ratio > 10.0:
-        failures.append(f"missing values: {q.missing_values_ratio:.1f}%")
-    if q.duplicate_rows > 0:
-        failures.append(f"{q.duplicate_rows} duplicate rows")
-    if q.outlier_ratio > 5.0:
-        failures.append(f"outlier ratio: {q.outlier_ratio:.1f}%")
+    if completeness and completeness["missing_values_ratio"] > 10.0:
+        failures.append(f"missing values: {completeness['missing_values_ratio']:.1f}%")
+    if uniqueness and uniqueness["duplicate_rows"] > 0:
+        failures.append(f"{uniqueness['duplicate_rows']} duplicate rows")
+    if accuracy and accuracy["outlier_ratio"] > 5.0:
+        failures.append(f"outlier ratio: {accuracy['outlier_ratio']:.1f}%")
     print(f"REJECTED (score={score:.2f}): {', '.join(failures)}")
     sys.exit(1)
 
@@ -372,7 +375,8 @@ report = dp.profile(
 )
 
 assert report["order_id"].data_type == "identifier"
-print(report.quality.negative_values_in_positive)
+if report.quality and report.quality.accuracy:
+    print(report.quality.accuracy["negative_values_in_positive"])
 ```
 
 ### Serialize a single column (0.8.0)

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -290,19 +290,24 @@ q = report.quality
 # Overall score
 print(q.overall_quality_score())
 
-# Flat accessors (return defaults when dimension not computed)
-print(q.missing_values_ratio)
-print(q.data_type_consistency)
-print(q.duplicate_rows)
-print(q.outlier_ratio)
-print(q.future_dates_count)
-
 # Nested dimension accessors (None when not computed)
 print(q.completeness)    # {"missing_values_ratio": ..., "complete_records_ratio": ..., "null_columns": [...]}
 print(q.consistency)     # {"data_type_consistency": ..., "format_violations": ..., "encoding_issues": ...}
 print(q.uniqueness)      # {"duplicate_rows": ..., "key_uniqueness": ..., "high_cardinality_warning": ...}
 print(q.accuracy)        # {"outlier_ratio": ..., "range_violations": ..., "negative_values_in_positive": ...}
 print(q.timeliness)      # {"future_dates_count": ..., "stale_data_ratio": ..., "temporal_violations": ...}
+```
+
+Flat `DataQualityMetrics` accessors are deprecated in 0.9. Use nested
+dimensions so skipped dimensions are explicit:
+
+```python
+# Old
+q.missing_values_ratio
+
+# New
+if q.completeness is not None:
+    q.completeness["missing_values_ratio"]
 ```
 
 `negative_values_in_positive` is driven by explicit `positive_columns`; dataprof

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -759,6 +759,96 @@ class _DictQuality:
         self._d = d
         self.low_sample_warning = bool(d.get("low_sample_warning", False))
 
+    def _warn_flat_accessor(self, name: str) -> None:
+        warnings.warn(
+            f"DataQualityMetrics.{name} is deprecated; use the nested dimension "
+            "properties such as completeness, consistency, uniqueness, accuracy, "
+            "or timeliness instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    def _dimension_value(self, dimension: str, key: str, default: Any) -> Any:
+        value = self._d.get(dimension)
+        if isinstance(value, dict):
+            return value.get(key, default)
+        return default
+
+    @property
+    def missing_values_ratio(self) -> float:
+        self._warn_flat_accessor("missing_values_ratio")
+        return self._dimension_value("completeness", "missing_values_ratio", 0.0)
+
+    @property
+    def complete_records_ratio(self) -> float:
+        self._warn_flat_accessor("complete_records_ratio")
+        return self._dimension_value("completeness", "complete_records_ratio", 100.0)
+
+    @property
+    def null_columns(self) -> list[str]:
+        self._warn_flat_accessor("null_columns")
+        return self._dimension_value("completeness", "null_columns", [])
+
+    @property
+    def data_type_consistency(self) -> float:
+        self._warn_flat_accessor("data_type_consistency")
+        return self._dimension_value("consistency", "data_type_consistency", 100.0)
+
+    @property
+    def format_violations(self) -> int:
+        self._warn_flat_accessor("format_violations")
+        return self._dimension_value("consistency", "format_violations", 0)
+
+    @property
+    def encoding_issues(self) -> int:
+        self._warn_flat_accessor("encoding_issues")
+        return self._dimension_value("consistency", "encoding_issues", 0)
+
+    @property
+    def duplicate_rows(self) -> int:
+        self._warn_flat_accessor("duplicate_rows")
+        return self._dimension_value("uniqueness", "duplicate_rows", 0)
+
+    @property
+    def key_uniqueness(self) -> float:
+        self._warn_flat_accessor("key_uniqueness")
+        return self._dimension_value("uniqueness", "key_uniqueness", 100.0)
+
+    @property
+    def high_cardinality_warning(self) -> bool:
+        self._warn_flat_accessor("high_cardinality_warning")
+        return self._dimension_value("uniqueness", "high_cardinality_warning", False)
+
+    @property
+    def outlier_ratio(self) -> float:
+        self._warn_flat_accessor("outlier_ratio")
+        return self._dimension_value("accuracy", "outlier_ratio", 0.0)
+
+    @property
+    def range_violations(self) -> int:
+        self._warn_flat_accessor("range_violations")
+        return self._dimension_value("accuracy", "range_violations", 0)
+
+    @property
+    def negative_values_in_positive(self) -> int:
+        self._warn_flat_accessor("negative_values_in_positive")
+        return self._dimension_value("accuracy", "negative_values_in_positive", 0)
+
+    @property
+    def future_dates_count(self) -> int:
+        self._warn_flat_accessor("future_dates_count")
+        return self._dimension_value("timeliness", "future_dates_count", 0)
+
+    @property
+    def stale_data_ratio(self) -> float:
+        self._warn_flat_accessor("stale_data_ratio")
+        return self._dimension_value("timeliness", "stale_data_ratio", 0.0)
+
+    @property
+    def temporal_violations(self) -> int:
+        self._warn_flat_accessor("temporal_violations")
+        return self._dimension_value("timeliness", "temporal_violations", 0)
+
     @property
     def completeness(self) -> dict[str, Any] | None:
         return self._d.get("completeness")

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -216,7 +216,7 @@ class TestProfileReport:
         nested = getattr(q, dimension)
         assert nested is not None
 
-        with pytest.warns(DeprecationWarning, match=f"DataQualityMetrics.{attr}"):
+        with pytest.warns(DeprecationWarning, match=f"DataQualityMetrics\\.{attr}"):
             value = getattr(q, attr)
 
         assert value == nested.get(key, default)
@@ -243,7 +243,7 @@ class TestProfileReport:
         assert q is not None
         assert q.uniqueness is None
 
-        with pytest.warns(DeprecationWarning, match="DataQualityMetrics.key_uniqueness"):
+        with pytest.warns(DeprecationWarning, match="DataQualityMetrics\\.key_uniqueness"):
             assert q.key_uniqueness == 100.0
 
     def test_reloaded_quality_flat_accessors_warn(self, report):
@@ -252,7 +252,7 @@ class TestProfileReport:
         assert q is not None
         assert q.completeness is not None
 
-        with pytest.warns(DeprecationWarning, match="DataQualityMetrics.missing_values_ratio"):
+        with pytest.warns(DeprecationWarning, match="DataQualityMetrics\\.missing_values_ratio"):
             assert q.missing_values_ratio == q.completeness["missing_values_ratio"]
 
     def test_to_dict(self, report):

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -188,6 +188,73 @@ class TestProfileReport:
         assert "score=" in r
         assert "dimensions=" in r
 
+    @pytest.mark.parametrize(
+        ("attr", "dimension", "key", "default"),
+        [
+            ("missing_values_ratio", "completeness", "missing_values_ratio", 0.0),
+            ("complete_records_ratio", "completeness", "complete_records_ratio", 100.0),
+            ("null_columns", "completeness", "null_columns", []),
+            ("data_type_consistency", "consistency", "data_type_consistency", 100.0),
+            ("format_violations", "consistency", "format_violations", 0),
+            ("encoding_issues", "consistency", "encoding_issues", 0),
+            ("duplicate_rows", "uniqueness", "duplicate_rows", 0),
+            ("key_uniqueness", "uniqueness", "key_uniqueness", 100.0),
+            ("high_cardinality_warning", "uniqueness", "high_cardinality_warning", False),
+            ("outlier_ratio", "accuracy", "outlier_ratio", 0.0),
+            ("range_violations", "accuracy", "range_violations", 0),
+            ("negative_values_in_positive", "accuracy", "negative_values_in_positive", 0),
+            ("future_dates_count", "timeliness", "future_dates_count", 0),
+            ("stale_data_ratio", "timeliness", "stale_data_ratio", 0.0),
+            ("temporal_violations", "timeliness", "temporal_violations", 0),
+        ],
+    )
+    def test_quality_flat_accessors_warn_and_match_nested(
+        self, report, attr, dimension, key, default
+    ):
+        q = report.quality
+        assert q is not None
+        nested = getattr(q, dimension)
+        assert nested is not None
+
+        with pytest.warns(DeprecationWarning, match=f"DataQualityMetrics.{attr}"):
+            value = getattr(q, attr)
+
+        assert value == nested.get(key, default)
+
+    @pytest.mark.parametrize(
+        ("dims", "present", "absent"),
+        [
+            (["completeness"], "completeness", ["uniqueness", "accuracy"]),
+            (["uniqueness"], "uniqueness", ["completeness", "accuracy"]),
+            (["accuracy"], "accuracy", ["completeness", "uniqueness"]),
+        ],
+    )
+    def test_quality_dimensions_nested_none_semantics(self, dims, present, absent):
+        report = dataprof.profile(CSV_FILE, quality_dimensions=dims)
+        q = report.quality
+        assert q is not None
+        assert getattr(q, present) is not None
+        for dimension in absent:
+            assert getattr(q, dimension) is None
+
+    def test_skipped_flat_accessor_warns_and_returns_default(self):
+        report = dataprof.profile(CSV_FILE, quality_dimensions=["completeness"])
+        q = report.quality
+        assert q is not None
+        assert q.uniqueness is None
+
+        with pytest.warns(DeprecationWarning, match="DataQualityMetrics.key_uniqueness"):
+            assert q.key_uniqueness == 100.0
+
+    def test_reloaded_quality_flat_accessors_warn(self, report):
+        reloaded = dataprof.ProfileReport.from_json(report.to_json())
+        q = reloaded.quality
+        assert q is not None
+        assert q.completeness is not None
+
+        with pytest.warns(DeprecationWarning, match="DataQualityMetrics.missing_values_ratio"):
+            assert q.missing_values_ratio == q.completeness["missing_values_ratio"]
+
     def test_to_dict(self, report):
         d = report.to_dict()
         assert "source" in d
@@ -1315,7 +1382,8 @@ class TestSemanticHints:
 
         without_hint = dataprof.profile(str(path), engine="incremental")
         assert without_hint.quality is not None
-        assert without_hint.quality.negative_values_in_positive == 0
+        assert without_hint.quality.accuracy is not None
+        assert without_hint.quality.accuracy["negative_values_in_positive"] == 0
 
         with_hint = dataprof.profile(
             str(path),
@@ -1323,7 +1391,8 @@ class TestSemanticHints:
             positive_columns=["pressure"],
         )
         assert with_hint.quality is not None
-        assert with_hint.quality.negative_values_in_positive == 1
+        assert with_hint.quality.accuracy is not None
+        assert with_hint.quality.accuracy["negative_values_in_positive"] == 1
 
     def test_identifier_columns_omit_numeric_stats(self, tmp_path):
         path = tmp_path / "orders.csv"
@@ -1339,7 +1408,8 @@ class TestSemanticHints:
         assert order_id.mean is None
         assert order_id.outlier_count is None
         assert report.quality is not None
-        assert report.quality.outlier_ratio == 0.0
+        assert report.quality.accuracy is not None
+        assert report.quality.accuracy["outlier_ratio"] == 0.0
 
     def test_dataframe_hints(self):
         pd = pytest.importorskip("pandas")
@@ -1351,7 +1421,8 @@ class TestSemanticHints:
         )
         assert report["order_id"].data_type == "identifier"
         assert report.quality is not None
-        assert report.quality.negative_values_in_positive == 1
+        assert report.quality.accuracy is not None
+        assert report.quality.accuracy["negative_values_in_positive"] == 1
 
 
 class TestColumnToDict:


### PR DESCRIPTION
## Summary

- deprecate flat Python `DataQualityMetrics` accessors with runtime `DeprecationWarning`s while preserving 0.9-compatible return values
- keep nested dimension accessors as the preferred API, including `None` for skipped dimensions, and mirror behavior for reloaded reports
- document the migration path, confirm the Python 3.10+ floor in CI, and add focused Rust/Python coverage

## Checks

- `cargo fmt --all`
- `cargo test -p dataprof-metrics`
- `cargo test -p dataprof-python`
- `uv run maturin develop`
- `uv run pytest python/tests/test_python_api.py -v -ra`
- `uv run ruff check python/`
- `uv run ruff format --check python/`

Closes #326