### PR TITLE
docs: add agent workflow guidance

### DIFF
--- a/.cursor/rules/dataprof.md
+++ b/.cursor/rules/dataprof.md
@@ -1,0 +1,18 @@
+# dataprof Agent Workflow
+
+Use this rule when working with tabular data, data-quality checks, or drift investigations in a project that uses `dataprof`.
+
+## Workflow
+
+1. Start with `dp.analyze_structure(path)` for a cheap first pass over columns, row shape, and obvious structural issues.
+2. Run `dp.profile(path, metrics=["schema", "statistics", "quality"])` when you need full profiling metrics.
+3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or selected fields from `report.to_dict()`.
+4. Use `report.compare(other_report)` for before/after drift, pipeline changes, or data-cleaning validation.
+5. Prefer summaries and quality metrics over raw row dumps.
+
+## Guardrails
+
+- Do not paste large raw datasets into chat.
+- Do not infer data quality from the first few visible rows.
+- Mention the source path, metrics requested, and any sampling or max-row limit when reporting results.
+- If data may be sensitive, keep the analysis local and share only aggregates.

--- a/.cursor/rules/dataprof.mdc
+++ b/.cursor/rules/dataprof.mdc
@@ -1,3 +1,9 @@
+---
+description: How to use dataprof for tabular data, data-quality checks, and drift investigations
+globs: **/*.csv,**/*.parquet,**/*.jsonl
+alwaysApply: false
+---
+
 # dataprof Agent Workflow
 
 Use this rule when working with tabular data, data-quality checks, or drift investigations in a project that uses `dataprof`.
@@ -5,8 +11,8 @@ Use this rule when working with tabular data, data-quality checks, or drift inve
 ## Workflow
 
 1. Start with `dp.analyze_structure(path)` for a cheap first pass over columns, row shape, and obvious structural issues.
-2. Run `dp.profile(path, metrics=["schema", "statistics", "quality"])` when you need full profiling metrics.
-3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or selected fields from `report.to_dict()`.
+2. Run `dp.profile(path)` when you need full profiling metrics. It computes every metric pack by default; pass `metrics=[...]` only to narrow it to a subset of `schema`, `statistics`, `patterns`, `quality`.
+3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or the top-level fields of `report.to_dict()` (`source`, `source_type`, `execution`, `quality`) -- its `columns` entry grows with table width.
 4. Use `report.compare(other_report)` for before/after drift, pipeline changes, or data-cleaning validation.
 5. Prefer summaries and quality metrics over raw row dumps.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ An overall quality score (0 -- 100) is computed as a weighted average of dimensi
 
 - [Getting Started](docs/guides/getting-started.md) -- the shortest path from mystery dataset to useful signal
 - [Examples Cookbook](docs/guides/examples.md) -- focused Rust and Python recipes you can adapt quickly
+- [Agent Workflows](docs/guides/agent-workflows.md) -- copy-paste guidance for AGENTS.md, Cursor rules, and Claude Code skills
 
 ### Integrate it
 

--- a/docs/guides/agent-workflows.md
+++ b/docs/guides/agent-workflows.md
@@ -10,8 +10,8 @@ These snippets teach coding agents how to use `dataprof` without dumping raw row
 When analyzing tabular data with dataprof:
 
 1. Start with `dp.analyze_structure(path)` for a cheap first pass over columns, row shape, and obvious structural issues.
-2. Use `dp.profile(path, metrics=["schema", "statistics", "quality"])` for full profiling.
-3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or selected fields from `report.to_dict()`.
+2. Use `dp.profile(path)` for full profiling. It computes every metric pack by default; pass `metrics=[...]` only to narrow it to a subset of `schema`, `statistics`, `patterns`, `quality`.
+3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or the top-level fields of `report.to_dict()` (`source`, `source_type`, `execution`, `quality`) -- its `columns` entry grows with table width.
 4. Use `report.compare(other_report)` for before/after drift, pipeline changes, or data-cleaning validation.
 5. Prefer schema summaries, quality metrics, and selected column details over raw row dumps.
 
@@ -20,7 +20,7 @@ Always report the source path, metrics requested, and any sampling or max-row li
 
 ## Cursor rule
 
-Copy `.cursor/rules/dataprof.md` into a project that uses Cursor. It contains the same workflow in Cursor rule form.
+Copy `.cursor/rules/dataprof.mdc` into a project that uses Cursor. It contains the same workflow in Cursor rule form. Keep the `.mdc` extension and its frontmatter -- a plain `.md` file in `.cursor/rules/` is ignored by Cursor.
 
 ## Claude Code skill
 
@@ -28,4 +28,4 @@ Copy `skills/dataprof/SKILL.md` into your Claude Code skills directory. It packa
 
 ## Why this order
 
-`analyze_structure()` is the cheap first look. It helps an agent avoid over-reading a dataset before it knows the shape. `profile()` is the full metrics pass. `to_markdown()`, `quality_summary()`, and selected fields from `to_dict()` keep the output compact enough for an LLM. `compare()` is the right tool when the question is about drift or whether a cleaning step helped.
+`analyze_structure()` is the cheap first look. It helps an agent avoid over-reading a dataset before it knows the shape. `profile()` is the full metrics pass. `to_markdown()`, `quality_summary()`, and the top-level fields of `to_dict()` keep the output compact enough for an LLM. `compare()` is the right tool when the question is about drift or whether a cleaning step helped.

--- a/docs/guides/agent-workflows.md
+++ b/docs/guides/agent-workflows.md
@@ -1,0 +1,31 @@
+# Agent Workflows
+
+These snippets teach coding agents how to use `dataprof` without dumping raw rows into chat. Copy the format that matches your agent runner.
+
+## AGENTS.md snippet
+
+```markdown
+## dataprof workflow
+
+When analyzing tabular data with dataprof:
+
+1. Start with `dp.analyze_structure(path)` for a cheap first pass over columns, row shape, and obvious structural issues.
+2. Use `dp.profile(path, metrics=["schema", "statistics", "quality"])` for full profiling.
+3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or selected fields from `report.to_dict()`.
+4. Use `report.compare(other_report)` for before/after drift, pipeline changes, or data-cleaning validation.
+5. Prefer schema summaries, quality metrics, and selected column details over raw row dumps.
+
+Always report the source path, metrics requested, and any sampling or max-row limit.
+```
+
+## Cursor rule
+
+Copy `.cursor/rules/dataprof.md` into a project that uses Cursor. It contains the same workflow in Cursor rule form.
+
+## Claude Code skill
+
+Copy `skills/dataprof/SKILL.md` into your Claude Code skills directory. It packages the structure -> profile -> summarize -> compare workflow as on-demand knowledge.
+
+## Why this order
+
+`analyze_structure()` is the cheap first look. It helps an agent avoid over-reading a dataset before it knows the shape. `profile()` is the full metrics pass. `to_markdown()`, `quality_summary()`, and selected fields from `to_dict()` keep the output compact enough for an LLM. `compare()` is the right tool when the question is about drift or whether a cleaning step helped.

--- a/skills/dataprof/SKILL.md
+++ b/skills/dataprof/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: dataprof
+description: Profile tabular data with dataprof before debugging schema, quality, drift, or data-cleaning questions.
+---
+
+# dataprof
+
+Use this skill when the user asks you to understand an unfamiliar dataset, inspect data quality, compare two dataset versions, or prepare compact evidence for a data-cleaning or pipeline decision.
+
+## Workflow
+
+1. Identify the dataset path and format.
+2. Run a cheap structure pass first:
+
+   ```python
+   import dataprof as dp
+
+   structure = dp.analyze_structure("data.csv")
+   ```
+
+3. Run the full profile when structural inspection is not enough:
+
+   ```python
+   report = dp.profile("data.csv", metrics=["schema", "statistics", "quality"])
+   ```
+
+4. Summarize for the user or another agent with compact outputs:
+
+   ```python
+   report.to_markdown()
+   report.quality_summary()
+   report.to_dict()
+   ```
+
+5. Compare reports for before/after drift:
+
+   ```python
+   before = dp.profile("data_before.csv")
+   after = dp.profile("data_after.csv")
+   delta = before.compare(after)
+   ```
+
+## Guardrails
+
+- Prefer aggregates, schema summaries, quality metrics, and selected column details over raw row dumps.
+- Do not paste large raw datasets into the conversation.
+- State the source path, metrics, sampling, and max-row limits used.
+- If the dataset may be sensitive, keep the work local and share only derived summaries.
+
+## Useful APIs
+
+- `dp.analyze_structure(path, max_rows=None)`
+- `dp.profile(source, metrics=[...])`
+- `report.to_markdown()`
+- `report.quality_summary()`
+- `report.to_dict()`
+- `report.compare(other_report)`

--- a/skills/dataprof/SKILL.md
+++ b/skills/dataprof/SKILL.md
@@ -21,15 +21,29 @@ Use this skill when the user asks you to understand an unfamiliar dataset, inspe
 3. Run the full profile when structural inspection is not enough:
 
    ```python
-   report = dp.profile("data.csv", metrics=["schema", "statistics", "quality"])
+   report = dp.profile("data.csv")
+   ```
+
+   `profile()` computes every metric pack by default. Pass `metrics=[...]` only to
+   *narrow* the work — the packs are `schema`, `statistics`, `patterns`, and `quality`:
+
+   ```python
+   report = dp.profile("data.csv", metrics=["schema", "quality"])
    ```
 
 4. Summarize for the user or another agent with compact outputs:
 
    ```python
-   report.to_markdown()
-   report.quality_summary()
-   report.to_dict()
+   report.to_markdown()      # markdown table of column profiles
+   report.quality_summary()  # single-row quality dict
+   ```
+
+   `to_dict()` embeds a full per-column entry under `["columns"]`, so it grows with
+   table width. Select the top-level summary fields instead of surfacing the whole dict:
+
+   ```python
+   d = report.to_dict()
+   summary = {k: d[k] for k in ("source", "source_type", "execution", "quality")}
    ```
 
 5. Compare reports for before/after drift:
@@ -50,8 +64,8 @@ Use this skill when the user asks you to understand an unfamiliar dataset, inspe
 ## Useful APIs
 
 - `dp.analyze_structure(path, max_rows=None)`
-- `dp.profile(source, metrics=[...])`
+- `dp.profile(source, *, metrics=None, max_rows=None, ...)` -- `metrics=None` means all packs
 - `report.to_markdown()`
 - `report.quality_summary()`
-- `report.to_dict()`
+- `report.to_dict()` -- keys: `source`, `source_type`, `execution`, `columns`, `quality`
 - `report.compare(other_report)`


### PR DESCRIPTION
## Summary

- Add a copy-pasteable AGENTS.md workflow snippet for dataprof.
- Add a Cursor rule at `.cursor/rules/dataprof.md`.
- Add a Claude Code skill at `skills/dataprof/SKILL.md`.
- Link the agent workflow guide from the README docs section.

Closes #333.

## Notes

The issue text mentions `report.to_llm_context()`, but that API does not exist in the current Python package. I used existing compact export APIs instead: `report.to_markdown()`, `report.quality_summary()`, and selected fields from `report.to_dict()`.

## Verification

- Confirmed referenced APIs exist in `python/dataprof/__init__.py` and `python/dataprof/__init__.pyi`.
- Ran `git diff --check`.
- Checked Markdown code fences in touched docs.

Not run:

- `cargo test --no-run` because Cargo is not installed in this environment.
