### PR TITLE
fix(python): keep sensitive samples out of agent context

### DIFF
--- a/docs/guides/agent-workflows.md
+++ b/docs/guides/agent-workflows.md
@@ -11,7 +11,7 @@ When analyzing tabular data with dataprof:
 
 1. Start with `dp.analyze_structure(path)` for a cheap first pass over columns, row shape, and obvious structural issues.
 2. Use `dp.profile(path)` for full profiling. It computes every metric pack by default; pass `metrics=[...]` only to narrow it to a subset of `schema`, `statistics`, `patterns`, `quality`.
-3. Export compact context with `report.to_markdown()`, `report.quality_summary()`, or the top-level fields of `report.to_dict()` (`source`, `source_type`, `execution`, `quality`) -- its `columns` entry grows with table width.
+3. Export compact context with `report.to_llm_context()`, `report.to_markdown()`, `report.quality_summary()`, or the top-level fields of `report.to_dict()` (`source`, `source_type`, `execution`, `quality`) -- its `columns` entry grows with table width.
 4. Use `report.compare(other_report)` for before/after drift, pipeline changes, or data-cleaning validation.
 5. Prefer schema summaries, quality metrics, and selected column details over raw row dumps.
 
@@ -28,6 +28,12 @@ Copy this repo's `.claude/skills/dataprof/` directory so that it lands at `.clau
 
 It packages the structure -> profile -> summarize -> compare workflow as on-demand knowledge, and it loads from that path in this repo too.
 
+## Agent-safe output
+
+`ProfileReport.to_llm_context()` is the preferred summary for chat or MCP-style agent surfaces. By default it emits dataset shape, caveats, quality flags, schema, and detected pattern names, but no raw cell values.
+
+`include_samples=True` is an explicit opt-in for non-sensitive numeric extrema only. If a column has a detected sensitive pattern, such as email, phone, identifier, financial, geographic, network, or file-path data, `to_llm_context()` still withholds the concrete values and reports only the pattern name and counts.
+
 ## Why this order
 
-`analyze_structure()` is the cheap first look. It helps an agent avoid over-reading a dataset before it knows the shape. `profile()` is the full metrics pass. `to_markdown()`, `quality_summary()`, and the top-level fields of `to_dict()` keep the output compact enough for an LLM. `compare()` is the right tool when the question is about drift or whether a cleaning step helped.
+`analyze_structure()` is the cheap first look. It helps an agent avoid over-reading a dataset before it knows the shape. `profile()` is the full metrics pass. `to_llm_context()` is the safest chat-facing summary; `to_markdown()`, `quality_summary()`, and the top-level fields of `to_dict()` are useful when a more structured export is needed. `compare()` is the right tool when the question is about drift or whether a cleaning step helped.

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -367,6 +367,17 @@ _CHARS_PER_TOKEN = 4
 #: A column is flagged ``null-heavy`` at or above this null percentage.
 _NULL_HEAVY_PCT = 20.0
 
+#: Pattern categories whose concrete values should stay out of agent-facing
+#: output even when ``include_samples=True`` asks for numeric extrema.
+_SENSITIVE_PATTERN_CATEGORIES = {
+    "contact",
+    "identifier",
+    "financial",
+    "geographic",
+    "network",
+    "file_path",
+}
+
 
 def _estimate_tokens(text: str) -> int:
     """Estimate the token count of ``text`` as ``ceil(len(text) / 4)``.
@@ -391,6 +402,17 @@ def _one_line(value: object) -> str:
     return "".join(
         _ESCAPES[ch] if ch in _ESCAPES else (ch if ch.isprintable() else f"\\x{ord(ch):02x}")
         for ch in text
+    )
+
+
+def _has_sensitive_pattern(col: ColumnProfile) -> bool:
+    """Return True when a detected pattern implies values may be sensitive."""
+    return bool(
+        col.patterns
+        and any(
+            (getattr(pattern, "category", "") or "").lower() in _SENSITIVE_PATTERN_CATEGORIES
+            for pattern in col.patterns
+        )
     )
 
 
@@ -1505,17 +1527,20 @@ class ProfileReport:
             print(report.to_llm_context())
 
         Emits structured signals only -- shape, provenance caveats, quality
-        flags, schema, and detected pattern names. No recommendations and no
-        generative prose; interpretation is the caller's job.
+        flags, schema, and detected pattern names. Raw cell values are redacted
+        by default, and detected sensitive-pattern values are never echoed. No
+        recommendations and no generative prose; interpretation is the caller's
+        job.
 
         :param max_tokens: Approximate upper bound on the output, enforced by
             deterministic truncation with a ``... +N more`` tail. Tokens are
             estimated as ``ceil(len(text) / 4)``, not counted with a real
             tokenizer, so treat this as a budget rather than an exact size. The
             dataset header is always emitted even if it exceeds the budget.
-        :param include_samples: When ``True``, include values drawn from the
-            data (column minima and maxima). Off by default: these are raw cell
-            values and may be sensitive.
+        :param include_samples: When ``True``, include non-sensitive numeric
+            extrema (column minima and maxima). Off by default because these
+            are raw cell values. Columns with sensitive detected patterns still
+            omit extrema.
         :returns: A plain-text summary. Stable across runs for a given report.
         """
         qs = self.quality_score
@@ -1555,7 +1580,12 @@ class ProfileReport:
         schema_items = []
         for col in cols:
             line = f"- {_one_line(col.name)}: {col.data_type}"
-            if include_samples and col.min is not None and col.max is not None:
+            if (
+                include_samples
+                and not _has_sensitive_pattern(col)
+                and col.min is not None
+                and col.max is not None
+            ):
                 line += f" [{_one_line(col.min)} .. {_one_line(col.max)}]"
             schema_items.append(line)
 

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -207,7 +207,8 @@ class ProfileReport:
         """Token-bounded, agent-oriented summary: shape, caveats, flags, schema, patterns.
 
         Tokens are estimated as ``ceil(len(text) / 4)``, not counted with a real
-        tokenizer. Raw cell values are excluded unless ``include_samples=True``.
+        tokenizer. Raw cell values are excluded by default; ``include_samples=True``
+        only includes non-sensitive numeric extrema.
         """
         ...
     def compare(self, other: ProfileReport) -> dict[str, Any]:

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -571,10 +571,26 @@ class TestToLlmContext:
         assert "999777333" not in out
 
     def test_include_samples_surfaces_extremes(self, tmp_path):
-        path = tmp_path / "secret.csv"
-        path.write_text("salary\n999777333\n123\n456\n", encoding="utf-8")
+        path = tmp_path / "readings.csv"
+        path.write_text("reading\n999.75\n123.5\n456.25\n", encoding="utf-8")
         out = dataprof.profile(str(path)).to_llm_context(include_samples=True)
-        assert "999777333" in out
+        assert "999.75" in out
+
+    def test_include_samples_withholds_sensitive_pattern_extremes(self, tmp_path):
+        path = tmp_path / "ssn.csv"
+        path.write_text(
+            "ssn\n"
+            "123456789\n"
+            "124456789\n"
+            "125456789\n"
+            "126456789\n"
+            "127456789\n",
+            encoding="utf-8",
+        )
+        out = dataprof.profile(str(path)).to_llm_context(include_samples=True)
+        assert "SSN (US)" in out
+        assert "123456789" not in out
+        assert "127456789" not in out
 
     def test_column_name_cannot_break_the_line_format(self, tmp_path):
         """A newline in a header must not split a schema entry across two lines.

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -579,12 +579,7 @@ class TestToLlmContext:
     def test_include_samples_withholds_sensitive_pattern_extremes(self, tmp_path):
         path = tmp_path / "ssn.csv"
         path.write_text(
-            "ssn\n"
-            "123456789\n"
-            "124456789\n"
-            "125456789\n"
-            "126456789\n"
-            "127456789\n",
+            "ssn\n123456789\n124456789\n125456789\n126456789\n127456789\n",
             encoding="utf-8",
         )
         out = dataprof.profile(str(path)).to_llm_context(include_samples=True)


### PR DESCRIPTION
## Summary
- suppress `to_llm_context(include_samples=True)` extrema for columns with sensitive detected patterns
- document the agent-safe output guarantee in the Python API and agent workflow guide
- add regression coverage for sensitive-pattern sample redaction

## Checks
- `uv run pytest python/tests/test_python_api.py::TestToLlmContext -v -ra`
- `uv run pytest python/tests/test_python_api.py -q`
- `uv run ruff check python/dataprof/__init__.py python/dataprof/__init__.pyi python/tests/test_python_api.py`

Closes #332