### PR TITLE
docs: improve contributor setup path

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,8 +6,10 @@ Thank you for considering contributing to dataprof! We welcome contributions fro
 
 ### Prerequisites
 
-- **Rust 1.80** or later ([install](https://rustup.rs/))
+- **Rust 1.96** or later ([install](https://rustup.rs/))
 - **Cargo** (comes with Rust)
+- **Python 3.10** or later
+- **uv** for Python dependency and test commands ([install](https://docs.astral.sh/uv/))
 - **Git**
 
 ### Fork & Clone
@@ -29,16 +31,27 @@ Thank you for considering contributing to dataprof! We welcome contributions fro
 ### Build & Test
 
 ```bash
-# Build the project
-cargo build
+# Install Python dev dependencies
+uv sync
 
-# Run tests
-cargo test
+# Build and install the local Python extension into the uv environment
+uv run maturin develop
+
+# Run focused Python API tests
+uv run pytest python/tests/test_python_api.py -q
+
+# Run focused Rust tests
+cargo test -p dataprof-core
+cargo test -p dataprof-metrics
 
 # Check everything locally before submitting PR
 cargo fmt --all
-cargo clippy --all --all-targets
+uv run ruff check python/dataprof python/tests
 ```
+
+You do not need to run every expensive workspace check for a small docs or
+Python-only PR. Prefer a focused test command that matches your change, and
+list exactly what you ran in the PR body.
 
 ## Development Workflow
 
@@ -60,7 +73,8 @@ Use descriptive branch names:
 2. **Write tests** - new features should have corresponding tests
 3. **Test locally**:
    ```bash
-   cargo test --all
+   uv run pytest python/tests/test_python_api.py -q
+   cargo test -p dataprof-core
    ```
 4. **Format code**:
    ```bash
@@ -68,6 +82,7 @@ Use descriptive branch names:
    ```
 5. **Lint checking**:
    ```bash
+   uv run ruff check python/dataprof python/tests
    cargo clippy --all --all-targets -- -D warnings
    ```
 6. **Build release** (verify no warnings):
@@ -88,6 +103,23 @@ Explain what changed and why, not how.
 Closes #123
 ```
 
+### Picking an Issue
+
+If you are new to the project, start with issues labelled `good first issue`,
+`difficulty: beginner`, or `mentor available`. These are expected to have a
+small scope and enough context for a first PR.
+
+Before opening a PR, leave a short comment on the issue saying which slice you
+want to take. Some larger issues are intentionally split into independent
+subtasks, so a focused partial PR is welcome.
+
+Good first issues in this repository usually mean:
+
+- no deep knowledge of the Rust engine internals is required
+- the desired behavior is described in the issue body
+- maintainers are happy to answer API or setup questions
+- a small PR is better than a sweeping rewrite
+
 ### Submit Pull Request
 
 1. **Push to your fork**:
@@ -100,6 +132,7 @@ Closes #123
    - Description of what changed and why
    - Reference to related issues (e.g., "Closes #123")
    - Screenshots/examples for user-visible changes
+   - A short list of the commands you ran
 
 3. **CI will automatically run**:
    - Tests
@@ -115,12 +148,21 @@ Closes #123
 
 ✅ **Checklist:**
 - [ ] Code builds without warnings
-- [ ] All tests pass (`cargo test`)
+- [ ] Relevant tests pass
 - [ ] Code is formatted (`cargo fmt --all`)
-- [ ] No linting errors (`cargo clippy`)
+- [ ] No linting errors in the area you touched
 - [ ] Added tests for new functionality
 - [ ] Updated documentation if needed
 - [ ] Commit messages are clear and descriptive
+
+### PR Size
+
+Small PRs are easier to review and merge. A good default is one behavior change
+or one documentation/example slice per PR. If an issue lists several scenarios,
+it is fine to implement one scenario and leave the rest for follow-ups.
+
+Avoid mixing unrelated cleanup with feature work. If you notice something
+nearby, open a follow-up issue or separate PR.
 
 ### PR Description Template
 
@@ -147,8 +189,13 @@ Any breaking changes? Document them here.
 
 1. **Automated checks** run first (format, lint, tests)
 2. **Code review** - maintainers will review your changes
-3. **Feedback loop** - we may ask for adjustments
+3. **Feedback loop** - we may ask for adjustments, but we try to explain the
+   project constraint behind each request
 4. **Merge** - once approved and checks pass
+
+Maintainer review style is direct but collaborative: expect requests to keep
+the public API small, preserve backward compatibility when possible, and add
+tests only where they protect real behavior.
 
 ## Feature Requests and Bug Reports
 
@@ -220,14 +267,28 @@ fn test_handles_empty_file() {
 ### Useful Commands
 
 ```bash
-# Run tests in watch mode
-cargo watch -x test
+# Install/update the Python dev environment
+uv sync
+
+# Rebuild the local Python extension after Rust/PyO3 changes
+uv run maturin develop
+
+# Run the main Python API regression file
+uv run pytest python/tests/test_python_api.py -q
+
+# Run a focused Python test
+uv run pytest python/tests/test_python_api.py::TestToLlmContext -v -ra
 
 # Generate documentation
 cargo doc --open
 
-# Check for unused dependencies
-cargo clippy -- -W clippy::all
+# Run targeted Rust package tests
+cargo test -p dataprof-core
+cargo test -p dataprof-python
+
+# Run lint checks
+uv run ruff check python/dataprof python/tests
+cargo clippy --all --all-targets -- -D warnings
 
 # Run benchmarks
 cargo bench
@@ -249,4 +310,5 @@ cargo check --workspace --all-targets
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the
+same dual license as the project: MIT OR Apache-2.0.


### PR DESCRIPTION
The contributing.md was heavily outdated, now that it actually serves a purpose, it'd seen few updates.

## Summary
- document Python contributor setup with `uv` and `maturin develop`
- add focused Python/Rust test and lint lanes for smaller PRs
- clarify issue picking, PR size, review expectations, and project licensing

## Checks
- `git diff --check`

Refs #356