### PR TITLE
fix(parquet): exclude nulls from numeric column statistics

### DIFF
--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -289,7 +289,8 @@ impl ColumnAnalyzer {
 
     fn process_float64_array(&mut self, array: &Float64Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 self.update_numeric_stats(value);
                 if self.unique_values.len() < 1000 {
                     self.unique_values.insert(value.to_string());
@@ -304,7 +305,8 @@ impl ColumnAnalyzer {
 
     fn process_float32_array(&mut self, array: &Float32Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -320,7 +322,8 @@ impl ColumnAnalyzer {
 
     fn process_int64_array(&mut self, array: &Int64Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -336,7 +339,8 @@ impl ColumnAnalyzer {
 
     fn process_int32_array(&mut self, array: &Int32Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -352,7 +356,8 @@ impl ColumnAnalyzer {
 
     fn process_int16_array(&mut self, array: &Int16Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -368,7 +373,8 @@ impl ColumnAnalyzer {
 
     fn process_int8_array(&mut self, array: &Int8Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -384,7 +390,8 @@ impl ColumnAnalyzer {
 
     fn process_uint64_array(&mut self, array: &UInt64Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -400,7 +407,8 @@ impl ColumnAnalyzer {
 
     fn process_uint32_array(&mut self, array: &UInt32Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -416,7 +424,8 @@ impl ColumnAnalyzer {
 
     fn process_uint16_array(&mut self, array: &UInt16Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -432,7 +441,8 @@ impl ColumnAnalyzer {
 
     fn process_uint8_array(&mut self, array: &UInt8Array) -> Result<()> {
         for index in 0..array.len() {
-            if let Some(value) = array.value(index).into() {
+            if !array.is_null(index) {
+                let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 if self.unique_values.len() < 1000 {
@@ -894,6 +904,54 @@ mod tests {
     use arrow::record_batch::RecordBatch;
     use dataprof_core::ColumnStats;
     use std::sync::Arc;
+
+    #[test]
+    fn test_nulls_are_excluded_from_numeric_stats() {
+        // A null slot still holds a physical value in its buffer -- 0.0 here.
+        // Folding that into the statistics silently corrupts min, mean and
+        // uniqueness for every nullable numeric column.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("score", ArrowDataType::Float64, true),
+            Field::new("rank", ArrowDataType::Int64, true),
+        ]));
+
+        let scores = Float64Array::from(vec![Some(100.0), None, Some(1.0), None, Some(2.0)]);
+        let ranks = Int64Array::from(vec![Some(7), None, Some(9), Some(8), None]);
+
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(scores), Arc::new(ranks)]).unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        analyzer.process_batch(&batch).unwrap();
+        let profiles = analyzer.to_profiles(false, false, None);
+
+        let score_col = profiles.iter().find(|p| p.name == "score").unwrap();
+        assert_eq!(score_col.null_count, 2);
+        assert_eq!(score_col.unique_count, Some(3));
+        match &score_col.stats {
+            ColumnStats::Numeric(stats) => {
+                assert!((stats.min - 1.0).abs() < 1e-9, "min was {}", stats.min);
+                assert!((stats.max - 100.0).abs() < 1e-9, "max was {}", stats.max);
+                // (100 + 1 + 2) / 3, not (100 + 0 + 1 + 0 + 2) / 5
+                assert!(
+                    (stats.mean - 34.333_333).abs() < 1e-5,
+                    "mean was {}",
+                    stats.mean
+                );
+            }
+            _ => panic!("Expected Numeric stats for score column"),
+        }
+
+        let rank_col = profiles.iter().find(|p| p.name == "rank").unwrap();
+        assert_eq!(rank_col.null_count, 2);
+        match &rank_col.stats {
+            ColumnStats::Numeric(stats) => {
+                assert!((stats.min - 7.0).abs() < 1e-9, "min was {}", stats.min);
+                // (7 + 9 + 8) / 3, not (7 + 0 + 9 + 8 + 0) / 5
+                assert!((stats.mean - 8.0).abs() < 1e-9, "mean was {}", stats.mean);
+            }
+            _ => panic!("Expected Numeric stats for rank column"),
+        }
+    }
 
     #[test]
     fn test_record_batch_analyzer_numeric_stats() {

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -69,9 +69,10 @@ class TestProfileFile:
 
     def test_parquet_nulls_excluded_from_numeric_stats(self, tmp_path):
         """A null slot carries a physical value; it must not enter the statistics."""
-        pd = pytest.importorskip("pandas")
+        pa = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
         path = tmp_path / "nullable.parquet"
-        pd.DataFrame({"x": [100.0, None, 1.0, None, 2.0]}).to_parquet(path)
+        pq.write_table(pa.table({"x": pa.array([100.0, None, 1.0, None, 2.0])}), path)
 
         col = dataprof.profile(str(path))["x"]
         assert col.null_count == 2

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -67,6 +67,18 @@ class TestProfileFile:
         r = dataprof.profile(PARQUET_FILE)
         assert r.rows > 0
 
+    def test_parquet_nulls_excluded_from_numeric_stats(self, tmp_path):
+        """A null slot carries a physical value; it must not enter the statistics."""
+        pd = pytest.importorskip("pandas")
+        path = tmp_path / "nullable.parquet"
+        pd.DataFrame({"x": [100.0, None, 1.0, None, 2.0]}).to_parquet(path)
+
+        col = dataprof.profile(str(path))["x"]
+        assert col.null_count == 2
+        assert col.unique_count == 3
+        assert col.min == 1.0  # not 0.0, the buffer's value under the null
+        assert col.mean == pytest.approx(34.333333, rel=1e-6)  # (100 + 1 + 2) / 3
+
     def test_path_object(self):
         r = dataprof.profile(Path(CSV_FILE))
         assert r.rows > 0


### PR DESCRIPTION
## The bug

Ten numeric array handlers in `record_batch_analyzer.rs` guarded with:

```rust
if let Some(value) = array.value(index).into() {
```

`array.value(index)` returns a plain `f64`/`i64`, and `impl<T> From<T> for Option<T>` makes that arm **always** taken. Null slots were never skipped, so the physical value sitting under a null was folded into `min`, `mean`, `std_dev` and `unique_count`.

The `string`, `boolean` and `timestamp` handlers already used `!array.is_null(index)`. Only the numeric ones were wrong.

## Impact

Every nullable numeric column read through **Parquet, pandas, polars, or Arrow** — the headline formats.

For `[100.0, null, 1.0, null, 2.0]`:

| | mean | min | unique |
|---|---:|---:|---:|
| truth | 34.33 | 1.0 | 3 |
| before | **20.80** | **0.00** | **4** |
| after | 34.33 | 1.0 | 3 |

This is in released **v0.8.1**.

## Why it survived

`test_record_batch_analyzer_numeric_stats` builds its arrays with `nullable: false`, so the null path was never exercised. The new test uses nullable arrays and, verified locally, fails on the old code (`unique_count`: `Some(4)` vs `Some(3)`) and passes on the new.

## Verification

- `cargo test -p dataprof-parquet --all-features` — 18 passed
- Full Python suite — 206 passed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- New test confirmed to fail without the fix

Found while building the wheel-smoke CI job for #328.