### PR TITLE
fix(python): fail closed when agent-context redaction cannot prove safety

### DIFF
--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -14,7 +14,13 @@ pub struct ColumnProfile {
     pub total_count: usize,
     pub unique_count: Option<usize>,
     pub stats: ColumnStats,
-    pub patterns: Vec<Pattern>,
+    /// Detected patterns, or `None` when pattern detection did not run.
+    ///
+    /// `None` and `Some(vec![])` are not interchangeable: the former means the
+    /// column was never scanned, the latter that it was scanned and nothing
+    /// matched. Consumers that gate on sensitivity -- redaction, agent-facing
+    /// output -- must treat `None` as "unknown", never as "no sensitive data".
+    pub patterns: Option<Vec<Pattern>>,
 }
 
 /// Quartile statistics for numeric distributions.
@@ -228,7 +234,7 @@ mod tests {
                 is_approximate: Some(false),
                 outlier_count: Some(0),
             }),
-            patterns: vec![],
+            patterns: Some(vec![]),
         };
 
         let json = serde_json::to_string(&profile).unwrap();
@@ -265,7 +271,7 @@ mod tests {
                 most_frequent: None,
                 least_frequent: None,
             }),
-            patterns: vec![],
+            patterns: Some(vec![]),
         };
 
         let json = serde_json::to_string(&profile).unwrap();

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -66,9 +66,9 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
 
     // Skip expensive operations in fast mode
     let patterns = if fast_mode {
-        Vec::new()
+        None
     } else {
-        detect_patterns(data, None)
+        Some(detect_patterns(data, None))
     };
 
     let unique_count = if fast_mode {
@@ -159,7 +159,7 @@ mod tests {
         ];
         let profile = analyze_column_fast("test_col", &data);
 
-        assert_eq!(profile.patterns.len(), 0); // Fast mode skips patterns
+        assert!(profile.patterns.is_none()); // Fast mode skips patterns entirely
         assert_eq!(profile.unique_count, None); // Fast mode skips unique count
     }
 
@@ -172,7 +172,8 @@ mod tests {
         ];
         let profile = analyze_column("test_col", &data);
 
-        assert!(!profile.patterns.is_empty()); // Normal mode detects patterns
+        // Normal mode detects patterns
+        assert!(profile.patterns.is_some_and(|p| !p.is_empty()));
         assert_eq!(profile.unique_count, Some(3)); // Normal mode calculates unique count
     }
 

--- a/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
@@ -223,7 +223,7 @@ mod tests {
             total_count: 0,
             unique_count: None,
             stats: ColumnStats::None,
-            patterns: vec![],
+            patterns: Some(vec![]),
         }
     }
 

--- a/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
@@ -173,7 +173,7 @@ mod tests {
             total_count: total,
             unique_count: Some(total - nulls),
             stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
-            patterns: vec![],
+            patterns: Some(vec![]),
         }
     }
 

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -217,7 +217,7 @@ mod tests {
             total_count: 0,
             unique_count: None,
             stats: ColumnStats::None,
-            patterns: vec![],
+            patterns: Some(vec![]),
         }
     }
 

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -99,7 +99,7 @@ pub struct PyColumnProfile {
     pub false_count: Option<usize>,
     #[pyo3(get)]
     pub true_ratio: Option<f64>,
-    // Patterns
+    // Patterns. `None` = detection did not run; `Some([])` = ran, nothing matched.
     #[pyo3(get)]
     pub patterns: Option<Vec<PyPattern>>,
 }
@@ -185,11 +185,12 @@ impl From<&ColumnProfile> for PyColumnProfile {
             _ => (None, None, None),
         };
 
-        let patterns = if !profile.patterns.is_empty() {
-            Some(profile.patterns.iter().map(PyPattern::from).collect())
-        } else {
-            None
-        };
+        // Preserve the None/Some([]) distinction: `None` means detection never
+        // ran, so redaction gates downstream cannot infer the column is safe.
+        let patterns = profile
+            .patterns
+            .as_ref()
+            .map(|ps| ps.iter().map(PyPattern::from).collect());
 
         Self {
             name: profile.name.clone(),

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -33,7 +33,7 @@ pub struct ColumnProfileInput<'a> {
     pub boolean_counts: Option<(usize, usize)>,
     /// When true, skip statistics computation (produce `ColumnStats::None`).
     pub skip_statistics: bool,
-    /// When true, skip pattern detection (produce empty patterns vec).
+    /// When true, skip pattern detection (produce `patterns: None`).
     pub skip_patterns: bool,
     /// Optional locale for pattern detection (e.g. "IT", "US").
     pub locale: Option<&'a str>,
@@ -112,9 +112,9 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
     };
 
     let patterns = if input.skip_patterns {
-        Vec::new()
+        None
     } else {
-        detect_patterns(input.sample_values, input.locale)
+        Some(detect_patterns(input.sample_values, input.locale))
     };
 
     ColumnProfile {
@@ -427,8 +427,33 @@ mod tests {
             locale: None,
         });
 
-        assert!(profile.patterns.is_empty());
+        // skip_patterns must be distinguishable from "scanned, nothing matched",
+        // otherwise downstream redaction gates cannot fail closed.
+        assert!(profile.patterns.is_none());
         assert!(matches!(profile.stats, ColumnStats::Text(_)));
+    }
+
+    #[test]
+    fn test_scanned_without_matches_is_not_none() {
+        // The counterpart to `test_skip_patterns`: a column that *was* scanned
+        // and matched nothing yields `Some([])`, which downstream consumers may
+        // safely read as "no sensitive data here".
+        let samples = vec!["hello".to_string(), "world".to_string()];
+        let profile = build_column_profile(ColumnProfileInput {
+            name: "text".to_string(),
+            data_type: DataType::String,
+            total_count: 2,
+            null_count: 0,
+            unique_count: Some(2),
+            sample_values: &samples,
+            text_lengths: None,
+            boolean_counts: None,
+            skip_statistics: false,
+            skip_patterns: false,
+            locale: None,
+        });
+
+        assert!(profile.patterns.is_some_and(|p| p.is_empty()));
     }
 
     #[test]

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -405,14 +405,23 @@ def _one_line(value: object) -> str:
     )
 
 
-def _has_sensitive_pattern(col: ColumnProfile) -> bool:
-    """Return True when a detected pattern implies values may be sensitive."""
-    return bool(
-        col.patterns
-        and any(
-            (getattr(pattern, "category", "") or "").lower() in _SENSITIVE_PATTERN_CATEGORIES
-            for pattern in col.patterns
-        )
+def _may_expose_values(col: ColumnProfile) -> bool:
+    """Return True only when ``col``'s raw values are *provably* safe to echo.
+
+    Safety here is a positive claim, not the absence of a negative one. A column
+    qualifies only if pattern detection actually ran (``patterns is not None``)
+    and matched nothing sensitive. When detection was skipped -- ``fast_mode``,
+    or a ``metrics=`` selection without the ``"patterns"`` pack -- we cannot
+    tell a credit-card column from a quantity column, so we fail closed.
+
+    Deserialized reports whose ``patterns`` key was absent also arrive as
+    ``None`` and are likewise treated as unknown.
+    """
+    if col.patterns is None:
+        return False
+    return not any(
+        (getattr(pattern, "category", "") or "").lower() in _SENSITIVE_PATTERN_CATEGORIES
+        for pattern in col.patterns
     )
 
 
@@ -1539,8 +1548,11 @@ class ProfileReport:
             dataset header is always emitted even if it exceeds the budget.
         :param include_samples: When ``True``, include non-sensitive numeric
             extrema (column minima and maxima). Off by default because these
-            are raw cell values. Columns with sensitive detected patterns still
-            omit extrema.
+            are raw cell values. Extrema are emitted only for columns that
+            pattern detection scanned and cleared. Columns with a sensitive
+            detected pattern omit them -- and so do *all* columns when pattern
+            detection never ran, which is the case for reports profiled without
+            the ``"patterns"`` metric pack or reloaded from disk.
         :returns: A plain-text summary. Stable across runs for a given report.
         """
         qs = self.quality_score
@@ -1582,7 +1594,7 @@ class ProfileReport:
             line = f"- {_one_line(col.name)}: {col.data_type}"
             if (
                 include_samples
-                and not _has_sensitive_pattern(col)
+                and _may_expose_values(col)
                 and col.min is not None
                 and col.max is not None
             ):

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1549,10 +1549,12 @@ class ProfileReport:
         :param include_samples: When ``True``, include non-sensitive numeric
             extrema (column minima and maxima). Off by default because these
             are raw cell values. Extrema are emitted only for columns that
-            pattern detection scanned and cleared. Columns with a sensitive
-            detected pattern omit them -- and so do *all* columns when pattern
-            detection never ran, which is the case for reports profiled without
-            the ``"patterns"`` metric pack or reloaded from disk.
+            pattern detection scanned and cleared. A column omits them when a
+            sensitive pattern was detected, and *every* column omits them when
+            the report carries no pattern evidence at all -- profiled without
+            the ``"patterns"`` metric pack, or rebuilt from a payload whose
+            ``patterns`` key was absent. Evidence survives ``save()``/``load()``,
+            so a round-tripped report redacts exactly as the original did.
         :returns: A plain-text summary. Stable across runs for a given report.
         """
         qs = self.quality_score

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -165,6 +165,9 @@ class ColumnProfile:
     true_count: int | None
     false_count: int | None
     true_ratio: float | None
+    #: Detected patterns. ``None`` means detection did not run (no "patterns"
+    #: metric pack, or a reloaded report); ``[]`` means it ran and matched
+    #: nothing. Redaction gates must treat ``None`` as unknown, not as safe.
     patterns: list[Pattern] | None
 
 class DataQualityMetrics:

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -165,9 +165,11 @@ class ColumnProfile:
     true_count: int | None
     false_count: int | None
     true_ratio: float | None
-    #: Detected patterns. ``None`` means detection did not run (no "patterns"
-    #: metric pack, or a reloaded report); ``[]`` means it ran and matched
-    #: nothing. Redaction gates must treat ``None`` as unknown, not as safe.
+    #: Detected patterns, or ``None`` when no pattern evidence is available for
+    #: this column -- detection did not run (no "patterns" metric pack), or the
+    #: payload it was rebuilt from omitted the key. ``[]`` means detection ran
+    #: and matched nothing. Redaction gates must treat ``None`` as unknown
+    #: rather than safe; ``[]`` is a positive all-clear.
     patterns: list[Pattern] | None
 
 class DataQualityMetrics:

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -602,9 +602,13 @@ class TestToLlmContext:
 
     @pytest.fixture()
     def cards(self, tmp_path):
-        """Credit-card numbers, which infer as `integer` and so carry extrema."""
+        """A sensitive integer column beside an innocuous one.
+
+        Both infer as `integer` and so carry extrema; only `card` matches a
+        sensitive pattern. The pair distinguishes redaction from over-redaction.
+        """
         path = tmp_path / "cards.csv"
-        rows = ["card"] + [f"411111111111{1000 + i}" for i in range(10)]
+        rows = ["card,qty"] + [f"411111111111{1000 + i},{i}" for i in range(10)]
         path.write_text("\n".join(rows) + "\n", encoding="utf-8")
         return str(path)
 
@@ -622,13 +626,34 @@ class TestToLlmContext:
         assert "4111111111111000" not in out
         assert "4111111111111009" not in out
 
-    def test_include_samples_withholds_extremes_for_reloaded_report(self, cards, tmp_path):
-        """A report reloaded from disk carries no pattern evidence, so it redacts."""
+    def test_include_samples_withholds_extremes_when_reload_lacks_evidence(self, cards, tmp_path):
+        """A payload saved without pattern evidence redacts once reloaded."""
         saved = tmp_path / "report.json"
         dataprof.profile(cards, metrics=["schema", "statistics"]).save(str(saved))
 
-        out = dataprof.ProfileReport.load(str(saved)).to_llm_context(include_samples=True)
+        reloaded = dataprof.ProfileReport.load(str(saved))
+        assert reloaded["card"].patterns is None  # the key was never written
+
+        out = reloaded.to_llm_context(include_samples=True)
         assert "4111111111111000" not in out
+
+    def test_reload_preserves_pattern_evidence(self, cards, tmp_path):
+        """`save()`/`load()` round-trips the evidence, so redaction is unchanged.
+
+        A reloaded report is not automatically "unscanned": a sensitive column
+        still redacts *because* its pattern survived, and a cleared column still
+        shows extrema. Only a payload missing the key falls back to unknown.
+        """
+        saved = tmp_path / "report.json"
+        dataprof.profile(cards).save(str(saved))  # default metrics: patterns run
+
+        reloaded = dataprof.ProfileReport.load(str(saved))
+        assert reloaded["card"].patterns  # sensitive pattern survived the round-trip
+        assert reloaded["qty"].patterns == []  # scanned, clean, and still provably so
+
+        out = reloaded.to_llm_context(include_samples=True)
+        assert "4111111111111000" not in out  # still redacted
+        assert "qty: integer [0" in out  # still exposed
 
     def test_scanned_column_without_matches_still_shows_extremes(self, tmp_path):
         """Failing closed must not swallow the safe case: `[]` is evidence, `None` is not."""

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -600,6 +600,45 @@ class TestToLlmContext:
         assert "123456789" not in out
         assert "127456789" not in out
 
+    @pytest.fixture()
+    def cards(self, tmp_path):
+        """Credit-card numbers, which infer as `integer` and so carry extrema."""
+        path = tmp_path / "cards.csv"
+        rows = ["card"] + [f"411111111111{1000 + i}" for i in range(10)]
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return str(path)
+
+    def test_include_samples_withholds_extremes_when_patterns_not_scanned(self, cards):
+        """Redaction must fail closed when pattern detection never ran.
+
+        A `metrics=` selection without the "patterns" pack leaves every column
+        with `patterns is None`. Reading that as "nothing sensitive found" would
+        echo raw card numbers into an agent's context on an unrelated opt-out.
+        """
+        report = dataprof.profile(cards, metrics=["schema", "statistics", "quality"])
+        assert report["card"].patterns is None  # detection skipped, not "no match"
+
+        out = report.to_llm_context(include_samples=True)
+        assert "4111111111111000" not in out
+        assert "4111111111111009" not in out
+
+    def test_include_samples_withholds_extremes_for_reloaded_report(self, cards, tmp_path):
+        """A report reloaded from disk carries no pattern evidence, so it redacts."""
+        saved = tmp_path / "report.json"
+        dataprof.profile(cards, metrics=["schema", "statistics"]).save(str(saved))
+
+        out = dataprof.ProfileReport.load(str(saved)).to_llm_context(include_samples=True)
+        assert "4111111111111000" not in out
+
+    def test_scanned_column_without_matches_still_shows_extremes(self, tmp_path):
+        """Failing closed must not swallow the safe case: `[]` is evidence, `None` is not."""
+        path = tmp_path / "qty.csv"
+        path.write_text("qty\n7\n19\n42\n", encoding="utf-8")
+        report = dataprof.profile(str(path))
+        assert report["qty"].patterns == []  # scanned, nothing matched
+
+        assert "42" in report.to_llm_context(include_samples=True)
+
     def test_column_name_cannot_break_the_line_format(self, tmp_path):
         """A newline in a header must not split a schema entry across two lines.
 


### PR DESCRIPTION
> Stacked on #358. Review the [second commit](https://github.com/AndreaBozzo/dataprof/pull/359/commits) only; merge #358 first and the base collapses to `master`.

## The bug

`to_llm_context(include_samples=True)` printed raw credit-card numbers whenever pattern detection had not run:

```python
r = dp.profile(data, metrics=["schema", "statistics", "quality"])
print(r.to_llm_context(include_samples=True))
# - card: integer [4111111111111111.0 .. 4222222222222222.0]
```

That `metrics=` call is the one on the README's front page. `fast_mode` opens the same path. Neither parameter says anything about safety.

## Root cause

Representational, across three layers:

1. `ColumnProfile.patterns` was a `Vec<Pattern>` — "detection was skipped" and "detection ran and matched nothing" were the same empty value.
2. The PyO3 boundary collapsed both to `None`: `if !profile.patterns.is_empty() { Some(..) } else { None }`.
3. `_has_sensitive_pattern()` returned `False` on `None`, reading **absence of evidence as evidence of absence**.

`MetricPack::include_patterns()` therefore made redaction opt-out via a parameter that is about cost, not privacy.

## The fix

`patterns` is now `Option<Vec<Pattern>>` end to end — `None` means unscanned, `Some([])` means scanned and clean. This mirrors the existing `ColumnStats::None`, which already represents "statistics not computed".

`_may_expose_values()` replaces `_has_sensitive_pattern()` and states safety **positively**: a column's values may be echoed only if detection ran and cleared it. Unscanned columns and reloaded reports both withhold extrema.

No production code read `.patterns` outside the PyO3 boundary, so the core change compiled clean; only test fixtures needed updating.

## Not a release regression

`to_llm_context()` has never shipped — it landed after v0.8.1. No advisory needed, but it must not reach 0.9.0.

## Why this matters beyond the one call site

#336 requires "redaction applied at the server boundary". An MCP server built on `to_llm_context()` would have inherited this gate — fail-open — by construction. The invariant worth carrying forward:

> Redaction is a property of the **output surface**, not of what the profiler happened to compute. If we cannot *prove* a column is non-sensitive, we do not emit its values.

## Verification

- 209 Python tests pass, including three new ones: unscanned column, reloaded report, and the safe case (`[]` must **not** be over-redacted — no false positives).
- Full Rust workspace green; clippy `-D warnings` and `cargo fmt` clean.
- Leak reproduced before, confirmed closed after.