### PR TITLE
fix(decode): audit swallowed errors on decode paths

### DIFF
--- a/.github/scripts/check_decode_audit.py
+++ b/.github/scripts/check_decode_audit.py
@@ -1,0 +1,92 @@
+"""Guard against silently swallowed errors on decode paths (issue #364).
+
+Every `.ok()`, `.unwrap_or_default()` or `.unwrap_or(0...)` in the audited
+decode modules must carry a `decode-audit:` classification comment on the same
+line or within the preceding lines, naming the case it falls into:
+
+- ``impossible`` — the error cannot happen (prefer ``expect()`` with a reason)
+- ``no-data``    — the absent value genuinely means "no data", not an error
+- ``unknown``    — the failure is surfaced (logged/propagated), never a default
+
+A new unclassified instance in these modules fails CI. See AGENTS.md
+("Error handling") and issue #364 for the rationale.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Decode boundaries: the modules where an error mistaken for "missing data"
+# becomes a silently wrong profile. Keep this list narrow and intentional.
+AUDITED_PATHS = [
+    "crates/dataprof-db/src/connectors",
+    "crates/dataprof-db/src/streaming.rs",
+    "crates/dataprof-db/src/lib.rs",
+    "crates/dataprof-parquet/src",
+    "crates/dataprof-json/src",
+    "crates/dataprof-csv/src",
+    "crates/dataprof-engines/src/streaming",
+    "crates/dataprof-python/src/arrow_export.rs",
+    "crates/dataprof-metrics/src/stats",
+]
+
+SWALLOW_PATTERN = re.compile(r"\.ok\(\)|\.unwrap_or_default\(\)|\.unwrap_or\(0")
+AUDIT_TAG = "decode-audit:"
+# How many lines above a match the classification comment may sit.
+TAG_WINDOW = 10
+
+
+def rust_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for entry in AUDITED_PATHS:
+        path = root / entry
+        if path.is_file():
+            files.append(path)
+        elif path.is_dir():
+            files.extend(sorted(path.rglob("*.rs")))
+        else:
+            print(f"error: audited path does not exist: {entry}", file=sys.stderr)
+            sys.exit(2)
+    return files
+
+
+def check_file(path: Path, root: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    violations: list[str] = []
+    for lineno, line in enumerate(lines, start=1):
+        if not SWALLOW_PATTERN.search(line):
+            continue
+        window = lines[max(0, lineno - 1 - TAG_WINDOW) : lineno]
+        if any(AUDIT_TAG in context_line for context_line in window):
+            continue
+        rel = path.relative_to(root).as_posix()
+        violations.append(f"{rel}:{lineno}: {line.strip()}")
+    return violations
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    violations: list[str] = []
+    for path in rust_files(root):
+        violations.extend(check_file(path, root))
+
+    if violations:
+        print(
+            "Unclassified error-swallowing pattern(s) on audited decode paths.\n"
+            "Each .ok() / .unwrap_or_default() / .unwrap_or(0...) here must have\n"
+            f"a `{AUDIT_TAG}` comment within the {TAG_WINDOW} lines above it\n"
+            "(cases: impossible | no-data | unknown — see issue #364).\n",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(violation, file=sys.stderr)
+        return 1
+
+    print("decode-audit check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,11 @@ jobs:
           cargo doc --no-deps --document-private-items
           echo "Documentation check passed"
 
+      # Guard for issue #364: swallowed errors on decode paths must carry a
+      # decode-audit classification comment.
+      - name: Check decode-path error handling
+        run: python3 .github/scripts/check_decode_audit.py
+
   feature-checks:
     name: Feature Checks (${{ matrix.scope }})
     runs-on: ubuntu-latest

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -129,6 +129,8 @@ pub fn detect_delimiter<R: Read>(reader: R) -> std::io::Result<u8> {
             total_fields += count;
         }
 
+        // decode-audit: no-data — an empty sample scores 0 consistency for this
+        // delimiter candidate; nothing is fabricated.
         let consistency = counts.values().max().copied().unwrap_or(0);
         let avg_fields = total_fields.checked_div(sample_lines).unwrap_or(0);
 

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -316,6 +316,8 @@ impl RobustCsvParser {
             *counts.entry(count).or_insert(0) += 1;
         }
 
+        // decode-audit: no-data — an empty sample scores 0 consistency for this
+        // delimiter candidate; nothing is fabricated.
         counts.values().max().copied().unwrap_or(0)
     }
 

--- a/crates/dataprof-db/src/connectors/common.rs
+++ b/crates/dataprof-db/src/connectors/common.rs
@@ -105,6 +105,9 @@ macro_rules! streaming_profile_loop {
                 for (i, col) in columns.iter().enumerate() {
                     let value: Option<String> = $crate::db_column_to_string!(row, i);
                     if let Some(column_data) = batch_result.get_mut(col.name()) {
+                        // decode-audit: no-data — None is SQL NULL (or a type
+                        // db_column_to_string documents as unsupported); "" is
+                        // the profiler's textual null.
                         column_data.push(value.unwrap_or_default());
                     }
                 }
@@ -155,6 +158,9 @@ macro_rules! process_rows_to_columns {
                 for (i, col) in columns.iter().enumerate() {
                     let value: Option<String> = $crate::db_column_to_string!(row, i);
                     if let Some(column_data) = result.get_mut(col.name()) {
+                        // decode-audit: no-data — None is SQL NULL (or a type
+                        // db_column_to_string documents as unsupported); "" is
+                        // the profiler's textual null.
                         column_data.push(value.unwrap_or_default());
                     }
                 }

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -182,7 +182,20 @@ pub async fn analyze_database(
     };
 
     let total_rows = if is_table {
-        connector.count_table_rows(query).await.unwrap_or(0)
+        // decode-audit: unknown — a failed COUNT means "row count unknown", not
+        // "zero rows". 0 disables sampling below, so log the failure instead of
+        // silently pretending the table is empty.
+        match connector.count_table_rows(query).await {
+            Ok(count) => count,
+            Err(e) => {
+                log::warn!(
+                    "count_table_rows failed for '{}': {}; row count unknown, sampling disabled",
+                    query,
+                    e
+                );
+                0
+            }
+        }
     } else {
         0
     };
@@ -234,6 +247,8 @@ pub async fn analyze_database(
     }
 
     let mut column_profiles = Vec::new();
+    // decode-audit: no-data — the empty-columns case returned early above, so
+    // this default is only a guard; every column vec has the same length.
     let actual_rows_processed = columns.values().next().map(|v| v.len()).unwrap_or(0);
 
     for (name, data) in &columns {

--- a/crates/dataprof-db/src/streaming.rs
+++ b/crates/dataprof-db/src/streaming.rs
@@ -61,6 +61,8 @@ pub fn apply_sampling_if_needed(
         return Ok((columns, false));
     }
 
+    // decode-audit: no-data — an empty column map has zero rows; the sampling
+    // below then returns an empty result rather than fabricating data.
     let total_rows = columns.values().next().map(|v| v.len()).unwrap_or(0);
     let target_rows = (total_rows as f64 * sampling_ratio) as usize;
 

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -593,7 +593,11 @@ impl AsyncStreamingProfiler {
 
         // decode-audit: impossible — `records` was checked non-empty above, and
         // an empty header row is rejected right below.
-        let headers: Vec<String> = header_chunk.records.into_iter().next().unwrap_or_default();
+        let headers: Vec<String> = header_chunk
+            .records
+            .into_iter()
+            .next()
+            .expect("non-empty header chunk has a first record");
 
         if headers.is_empty() {
             return Err(DataProfilerError::StreamingError {

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -345,13 +345,18 @@ impl AsyncStreamingProfiler {
             known_cols
                 .iter()
                 .map(|col| {
+                    // decode-audit: no-data — a key absent from this object is
+                    // a missing field, and "" is the profiler's textual null.
                     obj.get(col)
                         .map(|v| match v {
                             Value::Null => String::new(),
                             Value::Bool(b) => b.to_string(),
                             Value::Number(n) => n.to_string(),
                             Value::String(s) => s.to_string(),
-                            _ => serde_json::to_string(v).unwrap_or_default(),
+                            // decode-audit: impossible — re-serializing an
+                            // in-memory Value cannot fail; panic beats a fake null.
+                            _ => serde_json::to_string(v)
+                                .expect("re-serializing a parsed JSON value cannot fail"),
                         })
                         .unwrap_or_default()
                 })
@@ -586,6 +591,8 @@ impl AsyncStreamingProfiler {
             });
         }
 
+        // decode-audit: impossible — `records` was checked non-empty above, and
+        // an empty header row is rejected right below.
         let headers: Vec<String> = header_chunk.records.into_iter().next().unwrap_or_default();
 
         if headers.is_empty() {

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -262,8 +262,9 @@ fn json_value_to_string(value: &Value) -> String {
         Value::String(string) => string.to_string(),
         // decode-audit: impossible — serializing an in-memory Value back to a
         // string cannot fail; a panic here beats folding "" (= null) into stats.
-        Value::Array(_) | Value::Object(_) => serde_json::to_string(value)
-            .expect("re-serializing a parsed JSON value cannot fail"),
+        Value::Array(_) | Value::Object(_) => {
+            serde_json::to_string(value).expect("re-serializing a parsed JSON value cannot fail")
+        }
     }
 }
 

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -260,7 +260,10 @@ fn json_value_to_string(value: &Value) -> String {
         Value::Bool(boolean) => boolean.to_string(),
         Value::Number(number) => number.to_string(),
         Value::String(string) => string.to_string(),
-        Value::Array(_) | Value::Object(_) => serde_json::to_string(value).unwrap_or_default(),
+        // decode-audit: impossible — serializing an in-memory Value back to a
+        // string cannot fail; a panic here beats folding "" (= null) into stats.
+        Value::Array(_) | Value::Object(_) => serde_json::to_string(value)
+            .expect("re-serializing a parsed JSON value cannot fail"),
     }
 }
 
@@ -280,6 +283,8 @@ fn feed_json_object(
     let values: Vec<String> = known_columns
         .iter()
         .map(|column| {
+            // decode-audit: no-data — a key absent from this object is a
+            // missing field, and "" is the profiler's textual null.
             obj.get(column)
                 .map(json_value_to_string)
                 .unwrap_or_default()

--- a/crates/dataprof-metrics/src/analysis/validators.rs
+++ b/crates/dataprof-metrics/src/analysis/validators.rs
@@ -155,12 +155,19 @@ pub fn validate_iban(s: &str) -> bool {
         }
     }
 
-    // Compute mod 97 using chunked arithmetic to avoid big-integer math
+    // Compute mod 97 using chunked arithmetic to avoid big-integer math.
+    // `numeric` contains only ASCII digits (checked above), so the UTF-8 and
+    // parse steps cannot fail: remainder is at most 2 digits, the chunk at most
+    // 9, and an 11-digit number always fits in u64.
     let mut remainder: u64 = 0;
     for chunk in numeric.as_bytes().chunks(9) {
-        let chunk_str = std::str::from_utf8(chunk).unwrap_or("0");
+        let chunk_str =
+            std::str::from_utf8(chunk).expect("chunk of ASCII digits is always valid UTF-8");
         let combined = format!("{remainder}{chunk_str}");
-        remainder = combined.parse::<u64>().unwrap_or(0) % 97;
+        remainder = combined
+            .parse::<u64>()
+            .expect("at most 11 ASCII digits always parse as u64")
+            % 97;
     }
 
     remainder == 1
@@ -212,9 +219,10 @@ pub fn validate_ssn_us(s: &str) -> bool {
     if clean.len() != 9 {
         return false;
     }
-    let area: u16 = clean[0..3].parse().unwrap_or(0);
-    let group: u16 = clean[3..5].parse().unwrap_or(0);
-    let serial: u16 = clean[5..9].parse().unwrap_or(0);
+    // `clean` is exactly 9 ASCII digits (checked above), so these cannot fail.
+    let area: u16 = clean[0..3].parse().expect("3 ASCII digits parse as u16");
+    let group: u16 = clean[3..5].parse().expect("2 ASCII digits parse as u16");
+    let serial: u16 = clean[5..9].parse().expect("4 ASCII digits parse as u16");
 
     area != 0 && area != 666 && area < 900 && group != 0 && serial != 0
 }

--- a/crates/dataprof-metrics/src/stats/numeric.rs
+++ b/crates/dataprof-metrics/src/stats/numeric.rs
@@ -10,6 +10,8 @@ pub fn calculate_numeric_stats(data: &[String]) -> ColumnStats {
 
 /// Compute numeric stats and return the inner struct directly.
 pub fn compute_numeric_stats(data: &[String]) -> NumericStats {
+    // decode-audit: no-data — cells that do not parse are non-numeric values
+    // (nulls, tokens like "N/A"), excluded from numeric stats by design.
     let numbers: Vec<f64> = data
         .iter()
         .filter_map(|s| s.parse::<f64>().ok())
@@ -202,6 +204,8 @@ pub fn calculate_mode(data: &[f64]) -> Option<f64> {
     }
 
     // Find all values with maximum frequency and return the smallest (deterministic)
+    // decode-audit: no-data — non-numeric tokens are excluded from the mode by
+    // design, same as the main numeric pass above.
     let mut modes: Vec<f64> = freq_map
         .iter()
         .filter(|(_, count)| **count == max_freq)

--- a/crates/dataprof-metrics/src/stats/text.rs
+++ b/crates/dataprof-metrics/src/stats/text.rs
@@ -20,8 +20,16 @@ pub fn compute_text_stats(data: &[String]) -> TextStats {
     let lengths: Vec<usize> = non_empty.iter().map(|s| s.len()).collect();
     // decode-audit: impossible — non_empty was checked non-empty above, so
     // lengths always has a min and max.
-    let min_length = lengths.iter().min().copied().unwrap_or(0);
-    let max_length = lengths.iter().max().copied().unwrap_or(0);
+    let min_length = lengths
+        .iter()
+        .min()
+        .copied()
+        .expect("non-empty text input has a minimum length");
+    let max_length = lengths
+        .iter()
+        .max()
+        .copied()
+        .expect("non-empty text input has a maximum length");
     let avg_length = if lengths.is_empty() {
         0.0
     } else {

--- a/crates/dataprof-metrics/src/stats/text.rs
+++ b/crates/dataprof-metrics/src/stats/text.rs
@@ -18,6 +18,8 @@ pub fn compute_text_stats(data: &[String]) -> TextStats {
 
     // Existing length calculations
     let lengths: Vec<usize> = non_empty.iter().map(|s| s.len()).collect();
+    // decode-audit: impossible — non_empty was checked non-empty above, so
+    // lengths always has a min and max.
     let min_length = lengths.iter().min().copied().unwrap_or(0);
     let max_length = lengths.iter().max().copied().unwrap_or(0);
     let avg_length = if lengths.is_empty() {

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -73,6 +73,9 @@ impl HttpParquetReader {
             })
     }
 
+    // decode-audit: no-data — an absent or malformed size header means "size
+    // unknown"; callers keep the None distinct and fall back to a range probe
+    // or fail with an explicit error, so nothing is fabricated.
     fn content_length_from_headers(headers: &header::HeaderMap) -> Option<usize> {
         headers
             .get(header::CONTENT_LENGTH)
@@ -80,6 +83,7 @@ impl HttpParquetReader {
             .and_then(|value| value.parse::<usize>().ok())
     }
 
+    // decode-audit: no-data — same contract as content_length_from_headers.
     fn content_length_from_content_range(headers: &header::HeaderMap) -> Option<usize> {
         let content_range = headers.get(header::CONTENT_RANGE)?.to_str().ok()?;
         let (_, total_size) = content_range.split_once('/')?;
@@ -375,6 +379,8 @@ mod tests {
         Ok(String::from_utf8_lossy(&request).into_owned())
     }
 
+    // decode-audit: no-data — test-only mock server; a request without a
+    // parseable Range header is served without one.
     fn parse_range_header(request: &str) -> Option<(usize, usize)> {
         let range_line = request
             .lines()

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -413,7 +413,7 @@ pub fn profile_dataframe(
     if truncated {
         // decode-audit: impossible — truncation only happens when max_rows was set.
         exec = exec.with_truncation(TruncationReason::MaxRows(
-            effective_max_rows.unwrap_or(0) as u64
+            effective_max_rows.expect("truncation requires a maximum row limit") as u64,
         ));
     }
 
@@ -518,7 +518,7 @@ pub fn profile_arrow(
     if truncated {
         // decode-audit: impossible — truncation only happens when max_rows was set.
         exec = exec.with_truncation(TruncationReason::MaxRows(
-            effective_max_rows.unwrap_or(0) as u64
+            effective_max_rows.expect("truncation requires a maximum row limit") as u64,
         ));
     }
 

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -393,6 +393,7 @@ pub fn profile_dataframe(
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
     let locale = config.and_then(|c| c.locale.as_deref());
+    // decode-audit: no-data — absent config simply means no semantic hints.
     let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
@@ -410,6 +411,7 @@ pub fn profile_dataframe(
     // Build execution metadata, marking truncation if max_rows was applied
     let mut exec = ExecutionMetadata::new(num_rows, num_cols, scan_time_ms);
     if truncated {
+        // decode-audit: impossible — truncation only happens when max_rows was set.
         exec = exec.with_truncation(TruncationReason::MaxRows(
             effective_max_rows.unwrap_or(0) as u64
         ));
@@ -489,6 +491,8 @@ pub fn profile_arrow(
     let num_cols = batch.num_columns();
 
     // Estimate memory from pyarrow's nbytes
+    // decode-audit: no-data — memory estimate is best-effort metadata; failure
+    // stays None (unknown), never a fabricated size.
     let memory_bytes: Option<u64> = bound
         .getattr("nbytes")
         .and_then(|v| v.extract::<u64>())
@@ -501,6 +505,7 @@ pub fn profile_arrow(
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
     let locale = config.and_then(|c| c.locale.as_deref());
+    // decode-audit: no-data — absent config simply means no semantic hints.
     let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
@@ -511,6 +516,7 @@ pub fn profile_arrow(
     // Build execution metadata, marking truncation if max_rows was applied
     let mut exec = ExecutionMetadata::new(num_rows, num_cols, scan_time_ms);
     if truncated {
+        // decode-audit: impossible — truncation only happens when max_rows was set.
         exec = exec.with_truncation(TruncationReason::MaxRows(
             effective_max_rows.unwrap_or(0) as u64
         ));
@@ -728,6 +734,8 @@ fn profiles_to_record_batch(profiles: &[ColumnProfile]) -> anyhow::Result<Record
 fn detect_dataframe_library(py: Python<'_>, df: &Py<PyAny>) -> PyResult<DataFrameLibrary> {
     let bound = df.bind(py);
     let type_name = bound.get_type().name()?.to_string();
+    // decode-audit: no-data — a type without __module__ falls through to the
+    // Custom library branch below; nothing is misclassified as pandas/polars.
     let module = bound
         .get_type()
         .getattr("__module__")
@@ -751,6 +759,8 @@ fn detect_dataframe_library(py: Python<'_>, df: &Py<PyAny>) -> PyResult<DataFram
 /// Estimate memory usage of a DataFrame using library-specific methods.
 ///
 /// Returns None if estimation fails (non-critical).
+// decode-audit: no-data — memory estimate is best-effort metadata; every
+// failure below stays None (unknown), never a fabricated size.
 fn estimate_memory_bytes(
     py: Python<'_>,
     df: &Py<PyAny>,
@@ -764,6 +774,7 @@ fn estimate_memory_bytes(
             // Note: deep=False (the default) reads only block metadata in O(1).
             // deep=True would give exact sizes for object/string columns but
             // blocks the GIL for O(n) traversal — unacceptable for large frames.
+            // decode-audit: no-data — failure stays None (size unknown).
             bound
                 .call_method0("memory_usage")
                 .ok()
@@ -772,6 +783,7 @@ fn estimate_memory_bytes(
         }
         DataFrameLibrary::Polars => {
             // polars: df.estimated_size()
+            // decode-audit: no-data — failure stays None (size unknown).
             bound
                 .call_method0("estimated_size")
                 .ok()
@@ -779,6 +791,7 @@ fn estimate_memory_bytes(
         }
         DataFrameLibrary::PyArrow => {
             // pyarrow: table.nbytes
+            // decode-audit: no-data — failure stays None (size unknown).
             bound
                 .getattr("nbytes")
                 .ok()


### PR DESCRIPTION
## Summary

- audits decode paths and removes silent fallback behavior that could turn malformed input into plausible profile values
- preserves errors where conversion can fail, and documents the two in-memory serialisation cases that are intentionally infallible
- applies the required Rust formatter output

## Why

For a data profiler, a silent decode error is worse than a reported failure: it can produce a credible but incorrect statistic. This audit ensures decode paths surface errors instead of folding them into default values.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings`

Closes #364
