### PR TITLE
fix: replace columnar 1,000-value unique-count cap with bounded estimator

### DIFF
--- a/crates/dataprof-metrics/src/lib.rs
+++ b/crates/dataprof-metrics/src/lib.rs
@@ -14,4 +14,7 @@ pub use quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, QualityAssessment,
     QualityMetrics, TimelinessMetrics, UniquenessMetrics,
 };
-pub use stats::{calculate_datetime_stats, calculate_numeric_stats, calculate_text_stats};
+pub use stats::{
+    CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog, calculate_datetime_stats,
+    calculate_numeric_stats, calculate_text_stats,
+};

--- a/crates/dataprof-metrics/src/stats/cardinality.rs
+++ b/crates/dataprof-metrics/src/stats/cardinality.rs
@@ -189,6 +189,8 @@ impl CardinalityEstimator {
     }
 
     pub fn memory_usage_bytes(&self) -> usize {
+        // decode-audit: no-data — once the estimator spills, the exact set is
+        // dropped (None), so it genuinely holds zero bytes of string data.
         let exact_bytes = self
             .exact
             .as_ref()

--- a/crates/dataprof-metrics/src/stats/cardinality.rs
+++ b/crates/dataprof-metrics/src/stats/cardinality.rs
@@ -1,0 +1,290 @@
+//! Bounded-memory distinct-count estimation shared across engines.
+//!
+//! Every engine that reports `unique_count` needs the same guarantee: exact for
+//! small columns, and an *honest* estimate for large ones -- never a hard cap
+//! exposed as if it were the true count. [`CardinalityEstimator`] keeps an exact
+//! set until it crosses [`EXACT_CARDINALITY_THRESHOLD`] distinct values, then
+//! frees it and relies on a [`HyperLogLog`] sketch that has seen every value from
+//! the start. Memory is bounded by the threshold plus the fixed HLL registers.
+//!
+//! Because the HLL uses the same precision and hash for all engines, two engines
+//! fed the same values produce the same estimate; they agree exactly in the
+//! high-cardinality regime and within HLL's ~1% relative error elsewhere.
+
+use std::collections::HashSet;
+use std::hash::{BuildHasher, Hasher};
+
+/// Distinct values retained exactly before switching to the HLL sketch.
+///
+/// Chosen to match the streaming reservoir's order of magnitude so the file and
+/// streaming engines report the same exact counts for small/medium columns.
+pub const EXACT_CARDINALITY_THRESHOLD: usize = 10_000;
+
+/// Fixed-seed hasher so a given string maps to the same HLL register on every
+/// run and in every engine -- distinct-count estimates must be reproducible.
+struct HllBuildHasher;
+
+impl BuildHasher for HllBuildHasher {
+    type Hasher = std::collections::hash_map::DefaultHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        std::collections::hash_map::DefaultHasher::new()
+    }
+}
+
+/// HyperLogLog distinct-count sketch (~16 KB of fixed registers).
+#[derive(Clone)]
+pub struct HyperLogLog {
+    registers: Vec<u8>,
+}
+
+impl std::fmt::Debug for HyperLogLog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HyperLogLog")
+            .field("precision", &Self::PRECISION)
+            .field("registers_len", &self.registers.len())
+            .finish()
+    }
+}
+
+impl HyperLogLog {
+    const PRECISION: usize = 14;
+    const NUM_REGISTERS: usize = 1 << Self::PRECISION;
+
+    pub fn new() -> Self {
+        Self {
+            registers: vec![0u8; Self::NUM_REGISTERS],
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, value: &str) {
+        let mut hasher = HllBuildHasher.build_hasher();
+        hasher.write(value.as_bytes());
+        let hash = hasher.finish();
+
+        let index = (hash as usize) & (Self::NUM_REGISTERS - 1);
+        let window = hash >> Self::PRECISION;
+        let rank = (window.leading_zeros() - Self::PRECISION as u32 + 1) as u8;
+
+        if rank > self.registers[index] {
+            self.registers[index] = rank;
+        }
+    }
+
+    pub fn count(&self) -> u64 {
+        let register_count = Self::NUM_REGISTERS as f64;
+        let alpha = 0.7213 / (1.0 + 1.079 / register_count);
+
+        let raw_estimate: f64 = alpha * register_count * register_count
+            / self
+                .registers
+                .iter()
+                .map(|&register| 2.0_f64.powi(-(register as i32)))
+                .sum::<f64>();
+
+        if raw_estimate <= 2.5 * register_count {
+            let zeros = self
+                .registers
+                .iter()
+                .filter(|&&register| register == 0)
+                .count() as f64;
+            if zeros > 0.0 {
+                (register_count * (register_count / zeros).ln()) as u64
+            } else {
+                raw_estimate as u64
+            }
+        } else if raw_estimate <= (1u64 << 32) as f64 / 30.0 {
+            raw_estimate as u64
+        } else {
+            let two32 = (1u64 << 32) as f64;
+            (-two32 * (1.0 - raw_estimate / two32).ln()) as u64
+        }
+    }
+
+    pub fn merge(&mut self, other: &HyperLogLog) {
+        for (left, right) in self.registers.iter_mut().zip(other.registers.iter()) {
+            *left = (*left).max(*right);
+        }
+    }
+
+    /// Heap bytes held by the registers, for memory accounting.
+    pub fn memory_usage_bytes(&self) -> usize {
+        self.registers.len()
+    }
+}
+
+impl Default for HyperLogLog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Exact-then-approximate distinct-count estimator with bounded memory.
+///
+/// Reports an exact count while fewer than [`EXACT_CARDINALITY_THRESHOLD`]
+/// distinct values have been seen, then an HLL estimate. [`Self::is_approximate`]
+/// tells callers which regime a given count came from.
+#[derive(Debug, Clone)]
+pub struct CardinalityEstimator {
+    /// Exact distinct values, dropped once the threshold is crossed.
+    exact: Option<HashSet<String>>,
+    /// Fed on every insert so the estimate is accurate the moment `exact` is gone.
+    hll: HyperLogLog,
+    threshold: usize,
+}
+
+impl CardinalityEstimator {
+    pub fn new() -> Self {
+        Self::with_threshold(EXACT_CARDINALITY_THRESHOLD)
+    }
+
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self {
+            exact: Some(HashSet::new()),
+            hll: HyperLogLog::new(),
+            threshold,
+        }
+    }
+
+    #[inline]
+    pub fn insert(&mut self, value: &str) {
+        self.hll.insert(value);
+        if let Some(exact) = self.exact.as_mut() {
+            exact.insert(value.to_string());
+            // Once we exceed the exact budget, drop the set: the HLL has already
+            // seen every value, so the estimate stays accurate without the memory.
+            if exact.len() > self.threshold {
+                self.exact = None;
+            }
+        }
+    }
+
+    /// Best available distinct count: exact when retained, else the HLL estimate.
+    pub fn estimate(&self) -> usize {
+        match &self.exact {
+            Some(exact) => exact.len(),
+            None => self.hll.count() as usize,
+        }
+    }
+
+    /// Whether [`Self::estimate`] is an HLL approximation rather than an exact count.
+    pub fn is_approximate(&self) -> bool {
+        self.exact.is_none()
+    }
+
+    pub fn merge(&mut self, other: &CardinalityEstimator) {
+        self.hll.merge(&other.hll);
+        match (self.exact.as_mut(), other.exact.as_ref()) {
+            (Some(mine), Some(theirs)) => {
+                mine.extend(theirs.iter().cloned());
+                if mine.len() > self.threshold {
+                    self.exact = None;
+                }
+            }
+            // If either side already spilled, the union can only be larger, so the
+            // merged result is approximate too; the merged HLL carries the estimate.
+            _ => self.exact = None,
+        }
+    }
+
+    pub fn memory_usage_bytes(&self) -> usize {
+        let exact_bytes = self
+            .exact
+            .as_ref()
+            .map(|set| set.iter().map(|value| value.len()).sum::<usize>())
+            .unwrap_or(0);
+        std::mem::size_of::<Self>() + self.hll.memory_usage_bytes() + exact_bytes
+    }
+}
+
+impl Default for CardinalityEstimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn estimator_over(distinct: usize) -> CardinalityEstimator {
+        let mut est = CardinalityEstimator::new();
+        for value in 0..distinct {
+            est.insert(&value.to_string());
+        }
+        est
+    }
+
+    #[test]
+    fn small_columns_are_exact() {
+        for distinct in [0usize, 1, 999, 1_000, 1_001] {
+            let est = estimator_over(distinct);
+            assert!(
+                !est.is_approximate(),
+                "{distinct} distinct should stay exact"
+            );
+            assert_eq!(est.estimate(), distinct);
+        }
+    }
+
+    #[test]
+    fn exactly_at_threshold_is_still_exact() {
+        let est = estimator_over(EXACT_CARDINALITY_THRESHOLD);
+        assert!(!est.is_approximate());
+        assert_eq!(est.estimate(), EXACT_CARDINALITY_THRESHOLD);
+    }
+
+    #[test]
+    fn large_columns_estimate_without_the_hard_cap() {
+        // The bug this replaces reported exactly the cap; the estimate must be
+        // close to the truth instead, and flagged approximate.
+        for distinct in [10_000usize + 1, 100_000, 500_000] {
+            let est = estimator_over(distinct);
+            assert!(
+                est.is_approximate(),
+                "{distinct} distinct should spill to HLL"
+            );
+            let estimate = est.estimate();
+            assert_ne!(estimate, EXACT_CARDINALITY_THRESHOLD);
+            let error = (estimate as f64 - distinct as f64).abs() / distinct as f64;
+            assert!(
+                error < 0.03,
+                "{distinct} distinct: estimate {estimate} off by {error:.4}"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_of_exact_halves_stays_exact() {
+        let mut left = CardinalityEstimator::new();
+        let mut right = CardinalityEstimator::new();
+        for value in 0..400 {
+            left.insert(&value.to_string());
+        }
+        for value in 200..600 {
+            right.insert(&value.to_string());
+        }
+        left.merge(&right);
+        assert!(!left.is_approximate());
+        assert_eq!(left.estimate(), 600);
+    }
+
+    #[test]
+    fn merge_with_spilled_side_is_approximate() {
+        let mut small = estimator_over(10);
+        let big = estimator_over(100_000);
+        small.merge(&big);
+        assert!(small.is_approximate());
+        let error = (small.estimate() as f64 - 100_000.0).abs() / 100_000.0;
+        assert!(error < 0.03, "merged estimate off by {error:.4}");
+    }
+
+    #[test]
+    fn estimate_is_deterministic_across_runs() {
+        assert_eq!(
+            estimator_over(250_000).estimate(),
+            estimator_over(250_000).estimate()
+        );
+    }
+}

--- a/crates/dataprof-metrics/src/stats/cardinality.rs
+++ b/crates/dataprof-metrics/src/stats/cardinality.rs
@@ -152,11 +152,33 @@ impl CardinalityEstimator {
         self.hll.insert(value);
         if let Some(exact) = self.exact.as_mut() {
             exact.insert(value.to_string());
-            // Once we exceed the exact budget, drop the set: the HLL has already
-            // seen every value, so the estimate stays accurate without the memory.
-            if exact.len() > self.threshold {
-                self.exact = None;
-            }
+            self.spill_if_over_budget();
+        }
+    }
+
+    /// Like [`Self::insert`] but takes ownership, moving the string straight into
+    /// the exact set instead of cloning it. Callers that already hold a freshly
+    /// built `String` -- the numeric and temporal formatting paths -- should
+    /// prefer this to avoid a second allocation per row under the threshold.
+    #[inline]
+    pub fn insert_owned(&mut self, value: String) {
+        self.hll.insert(&value);
+        if let Some(exact) = self.exact.as_mut() {
+            exact.insert(value);
+            self.spill_if_over_budget();
+        }
+    }
+
+    /// Drop the exact set once it exceeds the budget: the HLL has already seen
+    /// every value, so the estimate stays accurate without holding the memory.
+    #[inline]
+    fn spill_if_over_budget(&mut self) {
+        if self
+            .exact
+            .as_ref()
+            .is_some_and(|exact| exact.len() > self.threshold)
+        {
+            self.exact = None;
         }
     }
 

--- a/crates/dataprof-metrics/src/stats/mod.rs
+++ b/crates/dataprof-metrics/src/stats/mod.rs
@@ -1,7 +1,9 @@
+pub mod cardinality;
 pub mod datetime;
 pub mod numeric;
 pub mod text;
 
+pub use cardinality::{CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog};
 pub use datetime::calculate_datetime_stats;
 pub use numeric::calculate_numeric_stats;
 pub use text::calculate_text_stats;

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -6,6 +6,7 @@ use dataprof_core::{
     MetricPack, QualityDimension, SemanticHints, TruncationReason,
 };
 use dataprof_csv::CsvParserConfig;
+use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::{infer_type, is_null_like_token};
 use dataprof_runtime::{
     ColumnProfileInput, ProfileReport, ReportAssembler, TextLengths, build_column_profile,
@@ -256,7 +257,7 @@ struct ColumnAnalyzer {
     data_type: arrow::datatypes::DataType,
     total_count: usize,
     null_count: usize,
-    unique_values: std::collections::HashSet<String>,
+    cardinality: CardinalityEstimator,
     // Numeric statistics
     min_value: Option<f64>,
     max_value: Option<f64>,
@@ -279,7 +280,7 @@ impl ColumnAnalyzer {
             data_type: data_type.clone(),
             total_count: 0,
             null_count: 0,
-            unique_values: std::collections::HashSet::new(),
+            cardinality: CardinalityEstimator::new(),
             min_value: None,
             max_value: None,
             sum: 0.0,
@@ -432,9 +433,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(value);
 
                 // Add to unique values (with limit)
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
 
                 // Keep samples for pattern detection
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
@@ -451,9 +450,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -469,9 +466,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -487,9 +482,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -509,9 +502,7 @@ impl ColumnAnalyzer {
                 }
                 self.update_text_stats(value);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(value);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -534,9 +525,7 @@ impl ColumnAnalyzer {
                 }
                 self.update_text_stats(value);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(value);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -557,9 +546,7 @@ impl ColumnAnalyzer {
                 }
                 let value_str = if value { "True" } else { "False" };
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value_str.to_string());
-                }
+                self.cardinality.insert(value_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value_str.to_string());
@@ -576,9 +563,7 @@ impl ColumnAnalyzer {
                 let date_str = format!("date32:{}", value);
                 self.update_text_stats(&date_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(date_str.clone());
-                }
+                self.cardinality.insert(&date_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(date_str);
@@ -595,9 +580,7 @@ impl ColumnAnalyzer {
                 let date_str = format!("date64:{}", value);
                 self.update_text_stats(&date_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(date_str.clone());
-                }
+                self.cardinality.insert(&date_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(date_str);
@@ -616,9 +599,7 @@ impl ColumnAnalyzer {
                 let ts_str = format!("timestamp_ns:{}", value);
                 self.update_text_stats(&ts_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(ts_str.clone());
-                }
+                self.cardinality.insert(&ts_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(ts_str);
@@ -637,9 +618,7 @@ impl ColumnAnalyzer {
                 let ts_str = format!("timestamp_us:{}", value);
                 self.update_text_stats(&ts_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(ts_str.clone());
-                }
+                self.cardinality.insert(&ts_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(ts_str);
@@ -658,9 +637,7 @@ impl ColumnAnalyzer {
                 let ts_str = format!("timestamp_ms:{}", value);
                 self.update_text_stats(&ts_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(ts_str.clone());
-                }
+                self.cardinality.insert(&ts_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(ts_str);
@@ -679,9 +656,7 @@ impl ColumnAnalyzer {
                 let ts_str = format!("timestamp_s:{}", value);
                 self.update_text_stats(&ts_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(ts_str.clone());
-                }
+                self.cardinality.insert(&ts_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(ts_str);
@@ -706,9 +681,7 @@ impl ColumnAnalyzer {
                 );
                 self.update_text_stats(&hex_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(hex_str.clone());
-                }
+                self.cardinality.insert(&hex_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(hex_str);
@@ -736,9 +709,7 @@ impl ColumnAnalyzer {
                 );
                 self.update_text_stats(&hex_str);
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(hex_str.clone());
-                }
+                self.cardinality.insert(&hex_str);
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(hex_str);
@@ -763,9 +734,7 @@ impl ColumnAnalyzer {
                     self.sample_values.push(value.clone());
                 }
 
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value);
-                }
+                self.cardinality.insert(&value);
             }
         }
         Ok(())
@@ -817,7 +786,7 @@ impl ColumnAnalyzer {
             data_type,
             total_count: self.total_count,
             null_count: self.null_count,
-            unique_count: Some(self.unique_values.len()),
+            unique_count: Some(self.cardinality.estimate()),
             sample_values: &self.sample_values,
             text_lengths: Some(TextLengths {
                 min_length: self.min_length,
@@ -896,6 +865,36 @@ mod tests {
             DataType::Integer,
             "age column should be detected as Integer"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unique_count_not_capped_for_high_cardinality_csv() -> Result<(), DataProfilerError> {
+        // Regression for the columnar hard cap: the Arrow CSV path used to stop
+        // counting distinct values at 1,000 and expose that cap as the exact
+        // count, wrecking uniqueness-based quality metrics for large columns.
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "id")?;
+        let rows = 50_000;
+        for id in 0..rows {
+            writeln!(temp_file, "{}", id)?;
+        }
+        temp_file.flush()?;
+
+        let profiler = ArrowProfiler::new();
+        let report = profiler.analyze_csv_file(temp_file.path())?;
+
+        let id_col = report
+            .column_profiles
+            .iter()
+            .find(|p| p.name == "id")
+            .expect("id column should exist");
+
+        let unique = id_col.unique_count.expect("unique_count should be present");
+        assert_ne!(unique, 1_000, "must not expose the old hard cap as exact");
+        let error = (unique as f64 - rows as f64).abs() / rows as f64;
+        assert!(error < 0.05, "{rows} distinct ids estimated as {unique}");
 
         Ok(())
     }

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -433,7 +433,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(value);
 
                 // Add to unique values (with limit)
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
 
                 // Keep samples for pattern detection
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
@@ -450,7 +450,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
 
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -466,7 +466,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
 
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -482,7 +482,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
 
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
 
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
@@ -734,7 +734,7 @@ impl ColumnAnalyzer {
                     self.sample_values.push(value.clone());
                 }
 
-                self.cardinality.insert(&value);
+                self.cardinality.insert_owned(value);
             }
         }
         Ok(())

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -300,7 +300,7 @@ impl ColumnAnalyzer {
             if !array.is_null(index) {
                 let value = array.value(index);
                 self.update_numeric_stats(value);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -315,7 +315,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -330,7 +330,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -345,7 +345,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -360,7 +360,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -375,7 +375,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -390,7 +390,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -405,7 +405,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -420,7 +420,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -435,7 +435,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                self.cardinality.insert(&value.to_string());
+                self.cardinality.insert_owned(value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -603,7 +603,7 @@ impl ColumnAnalyzer {
                 let bytes = array.value(index);
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
-                self.cardinality.insert(&format!("len:{}", len));
+                self.cardinality.insert_owned(format!("len:{}", len));
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(format!("<binary:{} bytes>", len));
                 }
@@ -618,7 +618,7 @@ impl ColumnAnalyzer {
                 let bytes = array.value(index);
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
-                self.cardinality.insert(&format!("len:{}", len));
+                self.cardinality.insert_owned(format!("len:{}", len));
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(format!("<binary:{} bytes>", len));
                 }
@@ -734,7 +734,7 @@ impl ColumnAnalyzer {
                         if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                             self.sample_values.push(value_str.clone());
                         }
-                        self.cardinality.insert(&value_str);
+                        self.cardinality.insert_owned(value_str);
                     }
                 }
             }
@@ -746,7 +746,7 @@ impl ColumnAnalyzer {
                         if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                             self.sample_values.push(value_str.clone());
                         }
-                        self.cardinality.insert(&value_str);
+                        self.cardinality.insert_owned(value_str);
                     }
                 }
             }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -5,6 +5,7 @@ use arrow::array::*;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::ArrayFormatter;
 use dataprof_core::{ColumnProfile, DataType, SemanticHints};
+use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::infer_type;
 use dataprof_runtime::{ColumnProfileInput, TextLengths, build_column_profile};
@@ -102,7 +103,7 @@ pub struct ColumnAnalyzer {
     data_type: arrow::datatypes::DataType,
     total_count: usize,
     null_count: usize,
-    unique_values: std::collections::HashSet<String>,
+    cardinality: CardinalityEstimator,
     min_value: Option<f64>,
     max_value: Option<f64>,
     sum: f64,
@@ -121,7 +122,7 @@ impl ColumnAnalyzer {
             data_type: data_type.clone(),
             total_count: 0,
             null_count: 0,
-            unique_values: std::collections::HashSet::new(),
+            cardinality: CardinalityEstimator::new(),
             min_value: None,
             max_value: None,
             sum: 0.0,
@@ -299,9 +300,7 @@ impl ColumnAnalyzer {
             if !array.is_null(index) {
                 let value = array.value(index);
                 self.update_numeric_stats(value);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -316,9 +315,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -333,9 +330,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -350,9 +345,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -367,9 +360,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -384,9 +375,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -401,9 +390,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -418,9 +405,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -435,9 +420,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -452,9 +435,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(&value.to_string());
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -472,9 +453,7 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(value);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -492,9 +471,7 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value.to_string());
-                }
+                self.cardinality.insert(value);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value.to_string());
                 }
@@ -513,9 +490,7 @@ impl ColumnAnalyzer {
                     self.false_count += 1;
                 }
                 let value_str = if value { "True" } else { "False" };
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(value_str.to_string());
-                }
+                self.cardinality.insert(value_str);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(value_str.to_string());
                 }
@@ -530,9 +505,7 @@ impl ColumnAnalyzer {
                 let days = array.value(index);
                 self.update_numeric_stats(days as f64);
                 let date_str = format!("1970-01-01+{}days", days);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(date_str.clone());
-                }
+                self.cardinality.insert(&date_str);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(date_str);
                 }
@@ -547,9 +520,7 @@ impl ColumnAnalyzer {
                 let millis = array.value(index);
                 self.update_numeric_stats(millis as f64);
                 let datetime_str = format!("1970-01-01T00:00:00.000+{}ms", millis);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(datetime_str.clone());
-                }
+                self.cardinality.insert(&datetime_str);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(datetime_str);
                 }
@@ -570,9 +541,7 @@ impl ColumnAnalyzer {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(ts_str.clone());
-                    }
+                    self.cardinality.insert(&ts_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(ts_str);
                     }
@@ -587,9 +556,7 @@ impl ColumnAnalyzer {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(ts_str.clone());
-                    }
+                    self.cardinality.insert(&ts_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(ts_str);
                     }
@@ -604,9 +571,7 @@ impl ColumnAnalyzer {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(ts_str.clone());
-                    }
+                    self.cardinality.insert(&ts_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(ts_str);
                     }
@@ -621,9 +586,7 @@ impl ColumnAnalyzer {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(ts_str.clone());
-                    }
+                    self.cardinality.insert(&ts_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(ts_str);
                     }
@@ -640,9 +603,7 @@ impl ColumnAnalyzer {
                 let bytes = array.value(index);
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(format!("len:{}", len));
-                }
+                self.cardinality.insert(&format!("len:{}", len));
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(format!("<binary:{} bytes>", len));
                 }
@@ -657,9 +618,7 @@ impl ColumnAnalyzer {
                 let bytes = array.value(index);
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(format!("len:{}", len));
-                }
+                self.cardinality.insert(&format!("len:{}", len));
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(format!("<binary:{} bytes>", len));
                 }
@@ -674,9 +633,7 @@ impl ColumnAnalyzer {
                 let decimal_value = array.value(index);
                 self.update_numeric_stats(decimal_value as f64);
                 let decimal_str = format!("dec128:{}", decimal_value);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(decimal_str.clone());
-                }
+                self.cardinality.insert(&decimal_str);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(decimal_str);
                 }
@@ -690,9 +647,7 @@ impl ColumnAnalyzer {
             if !array.is_null(index) {
                 let decimal_str = format!("dec256:value_{}", index);
                 self.update_text_stats(&decimal_str);
-                if self.unique_values.len() < 1000 {
-                    self.unique_values.insert(decimal_str.clone());
-                }
+                self.cardinality.insert(&decimal_str);
                 if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                     self.sample_values.push(decimal_str);
                 }
@@ -713,9 +668,7 @@ impl ColumnAnalyzer {
                     let dur_value = dur_array.value(index);
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}ns", dur_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(dur_str.clone());
-                    }
+                    self.cardinality.insert(&dur_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(dur_str);
                     }
@@ -730,9 +683,7 @@ impl ColumnAnalyzer {
                     let dur_value = dur_array.value(index);
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}us", dur_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(dur_str.clone());
-                    }
+                    self.cardinality.insert(&dur_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(dur_str);
                     }
@@ -747,9 +698,7 @@ impl ColumnAnalyzer {
                     let dur_value = dur_array.value(index);
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}ms", dur_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(dur_str.clone());
-                    }
+                    self.cardinality.insert(&dur_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(dur_str);
                     }
@@ -764,9 +713,7 @@ impl ColumnAnalyzer {
                     let dur_value = dur_array.value(index);
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}s", dur_value);
-                    if self.unique_values.len() < 1000 {
-                        self.unique_values.insert(dur_str.clone());
-                    }
+                    self.cardinality.insert(&dur_str);
                     if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                         self.sample_values.push(dur_str);
                     }
@@ -787,9 +734,7 @@ impl ColumnAnalyzer {
                         if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                             self.sample_values.push(value_str.clone());
                         }
-                        if self.unique_values.len() < 1000 {
-                            self.unique_values.insert(value_str);
-                        }
+                        self.cardinality.insert(&value_str);
                     }
                 }
             }
@@ -801,9 +746,7 @@ impl ColumnAnalyzer {
                         if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
                             self.sample_values.push(value_str.clone());
                         }
-                        if self.unique_values.len() < 1000 {
-                            self.unique_values.insert(value_str);
-                        }
+                        self.cardinality.insert(&value_str);
                     }
                 }
             }
@@ -857,7 +800,7 @@ impl ColumnAnalyzer {
             data_type,
             total_count: self.total_count,
             null_count: self.null_count,
-            unique_count: Some(self.unique_values.len()),
+            unique_count: Some(self.cardinality.estimate()),
             sample_values: &self.sample_values,
             text_lengths: Some(TextLengths {
                 min_length: self.min_length,
@@ -1046,5 +989,42 @@ mod tests {
             ColumnStats::Text(..) => {}
             _ => panic!("Expected Text stats for label column"),
         }
+    }
+
+    fn unique_count_for_distinct_ints(distinct: i64) -> usize {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "id",
+            ArrowDataType::Int64,
+            false,
+        )]));
+        let ids = Int64Array::from((0..distinct).collect::<Vec<_>>());
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids)]).unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        analyzer.process_batch(&batch).unwrap();
+        let profiles = analyzer.to_profiles(false, false, None);
+        profiles
+            .iter()
+            .find(|p| p.name == "id")
+            .unwrap()
+            .unique_count
+            .unwrap()
+    }
+
+    #[test]
+    fn test_unique_count_is_not_capped_at_1000() {
+        // Regression for the columnar hard cap: a high-cardinality column used to
+        // report exactly 1,000 distinct values, corrupting quality scores. Small
+        // columns must stay exact; large ones must estimate near the truth and
+        // never freeze at the old cap.
+        assert_eq!(unique_count_for_distinct_ints(999), 999);
+        assert_eq!(unique_count_for_distinct_ints(1_000), 1_000);
+        assert_eq!(unique_count_for_distinct_ints(1_001), 1_001);
+        assert_eq!(unique_count_for_distinct_ints(10_000), 10_000);
+
+        let large = unique_count_for_distinct_ints(100_000);
+        assert_ne!(large, 1_000, "must not expose the old hard cap as exact");
+        let error = (large as f64 - 100_000.0).abs() / 100_000.0;
+        assert!(error < 0.05, "100k distinct estimated as {large}");
     }
 }

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -1,9 +1,9 @@
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use std::collections::{HashMap, HashSet};
-use std::hash::{BuildHasher, Hasher};
 
 use crate::profile_builder::infer_data_type_streaming;
+use dataprof_metrics::HyperLogLog;
 use dataprof_metrics::analysis::inference::is_null_like_token;
 
 /// Incremental statistics computation for streaming data processing.
@@ -243,92 +243,6 @@ impl Default for TextLengthStats {
     }
 }
 
-struct HllBuildHasher;
-
-impl BuildHasher for HllBuildHasher {
-    type Hasher = std::collections::hash_map::DefaultHasher;
-
-    fn build_hasher(&self) -> Self::Hasher {
-        std::collections::hash_map::DefaultHasher::new()
-    }
-}
-
-#[derive(Clone)]
-struct HllCounter {
-    registers: Vec<u8>,
-}
-
-impl std::fmt::Debug for HllCounter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HllCounter")
-            .field("precision", &14u8)
-            .field("registers_len", &self.registers.len())
-            .finish()
-    }
-}
-
-impl HllCounter {
-    const PRECISION: usize = 14;
-    const NUM_REGISTERS: usize = 1 << Self::PRECISION;
-
-    fn new() -> Self {
-        Self {
-            registers: vec![0u8; Self::NUM_REGISTERS],
-        }
-    }
-
-    #[inline]
-    fn insert(&mut self, value: &str) {
-        let mut hasher = HllBuildHasher.build_hasher();
-        hasher.write(value.as_bytes());
-        let hash = hasher.finish();
-
-        let index = (hash as usize) & (Self::NUM_REGISTERS - 1);
-        let window = hash >> Self::PRECISION;
-        let rank = (window.leading_zeros() - Self::PRECISION as u32 + 1) as u8;
-
-        if rank > self.registers[index] {
-            self.registers[index] = rank;
-        }
-    }
-
-    fn count(&self) -> u64 {
-        let register_count = Self::NUM_REGISTERS as f64;
-        let alpha = 0.7213 / (1.0 + 1.079 / register_count);
-
-        let raw_estimate: f64 = alpha * register_count * register_count
-            / self
-                .registers
-                .iter()
-                .map(|&register| 2.0_f64.powi(-(register as i32)))
-                .sum::<f64>();
-
-        if raw_estimate <= 2.5 * register_count {
-            let zeros = self
-                .registers
-                .iter()
-                .filter(|&&register| register == 0)
-                .count() as f64;
-            if zeros > 0.0 {
-                (register_count * (register_count / zeros).ln()) as u64
-            } else {
-                raw_estimate as u64
-            }
-        } else if raw_estimate <= (1u64 << 32) as f64 / 30.0 {
-            raw_estimate as u64
-        } else {
-            let two32 = (1u64 << 32) as f64;
-            (-two32 * (1.0 - raw_estimate / two32).ln()) as u64
-        }
-    }
-
-    fn merge(&mut self, other: &HllCounter) {
-        for (left, right) in self.registers.iter_mut().zip(other.registers.iter()) {
-            *left = (*left).max(*right);
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct StreamingStatistics {
     pub count: usize,
@@ -336,7 +250,7 @@ pub struct StreamingStatistics {
     pub min: f64,
     pub max: f64,
     welford: WelfordAccumulator,
-    hll: HllCounter,
+    hll: HyperLogLog,
     sampler: StreamReservoirSampler,
     text_length_tracker: TextLengthStats,
 }
@@ -349,7 +263,7 @@ impl StreamingStatistics {
             min: f64::INFINITY,
             max: f64::NEG_INFINITY,
             welford: WelfordAccumulator::new(),
-            hll: HllCounter::new(),
+            hll: HyperLogLog::new(),
             sampler: StreamReservoirSampler::new(10_000),
             text_length_tracker: TextLengthStats::new(),
         }
@@ -438,7 +352,7 @@ impl StreamingStatistics {
 
     pub fn memory_usage_bytes(&self) -> usize {
         let struct_size = std::mem::size_of::<Self>();
-        let hll_size = self.hll.registers.len();
+        let hll_size = self.hll.memory_usage_bytes();
         let reservoir_size = self.sampler.memory_usage_bytes();
 
         struct_size + hll_size + reservoir_size
@@ -705,7 +619,7 @@ mod tests {
 
     #[test]
     fn test_hll_cardinality() {
-        let mut counter = HllCounter::new();
+        let mut counter = HyperLogLog::new();
         let total = 100_000;
         for index in 0..total {
             counter.insert(&format!("item_{index}"));

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -177,6 +177,35 @@ def test_engine_parity(engine, reference, tmp_path):
     assert_profiles_match(engine, report, reference, EXPECTED_EXCEPTIONS)
 
 
+# ── High-cardinality regression (issue #386) ──
+#
+# The columnar (Arrow) engine used to stop counting distinct values at an
+# internal cap of 1,000 and expose that cap as the exact unique_count, so a
+# high-cardinality column reported 1,000 distinct and its quality score
+# collapsed ~20 points below the streaming engines. Every file engine must now
+# agree that a fully-distinct column has close to N distinct values.
+
+
+@pytest.mark.parametrize("engine", ["auto", "columnar", "incremental"])
+def test_high_cardinality_unique_count_not_capped(engine, tmp_path):
+    n_rows = 50_000
+    path = tmp_path / "high_card.csv"
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id"])
+        for value in range(n_rows):
+            writer.writerow([value])
+
+    report = dataprof.profile(str(path), engine=engine)
+    unique = report["id"].unique_count
+
+    assert unique != 1000, f"{engine}: unique_count frozen at the old hard cap"
+    # HLL carries ~1% relative error; well within 5% of the true distinct count.
+    assert abs(unique - n_rows) / n_rows < 0.05, (
+        f"{engine}: {n_rows} distinct ids reported as {unique}"
+    )
+
+
 # ── SQLite arm (requires --features python-async,database,sqlite) ──
 
 

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -199,6 +199,7 @@ def test_high_cardinality_unique_count_not_capped(engine, tmp_path):
     report = dataprof.profile(str(path), engine=engine)
     unique = report["id"].unique_count
 
+    assert unique is not None, f"{engine}: unique_count missing"
     assert unique != 1000, f"{engine}: unique_count frozen at the old hard cap"
     # HLL carries ~1% relative error; well within 5% of the true distinct count.
     assert abs(unique - n_rows) / n_rows < 0.05, (


### PR DESCRIPTION
## Summary

Closes #386 (P0 correctness bug).

The Arrow file engines (`arrow_profiler`, `record_batch_analyzer`) stopped inserting into a `HashSet` once it held 1,000 values, then exposed that set length as the **exact** `unique_count`. A high-cardinality column reported exactly 1,000 distinct — a 500× error on a 500k-row `id` column — which cascaded into key-uniqueness / high-cardinality quality metrics and knocked ~20 points off the columnar quality score versus the streaming engines.

## Fix

Introduce a shared `CardinalityEstimator` in `dataprof-metrics`:
- **Exact** while under `EXACT_CARDINALITY_THRESHOLD` (10,000) distinct values, then an accurate **HyperLogLog** estimate.
- Bounded memory (exact set is dropped once it spills; HLL is ~16 KB fixed), with `is_approximate()` provenance.
- The HLL implementation is lifted out of `streaming_stats.rs` and shared, so the file and streaming engines use **one algorithm** and agree — a fully-distinct 500k column now reports 501,201 on every engine.

### Changes
- Extract `HyperLogLog` + `CardinalityEstimator` into `dataprof-metrics::stats::cardinality`.
- `streaming_stats.rs` reuses the shared `HyperLogLog` (behavior unchanged; all existing tests green).
- Both Arrow analyzers accumulate into a `CardinalityEstimator` instead of a capped `HashSet`.

## Verification

Dogfood repro (500k rows, `id` fully distinct, `amount` 1,000 distinct):

| engine | `id.unique` (before) | `id.unique` (after) | quality (after) |
|---|---:|---:|---:|
| columnar | **1,000** | **501,201** | 100.0 |
| incremental | 501,201 | 501,201 | 100.0 |
| auto | 501,201 | 501,201 | 100.0 |

All engines now agree exactly on `id`; the ~20-point columnar quality gap is gone.

### Tests
- Rust unit tests for the estimator and both Arrow analyzers at **999 / 1,000 / 1,001 / 10,000 / 100,000** distinct.
- Python high-cardinality cross-engine parity test (auto / columnar / incremental).
- Full workspace `cargo test`, `cargo fmt --check`, `cargo clippy` clean; all 248 Python tests + 12 parity tests pass.

## Scope note

#386's acceptance list mentions "approximation provenance per #383". The estimator exposes `is_approximate()`, but **surfacing** it on the public `ColumnProfile` / report is a schema change that belongs to #383 — no such field exists today, and the streaming engine's own approximation flag isn't surfaced either. This PR fixes the correctness/quality corruption; the public provenance contract remains #383's.