### PR TITLE
feat(metrics): track duplicate rows across streams

### DIFF
--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -335,6 +335,7 @@ pub fn analyze_csv_file_with_dimensions_and_hints(
     )
     .columns(column_profiles)
     .with_quality_data(sample_columns)
+    .with_row_duplicates(column_stats.row_duplicate_summary())
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {
         assembler = assembler.with_requested_dimensions(dimensions.to_vec());

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -219,6 +219,7 @@ impl AsyncStreamingProfiler {
         let mut assembler = ReportAssembler::new(data_source, execution)
             .columns(column_profiles)
             .with_quality_data(sample_columns)
+            .with_row_duplicates(column_stats.row_duplicate_summary())
             .with_semantic_hints(self.semantic_hints.clone());
         if let Some(ref dims) = self.quality_dimensions {
             assembler = assembler.with_requested_dimensions(dims.clone());

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -326,6 +326,7 @@ impl IncrementalProfiler {
         if MetricPack::include_quality(packs) {
             assembler = assembler
                 .with_quality_data(sample_columns)
+                .with_row_duplicates(column_stats.row_duplicate_summary())
                 .with_semantic_hints(self.semantic_hints.clone());
             if let Some(ref dims) = self.quality_dimensions {
                 assembler = assembler.with_requested_dimensions(dims.clone());

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -465,6 +465,7 @@ pub fn analyze_json_file_with_dimensions_and_hints(
     let mut assembler = ReportAssembler::new(file_source, execution)
         .columns(column_profiles)
         .with_quality_data(sample_columns)
+        .with_row_duplicates(column_stats.row_duplicate_summary())
         .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {
         assembler = assembler.with_requested_dimensions(dimensions.to_vec());

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -74,7 +74,7 @@ use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
 use crate::types::{
     AccuracyMetrics, ColumnProfile, CompletenessMetrics, ConsistencyMetrics, QualityDimension,
-    QualityMetrics, TimelinessMetrics, UniquenessMetrics,
+    QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
 };
 use std::collections::HashMap;
 
@@ -149,16 +149,20 @@ impl MetricsCalculator {
             column_profiles,
             requested_dimensions,
             &[],
+            None,
         )
     }
 
-    /// Calculate comprehensive metrics with explicit positive-only column hints.
+    /// Calculate comprehensive metrics with explicit positive-only column
+    /// hints and, when the engine tracked whole rows, full-stream duplicate
+    /// counts that supersede the sample-based duplicate scan.
     pub fn calculate_comprehensive_metrics_with_positive_columns(
         &self,
         data: &HashMap<String, Vec<String>>,
         column_profiles: &[ColumnProfile],
         requested_dimensions: Option<&[QualityDimension]>,
         positive_columns: &[String],
+        row_duplicates: Option<RowDuplicateSummary>,
     ) -> Result<QualityMetrics, DataProfilerError> {
         if data.is_empty() {
             return Ok(Self::default_metrics_for_empty_dataset(
@@ -215,6 +219,7 @@ impl MetricsCalculator {
                 data,
                 column_profiles,
                 sample_size,
+                row_duplicates,
             )?;
             Some(UniquenessMetrics {
                 duplicate_rows: u.duplicate_rows,
@@ -222,6 +227,7 @@ impl MetricsCalculator {
                 high_cardinality_warning: u.high_cardinality_warning,
                 rows_checked: u.rows_checked,
                 key_column: u.key_column,
+                duplicate_rows_approximate: u.duplicate_rows_approximate,
             })
         } else {
             None
@@ -310,6 +316,7 @@ impl MetricsCalculator {
                     high_cardinality_warning: false,
                     rows_checked: 0,
                     key_column: None,
+                    duplicate_rows_approximate: false,
                 })
             } else {
                 None
@@ -345,8 +352,9 @@ impl MetricsCalculator {
     /// from `ColumnProfile` stats (`null_count`, `total_count`) which are exact
     /// even for infinite streams. Key uniqueness already uses `ColumnProfile`.
     ///
-    /// **Phase B (sampled)**: Consistency, Accuracy, Timeliness, and duplicate_rows
-    /// are computed from the bounded reservoir sample.
+    /// **Phase B (sampled)**: Consistency, Accuracy, and Timeliness are computed
+    /// from the bounded reservoir sample. Duplicate rows use a full-stream row
+    /// tracker when supplied; otherwise they fall back to an aligned sample.
     ///
     /// Returns a [`BifurcatedResult`] containing the metrics plus provenance
     /// for which dimensions are exact vs sampled.
@@ -361,16 +369,20 @@ impl MetricsCalculator {
             column_profiles,
             requested_dimensions,
             &[],
+            None,
         )
     }
 
-    /// Calculate bifurcated metrics with explicit positive-only column hints.
+    /// Calculate bifurcated metrics with explicit positive-only column
+    /// hints and, when the engine tracked whole rows, full-stream duplicate
+    /// counts that supersede the sample-based duplicate scan.
     pub fn calculate_bifurcated_metrics_with_positive_columns(
         &self,
         data: &HashMap<String, Vec<String>>,
         column_profiles: &[ColumnProfile],
         requested_dimensions: Option<&[QualityDimension]>,
         positive_columns: &[String],
+        row_duplicates: Option<RowDuplicateSummary>,
     ) -> Result<BifurcatedResult, DataProfilerError> {
         if data.is_empty() && column_profiles.is_empty() {
             return Ok(BifurcatedResult {
@@ -431,16 +443,24 @@ impl MetricsCalculator {
                 data,
                 column_profiles,
                 total_rows,
+                row_duplicates,
             )?;
             // Only claim provenance for components that carry signal:
             // key_uniqueness means nothing without an identified key column,
             // and the duplicate scan refuses misaligned per-column samples
-            // (rows_checked == 0).
+            // (rows_checked == 0). Full-stream tracker counts are exact
+            // until the distinct estimator spills to its HLL sketch, after
+            // which they are flagged approximate and filed as non-exact.
             if u.key_column.is_some() {
                 exact_dimensions.push("key_uniqueness".to_string());
             }
             if u.rows_checked > 0 {
-                sampled_dimensions.push("duplicate_rows".to_string());
+                let from_tracker = row_duplicates.is_some_and(|s| s.rows_checked > 0);
+                if from_tracker && !u.duplicate_rows_approximate {
+                    exact_dimensions.push("duplicate_rows".to_string());
+                } else {
+                    sampled_dimensions.push("duplicate_rows".to_string());
+                }
             }
             Some(UniquenessMetrics {
                 duplicate_rows: u.duplicate_rows,
@@ -448,6 +468,7 @@ impl MetricsCalculator {
                 high_cardinality_warning: u.high_cardinality_warning,
                 rows_checked: u.rows_checked,
                 key_column: u.key_column,
+                duplicate_rows_approximate: u.duplicate_rows_approximate,
             })
         } else {
             None

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -215,10 +215,13 @@ impl MetricsCalculator {
 
         // Uniqueness dimension
         let uniqueness = if Self::is_requested(requested, QualityDimension::Uniqueness) {
+            let uniqueness_total_rows = row_duplicates
+                .filter(|summary| summary.rows_checked > 0)
+                .map_or(sample_size, |summary| summary.rows_checked);
             let u = UniquenessCalculator::new(&self.thresholds).calculate(
                 data,
                 column_profiles,
-                sample_size,
+                uniqueness_total_rows,
                 row_duplicates,
             )?;
             Some(UniquenessMetrics {
@@ -577,4 +580,50 @@ pub struct BifurcatedResult {
     pub sampled_dimensions: Vec<String>,
     /// Number of sample rows used for Phase B dimensions
     pub sample_size: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ColumnStats, DataType};
+
+    #[test]
+    fn comprehensive_metrics_use_tracker_rows_for_cardinality_ratio() {
+        let data = HashMap::from([(
+            "city".to_string(),
+            vec!["Rome".to_string(), "Milan".to_string()],
+        )]);
+        let profiles = vec![ColumnProfile {
+            name: "city".to_string(),
+            data_type: DataType::String,
+            null_count: 0,
+            total_count: 1_000,
+            unique_count: Some(100),
+            stats: ColumnStats::None,
+            patterns: Some(vec![]),
+        }];
+        let requested = [QualityDimension::Uniqueness];
+
+        let metrics = MetricsCalculator::new()
+            .calculate_comprehensive_metrics_with_positive_columns(
+                &data,
+                &profiles,
+                Some(&requested),
+                &[],
+                Some(RowDuplicateSummary {
+                    duplicate_rows: 0,
+                    rows_checked: 1_000,
+                    approximate: false,
+                }),
+            )
+            .expect("quality metrics");
+
+        assert!(
+            !metrics
+                .uniqueness
+                .expect("uniqueness metrics")
+                .high_cardinality_warning,
+            "100 distinct values out of 1,000 rows is not high cardinality"
+        );
+    }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
@@ -6,6 +6,7 @@
 use super::utils::is_likely_id_column;
 use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
+use crate::quality::RowDuplicateSummary;
 use crate::types::ColumnProfile;
 use std::collections::{HashMap, HashSet};
 
@@ -17,6 +18,7 @@ pub(crate) struct UniquenessMetrics {
     pub high_cardinality_warning: bool,
     pub rows_checked: usize,
     pub key_column: Option<String>,
+    pub duplicate_rows_approximate: bool,
 }
 
 /// Calculator for uniqueness dimension metrics
@@ -29,15 +31,29 @@ impl<'a> UniquenessCalculator<'a> {
         Self { thresholds }
     }
 
-    /// Calculate uniqueness dimension metrics
+    /// Calculate uniqueness dimension metrics.
+    ///
+    /// `row_duplicates` carries full-stream duplicate counts from an
+    /// engine's row tracker; when present it supersedes the sample-based
+    /// duplicate scan (which only works on provably row-aligned samples).
     pub fn calculate(
         &self,
         data: &HashMap<String, Vec<String>>,
         column_profiles: &[ColumnProfile],
         total_rows: usize,
+        row_duplicates: Option<RowDuplicateSummary>,
     ) -> Result<UniquenessMetrics, DataProfilerError> {
-        let (duplicate_rows, rows_checked) =
-            Self::count_exact_duplicate_rows(data, column_profiles)?;
+        let (duplicate_rows, rows_checked, duplicate_rows_approximate) = match row_duplicates {
+            Some(summary) if summary.rows_checked > 0 => (
+                summary.duplicate_rows,
+                summary.rows_checked,
+                summary.approximate,
+            ),
+            _ => {
+                let (duplicates, rows) = Self::count_exact_duplicate_rows(data, column_profiles)?;
+                (duplicates, rows, false)
+            }
+        };
         let (key_uniqueness, key_column) = Self::calculate_key_uniqueness(column_profiles)?;
         let high_cardinality_warning = self.check_high_cardinality(column_profiles, total_rows);
 
@@ -47,6 +63,7 @@ impl<'a> UniquenessCalculator<'a> {
             high_cardinality_warning,
             rows_checked,
             key_column,
+            duplicate_rows_approximate,
         })
     }
 
@@ -156,5 +173,249 @@ impl<'a> UniquenessCalculator<'a> {
                 false
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ColumnStats, DataType};
+
+    fn profile(name: &str, total: usize, unique: Option<usize>) -> ColumnProfile {
+        ColumnProfile {
+            name: name.to_string(),
+            data_type: DataType::String,
+            null_count: 0,
+            total_count: total,
+            unique_count: unique,
+            stats: ColumnStats::None,
+            patterns: Some(vec![]),
+        }
+    }
+
+    fn column(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| v.to_string()).collect()
+    }
+
+    fn cardinality_column(total: usize, unique: usize) -> Vec<String> {
+        (0..total).map(|i| (i % unique).to_string()).collect()
+    }
+
+    #[test]
+    fn test_uniqueness_case_table() {
+        struct Case {
+            name: &'static str,
+            data: HashMap<String, Vec<String>>,
+            profiles: Vec<ColumnProfile>,
+            total_rows: usize,
+            duplicate_rows: usize,
+            rows_checked: usize,
+            key_uniqueness: f64,
+            key_column: Option<&'static str>,
+            high_cardinality_warning: bool,
+        }
+
+        let cases = [
+            Case {
+                name: "all rows distinct",
+                data: HashMap::from([("city".to_string(), column(&["a", "b", "c"]))]),
+                profiles: vec![profile("city", 3, Some(3))],
+                total_rows: 3,
+                duplicate_rows: 0,
+                rows_checked: 3,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: true, // 3/3 unique, non-id column
+            },
+            Case {
+                name: "one exact duplicate row",
+                data: HashMap::from([("city".to_string(), column(&["a", "b", "a"]))]),
+                profiles: vec![profile("city", 3, Some(2))],
+                total_rows: 3,
+                duplicate_rows: 1,
+                rows_checked: 3,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: false,
+            },
+            Case {
+                name: "all rows identical",
+                data: HashMap::from([("city".to_string(), column(&["a", "a", "a", "a"]))]),
+                profiles: vec![profile("city", 4, Some(1))],
+                total_rows: 4,
+                duplicate_rows: 3,
+                rows_checked: 4,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: false,
+            },
+            Case {
+                name: "fully unique identifier column",
+                data: HashMap::from([("user_id".to_string(), column(&["1", "2", "3"]))]),
+                profiles: vec![profile("user_id", 3, Some(3))],
+                total_rows: 3,
+                duplicate_rows: 0,
+                rows_checked: 3,
+                key_uniqueness: 100.0,
+                key_column: Some("user_id"),
+                high_cardinality_warning: false, // id columns are excluded
+            },
+            Case {
+                name: "partially unique identifier column",
+                data: HashMap::from([("user_id".to_string(), column(&["1", "2", "2", "3"]))]),
+                profiles: vec![profile("user_id", 4, Some(3))],
+                total_rows: 4,
+                duplicate_rows: 1,
+                rows_checked: 4,
+                key_uniqueness: 75.0,
+                key_column: Some("user_id"),
+                high_cardinality_warning: false,
+            },
+            Case {
+                name: "high cardinality just below threshold",
+                data: HashMap::from([("note".to_string(), cardinality_column(100, 94))]),
+                profiles: vec![profile("note", 100, Some(94))],
+                total_rows: 100,
+                duplicate_rows: 6,
+                rows_checked: 100,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: false,
+            },
+            Case {
+                name: "high cardinality at threshold (not above)",
+                data: HashMap::from([("note".to_string(), cardinality_column(100, 95))]),
+                profiles: vec![profile("note", 100, Some(95))],
+                total_rows: 100,
+                duplicate_rows: 5,
+                rows_checked: 100,
+                key_uniqueness: 100.0,
+                key_column: None,
+                // 95/100 == threshold exactly; the check requires strictly above
+                high_cardinality_warning: false,
+            },
+            Case {
+                name: "high cardinality above threshold",
+                data: HashMap::from([("note".to_string(), cardinality_column(100, 96))]),
+                profiles: vec![profile("note", 100, Some(96))],
+                total_rows: 100,
+                duplicate_rows: 4,
+                rows_checked: 100,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: true,
+            },
+            Case {
+                name: "empty input",
+                data: HashMap::new(),
+                profiles: vec![],
+                total_rows: 0,
+                duplicate_rows: 0,
+                rows_checked: 0,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: false,
+            },
+            Case {
+                name: "single row",
+                data: HashMap::from([("city".to_string(), column(&["a"]))]),
+                profiles: vec![profile("city", 1, Some(1))],
+                total_rows: 1,
+                duplicate_rows: 0,
+                rows_checked: 1,
+                key_uniqueness: 100.0,
+                key_column: None,
+                high_cardinality_warning: true, // 1/1 unique, non-id column
+            },
+        ];
+
+        let thresholds = IsoQualityConfig::default();
+        let calculator = UniquenessCalculator::new(&thresholds);
+
+        for case in cases {
+            let metrics = calculator
+                .calculate(&case.data, &case.profiles, case.total_rows, None)
+                .unwrap_or_else(|e| panic!("{}: calculation failed: {e}", case.name));
+
+            assert_eq!(
+                metrics.duplicate_rows, case.duplicate_rows,
+                "{}: duplicate_rows",
+                case.name
+            );
+            assert_eq!(
+                metrics.rows_checked, case.rows_checked,
+                "{}: rows_checked",
+                case.name
+            );
+            assert!(
+                (metrics.key_uniqueness - case.key_uniqueness).abs() < 0.01,
+                "{}: key_uniqueness {} != {}",
+                case.name,
+                metrics.key_uniqueness,
+                case.key_uniqueness
+            );
+            assert_eq!(
+                metrics.key_column.as_deref(),
+                case.key_column,
+                "{}: key_column",
+                case.name
+            );
+            assert_eq!(
+                metrics.high_cardinality_warning, case.high_cardinality_warning,
+                "{}: high_cardinality_warning",
+                case.name
+            );
+            assert!(
+                !metrics.duplicate_rows_approximate,
+                "{}: sample-scan duplicates are never approximate",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_row_duplicate_summary_supersedes_sample_scan() {
+        let thresholds = IsoQualityConfig::default();
+        let calculator = UniquenessCalculator::new(&thresholds);
+        // Misaligned sample (2 vs 3 values): the scan alone would refuse it.
+        let data = HashMap::from([
+            ("a".to_string(), column(&["x", "y"])),
+            ("b".to_string(), column(&["1", "2", "3"])),
+        ]);
+        let profiles = vec![profile("a", 1000, Some(2)), profile("b", 1000, Some(3))];
+
+        let without = calculator
+            .calculate(&data, &profiles, 1000, None)
+            .expect("scan-only path");
+        assert_eq!(without.rows_checked, 0, "misaligned sample must not scan");
+
+        let summary = RowDuplicateSummary {
+            duplicate_rows: 40,
+            rows_checked: 1000,
+            approximate: true,
+        };
+        let with = calculator
+            .calculate(&data, &profiles, 1000, Some(summary))
+            .expect("summary path");
+        assert_eq!(with.duplicate_rows, 40);
+        assert_eq!(with.rows_checked, 1000);
+        assert!(with.duplicate_rows_approximate);
+    }
+
+    #[test]
+    fn test_misaligned_sample_lengths_are_not_scanned() {
+        let thresholds = IsoQualityConfig::default();
+        let calculator = UniquenessCalculator::new(&thresholds);
+        let data = HashMap::from([
+            ("a".to_string(), column(&["x", "x", "x"])),
+            ("b".to_string(), column(&["1", "1"])),
+        ]);
+        let profiles = vec![profile("a", 3, Some(1)), profile("b", 3, Some(1))];
+
+        let metrics = calculator
+            .calculate(&data, &profiles, 3, None)
+            .expect("metrics");
+        assert_eq!(metrics.duplicate_rows, 0);
+        assert_eq!(metrics.rows_checked, 0);
     }
 }

--- a/crates/dataprof-metrics/src/lib.rs
+++ b/crates/dataprof-metrics/src/lib.rs
@@ -12,7 +12,7 @@ pub use analysis::{
 };
 pub use quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, QualityAssessment,
-    QualityMetrics, TimelinessMetrics, UniquenessMetrics,
+    QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
 };
 pub use stats::{
     CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog, calculate_datetime_stats,

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -48,6 +48,25 @@ pub struct UniquenessMetrics {
     /// and does not contribute to the dimension score.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_column: Option<String>,
+    /// True when `duplicate_rows` comes from the full-stream distinct-count
+    /// estimator after it spilled to its HLL sketch (~1% relative error on
+    /// the distinct count), rather than an exact count.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub duplicate_rows_approximate: bool,
+}
+
+/// Full-stream row-duplicate counts produced by an engine's row tracker.
+///
+/// Engines that see whole records (CSV, JSON, streaming readers) count
+/// duplicates over *every* row with bounded memory: exact below the
+/// distinct-row threshold, HLL-estimated (and flagged) beyond it. When
+/// available this supersedes the sample-based duplicate scan, which cannot
+/// run at all on misaligned per-column samples.
+#[derive(Debug, Clone, Copy)]
+pub struct RowDuplicateSummary {
+    pub duplicate_rows: usize,
+    pub rows_checked: usize,
+    pub approximate: bool,
 }
 
 /// Accuracy metrics (ISO 25012).
@@ -130,6 +149,7 @@ impl QualityMetrics {
                 high_cardinality_warning: false,
                 rows_checked: 0,
                 key_column: None,
+                duplicate_rows_approximate: false,
             }),
             accuracy: Some(AccuracyMetrics {
                 outlier_ratio: 0.0,
@@ -189,9 +209,10 @@ impl QualityMetrics {
     /// dimension was not computed or neither component had data.
     ///
     /// Mean of the available components: share of non-duplicate rows (when
-    /// rows could be scanned for duplicates) and `key_uniqueness` (when a
-    /// key column was identified). In streaming runs the duplicate scan is
-    /// typically not assessable while key uniqueness stays exact.
+    /// a row tracker or an aligned sample scan produced a count) and
+    /// `key_uniqueness` (when a key column was identified). Engines without
+    /// a row tracker whose samples cannot be proven row-aligned contribute
+    /// only the key component.
     pub fn uniqueness_score(&self) -> Option<f64> {
         let u = self.uniqueness.as_ref()?;
         let duplicate_score = (u.rows_checked > 0)
@@ -465,6 +486,7 @@ mod tests {
                 high_cardinality_warning: false,
                 rows_checked: 100,
                 key_column: None,
+                duplicate_rows_approximate: false,
             }),
             accuracy: Some(AccuracyMetrics {
                 outlier_ratio: 0.0,
@@ -699,6 +721,7 @@ mod tests {
                 high_cardinality_warning: false,
                 rows_checked: 100,
                 key_column: None,
+                duplicate_rows_approximate: false,
             }),
             ..QualityMetrics::default()
         };
@@ -783,6 +806,7 @@ mod tests {
                         high_cardinality_warning: true,
                         rows_checked: 25,
                         key_column: Some("user_id".to_string()),
+                        duplicate_rows_approximate: false,
                     }),
                     ..QualityMetrics::default()
                 },

--- a/crates/dataprof-metrics/src/types.rs
+++ b/crates/dataprof-metrics/src/types.rs
@@ -5,5 +5,5 @@ pub use dataprof_core::{
 
 pub use crate::quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, QualityAssessment,
-    QualityMetrics, TimelinessMetrics, UniquenessMetrics,
+    QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
 };

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -489,6 +489,14 @@ impl PyDataQualityMetrics {
                         .unbind()
                         .into_any(),
                 );
+                m.insert(
+                    "duplicate_rows_approximate".into(),
+                    u.duplicate_rows_approximate
+                        .into_pyobject(py)?
+                        .to_owned()
+                        .unbind()
+                        .into_any(),
+                );
                 Ok(m)
             })
             .transpose()

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -11,7 +11,8 @@ use dataprof_core::{
     ColumnProfile, DataSource, ExecutionMetadata, QualityDimension, SemanticHints,
 };
 use dataprof_metrics::{
-    MetricConfidence, MetricsCalculator, QualityAssessment, analysis::metrics::BifurcatedResult,
+    MetricConfidence, MetricsCalculator, QualityAssessment, RowDuplicateSummary,
+    analysis::metrics::BifurcatedResult,
 };
 
 use crate::ProfileReport;
@@ -26,6 +27,7 @@ pub struct ReportAssembler {
     skip_quality: bool,
     requested_dimensions: Option<Vec<QualityDimension>>,
     semantic_hints: SemanticHints,
+    row_duplicates: Option<RowDuplicateSummary>,
 }
 
 impl ReportAssembler {
@@ -40,6 +42,7 @@ impl ReportAssembler {
             skip_quality: false,
             requested_dimensions: None,
             semantic_hints: SemanticHints::default(),
+            row_duplicates: None,
         }
     }
 
@@ -76,6 +79,13 @@ impl ReportAssembler {
     /// Set semantic hints used by quality metrics.
     pub fn with_semantic_hints(mut self, hints: SemanticHints) -> Self {
         self.semantic_hints = hints;
+        self
+    }
+
+    /// Provide full-stream row-duplicate counts from an engine's row
+    /// tracker; they supersede the sample-based duplicate scan.
+    pub fn with_row_duplicates(mut self, summary: Option<RowDuplicateSummary>) -> Self {
+        self.row_duplicates = summary;
         self
     }
 
@@ -118,6 +128,7 @@ impl ReportAssembler {
             &self.columns,
             self.requested_dimensions.as_deref(),
             &self.semantic_hints.positive_columns,
+            self.row_duplicates,
         ) {
             Ok(result) => {
                 let confidence = self
@@ -146,6 +157,7 @@ impl ReportAssembler {
             &self.columns,
             self.requested_dimensions.as_deref(),
             &self.semantic_hints.positive_columns,
+            self.row_duplicates,
         ) {
             Ok(metrics) => {
                 let confidence = self.confidence.clone().unwrap_or(MetricConfidence::Exact);
@@ -250,6 +262,66 @@ mod tests {
                 assert_eq!(*sample_size, 2);
             }
             other => panic!("Expected Mixed confidence, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_streaming_exact_row_duplicates_have_exact_provenance() {
+        let data = HashMap::from([("col".to_string(), vec!["a".to_string(), "b".to_string()])]);
+
+        let report = ReportAssembler::new(test_source(), ExecutionMetadata::new(1000, 1, 50))
+            .with_quality_data(data)
+            .with_row_duplicates(Some(RowDuplicateSummary {
+                duplicate_rows: 25,
+                rows_checked: 1000,
+                approximate: false,
+            }))
+            .build();
+
+        let quality = report.quality.expect("quality assessment");
+        let uniqueness = quality.metrics.uniqueness.expect("uniqueness metrics");
+        assert_eq!(uniqueness.duplicate_rows, 25);
+        assert_eq!(uniqueness.rows_checked, 1000);
+        assert!(!uniqueness.duplicate_rows_approximate);
+        match quality.confidence {
+            MetricConfidence::Mixed {
+                exact_dimensions,
+                sampled_dimensions,
+                ..
+            } => {
+                assert!(exact_dimensions.contains(&"duplicate_rows".to_string()));
+                assert!(!sampled_dimensions.contains(&"duplicate_rows".to_string()));
+            }
+            other => panic!("Expected Mixed confidence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_streaming_approximate_row_duplicates_have_sampled_provenance() {
+        let data = HashMap::from([("col".to_string(), vec!["a".to_string(), "b".to_string()])]);
+
+        let report = ReportAssembler::new(test_source(), ExecutionMetadata::new(20_000, 1, 50))
+            .with_quality_data(data)
+            .with_row_duplicates(Some(RowDuplicateSummary {
+                duplicate_rows: 500,
+                rows_checked: 20_000,
+                approximate: true,
+            }))
+            .build();
+
+        let quality = report.quality.expect("quality assessment");
+        let uniqueness = quality.metrics.uniqueness.expect("uniqueness metrics");
+        assert!(uniqueness.duplicate_rows_approximate);
+        match quality.confidence {
+            MetricConfidence::Mixed {
+                exact_dimensions,
+                sampled_dimensions,
+                ..
+            } => {
+                assert!(!exact_dimensions.contains(&"duplicate_rows".to_string()));
+                assert!(sampled_dimensions.contains(&"duplicate_rows".to_string()));
+            }
+            other => panic!("Expected Mixed confidence, got {other:?}"),
         }
     }
 

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -485,12 +485,15 @@ impl StreamingColumnCollection {
         // Length-prefixed so field boundaries are unambiguous:
         // ["ab", "c"] and ["a", "bc"] must produce different signatures.
         let mut row_signature = String::new();
-        let mut saw_field = false;
+        let mut values = values.into_iter();
 
-        for (header, value) in headers.iter().zip(values) {
+        // Headers define the row schema. Normalize a missing trailing field to
+        // the profiler's empty/null representation so ragged flexible records
+        // update every column and hash identically to an explicit empty field.
+        for header in headers {
+            let value = values.next().unwrap_or_default();
             let _ = write!(row_signature, "{}:", value.len());
             row_signature.push_str(&value);
-            saw_field = true;
 
             if !self.columns.contains_key(header) {
                 self.ordered_names.push(header.clone());
@@ -499,7 +502,7 @@ impl StreamingColumnCollection {
             stats.update(&value);
         }
 
-        if saw_field {
+        if !headers.is_empty() {
             self.row_tracker.observe(row_signature);
         }
     }
@@ -614,6 +617,27 @@ mod row_tracker_tests {
         assert_eq!(
             summary.duplicate_rows, 0,
             "different field splits must not collide"
+        );
+    }
+
+    #[test]
+    fn test_ragged_rows_normalize_missing_trailing_fields() {
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        record(&mut collection, &headers, &["x"]);
+        record(&mut collection, &headers, &["x", ""]);
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert_eq!(summary.rows_checked, 2);
+        assert_eq!(summary.duplicate_rows, 1);
+        assert_eq!(
+            collection
+                .get_column_stats("b")
+                .expect("column b")
+                .null_count,
+            2
         );
     }
 

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -1,10 +1,11 @@
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 
 use crate::profile_builder::infer_data_type_streaming;
-use dataprof_metrics::HyperLogLog;
 use dataprof_metrics::analysis::inference::is_null_like_token;
+use dataprof_metrics::{CardinalityEstimator, HyperLogLog, RowDuplicateSummary};
 
 /// Incremental statistics computation for streaming data processing.
 ///
@@ -365,10 +366,67 @@ impl Default for StreamingStatistics {
     }
 }
 
+/// Full-stream row-duplicate tracking with bounded memory.
+///
+/// Every record's fields are folded into a canonical length-prefixed
+/// signature and fed to a [`CardinalityEstimator`]: duplicates are counted
+/// exactly while the distinct-row signatures fit the estimator's exact set,
+/// and estimated (flagged approximate) once it spills to its HLL sketch.
+/// Unlike the per-column reservoirs, this sees whole rows — including
+/// null-like values — so the count is row-aligned by construction.
+#[derive(Debug, Clone, Default)]
+pub struct RowUniquenessTracker {
+    rows_seen: usize,
+    distinct: CardinalityEstimator,
+}
+
+impl RowUniquenessTracker {
+    pub fn observe(&mut self, signature: String) {
+        self.rows_seen += 1;
+        self.distinct.insert_owned(signature);
+    }
+
+    pub fn rows_seen(&self) -> usize {
+        self.rows_seen
+    }
+
+    /// Rows minus distinct rows; exact until the estimator spills.
+    pub fn duplicate_rows(&self) -> usize {
+        self.rows_seen.saturating_sub(self.distinct.estimate())
+    }
+
+    pub fn is_approximate(&self) -> bool {
+        self.distinct.is_approximate()
+    }
+
+    pub fn merge(&mut self, other: &RowUniquenessTracker) {
+        self.rows_seen += other.rows_seen;
+        self.distinct.merge(&other.distinct);
+    }
+
+    pub fn memory_usage_bytes(&self) -> usize {
+        self.distinct.memory_usage_bytes()
+    }
+
+    /// Summary for quality metrics, or `None` when no rows were observed
+    /// (e.g. an engine that never fed whole records through this tracker).
+    pub fn summary(&self) -> Option<RowDuplicateSummary> {
+        if self.rows_seen == 0 {
+            return None;
+        }
+        Some(RowDuplicateSummary {
+            duplicate_rows: self.duplicate_rows(),
+            rows_checked: self.rows_seen,
+            approximate: self.is_approximate(),
+        })
+    }
+}
+
 pub struct StreamingColumnCollection {
     columns: HashMap<String, StreamingStatistics>,
     ordered_names: Vec<String>,
     memory_limit_bytes: usize,
+    row_tracker: RowUniquenessTracker,
 }
 
 impl StreamingColumnCollection {
@@ -377,6 +435,7 @@ impl StreamingColumnCollection {
             columns: HashMap::new(),
             ordered_names: Vec::new(),
             memory_limit_bytes: 100 * 1024 * 1024,
+            row_tracker: RowUniquenessTracker::default(),
         }
     }
 
@@ -385,6 +444,7 @@ impl StreamingColumnCollection {
             columns: HashMap::new(),
             ordered_names: Vec::new(),
             memory_limit_bytes: limit_mb * 1024 * 1024,
+            row_tracker: RowUniquenessTracker::default(),
         }
     }
 
@@ -422,13 +482,31 @@ impl StreamingColumnCollection {
     where
         I: IntoIterator<Item = String>,
     {
+        // Length-prefixed so field boundaries are unambiguous:
+        // ["ab", "c"] and ["a", "bc"] must produce different signatures.
+        let mut row_signature = String::new();
+        let mut saw_field = false;
+
         for (header, value) in headers.iter().zip(values) {
+            let _ = write!(row_signature, "{}:", value.len());
+            row_signature.push_str(&value);
+            saw_field = true;
+
             if !self.columns.contains_key(header) {
                 self.ordered_names.push(header.clone());
             }
             let stats = self.columns.entry(header.to_string()).or_default();
             stats.update(&value);
         }
+
+        if saw_field {
+            self.row_tracker.observe(row_signature);
+        }
+    }
+
+    /// Full-stream row-duplicate counts, or `None` when no rows were seen.
+    pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
+        self.row_tracker.summary()
     }
 
     pub fn get_column_stats(&self, column_name: &str) -> Option<&StreamingStatistics> {
@@ -443,7 +521,8 @@ impl StreamingColumnCollection {
         self.columns
             .values()
             .map(|stats| stats.memory_usage_bytes())
-            .sum()
+            .sum::<usize>()
+            + self.row_tracker.memory_usage_bytes()
     }
 
     pub fn is_memory_pressure(&self) -> bool {
@@ -485,12 +564,104 @@ impl StreamingColumnCollection {
                 }
             }
         }
+        self.row_tracker.merge(&other.row_tracker);
     }
 }
 
 impl Default for StreamingColumnCollection {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod row_tracker_tests {
+    use super::*;
+
+    fn record(collection: &mut StreamingColumnCollection, headers: &[String], values: &[&str]) {
+        collection.process_record(headers, values.iter().map(|v| v.to_string()));
+    }
+
+    #[test]
+    fn test_exact_duplicates_including_null_rows() {
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        record(&mut collection, &headers, &["x", ""]);
+        record(&mut collection, &headers, &["x", ""]);
+        record(&mut collection, &headers, &["x", "1"]);
+        record(&mut collection, &headers, &["", ""]);
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert_eq!(summary.rows_checked, 4);
+        // Null-like values are part of the row identity: the per-column
+        // reservoirs drop them, but the row tracker must not.
+        assert_eq!(summary.duplicate_rows, 1);
+        assert!(!summary.approximate);
+    }
+
+    #[test]
+    fn test_field_boundaries_are_unambiguous() {
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        record(&mut collection, &headers, &["ab", "c"]);
+        record(&mut collection, &headers, &["a", "bc"]);
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert_eq!(
+            summary.duplicate_rows, 0,
+            "different field splits must not collide"
+        );
+    }
+
+    #[test]
+    fn test_no_rows_means_no_summary() {
+        let collection = StreamingColumnCollection::new();
+        assert!(collection.row_duplicate_summary().is_none());
+    }
+
+    #[test]
+    fn test_spills_to_approximate_beyond_distinct_threshold() {
+        let headers = vec!["n".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        let distinct = dataprof_metrics::EXACT_CARDINALITY_THRESHOLD + 500;
+        for i in 0..distinct {
+            record(&mut collection, &headers, &[&i.to_string()]);
+        }
+        // Every row twice: duplicates == distinct.
+        for i in 0..distinct {
+            record(&mut collection, &headers, &[&i.to_string()]);
+        }
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert!(summary.approximate, "past the threshold the count is HLL");
+        assert_eq!(summary.rows_checked, distinct * 2);
+        let error = (summary.duplicate_rows as f64 - distinct as f64).abs() / distinct as f64;
+        assert!(
+            error < 0.05,
+            "estimated {} duplicates for {distinct} true, off by {error:.4}",
+            summary.duplicate_rows
+        );
+    }
+
+    #[test]
+    fn test_merge_combines_row_trackers() {
+        let headers = vec!["a".to_string()];
+        let mut left = StreamingColumnCollection::new();
+        let mut right = StreamingColumnCollection::new();
+        record(&mut left, &headers, &["x"]);
+        record(&mut left, &headers, &["y"]);
+        record(&mut right, &headers, &["x"]);
+
+        left.merge(right);
+        let summary = left.row_duplicate_summary().expect("rows were observed");
+        assert_eq!(summary.rows_checked, 3);
+        assert_eq!(summary.duplicate_rows, 1);
     }
 }
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -30,8 +30,7 @@ Now:
   of "assume perfect".
 - The duplicate-row scan refuses per-column samples it cannot prove
   row-aligned (null-stripped or reservoir-evicted columns) instead of
-  comparing unrelated values. In streaming runs `duplicate_rows` is reported
-  as not assessed (`rows_checked == 0`); key uniqueness stays exact.
+  comparing unrelated values.
 - `report.quality_score()` returns `None` when nothing was assessable (empty
   dataset, or a report serialized by an older version) instead of a
   fabricated 100. `overall_score()` on raw metrics returns 0.0 in that case —
@@ -41,6 +40,28 @@ Now:
 move down or stay; datasets whose old score leaned on vacuous-perfect
 dimensions drop the most. The weights (0.30 / 0.25 / 0.20 / 0.15 / 0.10) are
 unchanged and still dataprof's own formula, not an ISO-mandated one.
+
+## Duplicate rows are now counted over the full stream
+
+The CSV, JSON, and streaming engines track row identity while they read:
+every record's fields fold into a length-prefixed signature fed to the same
+exact-then-HLL distinct estimator that backs `unique_count`. As a result:
+
+- `duplicate_rows` covers **every row of the source** — including rows with
+  null values, which the old sample-based scan could never see — with
+  `rows_checked` reporting the full row count.
+- Below ~10,000 distinct rows the count is exact. Beyond that the distinct
+  estimator spills to its HLL sketch and the derived duplicate count is an
+  estimate (~1% relative error on distincts), flagged by the new
+  `UniquenessMetrics.duplicate_rows_approximate` field and filed as
+  non-exact provenance.
+- Engines without a row tracker (Parquet record batches, DataFrames, Arrow)
+  keep the alignment-guarded sample scan; when the sample cannot be proven
+  row-aligned, `duplicate_rows` stays not-assessed rather than wrong.
+
+`MetricsCalculator::calculate_{comprehensive,bifurcated}_metrics_with_positive_columns`
+gained a `row_duplicates: Option<RowDuplicateSummary>` parameter; pass `None`
+to keep the previous behavior.
 
 ---
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -368,6 +368,20 @@ class TestProfileReport:
         assert "score=" in r
         assert "dimensions=" in r
 
+    def test_csv_duplicate_rows_cover_full_stream_and_expose_provenance(self, tmp_path):
+        path = tmp_path / "duplicates.csv"
+        path.write_text("a,b\nx,1\nx,1\ny,2\n", encoding="utf-8")
+
+        report = dataprof.profile(str(path), quality_dimensions=["uniqueness"])
+        quality = report.quality
+        assert quality is not None
+        uniqueness = quality.uniqueness
+        assert uniqueness is not None
+
+        assert uniqueness["duplicate_rows"] == 1
+        assert uniqueness["rows_checked"] == 3
+        assert uniqueness["duplicate_rows_approximate"] is False
+
     @pytest.mark.parametrize(
         ("attr", "dimension", "key", "default"),
         [


### PR DESCRIPTION
## Summary

- track duplicate rows across CSV, JSON, and streaming engine records with the bounded exact-then-HLL cardinality estimator
- thread `RowDuplicateSummary` through `MetricsCalculator` and `ReportAssembler`, exposing whether counts are approximate and labeling provenance accordingly
- add the #377 table-driven uniqueness cases, row-tracker and provenance tests, plus Python end-to-end coverage
- document the behavior and public API change in the release notes

## Why

Per-column reservoirs can discard null-like values and evict rows independently, so their samples are not always row-aligned. That made sample-derived duplicate counts unavailable for streaming profiles. Tracking whole-record signatures while engines read records provides a correct full-stream signal with bounded memory and explicit approximation provenance after the exact estimator spills.

## User impact

Streaming profiles now report `duplicate_rows` and `rows_checked` for the records processed by the engine. Python uniqueness dictionaries include `duplicate_rows_approximate`. The public `MetricsCalculator::calculate_{comprehensive,bifurcated}_metrics_with_positive_columns` methods gain a `row_duplicates` argument; callers without an engine summary pass `None`.

## Verification

- `cargo test -p dataprof-metrics uniqueness`
- `cargo test -p dataprof-runtime streaming_stats`
- `cargo test -p dataprof-runtime report_assembler`
- `cargo test -p dataprof-csv -p dataprof-json -p dataprof-engines -p dataprof-python`
- `uv run maturin develop`
- `uv run pytest python/tests/test_python_api.py -q` (238 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings`
- `uv run ruff format python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`

Closes #377
