### PR TITLE
feat(metrics): honor identifier column hints

### DIFF
--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -160,6 +160,24 @@ impl MetricsCalculator {
         requested_dimensions: Option<&[QualityDimension]>,
         positive_columns: &[String],
     ) -> Result<QualityMetrics, DataProfilerError> {
+        self.calculate_comprehensive_metrics_with_semantic_hints(
+            data,
+            column_profiles,
+            requested_dimensions,
+            positive_columns,
+            &[],
+        )
+    }
+
+    /// Calculate comprehensive metrics with explicit semantic column hints.
+    pub fn calculate_comprehensive_metrics_with_semantic_hints(
+        &self,
+        data: &HashMap<String, Vec<String>>,
+        column_profiles: &[ColumnProfile],
+        requested_dimensions: Option<&[QualityDimension]>,
+        positive_columns: &[String],
+        identifier_columns: &[String],
+    ) -> Result<QualityMetrics, DataProfilerError> {
         if data.is_empty() {
             return Ok(Self::default_metrics_for_empty_dataset(
                 &requested_dimensions,
@@ -215,6 +233,7 @@ impl MetricsCalculator {
                 data,
                 column_profiles,
                 sample_size,
+                identifier_columns,
             )?;
             Some(UniquenessMetrics {
                 duplicate_rows: u.duplicate_rows,
@@ -372,6 +391,24 @@ impl MetricsCalculator {
         requested_dimensions: Option<&[QualityDimension]>,
         positive_columns: &[String],
     ) -> Result<BifurcatedResult, DataProfilerError> {
+        self.calculate_bifurcated_metrics_with_semantic_hints(
+            data,
+            column_profiles,
+            requested_dimensions,
+            positive_columns,
+            &[],
+        )
+    }
+
+    /// Calculate bifurcated metrics with explicit semantic column hints.
+    pub fn calculate_bifurcated_metrics_with_semantic_hints(
+        &self,
+        data: &HashMap<String, Vec<String>>,
+        column_profiles: &[ColumnProfile],
+        requested_dimensions: Option<&[QualityDimension]>,
+        positive_columns: &[String],
+        identifier_columns: &[String],
+    ) -> Result<BifurcatedResult, DataProfilerError> {
         if data.is_empty() && column_profiles.is_empty() {
             return Ok(BifurcatedResult {
                 metrics: Self::default_metrics_for_empty_dataset(&requested_dimensions),
@@ -431,6 +468,7 @@ impl MetricsCalculator {
                 data,
                 column_profiles,
                 total_rows,
+                identifier_columns,
             )?;
             // Only claim provenance for components that carry signal:
             // key_uniqueness means nothing without an identified key column,

--- a/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
@@ -35,11 +35,14 @@ impl<'a> UniquenessCalculator<'a> {
         data: &HashMap<String, Vec<String>>,
         column_profiles: &[ColumnProfile],
         total_rows: usize,
+        identifier_columns: &[String],
     ) -> Result<UniquenessMetrics, DataProfilerError> {
         let (duplicate_rows, rows_checked) =
             Self::count_exact_duplicate_rows(data, column_profiles)?;
-        let (key_uniqueness, key_column) = Self::calculate_key_uniqueness(column_profiles)?;
-        let high_cardinality_warning = self.check_high_cardinality(column_profiles, total_rows);
+        let (key_uniqueness, key_column) =
+            Self::calculate_key_uniqueness(column_profiles, identifier_columns)?;
+        let high_cardinality_warning =
+            self.check_high_cardinality(column_profiles, total_rows, identifier_columns);
 
         Ok(UniquenessMetrics {
             duplicate_rows,
@@ -108,15 +111,18 @@ impl<'a> UniquenessCalculator<'a> {
     /// signal" rather than "perfect key".
     fn calculate_key_uniqueness(
         column_profiles: &[ColumnProfile],
+        identifier_columns: &[String],
     ) -> Result<(f64, Option<String>), DataProfilerError> {
-        // Look for ID-like columns
-        let key_column = column_profiles.iter().find(|profile| {
-            let name_lower = profile.name.to_lowercase();
-            name_lower.contains("id")
-                || name_lower.contains("key")
-                || name_lower == "pk"
-                || name_lower.ends_with("_id")
-        });
+        // Explicit semantic hints take precedence and retain user-supplied
+        // order. Fall back to the conservative name heuristic when absent.
+        let key_column = identifier_columns
+            .iter()
+            .find_map(|name| column_profiles.iter().find(|profile| profile.name == *name))
+            .or_else(|| {
+                column_profiles
+                    .iter()
+                    .find(|profile| is_likely_id_column(&profile.name))
+            });
 
         if let Some(key_col) = key_column {
             if let Some(unique_count) = key_col.unique_count {
@@ -140,7 +146,12 @@ impl<'a> UniquenessCalculator<'a> {
 
     /// Check for high cardinality warning
     /// Uses configurable high_cardinality_threshold from ISO thresholds (default: 95%)
-    fn check_high_cardinality(&self, column_profiles: &[ColumnProfile], total_rows: usize) -> bool {
+    fn check_high_cardinality(
+        &self,
+        column_profiles: &[ColumnProfile],
+        total_rows: usize,
+        identifier_columns: &[String],
+    ) -> bool {
         if total_rows == 0 {
             return false;
         }
@@ -151,7 +162,9 @@ impl<'a> UniquenessCalculator<'a> {
             if let Some(unique_count) = profile.unique_count {
                 let cardinality_ratio = unique_count as f64 / total_rows as f64;
                 // Flag if a column exceeds threshold (excluding obvious ID columns)
-                cardinality_ratio > threshold && !is_likely_id_column(&profile.name)
+                let is_identifier = identifier_columns.contains(&profile.name)
+                    || is_likely_id_column(&profile.name);
+                cardinality_ratio > threshold && !is_identifier
             } else {
                 false
             }

--- a/crates/dataprof-metrics/src/analysis/metrics/utils.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/utils.rs
@@ -120,11 +120,51 @@ pub(crate) fn is_likely_date_column(column_name: &str) -> bool {
 
 /// Check if column is likely an ID column
 pub(crate) fn is_likely_id_column(column_name: &str) -> bool {
-    let name_lower = column_name.to_lowercase();
-    name_lower.contains("id")
-        || name_lower.contains("key")
-        || name_lower == "pk"
-        || name_lower.ends_with("_id")
+    identifier_words(column_name).into_iter().any(|word| {
+        word.eq_ignore_ascii_case("id")
+            || word.eq_ignore_ascii_case("key")
+            || word.eq_ignore_ascii_case("pk")
+    })
+}
+
+/// Split snake/kebab/spaced and camel/Pascal case names into semantic words.
+/// This keeps identifier inference from treating unrelated names such as
+/// `paid`, `valid`, or `monkey` as keys merely because they contain `id` or
+/// `key` as a substring.
+fn identifier_words(column_name: &str) -> Vec<&str> {
+    let mut boundaries = Vec::with_capacity(column_name.len() / 2 + 2);
+    boundaries.push(0);
+
+    let chars: Vec<(usize, char)> = column_name.char_indices().collect();
+    for (index, &(byte_index, current)) in chars.iter().enumerate() {
+        if !current.is_alphanumeric() {
+            boundaries.push(byte_index);
+            boundaries.push(byte_index + current.len_utf8());
+            continue;
+        }
+
+        let previous = index
+            .checked_sub(1)
+            .and_then(|i| chars.get(i))
+            .map(|(_, c)| *c);
+        let next = chars.get(index + 1).map(|(_, c)| *c);
+        let camel_boundary = current.is_uppercase() && previous.is_some_and(char::is_lowercase)
+            || current.is_uppercase()
+                && previous.is_some_and(char::is_uppercase)
+                && next.is_some_and(char::is_lowercase);
+        if camel_boundary {
+            boundaries.push(byte_index);
+        }
+    }
+    boundaries.push(column_name.len());
+    boundaries.sort_unstable();
+    boundaries.dedup();
+
+    boundaries
+        .windows(2)
+        .filter_map(|range| column_name.get(range[0]..range[1]))
+        .filter(|word| word.chars().any(char::is_alphanumeric))
+        .collect()
 }
 
 /// Extract year from common date formats
@@ -188,4 +228,34 @@ pub(crate) fn calculate_percentile(sorted_values: &[f64], percentile: f64) -> f6
     let fraction = h - h_floor as f64;
 
     lower + fraction * (upper - lower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_likely_id_column;
+
+    #[test]
+    fn identifier_heuristic_matches_words_not_substrings() {
+        for name in [
+            "id",
+            "user_id",
+            "order-key",
+            "primary key",
+            "CustomerId",
+            "APIKey",
+            "pk",
+        ] {
+            assert!(
+                is_likely_id_column(name),
+                "expected {name:?} to be identifier-like"
+            );
+        }
+
+        for name in ["paid", "valid", "identity", "monkey", "skid", "keyboard"] {
+            assert!(
+                !is_likely_id_column(name),
+                "expected {name:?} not to be identifier-like"
+            );
+        }
+    }
 }

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -113,11 +113,12 @@ impl ReportAssembler {
         data: &HashMap<String, Vec<String>>,
     ) -> Option<QualityAssessment> {
         let calculator = MetricsCalculator::new();
-        match calculator.calculate_bifurcated_metrics_with_positive_columns(
+        match calculator.calculate_bifurcated_metrics_with_semantic_hints(
             data,
             &self.columns,
             self.requested_dimensions.as_deref(),
             &self.semantic_hints.positive_columns,
+            &self.semantic_hints.identifier_columns,
         ) {
             Ok(result) => {
                 let confidence = self
@@ -141,11 +142,12 @@ impl ReportAssembler {
         data: &HashMap<String, Vec<String>>,
     ) -> Option<QualityAssessment> {
         let calculator = MetricsCalculator::new();
-        match calculator.calculate_comprehensive_metrics_with_positive_columns(
+        match calculator.calculate_comprehensive_metrics_with_semantic_hints(
             data,
             &self.columns,
             self.requested_dimensions.as_deref(),
             &self.semantic_hints.positive_columns,
+            &self.semantic_hints.identifier_columns,
         ) {
             Ok(metrics) => {
                 let confidence = self.confidence.clone().unwrap_or(MetricConfidence::Exact);

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -28,6 +28,10 @@ Now:
 - `UniquenessMetrics.key_column` names the column `key_uniqueness` describes;
   when no key column is identified, key uniqueness carries no signal instead
   of "assume perfect".
+- Explicit `identifier_columns` hints now select the column used by
+  `key_uniqueness`. Without a hint, key-name inference matches complete words
+  such as `id`, `key`, and `pk` (including snake/kebab/camel case) instead of
+  substring false positives such as `paid`, `valid`, or `monkey`.
 - The duplicate-row scan refuses per-column samples it cannot prove
   row-aligned (null-stripped or reservoir-evicted columns) instead of
   comparing unrelated values. In streaming runs `duplicate_rows` is reported

--- a/tests/semantic_hints.rs
+++ b/tests/semantic_hints.rs
@@ -86,3 +86,32 @@ fn identifier_columns_are_semantic_strings_and_excluded_from_outliers() {
         0.0
     );
 }
+
+#[test]
+fn identifier_columns_drive_key_uniqueness_without_name_guessing() {
+    let csv = write_csv("invoice_number\nA\nB\nB\nC\n");
+
+    let without_hint = Profiler::new()
+        .engine(EngineType::Incremental)
+        .analyze_file(csv.path())
+        .expect("profile should succeed");
+    let without_uniqueness = without_hint
+        .quality
+        .as_ref()
+        .and_then(|quality| quality.metrics.uniqueness.as_ref())
+        .expect("uniqueness metrics");
+    assert_eq!(without_uniqueness.key_column, None);
+
+    let with_hint = Profiler::new()
+        .engine(EngineType::Incremental)
+        .identifier_columns(vec!["invoice_number".to_string()])
+        .analyze_file(csv.path())
+        .expect("profile should succeed");
+    let uniqueness = with_hint
+        .quality
+        .as_ref()
+        .and_then(|quality| quality.metrics.uniqueness.as_ref())
+        .expect("uniqueness metrics");
+    assert_eq!(uniqueness.key_column.as_deref(), Some("invoice_number"));
+    assert!((uniqueness.key_uniqueness - 75.0).abs() < 0.01);
+}


### PR DESCRIPTION
## Summary

- route explicit `identifier_columns` semantic hints into key-uniqueness calculation
- prefer hinted identifiers, while retaining name inference as a fallback
- replace substring matching with word-aware snake/kebab/camel/Pascal-case inference
- exclude explicitly hinted identifiers from high-cardinality warnings

## Why

The profiling pipeline already used `identifier_columns` to preserve semantic IDs and exclude them from numeric outlier analysis, but quality assembly dropped the hint before calculating uniqueness. At the same time, the fallback used raw `contains("id")` / `contains("key")`, so unrelated names such as `paid`, `valid`, and `monkey` could be treated as keys.

## User impact

An explicitly configured identifier now drives `key_uniqueness` and `key_column` even when its name does not look like an ID. Without a hint, common names such as `user_id`, `CustomerId`, `APIKey`, and `primary_key` still work, while substring false positives do not.

## Verification

- `cargo test -p dataprof-metrics` (190 passed)
- `cargo test --test semantic_hints` (3 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings`
