### PR TITLE
feat(metrics): require explicit temporal columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ dataprof evaluates data quality against the five dimensions defined in [ISO 8000
 | **Consistency** | Data type consistency, format violations, encoding issues |
 | **Uniqueness** | Duplicate rows, key uniqueness, high-cardinality warnings |
 | **Accuracy** | Outlier ratio, range violations, negative values in positive-only columns |
-| **Timeliness** | Future dates, stale data ratio, temporal ordering violations |
+| **Timeliness** | Future dates, stale data ratio, temporal ordering violations in explicit temporal columns |
 
 An overall quality score (0 -- 100) is computed as a weighted average of dimension scores.
 

--- a/crates/dataprof-core/src/semantic.rs
+++ b/crates/dataprof-core/src/semantic.rs
@@ -1,5 +1,6 @@
 /// User-supplied semantic hints that affect profiling and quality metrics.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct SemanticHints {
     pub positive_columns: Vec<String>,
     pub identifier_columns: Vec<String>,

--- a/crates/dataprof-core/src/semantic.rs
+++ b/crates/dataprof-core/src/semantic.rs
@@ -3,6 +3,7 @@
 pub struct SemanticHints {
     pub positive_columns: Vec<String>,
     pub identifier_columns: Vec<String>,
+    pub temporal_columns: Vec<String>,
 }
 
 impl SemanticHints {
@@ -10,11 +11,19 @@ impl SemanticHints {
         Self {
             positive_columns,
             identifier_columns,
+            temporal_columns: Vec::new(),
         }
     }
 
+    pub fn with_temporal_columns(mut self, temporal_columns: Vec<String>) -> Self {
+        self.temporal_columns = temporal_columns;
+        self
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.positive_columns.is_empty() && self.identifier_columns.is_empty()
+        self.positive_columns.is_empty()
+            && self.identifier_columns.is_empty()
+            && self.temporal_columns.is_empty()
     }
 
     pub fn is_identifier_column(&self, column_name: &str) -> bool {
@@ -25,6 +34,12 @@ impl SemanticHints {
 
     pub fn is_positive_column(&self, column_name: &str) -> bool {
         self.positive_columns
+            .iter()
+            .any(|candidate| candidate == column_name)
+    }
+
+    pub fn is_temporal_column(&self, column_name: &str) -> bool {
+        self.temporal_columns
             .iter()
             .any(|candidate| candidate == column_name)
     }

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -76,6 +76,7 @@ use crate::types::{
     AccuracyMetrics, ColumnProfile, CompletenessMetrics, ConsistencyMetrics, QualityDimension,
     QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
 };
+use dataprof_core::SemanticHints;
 use std::collections::HashMap;
 
 /// Engine for calculating comprehensive data quality metrics
@@ -184,6 +185,26 @@ impl MetricsCalculator {
         identifier_columns: &[String],
         row_duplicates: Option<RowDuplicateSummary>,
     ) -> Result<QualityMetrics, DataProfilerError> {
+        let semantic_hints =
+            SemanticHints::new(positive_columns.to_vec(), identifier_columns.to_vec());
+        self.calculate_comprehensive_metrics_with_all_semantic_hints(
+            data,
+            column_profiles,
+            requested_dimensions,
+            &semantic_hints,
+            row_duplicates,
+        )
+    }
+
+    /// Calculate comprehensive metrics with all explicit semantic column hints.
+    pub fn calculate_comprehensive_metrics_with_all_semantic_hints(
+        &self,
+        data: &HashMap<String, Vec<String>>,
+        column_profiles: &[ColumnProfile],
+        requested_dimensions: Option<&[QualityDimension]>,
+        semantic_hints: &SemanticHints,
+        row_duplicates: Option<RowDuplicateSummary>,
+    ) -> Result<QualityMetrics, DataProfilerError> {
         if data.is_empty() {
             return Ok(Self::default_metrics_for_empty_dataset(
                 &requested_dimensions,
@@ -242,7 +263,7 @@ impl MetricsCalculator {
                 data,
                 column_profiles,
                 uniqueness_total_rows,
-                identifier_columns,
+                &semantic_hints.identifier_columns,
                 row_duplicates,
             )?;
             Some(UniquenessMetrics {
@@ -260,13 +281,13 @@ impl MetricsCalculator {
         // Accuracy dimension
         let accuracy = if Self::is_requested(requested, QualityDimension::Accuracy) {
             let accuracy_calculator = AccuracyCalculator::new(&self.thresholds);
-            let a = if positive_columns.is_empty() {
+            let a = if semantic_hints.positive_columns.is_empty() {
                 accuracy_calculator.calculate(data, column_profiles)?
             } else {
                 accuracy_calculator.calculate_with_positive_columns(
                     data,
                     column_profiles,
-                    positive_columns,
+                    &semantic_hints.positive_columns,
                 )?
             };
             Some(AccuracyMetrics {
@@ -281,7 +302,8 @@ impl MetricsCalculator {
 
         // Timeliness dimension
         let timeliness = if Self::is_requested(requested, QualityDimension::Timeliness) {
-            let t = TimelinessCalculator::new(&self.thresholds).calculate(data, column_profiles)?;
+            let t = TimelinessCalculator::new(&self.thresholds)
+                .calculate(data, &semantic_hints.temporal_columns)?;
             Some(TimelinessMetrics {
                 future_dates_count: t.future_dates_count,
                 stale_data_ratio: t.stale_data_ratio,
@@ -428,6 +450,26 @@ impl MetricsCalculator {
         identifier_columns: &[String],
         row_duplicates: Option<RowDuplicateSummary>,
     ) -> Result<BifurcatedResult, DataProfilerError> {
+        let semantic_hints =
+            SemanticHints::new(positive_columns.to_vec(), identifier_columns.to_vec());
+        self.calculate_bifurcated_metrics_with_all_semantic_hints(
+            data,
+            column_profiles,
+            requested_dimensions,
+            &semantic_hints,
+            row_duplicates,
+        )
+    }
+
+    /// Calculate bifurcated metrics with all explicit semantic column hints.
+    pub fn calculate_bifurcated_metrics_with_all_semantic_hints(
+        &self,
+        data: &HashMap<String, Vec<String>>,
+        column_profiles: &[ColumnProfile],
+        requested_dimensions: Option<&[QualityDimension]>,
+        semantic_hints: &SemanticHints,
+        row_duplicates: Option<RowDuplicateSummary>,
+    ) -> Result<BifurcatedResult, DataProfilerError> {
         if data.is_empty() && column_profiles.is_empty() {
             return Ok(BifurcatedResult {
                 metrics: Self::default_metrics_for_empty_dataset(&requested_dimensions),
@@ -487,7 +529,7 @@ impl MetricsCalculator {
                 data,
                 column_profiles,
                 total_rows,
-                identifier_columns,
+                &semantic_hints.identifier_columns,
                 row_duplicates,
             )?;
             // Only claim provenance for components that carry signal:
@@ -524,7 +566,7 @@ impl MetricsCalculator {
                 AccuracyCalculator::new(&self.thresholds).calculate_with_positive_columns(
                     data,
                     column_profiles,
-                    positive_columns,
+                    &semantic_hints.positive_columns,
                 )?
             } else {
                 accuracy::AccuracyMetrics {
@@ -547,7 +589,8 @@ impl MetricsCalculator {
 
         let timeliness = if Self::is_requested(requested, QualityDimension::Timeliness) {
             let t = if !data.is_empty() {
-                TimelinessCalculator::new(&self.thresholds).calculate(data, column_profiles)?
+                TimelinessCalculator::new(&self.thresholds)
+                    .calculate(data, &semantic_hints.temporal_columns)?
             } else {
                 timeliness::TimelinessMetrics {
                     future_dates_count: 0,

--- a/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
@@ -6,7 +6,6 @@
 use super::utils::extract_year;
 use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
-use crate::types::{ColumnProfile, DataType};
 use chrono::Datelike;
 use std::collections::HashMap;
 
@@ -34,12 +33,13 @@ impl<'a> TimelinessCalculator<'a> {
     pub fn calculate(
         &self,
         data: &HashMap<String, Vec<String>>,
-        column_profiles: &[ColumnProfile],
+        temporal_columns: &[String],
     ) -> Result<TimelinessMetrics, DataProfilerError> {
-        let future_dates_count = Self::count_future_dates(data, column_profiles)?;
+        let future_dates_count = Self::count_future_dates(data, temporal_columns)?;
         let (stale_data_ratio, date_values_checked) =
-            self.calculate_stale_data_ratio(data, column_profiles)?;
-        let (temporal_violations, temporal_pairs_checked) = Self::count_temporal_violations(data)?;
+            self.calculate_stale_data_ratio(data, temporal_columns)?;
+        let (temporal_violations, temporal_pairs_checked) =
+            Self::count_temporal_violations(data, temporal_columns)?;
 
         Ok(TimelinessMetrics {
             future_dates_count,
@@ -53,30 +53,27 @@ impl<'a> TimelinessCalculator<'a> {
     /// Count dates that are in the future (beyond current date)
     fn count_future_dates(
         data: &HashMap<String, Vec<String>>,
-        column_profiles: &[ColumnProfile],
+        temporal_columns: &[String],
     ) -> Result<usize, DataProfilerError> {
         let mut future_count = 0;
 
         // Get current year from system time
         let current_year = chrono::Utc::now().year();
 
-        for profile in column_profiles {
-            if !matches!(profile.data_type, DataType::Date) {
+        for (column_name, column_data) in data {
+            if !temporal_columns.contains(column_name) {
                 continue;
             }
+            for value in column_data {
+                if value.is_empty() {
+                    continue;
+                }
 
-            if let Some(column_data) = data.get(&profile.name) {
-                for value in column_data {
-                    if value.is_empty() {
-                        continue;
-                    }
-
-                    // Extract year from common date formats
-                    if let Some(year) = extract_year(value)
-                        && year > current_year
-                    {
-                        future_count += 1;
-                    }
+                // Extract year from common date formats
+                if let Some(year) = extract_year(value)
+                    && year > current_year
+                {
+                    future_count += 1;
                 }
             }
         }
@@ -89,7 +86,7 @@ impl<'a> TimelinessCalculator<'a> {
     fn calculate_stale_data_ratio(
         &self,
         data: &HashMap<String, Vec<String>>,
-        column_profiles: &[ColumnProfile],
+        temporal_columns: &[String],
     ) -> Result<(f64, usize), DataProfilerError> {
         let mut total_dates = 0;
         let mut stale_dates = 0;
@@ -98,22 +95,19 @@ impl<'a> TimelinessCalculator<'a> {
         let current_year = chrono::Utc::now().year();
         let threshold_year = current_year - self.thresholds.max_data_age_years as i32;
 
-        for profile in column_profiles {
-            if !matches!(profile.data_type, DataType::Date) {
+        for (column_name, column_data) in data {
+            if !temporal_columns.contains(column_name) {
                 continue;
             }
+            for value in column_data {
+                if value.is_empty() {
+                    continue;
+                }
 
-            if let Some(column_data) = data.get(&profile.name) {
-                for value in column_data {
-                    if value.is_empty() {
-                        continue;
-                    }
-
-                    if let Some(year) = extract_year(value) {
-                        total_dates += 1;
-                        if year < threshold_year {
-                            stale_dates += 1;
-                        }
+                if let Some(year) = extract_year(value) {
+                    total_dates += 1;
+                    if year < threshold_year {
+                        stale_dates += 1;
                     }
                 }
             }
@@ -135,6 +129,7 @@ impl<'a> TimelinessCalculator<'a> {
     /// bounded by the number of date-typed values.
     fn count_temporal_violations(
         data: &HashMap<String, Vec<String>>,
+        temporal_columns: &[String],
     ) -> Result<(usize, usize), DataProfilerError> {
         let mut violations = 0;
         let mut pairs_checked = 0;
@@ -150,12 +145,12 @@ impl<'a> TimelinessCalculator<'a> {
         ];
 
         for (start_col, end_col) in &temporal_pairs {
-            let start_data = data
-                .iter()
-                .find(|(k, _)| k.to_lowercase().contains(start_col));
+            let start_data = data.iter().find(|(k, _)| {
+                temporal_columns.contains(k) && k.to_lowercase().contains(start_col)
+            });
             let end_data = data
                 .iter()
-                .find(|(k, _)| k.to_lowercase().contains(end_col));
+                .find(|(k, _)| temporal_columns.contains(k) && k.to_lowercase().contains(end_col));
 
             if let (Some((_, start_values)), Some((_, end_values))) = (start_data, end_data) {
                 for (start_val, end_val) in start_values.iter().zip(end_values.iter()) {
@@ -173,5 +168,69 @@ impl<'a> TimelinessCalculator<'a> {
         }
 
         Ok((violations, pairs_checked))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inferred_dates_are_not_assessed_without_explicit_temporal_columns() {
+        let data = HashMap::from([(
+            "observed_on".to_string(),
+            vec!["2020-01-01".to_string(), "2021-01-01".to_string()],
+        )]);
+        let config = IsoQualityConfig::default();
+
+        let metrics = TimelinessCalculator::new(&config)
+            .calculate(&data, &[])
+            .expect("timeliness metrics");
+
+        assert_eq!(metrics.date_values_checked, 0);
+        assert_eq!(metrics.future_dates_count, 0);
+        assert_eq!(metrics.temporal_pairs_checked, 0);
+    }
+
+    #[test]
+    fn explicit_temporal_columns_assess_parseable_values_even_in_mixed_columns() {
+        let data = HashMap::from([(
+            "event_value".to_string(),
+            vec!["2020-01-01".to_string(), "not-a-date".to_string()],
+        )]);
+        let config = IsoQualityConfig::default();
+
+        let metrics = TimelinessCalculator::new(&config)
+            .calculate(&data, &["event_value".to_string()])
+            .expect("timeliness metrics");
+
+        assert_eq!(metrics.date_values_checked, 1);
+    }
+
+    #[test]
+    fn temporal_ordering_requires_both_columns_to_be_explicit() {
+        let data = HashMap::from([
+            (
+                "start".to_string(),
+                vec!["2024-01-02".to_string(), "2024-01-01".to_string()],
+            ),
+            (
+                "end".to_string(),
+                vec!["2024-01-01".to_string(), "2024-01-02".to_string()],
+            ),
+        ]);
+        let config = IsoQualityConfig::default();
+        let calculator = TimelinessCalculator::new(&config);
+
+        let partial = calculator
+            .calculate(&data, &["start".to_string()])
+            .expect("partial timeliness metrics");
+        assert_eq!(partial.temporal_pairs_checked, 0);
+
+        let complete = calculator
+            .calculate(&data, &["start".to_string(), "end".to_string()])
+            .expect("complete timeliness metrics");
+        assert_eq!(complete.temporal_pairs_checked, 2);
+        assert_eq!(complete.temporal_violations, 1);
     }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
@@ -145,14 +145,23 @@ impl<'a> TimelinessCalculator<'a> {
         ];
 
         for (start_col, end_col) in &temporal_pairs {
-            let start_data = data.iter().find(|(k, _)| {
-                temporal_columns.contains(k) && k.to_lowercase().contains(start_col)
+            // Resolve ambiguous role matches in the order supplied by the user.
+            // Iterating `data` here would make the selected pair depend on the
+            // randomized iteration order of its HashMap.
+            let start_data = temporal_columns.iter().find_map(|name| {
+                name.to_lowercase()
+                    .contains(start_col)
+                    .then(|| data.get(name))
+                    .flatten()
             });
-            let end_data = data
-                .iter()
-                .find(|(k, _)| temporal_columns.contains(k) && k.to_lowercase().contains(end_col));
+            let end_data = temporal_columns.iter().find_map(|name| {
+                name.to_lowercase()
+                    .contains(end_col)
+                    .then(|| data.get(name))
+                    .flatten()
+            });
 
-            if let (Some((_, start_values)), Some((_, end_values))) = (start_data, end_data) {
+            if let (Some(start_values), Some(end_values)) = (start_data, end_data) {
                 for (start_val, end_val) in start_values.iter().zip(end_values.iter()) {
                     if start_val.is_empty() || end_val.is_empty() {
                         continue;
@@ -232,5 +241,43 @@ mod tests {
             .expect("complete timeliness metrics");
         assert_eq!(complete.temporal_pairs_checked, 2);
         assert_eq!(complete.temporal_violations, 1);
+    }
+
+    #[test]
+    fn temporal_ordering_uses_explicit_column_order_for_ambiguous_roles() {
+        let data = HashMap::from([
+            ("primary_start".to_string(), vec!["2024-01-01".to_string()]),
+            (
+                "secondary_start".to_string(),
+                vec!["2024-01-03".to_string()],
+            ),
+            ("end".to_string(), vec!["2024-01-02".to_string()]),
+        ]);
+        let config = IsoQualityConfig::default();
+        let calculator = TimelinessCalculator::new(&config);
+
+        let primary_first = calculator
+            .calculate(
+                &data,
+                &[
+                    "primary_start".to_string(),
+                    "secondary_start".to_string(),
+                    "end".to_string(),
+                ],
+            )
+            .expect("primary-first timeliness metrics");
+        assert_eq!(primary_first.temporal_violations, 0);
+
+        let secondary_first = calculator
+            .calculate(
+                &data,
+                &[
+                    "secondary_start".to_string(),
+                    "primary_start".to_string(),
+                    "end".to_string(),
+                ],
+            )
+            .expect("secondary-first timeliness metrics");
+        assert_eq!(secondary_first.temporal_violations, 1);
     }
 }

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -246,7 +246,8 @@ impl QualityMetrics {
     }
 
     /// Score for the timeliness dimension (0-100), or `None` when the
-    /// dimension was not computed or no date values were found.
+    /// dimension was not computed or no parseable values were found in the
+    /// explicitly configured temporal columns.
     ///
     /// `100 - stale_data_ratio`, penalized by future dates as a share of
     /// the date values checked and by temporal ordering violations as a

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -35,6 +35,7 @@ pub struct PyProfilerConfig {
     pub(crate) locale: Option<String>,
     pub(crate) positive_columns: Vec<String>,
     pub(crate) identifier_columns: Vec<String>,
+    pub(crate) temporal_columns: Vec<String>,
 }
 
 #[pymethods]
@@ -57,6 +58,7 @@ impl PyProfilerConfig {
         locale = None,
         positive_columns = None,
         identifier_columns = None,
+        temporal_columns = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -76,6 +78,7 @@ impl PyProfilerConfig {
         locale: Option<String>,
         positive_columns: Option<Vec<String>>,
         identifier_columns: Option<Vec<String>>,
+        temporal_columns: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let engine = parse_engine(engine)?;
         let format_override = format.map(parse_format).transpose()?;
@@ -144,6 +147,7 @@ impl PyProfilerConfig {
             locale,
             positive_columns: positive_columns.unwrap_or_default(),
             identifier_columns: identifier_columns.unwrap_or_default(),
+            temporal_columns: temporal_columns.unwrap_or_default(),
         })
     }
 
@@ -209,6 +213,12 @@ impl PyProfilerConfig {
     #[getter]
     fn identifier_columns(&self) -> Vec<String> {
         self.identifier_columns.clone()
+    }
+
+    /// Columns whose values should contribute to timeliness metrics
+    #[getter]
+    fn temporal_columns(&self) -> Vec<String> {
+        self.temporal_columns.clone()
     }
 
     fn __repr__(&self) -> String {
@@ -281,6 +291,9 @@ impl PyProfilerConfig {
         if !self.identifier_columns.is_empty() {
             profiler = profiler.identifier_columns(self.identifier_columns.clone());
         }
+        if !self.temporal_columns.is_empty() {
+            profiler = profiler.temporal_columns(self.temporal_columns.clone());
+        }
 
         profiler
     }
@@ -290,6 +303,7 @@ impl PyProfilerConfig {
             self.positive_columns.clone(),
             self.identifier_columns.clone(),
         )
+        .with_temporal_columns(self.temporal_columns.clone())
     }
 }
 

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -123,12 +123,11 @@ impl ReportAssembler {
         data: &HashMap<String, Vec<String>>,
     ) -> Option<QualityAssessment> {
         let calculator = MetricsCalculator::new();
-        match calculator.calculate_bifurcated_metrics_with_semantic_hints(
+        match calculator.calculate_bifurcated_metrics_with_all_semantic_hints(
             data,
             &self.columns,
             self.requested_dimensions.as_deref(),
-            &self.semantic_hints.positive_columns,
-            &self.semantic_hints.identifier_columns,
+            &self.semantic_hints,
             self.row_duplicates,
         ) {
             Ok(result) => {
@@ -153,12 +152,11 @@ impl ReportAssembler {
         data: &HashMap<String, Vec<String>>,
     ) -> Option<QualityAssessment> {
         let calculator = MetricsCalculator::new();
-        match calculator.calculate_comprehensive_metrics_with_semantic_hints(
+        match calculator.calculate_comprehensive_metrics_with_all_semantic_hints(
             data,
             &self.columns,
             self.requested_dimensions.as_deref(),
-            &self.semantic_hints.positive_columns,
-            &self.semantic_hints.identifier_columns,
+            &self.semantic_hints,
             self.row_duplicates,
         ) {
             Ok(metrics) => {

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -58,6 +58,8 @@ pub struct ProfilerConfig {
     pub positive_columns: Vec<String>,
     /// Columns that should be treated as semantic identifiers, not measures.
     pub identifier_columns: Vec<String>,
+    /// Columns whose values should contribute to timeliness quality metrics.
+    pub temporal_columns: Vec<String>,
     /// Database connection configuration. Required for `analyze_query()`.
     #[cfg(feature = "database")]
     pub database_config: Option<DatabaseConfig>,
@@ -80,6 +82,7 @@ impl Default for ProfilerConfig {
             locale: None,
             positive_columns: Vec::new(),
             identifier_columns: Vec::new(),
+            temporal_columns: Vec::new(),
             #[cfg(feature = "database")]
             database_config: None,
         }
@@ -246,6 +249,12 @@ impl Profiler {
         self
     }
 
+    /// Mark columns whose values should contribute to timeliness metrics.
+    pub fn temporal_columns(mut self, columns: Vec<String>) -> Self {
+        self.config.temporal_columns = columns;
+        self
+    }
+
     /// Set the progress update interval (default: 500ms)
     pub fn progress_interval(mut self, interval: Duration) -> Self {
         self.config.progress_interval = interval;
@@ -409,6 +418,7 @@ impl Profiler {
             self.config.positive_columns.clone(),
             self.config.identifier_columns.clone(),
         )
+        .with_temporal_columns(self.config.temporal_columns.clone())
     }
 
     /// Reject a stop condition richer than a plain row limit.
@@ -709,7 +719,7 @@ impl Profiler {
         let semantic_hints = self.semantic_hints();
         if !semantic_hints.is_empty() {
             return Err(DataProfilerError::UnsupportedDataSource {
-                message: "positive_columns and identifier_columns are not supported for database profiling yet".to_string(),
+                message: "positive_columns, identifier_columns, and temporal_columns are not supported for database profiling yet".to_string(),
             });
         }
         let config = self
@@ -737,7 +747,7 @@ impl Profiler {
         let semantic_hints = self.semantic_hints();
         if !semantic_hints.is_empty() {
             return Err(DataProfilerError::UnsupportedDataSource {
-                message: "positive_columns and identifier_columns are not supported for database profiling yet".to_string(),
+                message: "positive_columns, identifier_columns, and temporal_columns are not supported for database profiling yet".to_string(),
             });
         }
         let config = self

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -125,7 +125,9 @@ Measures whether values fall within expected ranges.
 
 ### Timeliness
 
-Measures whether date/time values are current and consistent.
+Measures whether explicitly selected date/time values are current and
+consistent. Pass `temporal_columns=["created_at", "updated_at"]` in Python or
+call `.temporal_columns(...)` on the Rust profiler to opt columns into scoring.
 
 - `future_dates_count` -- dates that are in the future
 - `stale_data_ratio` -- fraction of temporal data that appears outdated

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -79,6 +79,7 @@ dp.profile(
     locale=None,                     # str -- pattern locale hint, e.g. "IT"
     positive_columns=None,           # list[str] -- columns expected to be non-negative
     identifier_columns=None,         # list[str] -- semantic IDs, not measures
+    temporal_columns=None,           # list[str] -- columns assessed for timeliness
 ) -> ProfileReport
 ```
 
@@ -323,6 +324,9 @@ if q.completeness is not None:
 does not infer positive-only domains from column names. `identifier_columns`
 marks numeric-looking IDs as semantic strings so numeric stats and outlier
 metrics do not treat them as measures.
+Timeliness scoring is opt-in through `temporal_columns`; inferred date columns
+remain visible in column profiles but do not affect the quality score unless
+their names are explicitly selected.
 
 **Selective dimensions** -- compute only what you need:
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -25,6 +25,10 @@ Now:
   violations drive accuracy, future dates and temporal violations drive
   timeliness. Completeness is the mean of cell-level and row-level
   completeness.
+- Timeliness scoring is now opt-in through explicit `temporal_columns` hints.
+  Date inference still describes column types, but inferred dates do not affect
+  the quality score unless selected; this prevents arbitrary date-like fields
+  from silently imposing a freshness policy.
 - `UniquenessMetrics.key_column` names the column `key_uniqueness` describes;
   when no key column is identified, key uniqueness carries no signal instead
   of "assume perfect".

--- a/examples/messy_csv_inspection.rs
+++ b/examples/messy_csv_inspection.rs
@@ -36,11 +36,13 @@ fn main() -> Result<()> {
     let path = dir.path().join("orders.csv");
     write!(std::fs::File::create(&path)?, "{MESSY_ORDERS}")?;
 
-    // `amount_eur` should never be negative; telling the profiler makes the
-    // violation an accuracy signal instead of just an unusual number.
+    // `amount_eur` should never be negative, and `shipped_at` is the date whose
+    // freshness we care about. Explicit hints turn both into quality signals
+    // instead of relying on names or inferred types.
     let report = Profiler::new()
         .positive_columns(vec!["amount_eur".to_string()])
         .identifier_columns(vec!["order_id".to_string()])
+        .temporal_columns(vec!["shipped_at".to_string()])
         .analyze_file(&path)?;
 
     println!(

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -719,6 +719,7 @@ def profile_file(
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
+    temporal_columns: list[str] | None = None,
 ) -> ProfileReport:
     """Profile a file path and return a report.
 
@@ -754,6 +755,8 @@ def profile_file(
             non-negative.
         identifier_columns: Numeric-looking columns to treat as semantic
             identifiers instead of measures.
+        temporal_columns: Columns whose values should contribute to timeliness
+            quality metrics.
 
     Returns:
         ProfileReport with analysis results and quality metrics.
@@ -776,6 +779,7 @@ def profile_file(
         locale=locale,
         positive_columns=positive_columns,
         identifier_columns=identifier_columns,
+        temporal_columns=temporal_columns,
     )
     rust_report = _analyze_file(normalized_path, config)
     return ProfileReport(rust_report)
@@ -801,6 +805,7 @@ def profile(
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
+    temporal_columns: list[str] | None = None,
 ) -> ProfileReport:
     """Profile a data source and return a report.
 
@@ -840,6 +845,8 @@ def profile(
             non-negative.
         identifier_columns: Numeric-looking columns to treat as semantic
             identifiers instead of measures.
+        temporal_columns: Columns whose values should contribute to timeliness
+            quality metrics.
 
     Returns:
         ProfileReport with analysis results and quality metrics.
@@ -864,6 +871,7 @@ def profile(
             locale=locale,
             positive_columns=positive_columns,
             identifier_columns=identifier_columns,
+            temporal_columns=temporal_columns,
         )
 
     # DataFrame/Arrow paths — build config for metric packs + quality dims + locale
@@ -878,6 +886,7 @@ def profile(
                 locale,
                 positive_columns,
                 identifier_columns,
+                temporal_columns,
             )
         ):
             return ProfilerConfig(
@@ -887,6 +896,7 @@ def profile(
                 locale=locale,
                 positive_columns=positive_columns,
                 identifier_columns=identifier_columns,
+                temporal_columns=temporal_columns,
             )
         return None
 
@@ -1116,6 +1126,11 @@ class Profiler:
     def identifier_columns(self, columns: list[str]) -> Profiler:
         """Mark columns to profile as semantic identifiers."""
         self._kwargs["identifier_columns"] = columns
+        return self
+
+    def temporal_columns(self, columns: list[str]) -> Profiler:
+        """Mark columns whose values should contribute to timeliness metrics."""
+        self._kwargs["temporal_columns"] = columns
         return self
 
     def metrics(self, packs: list[str]) -> Profiler:

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -46,6 +46,7 @@ def profile(
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
+    temporal_columns: list[str] | None = None,
 ) -> ProfileReport:
     """Profile a data source (file path, DataFrame, or Arrow object)."""
     ...
@@ -69,6 +70,7 @@ def profile_file(
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
+    temporal_columns: list[str] | None = None,
 ) -> ProfileReport:
     """Profile a file path with file-oriented options."""
     ...
@@ -122,6 +124,7 @@ class Profiler:
     def locale(self, locale: str) -> Profiler: ...
     def positive_columns(self, columns: list[str]) -> Profiler: ...
     def identifier_columns(self, columns: list[str]) -> Profiler: ...
+    def temporal_columns(self, columns: list[str]) -> Profiler: ...
     def profile(self, source: Any) -> ProfileReport: ...
 
 # --- Result Types ---

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -35,6 +35,7 @@ class ProfilerConfig:
         locale: str | None = None,
         positive_columns: list[str] | None = None,
         identifier_columns: list[str] | None = None,
+        temporal_columns: list[str] | None = None,
     ) -> None: ...
     @property
     def engine(self) -> str: ...
@@ -52,6 +53,8 @@ class ProfilerConfig:
     def positive_columns(self) -> list[str]: ...
     @property
     def identifier_columns(self) -> list[str]: ...
+    @property
+    def temporal_columns(self) -> list[str]: ...
 
 # --- Sampling ---
 

--- a/python/examples/messy_csv_inspection.py
+++ b/python/examples/messy_csv_inspection.py
@@ -41,12 +41,14 @@ def main() -> None:
         path = Path(tmp) / "orders.csv"
         path.write_text(MESSY_ORDERS, encoding="utf-8")
 
-        # `amount_eur` should never be negative; telling the profiler makes the
-        # violation an accuracy signal instead of just an unusual number.
+        # `amount_eur` should never be negative, and `shipped_at` is the date
+        # whose freshness we care about. Explicit hints turn both into quality
+        # signals instead of relying on names or inferred types.
         report = dp.profile(
             str(path),
             positive_columns=["amount_eur"],
             identifier_columns=["order_id"],
+            temporal_columns=["shipped_at"],
         )
 
         print(f"orders.csv: {report.rows} rows x {report.columns} columns\n")

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -382,6 +382,26 @@ class TestProfileReport:
         assert uniqueness["rows_checked"] == 3
         assert uniqueness["duplicate_rows_approximate"] is False
 
+    def test_temporal_columns_gate_timeliness_score(self, tmp_path):
+        path = tmp_path / "events.csv"
+        path.write_text(
+            "observed_on,value\n2020-01-01,1\n2021-01-01,2\n",
+            encoding="utf-8",
+        )
+
+        without_hint = dataprof.profile(str(path))
+        without_quality = without_hint.quality
+        assert without_quality is not None
+        assert without_quality.dimension_scores()["timeliness"] is None
+
+        with_hint = dataprof.profile(str(path), temporal_columns=["observed_on"])
+        with_quality = with_hint.quality
+        assert with_quality is not None
+        assert with_quality.dimension_scores()["timeliness"] is not None
+        timeliness = with_quality.timeliness
+        assert timeliness is not None
+        assert timeliness["date_values_checked"] == 2
+
     @pytest.mark.parametrize(
         ("attr", "dimension", "key", "default"),
         [
@@ -1006,9 +1026,11 @@ class TestProfilerConfig:
         cfg = dataprof.ProfilerConfig(
             positive_columns=["pressure"],
             identifier_columns=["order_id", "customer_id"],
+            temporal_columns=["observed_on"],
         )
         assert cfg.positive_columns == ["pressure"]
         assert cfg.identifier_columns == ["order_id", "customer_id"]
+        assert cfg.temporal_columns == ["observed_on"]
 
     def test_max_rows(self):
         if not os.path.exists(CSV_LARGE_FILE):
@@ -1248,6 +1270,7 @@ class TestNamespace:
             "locale",
             "positive_columns",
             "identifier_columns",
+            "temporal_columns",
         }
         actual_params = set(sig.parameters.keys())
         assert actual_params == expected_params, (
@@ -1802,6 +1825,7 @@ class TestProfilerBuilder:
         assert p.quality_dimensions(["completeness"]) is p
         assert p.positive_columns(["pressure"]) is p
         assert p.identifier_columns(["order_id"]) is p
+        assert p.temporal_columns(["observed_on"]) is p
 
     def test_csv_delimiter(self):
         if not os.path.exists(SEMICOLON_FILE):

--- a/tests/semantic_hints.rs
+++ b/tests/semantic_hints.rs
@@ -115,3 +115,38 @@ fn identifier_columns_drive_key_uniqueness_without_name_guessing() {
     assert_eq!(uniqueness.key_column.as_deref(), Some("invoice_number"));
     assert!((uniqueness.key_uniqueness - 75.0).abs() < 0.01);
 }
+
+#[test]
+fn temporal_columns_gate_timeliness_scoring() {
+    let csv = write_csv("observed_on,value\n2020-01-01,1\n2021-01-01,2\n2022-01-01,3\n");
+
+    let without_hint = Profiler::new()
+        .engine(EngineType::Incremental)
+        .analyze_file(csv.path())
+        .expect("profile should succeed");
+    assert_eq!(
+        without_hint
+            .quality
+            .as_ref()
+            .expect("quality")
+            .metrics
+            .timeliness_score(),
+        None
+    );
+
+    let with_hint = Profiler::new()
+        .engine(EngineType::Incremental)
+        .temporal_columns(vec!["observed_on".to_string()])
+        .analyze_file(csv.path())
+        .expect("profile should succeed");
+    let metrics = &with_hint.quality.as_ref().expect("quality").metrics;
+    assert!(metrics.timeliness_score().is_some());
+    assert_eq!(
+        metrics
+            .timeliness
+            .as_ref()
+            .expect("timeliness metrics")
+            .date_values_checked,
+        3
+    );
+}


### PR DESCRIPTION
## Summary

- add `temporal_columns` as an explicit semantic hint across the Rust and Python APIs
- assess timeliness only from configured temporal columns, including parseable values in mixed/string columns
- keep inferred date types available for profiling without silently imposing a freshness policy
- preserve the existing metrics calculator entry points while adding semantic-hint-aware variants

## Why

Date inference describes the shape of a value, but it does not establish that the field should affect freshness or ordering quality. Requiring an explicit temporal hint makes timeliness scoring intentional and leaves the dimension unassessed when no temporal policy is configured.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p dataprof-metrics timeliness`
- `cargo test --test semantic_hints`
- `cargo test -p dataprof-runtime report_assembler`
- `uv run maturin develop`
- `uv run pytest python/tests/test_python_api.py -q` (239 passed)
- `uv run ruff format python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`
