### PR TITLE
feat(metrics): make quality score weights configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/images/logo.png" alt="dataprof logo" width="800" height="auto" />
   <h1>dataprof</h1>
   <p>
-    <strong>High-performance data profiling with ISO 8000/25012 quality metrics</strong>
+    <strong>High-performance data profiling and quality assessment</strong>
   </p>
 
   [![Crates.io](https://img.shields.io/crates/v/dataprof.svg)](https://crates.io/crates/dataprof)
@@ -16,7 +16,7 @@
 
 ---
 
-dataprof is a Rust and Python library for profiling tabular data. It computes column-level statistics, detects data types and patterns, and evaluates data quality against the ISO 8000/25012 standard, all with bounded memory usage that lets you profile datasets far larger than your available RAM.
+dataprof is a Rust and Python library for profiling tabular data. It computes column-level statistics, detects data types and patterns, and assesses data quality across dimensions informed by ISO 8000 and ISO/IEC 25012, all with bounded memory usage that lets you profile datasets far larger than your available RAM.
 
 It is built for the first ten minutes with unfamiliar data: find sparse columns, unstable types, duplicate keys, stale timestamps, and suspicious values before they turn into pipeline bugs.
 
@@ -76,7 +76,7 @@ print(structure.format, len(structure.columns), structure.row_count.count)
 #### 2. Interpret
 
 ```python
-print(f"quality={report.quality_score:.1f}")   # 0-100, weighted across five ISO dimensions
+print(f"quality={report.quality_score:.1f}")   # 0-100, weighted across assessed dimensions
 print(report.quality_summary())                # per-dimension scores
 
 age = report["age"]
@@ -154,7 +154,7 @@ for col in &report.column_profiles {
 - **Multi-format by default** -- move from CSV and JSON to Parquet, live databases, DataFrames, and Arrow batches without changing tools
 - **Two polished entry points** -- a compact Rust facade and a Python package that feels natural in notebooks
 - **Async-ready** -- Rust async APIs and opt-in Python extension builds cover stream pipelines, services, and remote Parquet sources
-- **ISO 8000/25012 quality assessment** -- five dimensions: Completeness, Consistency, Uniqueness, Accuracy, Timeliness
+- **Explainable quality assessment** -- completeness, consistency, uniqueness, accuracy, and timeliness with inspectable facts behind every score
 
 ## Feature Flags
 
@@ -189,7 +189,7 @@ For the leanest Rust build, use `default-features = false` or `cargo --no-defaul
 
 ## Quality Metrics
 
-dataprof evaluates data quality against the five dimensions defined in [ISO 8000-8](https://www.iso.org/standard/76834.html) and [ISO/IEC 25012](https://www.iso.org/standard/35749.html):
+dataprof reports five quality dimensions informed by concepts in [ISO 8000-8](https://www.iso.org/standard/76834.html) and [ISO/IEC 25012](https://www.iso.org/standard/35749.html):
 
 | Dimension | What it measures |
 |---|---|
@@ -199,7 +199,11 @@ dataprof evaluates data quality against the five dimensions defined in [ISO 8000
 | **Accuracy** | Outlier ratio, range violations, negative values in positive-only columns |
 | **Timeliness** | Future dates, stale data ratio, temporal ordering violations |
 
-An overall quality score (0 -- 100) is computed as a weighted average of dimension scores.
+The overall quality score (0 -- 100) is dataprof's weighted average of the
+dimensions that had data to assess. The aggregation formula is not mandated or
+certified by ISO. Rust callers can customize the relative weights through
+`IsoQualityConfig::score_weights`; default weights are 0.30 / 0.25 / 0.20 /
+0.15 / 0.10 in the table order above.
 
 ## Documentation
 

--- a/crates/dataprof-core/src/config.rs
+++ b/crates/dataprof-core/src/config.rs
@@ -4,8 +4,54 @@ use std::path::{Path, PathBuf};
 
 use crate::errors::DataProfilerError;
 
-/// ISO 8000/25012 compliant quality thresholds.
-/// These thresholds are configurable for industry-specific requirements.
+/// Relative weights used to aggregate assessed quality dimensions.
+///
+/// Weights do not need to sum to one: the score renormalizes them over the
+/// dimensions that were actually assessed. Values should be non-negative and
+/// at least one weight must be positive.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct QualityScoreWeights {
+    pub completeness: f64,
+    pub consistency: f64,
+    pub uniqueness: f64,
+    pub accuracy: f64,
+    pub timeliness: f64,
+}
+
+impl Default for QualityScoreWeights {
+    fn default() -> Self {
+        Self {
+            completeness: 0.30,
+            consistency: 0.25,
+            uniqueness: 0.20,
+            accuracy: 0.15,
+            timeliness: 0.10,
+        }
+    }
+}
+
+impl QualityScoreWeights {
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    pub fn is_valid(&self) -> bool {
+        let weights = [
+            self.completeness,
+            self.consistency,
+            self.uniqueness,
+            self.accuracy,
+            self.timeliness,
+        ];
+        weights
+            .iter()
+            .all(|weight| weight.is_finite() && *weight >= 0.0)
+            && weights.iter().any(|weight| *weight > 0.0)
+    }
+}
+
+/// Quality thresholds and score settings informed by ISO 8000/25012 concepts.
+/// These values are dataprof configuration, not ISO-mandated parameters.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IsoQualityConfig {
     /// Maximum acceptable null percentage for a column (default: 50%).
@@ -26,6 +72,9 @@ pub struct IsoQualityConfig {
     pub max_data_age_years: f64,
     /// Percentage threshold for reporting stale data (default: 20%).
     pub stale_data_threshold: f64,
+    /// Dataprof-defined weights for the overall quality score.
+    #[serde(default)]
+    pub score_weights: QualityScoreWeights,
 }
 
 impl Default for IsoQualityConfig {
@@ -40,6 +89,7 @@ impl Default for IsoQualityConfig {
             outlier_min_samples: 4,
             max_data_age_years: 5.0,
             stale_data_threshold: 20.0,
+            score_weights: QualityScoreWeights::default(),
         }
     }
 }
@@ -57,6 +107,7 @@ impl IsoQualityConfig {
             outlier_min_samples: 10,
             max_data_age_years: 2.0,
             stale_data_threshold: 10.0,
+            score_weights: QualityScoreWeights::default(),
         }
     }
 
@@ -72,6 +123,7 @@ impl IsoQualityConfig {
             outlier_min_samples: 4,
             max_data_age_years: 10.0,
             stale_data_threshold: 30.0,
+            score_weights: QualityScoreWeights::default(),
         }
     }
 }
@@ -612,6 +664,14 @@ impl DataprofConfig {
             });
         }
 
+        if !iso.score_weights.is_valid() {
+            return Err(DataProfilerError::ConfigValidationError {
+                message: "Quality score weights must be finite and non-negative, with at least one positive weight.\n\
+                     → Fix: Set quality.iso_thresholds.score_weights to valid relative weights."
+                    .to_string(),
+            });
+        }
+
         // Validate engine
         let valid_engines = ["auto", "streaming", "memory_efficient", "true_streaming"];
         if !valid_engines.contains(&self.engine.default_engine.as_str()) {
@@ -821,9 +881,15 @@ impl DataprofConfigBuilder {
         self
     }
 
-    /// Set custom ISO quality thresholds.
+    /// Set custom quality thresholds and score settings.
     pub fn iso_quality_thresholds(mut self, thresholds: IsoQualityConfig) -> Self {
         self.quality.iso_thresholds = thresholds;
+        self
+    }
+
+    /// Set relative weights for the overall quality score.
+    pub fn quality_score_weights(mut self, weights: QualityScoreWeights) -> Self {
+        self.quality.iso_thresholds.score_weights = weights;
         self
     }
 
@@ -1009,5 +1075,38 @@ impl DataprofConfigBuilder {
 impl Default for DataprofConfigBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_quality_config_defaults_score_weights() {
+        let mut value = serde_json::to_value(IsoQualityConfig::default()).unwrap();
+        value
+            .as_object_mut()
+            .expect("quality config object")
+            .remove("score_weights");
+
+        let restored: IsoQualityConfig = serde_json::from_value(value).unwrap();
+        assert_eq!(restored.score_weights, QualityScoreWeights::default());
+    }
+
+    #[test]
+    fn config_validation_rejects_invalid_score_weights() {
+        let weights = QualityScoreWeights {
+            completeness: 0.0,
+            consistency: 0.0,
+            uniqueness: 0.0,
+            accuracy: 0.0,
+            timeliness: 0.0,
+        };
+        let config = DataprofConfigBuilder::new()
+            .quality_score_weights(weights)
+            .build();
+
+        assert!(config.is_err());
     }
 }

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -21,7 +21,7 @@ pub use classification::{DataType, PatternCategory};
 pub use config::{DatabaseSamplingConfig, DatabaseSettings};
 pub use config::{
     DataprofConfig, DataprofConfigBuilder, EngineConfig, IsoQualityConfig, MemoryConfig,
-    OutputConfig, QualityConfig,
+    OutputConfig, QualityConfig, QualityScoreWeights,
 };
 pub use errors::{DataProfilerError, RecoveryAttempt, RecoveryStrategy, RetryConfig};
 pub use execution::{ExecutionMetadata, TruncationReason};

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -78,10 +78,9 @@ use crate::types::{
 };
 use std::collections::HashMap;
 
-/// Engine for calculating comprehensive data quality metrics
-/// Supports ISO 8000/25012 configurable thresholds
+/// Engine for calculating comprehensive data quality metrics.
 pub struct MetricsCalculator {
-    /// ISO-compliant quality thresholds
+    /// Configurable quality thresholds and score weights.
     pub thresholds: IsoQualityConfig,
 }
 
@@ -92,7 +91,7 @@ impl Default for MetricsCalculator {
 }
 
 impl MetricsCalculator {
-    /// Create a new calculator with default ISO thresholds
+    /// Create a new calculator with default quality settings.
     pub fn new() -> Self {
         Self {
             thresholds: IsoQualityConfig::default(),
@@ -187,6 +186,7 @@ impl MetricsCalculator {
         if data.is_empty() {
             return Ok(Self::default_metrics_for_empty_dataset(
                 &requested_dimensions,
+                self.thresholds.score_weights,
             ));
         }
 
@@ -300,12 +300,14 @@ impl MetricsCalculator {
             accuracy,
             timeliness,
             low_sample_warning: !validation.sufficient_sample,
+            score_weights: self.thresholds.score_weights,
         })
     }
 
     /// Create default metrics for empty dataset (only requested dimensions are populated).
     fn default_metrics_for_empty_dataset(
         requested: &Option<&[QualityDimension]>,
+        score_weights: dataprof_core::QualityScoreWeights,
     ) -> QualityMetrics {
         let is_req = |d| match requested {
             None => true,
@@ -367,6 +369,7 @@ impl MetricsCalculator {
                 None
             },
             low_sample_warning: false,
+            score_weights,
         }
     }
 
@@ -430,7 +433,10 @@ impl MetricsCalculator {
     ) -> Result<BifurcatedResult, DataProfilerError> {
         if data.is_empty() && column_profiles.is_empty() {
             return Ok(BifurcatedResult {
-                metrics: Self::default_metrics_for_empty_dataset(&requested_dimensions),
+                metrics: Self::default_metrics_for_empty_dataset(
+                    &requested_dimensions,
+                    self.thresholds.score_weights,
+                ),
                 exact_dimensions: vec![],
                 sampled_dimensions: vec![],
                 sample_size: 0,
@@ -586,6 +592,7 @@ impl MetricsCalculator {
             accuracy,
             timeliness,
             low_sample_warning: !validation.sufficient_sample,
+            score_weights: self.thresholds.score_weights,
         };
 
         Ok(BifurcatedResult {
@@ -628,6 +635,7 @@ pub struct BifurcatedResult {
 mod tests {
     use super::*;
     use crate::types::{ColumnStats, DataType};
+    use dataprof_core::QualityScoreWeights;
 
     #[test]
     fn comprehensive_metrics_use_tracker_rows_for_cardinality_ratio() {
@@ -667,5 +675,36 @@ mod tests {
                 .high_cardinality_warning,
             "100 distinct values out of 1,000 rows is not high cardinality"
         );
+    }
+
+    #[test]
+    fn calculator_copies_custom_score_weights_into_metrics() {
+        let weights = QualityScoreWeights {
+            completeness: 1.0,
+            consistency: 0.0,
+            uniqueness: 0.0,
+            accuracy: 0.0,
+            timeliness: 0.0,
+        };
+        let config = IsoQualityConfig {
+            score_weights: weights,
+            ..IsoQualityConfig::default()
+        };
+        let data = HashMap::from([("value".to_string(), vec!["x".to_string()])]);
+        let profiles = vec![ColumnProfile {
+            name: "value".to_string(),
+            data_type: DataType::String,
+            null_count: 0,
+            total_count: 1,
+            unique_count: Some(1),
+            stats: ColumnStats::None,
+            patterns: Some(vec![]),
+        }];
+
+        let metrics = MetricsCalculator::with_thresholds(config)
+            .calculate_comprehensive_metrics(&data, &profiles, None)
+            .expect("quality metrics");
+
+        assert_eq!(metrics.score_weights, weights);
     }
 }

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -310,7 +310,7 @@ impl QualityMetrics {
     pub fn assessed_dimensions(&self) -> Vec<QualityDimension> {
         self.weighted_scores()
             .iter()
-            .filter(|(_, _, score)| score.is_some())
+            .filter(|(_, weight, score)| *weight > 0.0 && score.is_some())
             .map(|(dim, _, _)| *dim)
             .collect()
     }
@@ -547,6 +547,10 @@ mod tests {
             serde_json::from_str(&json).expect("deserialize custom weights");
         assert_eq!(restored.score_weights, metrics.score_weights);
         assert!((restored.overall_score() - metrics.overall_score()).abs() < 0.01);
+        assert_eq!(
+            restored.assessed_dimensions(),
+            vec![QualityDimension::Completeness]
+        );
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use dataprof_core::{ColumnProfile, QualityDimension};
+use dataprof_core::{ColumnProfile, QualityDimension, QualityScoreWeights};
 use serde::{Deserialize, Serialize};
 
 use crate::core::errors::DataProfilerError;
@@ -122,6 +122,11 @@ pub struct QualityMetrics {
     /// reliable. Backwards-compatible: defaults to `false`.
     #[serde(default, skip_serializing_if = "is_false")]
     pub low_sample_warning: bool,
+    /// Weights used to aggregate dimension scores. Default weights are omitted
+    /// from serialized reports; custom weights are retained for reproducible
+    /// score calculation after a round trip.
+    #[serde(default, skip_serializing_if = "QualityScoreWeights::is_default")]
+    pub score_weights: QualityScoreWeights,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -165,6 +170,7 @@ impl QualityMetrics {
                 temporal_pairs_checked: 0,
             }),
             low_sample_warning: false,
+            score_weights: QualityScoreWeights::default(),
         }
     }
 
@@ -273,17 +279,29 @@ impl QualityMetrics {
         [
             (
                 QualityDimension::Completeness,
-                0.30,
+                self.score_weights.completeness,
                 self.completeness_score(),
             ),
             (
                 QualityDimension::Consistency,
-                0.25,
+                self.score_weights.consistency,
                 self.consistency_score(),
             ),
-            (QualityDimension::Uniqueness, 0.20, self.uniqueness_score()),
-            (QualityDimension::Accuracy, 0.15, self.accuracy_score()),
-            (QualityDimension::Timeliness, 0.10, self.timeliness_score()),
+            (
+                QualityDimension::Uniqueness,
+                self.score_weights.uniqueness,
+                self.uniqueness_score(),
+            ),
+            (
+                QualityDimension::Accuracy,
+                self.score_weights.accuracy,
+                self.accuracy_score(),
+            ),
+            (
+                QualityDimension::Timeliness,
+                self.score_weights.timeliness,
+                self.timeliness_score(),
+            ),
         ]
     }
 
@@ -502,7 +520,33 @@ mod tests {
                 temporal_pairs_checked: 100,
             }),
             low_sample_warning: false,
+            score_weights: QualityScoreWeights::default(),
         }
+    }
+
+    #[test]
+    fn test_custom_weights_change_and_survive_serialized_score() {
+        let mut metrics = perfect_assessed();
+        if let Some(ref mut c) = metrics.completeness {
+            c.missing_values_ratio = 100.0;
+            c.complete_records_ratio = 0.0;
+        }
+        metrics.score_weights = QualityScoreWeights {
+            completeness: 1.0,
+            consistency: 0.0,
+            uniqueness: 0.0,
+            accuracy: 0.0,
+            timeliness: 0.0,
+        };
+
+        assert!((metrics.overall_score() - 0.0).abs() < 0.01);
+
+        let json = serde_json::to_string(&metrics).expect("serialize custom weights");
+        assert!(json.contains("score_weights"));
+        let restored: QualityMetrics =
+            serde_json::from_str(&json).expect("deserialize custom weights");
+        assert_eq!(restored.score_weights, metrics.score_weights);
+        assert!((restored.overall_score() - metrics.overall_score()).abs() < 0.01);
     }
 
     #[test]

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -256,7 +256,7 @@ impl PyColumnProfile {
     }
 }
 
-/// Python wrapper for QualityMetrics — ISO 8000/25012 quality dimensions.
+/// Python wrapper for quality dimensions informed by ISO 8000/25012 concepts.
 ///
 /// Exposes both flat backward-compatible properties and new nested dimension
 /// accessors (completeness, consistency, uniqueness, accuracy, timeliness).
@@ -369,6 +369,19 @@ impl PyDataQualityMetrics {
     #[getter]
     fn low_sample_warning(&self) -> bool {
         self.inner.low_sample_warning
+    }
+
+    /// Relative weights used by the aggregate quality score.
+    #[getter]
+    fn score_weights(&self) -> std::collections::HashMap<String, f64> {
+        let weights = self.inner.score_weights;
+        std::collections::HashMap::from([
+            ("completeness".to_string(), weights.completeness),
+            ("consistency".to_string(), weights.consistency),
+            ("uniqueness".to_string(), weights.uniqueness),
+            ("accuracy".to_string(), weights.accuracy),
+            ("timeliness".to_string(), weights.timeliness),
+        ])
     }
 
     // -- Nested dimension accessors (composable API) --

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -4,7 +4,7 @@ use dataprof_metrics::{QualityAssessment, QualityMetrics};
 /// Complete profiling report for a data source.
 ///
 /// Contains column-level statistics, execution metadata, and an optional
-/// ISO 8000/25012 quality assessment. This is the primary output of all
+/// Quality assessment informed by ISO 8000/25012 concepts. This is the primary output of all
 /// profiling operations (`Profiler::analyze_file`, `Profiler::analyze_source`,
 /// `Profiler::profile_stream`, etc.).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -1,4 +1,4 @@
-//! High-performance data profiling with ISO 8000/25012 quality metrics.
+//! High-performance data profiling and quality assessment.
 //!
 //! The `dataprof` crate is the user-facing facade for profiling CSV, JSON,
 //! JSONL, Parquet, database, DataFrame, and Arrow sources. Implementation
@@ -26,10 +26,11 @@ pub use dataprof_core::{
     BooleanStats, ChunkSize, ColumnProfile, ColumnSchema, ColumnStats, CountMethod,
     DataFrameLibrary, DataProfilerError, DataSource, DataType, DataprofConfig,
     DataprofConfigBuilder, DateTimeStats, ExecutionMetadata, FileFormat, FrequencyItem,
-    InputValidator, MetricPack, NumericStats, OutputFormat, ParquetMetadata, Pattern,
-    PatternCategory, ProgressEvent, ProgressSink, QualityDimension, Quartiles, QueryEngine,
-    RowCountEstimate, SamplingStrategy, SchemaResult, SemanticHints, StopCondition, StopEvaluator,
-    StructureColumnSummary, StructureReport, TextStats, TruncationReason, ValidationError,
+    InputValidator, IsoQualityConfig, MetricPack, NumericStats, OutputFormat, ParquetMetadata,
+    Pattern, PatternCategory, ProgressEvent, ProgressSink, QualityDimension, QualityScoreWeights,
+    Quartiles, QueryEngine, RowCountEstimate, SamplingStrategy, SchemaResult, SemanticHints,
+    StopCondition, StopEvaluator, StructureColumnSummary, StructureReport, TextStats,
+    TruncationReason, ValidationError,
 };
 pub use dataprof_csv::{
     CsvDiagnostics, CsvParserConfig, analyze_csv_file, analyze_csv_from_reader,

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -1,6 +1,6 @@
 # Database Connectors Guide
 
-Profile data directly from PostgreSQL, MySQL, and SQLite databases with ISO 8000/25012 quality assessment.
+Profile data directly from PostgreSQL, MySQL, and SQLite databases with quality assessment informed by ISO 8000/25012 concepts.
 
 > [!NOTE]
 > Before 0.9.0, every column was read as text and non-text columns profiled as

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -12,7 +12,7 @@ Data profiling is the process of examining a dataset to collect statistics and a
 - Are there duplicates? Outliers? Impossible values?
 - Is the data fresh or stale?
 
-dataprof automates this analysis and scores data quality against the ISO 8000/25012 standard, producing a structured report you can use for data validation, ETL pipelines, and quality monitoring.
+dataprof automates this analysis and assesses quality across dimensions informed by ISO 8000 and ISO/IEC 25012, producing a structured report you can use for data validation, ETL pipelines, and quality monitoring. The aggregate score is dataprof's configurable formula, not an ISO certification.
 
 ## Installation
 
@@ -87,7 +87,9 @@ fn main() -> Result<(), dataprof::DataProfilerError> {
 
 ## Understanding Quality Metrics
 
-dataprof evaluates data quality across five ISO 8000/25012 dimensions. Each is scored from 0 to 100, and the overall score is a weighted average.
+dataprof evaluates five quality dimensions informed by ISO 8000 and ISO/IEC
+25012. Each is scored from 0 to 100, and dataprof computes its overall score as
+a configurable weighted average of the dimensions that were actually assessed.
 
 ### Completeness
 

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -291,13 +291,16 @@ Event fields: `kind`, `rows_processed`, `bytes_consumed`, `elapsed_ms`, `process
 
 ## `DataQualityMetrics`
 
-ISO 8000/25012 quality metrics, accessible via `report.quality`:
+Quality metrics informed by ISO 8000 and ISO/IEC 25012, accessible via
+`report.quality`. The aggregate score is dataprof's formula, not an ISO-defined
+or certified score:
 
 ```python
 q = report.quality
 
 # Overall score
 print(q.overall_quality_score())
+print(q.score_weights)  # relative weights used by dataprof's aggregate formula
 
 # Nested dimension accessors (None when not computed)
 print(q.completeness)    # {"missing_values_ratio": ..., "complete_records_ratio": ..., "null_columns": [...]}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,18 @@
 # Unreleased
 
+## Quality score weights are configurable
+
+The overall score's relative dimension weights now live in
+`IsoQualityConfig::score_weights`. `MetricsCalculator::with_thresholds(...)`
+copies them into each `QualityMetrics` result, so custom scores remain
+reproducible after report serialization. The defaults remain 0.30 completeness,
+0.25 consistency, 0.20 uniqueness, 0.15 accuracy, and 0.10 timeliness; weights
+renormalize over the dimensions that were actually assessed.
+
+The documentation now describes ISO 8000 and ISO/IEC 25012 as sources for the
+quality-dimension concepts. Dataprof's aggregate score and its weights are a
+configurable project formula, not an ISO-mandated or certified score.
+
 ## The quality score now only scores what was actually assessed
 
 **`quality_score` changes value for almost every dataset.** The facts

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1225,6 +1225,14 @@ class _DictColumn:
 class _DictQuality:
     """Read-only stand-in for native DataQualityMetrics, built from to_dict()."""
 
+    _DEFAULT_SCORE_WEIGHTS = {
+        "completeness": 0.30,
+        "consistency": 0.25,
+        "uniqueness": 0.20,
+        "accuracy": 0.15,
+        "timeliness": 0.10,
+    }
+
     def __init__(self, d: dict[str, Any]):
         self._d = d
         self.low_sample_warning = bool(d.get("low_sample_warning", False))
@@ -1344,13 +1352,7 @@ class _DictQuality:
         weights = self._d.get("score_weights")
         if isinstance(weights, dict):
             return weights
-        return {
-            "completeness": 0.30,
-            "consistency": 0.25,
-            "uniqueness": 0.20,
-            "accuracy": 0.15,
-            "timeliness": 0.10,
-        }
+        return self._DEFAULT_SCORE_WEIGHTS
 
     def overall_quality_score(self) -> float | None:
         return self._d.get("overall_score")

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -742,7 +742,7 @@ def profile_file(
             than ``progress_interval_ms`` may emit only start and finish events.
         progress_interval_ms: Minimum interval between progress events in ms
             (default: 500).
-        quality_dimensions: List of ISO 25012 quality dimensions to evaluate.
+        quality_dimensions: List of quality dimensions to evaluate.
             Valid values: "completeness", "consistency", "uniqueness",
             "accuracy", "timeliness". None = all dimensions (default).
         metrics: List of metric packs to compute. Valid values: "schema"
@@ -826,7 +826,7 @@ def profile(
             than ``progress_interval_ms`` may emit only start and finish events.
         progress_interval_ms: Minimum interval between progress events in ms
             (default: 500).
-        quality_dimensions: List of ISO 25012 quality dimensions to evaluate.
+        quality_dimensions: List of quality dimensions to evaluate.
             Valid values: "completeness", "consistency", "uniqueness",
             "accuracy", "timeliness". None = all dimensions (default).
         metrics: List of metric packs to compute. Valid values: "schema"
@@ -1083,7 +1083,7 @@ class Profiler:
         return self
 
     def quality_dimensions(self, dims: list[str]) -> Profiler:
-        """Select ISO 25012 quality dimensions to evaluate."""
+        """Select quality dimensions to evaluate."""
         self._kwargs["quality_dimensions"] = dims
         return self
 
@@ -1338,6 +1338,19 @@ class _DictQuality:
     @property
     def timeliness(self) -> dict[str, Any] | None:
         return self._d.get("timeliness")
+
+    @property
+    def score_weights(self) -> dict[str, float]:
+        weights = self._d.get("score_weights")
+        if isinstance(weights, dict):
+            return weights
+        return {
+            "completeness": 0.30,
+            "consistency": 0.25,
+            "uniqueness": 0.20,
+            "accuracy": 0.15,
+            "timeliness": 0.10,
+        }
 
     def overall_quality_score(self) -> float | None:
         return self._d.get("overall_score")

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -173,7 +173,7 @@ class ColumnProfile:
     patterns: list[Pattern] | None
 
 class DataQualityMetrics:
-    """ISO 8000/25012 data quality metrics."""
+    """Quality metrics informed by ISO 8000/25012 concepts."""
 
     missing_values_ratio: float
     complete_records_ratio: float
@@ -191,6 +191,7 @@ class DataQualityMetrics:
     stale_data_ratio: float
     temporal_violations: int
     low_sample_warning: bool
+    score_weights: dict[str, float]
 
     @property
     def completeness(self) -> dict[str, Any] | None: ...

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -561,6 +561,7 @@ class TestReportErgonomics:
         reloaded = dataprof.ProfileReport.from_json(report.to_json())
         assert reloaded.quality is not None
         assert reloaded.quality.score_weights == expected
+        assert reloaded.quality.score_weights is reloaded.quality.score_weights
 
     def test_from_dict_round_trip_idempotent(self, report):
         reloaded = dataprof.ProfileReport.from_dict(report.to_dict())

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -548,6 +548,20 @@ class TestReportErgonomics:
         reloaded = dataprof.ProfileReport.from_json(report.to_json())
         assert reloaded.quality_score == report.quality_score
 
+    def test_quality_score_weights_are_exposed_and_round_trip(self, report):
+        expected = {
+            "completeness": 0.30,
+            "consistency": 0.25,
+            "uniqueness": 0.20,
+            "accuracy": 0.15,
+            "timeliness": 0.10,
+        }
+        assert report.quality.score_weights == expected
+
+        reloaded = dataprof.ProfileReport.from_json(report.to_json())
+        assert reloaded.quality is not None
+        assert reloaded.quality.score_weights == expected
+
     def test_from_dict_round_trip_idempotent(self, report):
         reloaded = dataprof.ProfileReport.from_dict(report.to_dict())
         assert reloaded.to_dict() == report.to_dict()


### PR DESCRIPTION
## Summary

- add typed, validated `QualityScoreWeights` to `IsoQualityConfig`
- carry score weights into `QualityMetrics` so custom aggregation survives serialization
- expose the applied weights through the Python quality object
- describe the aggregate score as dataprof's configurable formula rather than an ISO-defined score

## Compatibility

- default weights remain 0.30 / 0.25 / 0.20 / 0.15 / 0.10
- legacy configs and reports without weight fields deserialize with those defaults
- default weights are omitted from report JSON; custom weights are serialized

## Validation

- `cargo test --workspace`
- `cargo clippy --all --all-targets -- -D warnings`
- `uv run maturin develop`
- `uv run pytest python/tests/test_python_api.py -q` (239 passed)
- `uv run ruff format --check python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`
