### PR TITLE
feat(metrics): expose provenance for approximate distinct counts

### DIFF
--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -13,6 +13,17 @@ pub struct ColumnProfile {
     pub null_count: usize,
     pub total_count: usize,
     pub unique_count: Option<usize>,
+    /// Whether `unique_count` is an approximate (HyperLogLog) estimate rather
+    /// than an exact distinct count.
+    ///
+    /// `None` when `unique_count` is `None` (never computed); `Some(false)` for
+    /// an exact count; `Some(true)` once the cardinality estimator has spilled
+    /// to its HLL sketch (~1% relative error). Consumers running key or
+    /// high-cardinality/uniqueness gates must treat `Some(true)` as "do not rely
+    /// on this as an exact integer" -- an exact-looking count with no provenance
+    /// is unsafe for those checks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unique_count_is_approximate: Option<bool>,
     pub stats: ColumnStats,
     /// Detected patterns, or `None` when pattern detection did not run.
     ///
@@ -214,6 +225,7 @@ mod tests {
             null_count: 2,
             total_count: 10,
             unique_count: Some(8),
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::Numeric(NumericStats {
                 min: 1.0,
                 max: 100.0,
@@ -244,6 +256,7 @@ mod tests {
         assert_eq!(deserialized.data_type, DataType::Integer);
         assert_eq!(deserialized.total_count, 10);
         assert_eq!(deserialized.null_count, 2);
+        assert_eq!(deserialized.unique_count_is_approximate, Some(false));
 
         if let ColumnStats::Numeric(n) = &deserialized.stats {
             assert!((n.min - 1.0).abs() < 0.01);
@@ -264,6 +277,7 @@ mod tests {
             null_count: 0,
             total_count: 3,
             unique_count: Some(3),
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::Text(TextStats {
                 min_length: 3,
                 max_length: 7,

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -89,6 +89,9 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
         null_count,
         total_count,
         unique_count,
+        // analyze_column counts distinct values with an exact HashSet, so the
+        // count is exact whenever it was computed (never in fast mode).
+        unique_count_is_approximate: unique_count.map(|_| false),
         stats,
         patterns,
     }

--- a/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
@@ -238,6 +238,7 @@ mod tests {
             null_count: 0,
             total_count: 0,
             unique_count: None,
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
@@ -179,7 +179,7 @@ mod tests {
             null_count: nulls,
             total_count: total,
             unique_count: Some(total - nulls),
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
@@ -179,6 +179,7 @@ mod tests {
             null_count: nulls,
             total_count: total,
             unique_count: Some(total - nulls),
+            unique_count_is_approximate: None,
             stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -222,6 +222,7 @@ mod tests {
             null_count: 0,
             total_count: 0,
             unique_count: None,
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -759,6 +759,7 @@ mod tests {
             null_count: 0,
             total_count: 1_000,
             unique_count: Some(100),
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -809,6 +810,7 @@ mod tests {
             null_count: 0,
             total_count: 1,
             unique_count: Some(1),
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -828,6 +830,7 @@ mod tests {
             null_count: 0,
             total_count: 100,
             unique_count: Some(10),
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -759,7 +759,7 @@ mod tests {
             null_count: 0,
             total_count: 1_000,
             unique_count: Some(100),
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -810,7 +810,7 @@ mod tests {
             null_count: 0,
             total_count: 1,
             unique_count: Some(1),
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -830,7 +830,7 @@ mod tests {
             null_count: 0,
             total_count: 100,
             unique_count: Some(10),
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];

--- a/crates/dataprof-metrics/src/analysis/metrics/precision.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/precision.rs
@@ -99,6 +99,7 @@ mod tests {
             null_count: 0,
             total_count: 4,
             unique_count: Some(4),
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/precision.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/precision.rs
@@ -99,7 +99,7 @@ mod tests {
             null_count: 0,
             total_count: 4,
             unique_count: Some(4),
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
@@ -205,7 +205,7 @@ mod tests {
             null_count: 0,
             total_count: total,
             unique_count: unique,
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: unique.map(|_| false),
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
@@ -205,6 +205,7 @@ mod tests {
             null_count: 0,
             total_count: total,
             unique_count: unique,
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/validity.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/validity.rs
@@ -83,6 +83,7 @@ mod tests {
             null_count: 0,
             total_count: 4,
             unique_count: Some(4),
+            unique_count_is_approximate: None,
             stats: ColumnStats::None,
             patterns,
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/validity.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/validity.rs
@@ -83,7 +83,7 @@ mod tests {
             null_count: 0,
             total_count: 4,
             unique_count: Some(4),
-            unique_count_is_approximate: None,
+            unique_count_is_approximate: Some(false),
             stats: ColumnStats::None,
             patterns,
         }

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -787,6 +787,7 @@ impl ColumnAnalyzer {
             total_count: self.total_count,
             null_count: self.null_count,
             unique_count: Some(self.cardinality.estimate()),
+            unique_count_is_approximate: Some(self.cardinality.is_approximate()),
             sample_values: &self.sample_values,
             text_lengths: Some(TextLengths {
                 min_length: self.min_length,

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -801,6 +801,7 @@ impl ColumnAnalyzer {
             total_count: self.total_count,
             null_count: self.null_count,
             unique_count: Some(self.cardinality.estimate()),
+            unique_count_is_approximate: Some(self.cardinality.is_approximate()),
             sample_values: &self.sample_values,
             text_lengths: Some(TextLengths {
                 min_length: self.min_length,

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -98,6 +98,8 @@ pub fn profile_columns(
                 total_count: num_rows,
                 null_count,
                 unique_count: Some(unique_count),
+                // Distinct values are counted with an exact HashSet above.
+                unique_count_is_approximate: Some(false),
                 sample_values: &present,
                 text_lengths: None,
                 boolean_counts: None,

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -54,6 +54,10 @@ pub struct PyColumnProfile {
     pub null_count: usize,
     #[pyo3(get)]
     pub unique_count: Option<usize>,
+    /// `None` when `unique_count` is `None`; `Some(False)` for an exact count;
+    /// `Some(True)` when it is a HyperLogLog estimate (~1% relative error).
+    #[pyo3(get)]
+    pub unique_count_is_approximate: Option<bool>,
     #[pyo3(get)]
     pub null_percentage: f64,
     #[pyo3(get)]
@@ -205,6 +209,7 @@ impl From<&ColumnProfile> for PyColumnProfile {
             total_count: profile.total_count,
             null_count: profile.null_count,
             unique_count: profile.unique_count,
+            unique_count_is_approximate: profile.unique_count_is_approximate,
             null_percentage,
             uniqueness_ratio,
             min,

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -25,6 +25,10 @@ pub struct ColumnProfileInput<'a> {
     pub total_count: usize,
     pub null_count: usize,
     pub unique_count: Option<usize>,
+    /// Whether `unique_count` is an approximate (HLL) estimate. `None` mirrors
+    /// `unique_count: None`; `Some(false)` for exact counts; `Some(true)` once
+    /// the engine's cardinality estimator has spilled to its HLL sketch.
+    pub unique_count_is_approximate: Option<bool>,
     pub sample_values: &'a [String],
     /// Pre-computed text lengths for engines that track them incrementally.
     /// When `Some`, text stats are built from these instead of re-scanning samples.
@@ -123,6 +127,7 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
         null_count: input.null_count,
         total_count: input.total_count,
         unique_count: input.unique_count,
+        unique_count_is_approximate: input.unique_count_is_approximate,
         stats,
         patterns,
     }
@@ -211,6 +216,7 @@ pub fn profile_from_stats_with_hints(
         total_count: stats.count,
         null_count: stats.null_count,
         unique_count: Some(stats.unique_count()),
+        unique_count_is_approximate: Some(stats.unique_count_is_approximate()),
         sample_values: stats.sample_values(),
         text_lengths: Some(TextLengths {
             min_length: text_stats.min_length,
@@ -340,6 +346,7 @@ mod tests {
             total_count: 3,
             null_count: 0,
             unique_count: Some(2),
+            unique_count_is_approximate: Some(false),
             sample_values: &samples,
             text_lengths: None,
             boolean_counts: Some((2, 1)),
@@ -371,6 +378,7 @@ mod tests {
             total_count: 3,
             null_count: 0,
             unique_count: Some(2),
+            unique_count_is_approximate: Some(false),
             sample_values: &samples,
             text_lengths: None,
             boolean_counts: None,
@@ -398,6 +406,7 @@ mod tests {
             total_count: 3,
             null_count: 0,
             unique_count: Some(3),
+            unique_count_is_approximate: Some(false),
             sample_values: &samples,
             text_lengths: None,
             boolean_counts: None,
@@ -419,6 +428,7 @@ mod tests {
             total_count: 2,
             null_count: 0,
             unique_count: Some(2),
+            unique_count_is_approximate: Some(false),
             sample_values: &samples,
             text_lengths: None,
             boolean_counts: None,
@@ -445,6 +455,7 @@ mod tests {
             total_count: 2,
             null_count: 0,
             unique_count: Some(2),
+            unique_count_is_approximate: Some(false),
             sample_values: &samples,
             text_lengths: None,
             boolean_counts: None,
@@ -465,6 +476,7 @@ mod tests {
             total_count: 2,
             null_count: 0,
             unique_count: Some(2),
+            unique_count_is_approximate: Some(false),
             sample_values: &samples,
             text_lengths: None,
             boolean_counts: None,

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -405,6 +405,7 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
         "null_count": col.null_count,
         "null_percentage": _r2(col.null_percentage),
         "unique_count": col.unique_count,
+        "unique_count_is_approximate": col.unique_count_is_approximate,
         "uniqueness_ratio": _r2(col.uniqueness_ratio),
     }
     if col.min is not None:
@@ -487,6 +488,7 @@ def _column_record(col: ColumnProfile) -> dict[str, Any]:
         "null_count": col.null_count,
         "null_percentage": _r2(col.null_percentage),
         "unique_count": col.unique_count,
+        "unique_count_is_approximate": col.unique_count_is_approximate,
         "uniqueness_ratio": _r2(col.uniqueness_ratio),
         "min": _r4(col.min),
         "max": _r4(col.max),
@@ -1222,6 +1224,7 @@ class _DictColumn:
         self.null_count = d.get("null_count")
         self.null_percentage = d.get("null_percentage")
         self.unique_count = d.get("unique_count")
+        self.unique_count_is_approximate = d.get("unique_count_is_approximate")
         self.uniqueness_ratio = d.get("uniqueness_ratio")
         # Overlay only known stat attributes — never setattr arbitrary keys from
         # (possibly malformed) input, which could inject unexpected/dunder names.
@@ -1791,7 +1794,11 @@ class ProfileReport:
             "|---|---|---|---|---|---|---|",
         ]
         for col in self._report.column_profiles:
-            unique_str = f"{col.unique_count:,}" if col.unique_count is not None else ""
+            unique_str = (
+                ""
+                if col.unique_count is None
+                else f"{'~' if col.unique_count_is_approximate else ''}{col.unique_count:,}"
+            )
             row = [
                 esc(col.name),
                 esc(col.data_type),
@@ -2084,7 +2091,8 @@ class ProfileReport:
             parts = [f"  {col.name:<20s} {col.data_type:<10s}"]
             parts.append(f"{_r2(col.null_percentage):>5.1f}% null")
             if col.unique_count is not None:
-                parts.append(f"{col.unique_count:,} unique")
+                approx = "~" if col.unique_count_is_approximate else ""
+                parts.append(f"{approx}{col.unique_count:,} unique")
             if col.mean is not None:
                 parts.append(f"mean={_r4(col.mean)}")
                 if col.std_dev is not None:
@@ -2127,7 +2135,11 @@ class ProfileReport:
             bg = "#f9fafb" if i % 2 else "#ffffff"
             stats = _stats_cell(col)
             pattern = _html.escape(_pattern_cell(col))
-            unique_str = f"{col.unique_count:,}" if col.unique_count is not None else ""
+            unique_str = (
+                ""
+                if col.unique_count is None
+                else f"{'~' if col.unique_count_is_approximate else ''}{col.unique_count:,}"
+            )
 
             col_rows += (
                 f'<tr style="background:{bg}">'

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -390,7 +390,8 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
 
         {
           "name": ..., "data_type": ..., "total_count": ..., "null_count": ...,
-          "null_percentage": ..., "unique_count": ..., "uniqueness_ratio": ...,
+          "null_percentage": ..., "unique_count": ...,
+          "unique_count_is_approximate": ..., "uniqueness_ratio": ...,
           "stats": {"min": ..., "max": ..., ...},      # numeric / text / boolean
           "patterns": [{"name": ..., "regex": ..., ...}, ...]
         }

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1794,11 +1794,13 @@ class ProfileReport:
             "|---|---|---|---|---|---|---|",
         ]
         for col in self._report.column_profiles:
-            unique_str = (
-                ""
-                if col.unique_count is None
-                else f"{'~' if col.unique_count_is_approximate else ''}{col.unique_count:,}"
-            )
+            if col.unique_count is None:
+                unique_str = ""
+            else:
+                # Unknown provenance (None) must not look exact -- only an
+                # explicit False drops the ~ prefix.
+                prefix = "" if col.unique_count_is_approximate is False else "~"
+                unique_str = f"{prefix}{col.unique_count:,}"
             row = [
                 esc(col.name),
                 esc(col.data_type),
@@ -2091,7 +2093,9 @@ class ProfileReport:
             parts = [f"  {col.name:<20s} {col.data_type:<10s}"]
             parts.append(f"{_r2(col.null_percentage):>5.1f}% null")
             if col.unique_count is not None:
-                approx = "~" if col.unique_count_is_approximate else ""
+                # Unknown provenance (None, e.g. an older deserialized report)
+                # must not render as exact -- only an explicit False drops the ~.
+                approx = "" if col.unique_count_is_approximate is False else "~"
                 parts.append(f"{approx}{col.unique_count:,} unique")
             if col.mean is not None:
                 parts.append(f"mean={_r4(col.mean)}")
@@ -2135,11 +2139,13 @@ class ProfileReport:
             bg = "#f9fafb" if i % 2 else "#ffffff"
             stats = _stats_cell(col)
             pattern = _html.escape(_pattern_cell(col))
-            unique_str = (
-                ""
-                if col.unique_count is None
-                else f"{'~' if col.unique_count_is_approximate else ''}{col.unique_count:,}"
-            )
+            if col.unique_count is None:
+                unique_str = ""
+            else:
+                # Unknown provenance (None) must not look exact -- only an
+                # explicit False drops the ~ prefix.
+                prefix = "" if col.unique_count_is_approximate is False else "~"
+                unique_str = f"{prefix}{col.unique_count:,}"
 
             col_rows += (
                 f'<tr style="background:{bg}">'

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -147,6 +147,7 @@ class ColumnProfile:
     total_count: int
     null_count: int
     unique_count: int | None
+    unique_count_is_approximate: bool | None
     null_percentage: float
     uniqueness_ratio: float
     min: float | None

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -235,7 +235,9 @@ def test_small_distinct_count_marked_exact(engine, tmp_path):
 
 @pytest.mark.parametrize("engine", ["auto", "columnar", "incremental"])
 def test_high_cardinality_distinct_count_marked_approximate(engine, tmp_path):
-    n_rows = 50_000
+    # 20k comfortably clears the 10k estimator threshold (matches the Rust
+    # parity test) without the IO of a larger file across three engines.
+    n_rows = 20_000
     path = tmp_path / "high_card.csv"
     with open(path, "w", newline="", encoding="utf-8") as handle:
         writer = csv.writer(handle)

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -207,6 +207,50 @@ def test_high_cardinality_unique_count_not_capped(engine, tmp_path):
     )
 
 
+# ── Distinct-count provenance (issue #383) ──
+#
+# unique_count must not present an approximate HLL estimate as an exact integer.
+# Small columns are exact across every engine; a high-cardinality column past the
+# estimator threshold is flagged approximate. The flag also survives to_dict().
+
+
+@pytest.mark.parametrize("engine", ["auto", "columnar", "incremental"])
+def test_small_distinct_count_marked_exact(engine, tmp_path):
+    path = tmp_path / "small.csv"
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["category"])
+        for value in ["a", "b", "c", "a", "b"]:
+            writer.writerow([value])
+
+    report = dataprof.profile(str(path), engine=engine)
+    col = report["category"]
+    assert col.unique_count == 3
+    assert col.unique_count_is_approximate is False, (
+        f"{engine}: small exact count must be flagged exact, not "
+        f"{col.unique_count_is_approximate!r}"
+    )
+    assert report.to_dict()["columns"][0]["unique_count_is_approximate"] is False
+
+
+@pytest.mark.parametrize("engine", ["auto", "columnar", "incremental"])
+def test_high_cardinality_distinct_count_marked_approximate(engine, tmp_path):
+    n_rows = 50_000
+    path = tmp_path / "high_card.csv"
+    with open(path, "w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["id"])
+        for value in range(n_rows):
+            writer.writerow([value])
+
+    report = dataprof.profile(str(path), engine=engine)
+    col = report["id"]
+    assert col.unique_count_is_approximate is True, (
+        f"{engine}: HLL-estimated count must be flagged approximate, not "
+        f"{col.unique_count_is_approximate!r}"
+    )
+
+
 # ── SQLite arm (requires --features python-async,database,sqlite) ──
 
 

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -440,6 +440,92 @@ fn test_streaming_bifurcation_with_large_dataset() {
     );
 }
 
+// -- Distinct-count provenance (#383) --
+
+/// On a small dataset every column's distinct count is exact, and both engines
+/// must say so: `unique_count_is_approximate == Some(false)`, never `None` or
+/// `Some(true)`. An exact-looking count with no provenance is unsafe for key
+/// checks, so the flag must be present and truthful.
+#[test]
+fn test_distinct_count_marked_exact_on_small_data_across_engines() {
+    let csv = create_test_csv(); // 100 rows, well under the estimator threshold
+    let path = csv.path();
+
+    let std_report = analyze_csv_file(path, &CsvParserConfig::default()).unwrap();
+    let arrow_report = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(path)
+        .unwrap();
+
+    for std_col in &std_report.column_profiles {
+        let arrow_col = arrow_report
+            .column_profiles
+            .iter()
+            .find(|c| c.name == std_col.name)
+            .unwrap();
+
+        assert_eq!(
+            std_col.unique_count_is_approximate,
+            Some(false),
+            "standard engine should mark '{}' exact",
+            std_col.name
+        );
+        assert_eq!(
+            arrow_col.unique_count_is_approximate,
+            Some(false),
+            "columnar engine should mark '{}' exact",
+            std_col.name
+        );
+        assert_eq!(
+            std_col.unique_count, arrow_col.unique_count,
+            "exact unique_count should match across engines for '{}'",
+            std_col.name
+        );
+    }
+}
+
+/// A high-cardinality column past the estimator threshold is a *legitimate*
+/// approximation, not a semantic mismatch: both engines must flag it
+/// `Some(true)` and land near the true distinct count.
+#[test]
+fn test_high_cardinality_marked_approximate_across_engines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "id,category").unwrap();
+    let rows = 20_000;
+    for i in 0..rows {
+        // `id` is unique per row (past the 10k exact threshold → HLL estimate);
+        // `category` stays tiny.
+        writeln!(f, "id-{i},{}", if i % 2 == 0 { "A" } else { "B" }).unwrap();
+    }
+    f.flush().unwrap();
+
+    let std_report = analyze_csv_file(f.path(), &CsvParserConfig::default()).unwrap();
+    let arrow_report = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(f.path())
+        .unwrap();
+
+    for report in [&std_report, &arrow_report] {
+        let id_col = report
+            .column_profiles
+            .iter()
+            .find(|c| c.name == "id")
+            .expect("id column present");
+
+        assert_eq!(
+            id_col.unique_count_is_approximate,
+            Some(true),
+            "high-cardinality 'id' must be flagged approximate"
+        );
+        let estimate = id_col.unique_count.expect("id unique_count present");
+        let error = (estimate as f64 - rows as f64).abs() / rows as f64;
+        assert!(
+            error < 0.05,
+            "approximate estimate {estimate} should be near {rows} (error {error:.4})"
+        );
+    }
+}
+
 // -- Selective dimension computation --
 
 #[test]


### PR DESCRIPTION
Closes #383.

## Problem

`unique_count` could be an exact `HashSet` count or a HyperLogLog estimate, but the report exposed only a bare integer. An exact-looking distinct count with no provenance is unsafe for key/uniqueness gates — a consumer cannot tell a true count from a ~1% HLL estimate.

## Change

Adds a flat `unique_count_is_approximate: Option<bool>` companion on `ColumnProfile`, threaded end to end:

- **Core** — new field with serde `skip_serializing_if = None` + `default` (back-compatible with older serialized reports).
- **Every production path sets it truthfully**: streaming → `StreamingStatistics::unique_count_is_approximate()`; parquet/Arrow → `CardinalityEstimator::is_approximate()`; exact-HashSet paths (`analyze_column`, Python columnar) → `Some(false)`.
- **Python** — `#[pyo3(get)]` getter, `.pyi` stub, both `to_dict` serializers, `from_dict`, and the markdown/HTML/repr renderers (approximate counts render with a `~` prefix so they never read as exact).

## Design notes

- Flat `Option<bool>`, not a new `MetricConfidence` struct — mirrors the existing `NumericStats.is_approximate` and the partial-analysis `distinct_count_approximate`, keeping the report contract consistent. `None` mirrors `unique_count: None` (never computed).
- `describe()` stays numeric on purpose (a `~` string would corrupt pandas dtypes); the flag remains reachable via the attribute and `to_dict()`.
- The richer `estimate`/`error` numeric-bound shape is intentionally deferred to the comparison-matrix work in #404; this PR owns the report-side flag.

## Acceptance criteria

- [x] Exact in-memory/small counts marked exact (`Some(false)`).
- [x] HLL-derived counts marked approximate (`Some(true)`).
- [x] Rust, Python, JSON, Markdown, and repr output do not imply approximation is exact.
- [x] Cross-engine parity tests distinguish a legitimate approximation from a semantic mismatch.
- [x] No unbounded set introduced.

## Verification

- Rust: 326 existing + 2 new cross-engine provenance tests pass; the new tests assert both engines agree (`Some(false)` on small data; `Some(true)` near-truth on 20k distinct).
- Python: 261 passed, 3 skipped (feature-gated); 2 new provenance tests across `auto`/`columnar`/`incremental`.
- `clippy --all-targets --all-features`, `cargo fmt --check`, and `ruff format --check` all clean.
