### PR TITLE
test(metrics): add table-driven completeness scenarios

### DIFF
--- a/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
@@ -169,72 +169,60 @@ impl<'a> CompletenessCalculator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::testing::{
+        CompletenessInput, CompletenessScenario, assert_completeness, column_data,
+        expected_completeness, null_threshold, string_profile,
+    };
     use super::*;
-    use crate::types::{ColumnStats, DataType, TextStats};
 
-    fn make_profile(name: &str, total: usize, nulls: usize) -> ColumnProfile {
-        ColumnProfile {
-            name: name.to_string(),
-            data_type: DataType::String,
-            null_count: nulls,
-            total_count: total,
-            unique_count: Some(total - nulls),
-            unique_count_is_approximate: Some(false),
-            stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
-            patterns: Some(vec![]),
+    #[test]
+    fn completeness_scenarios_cover_boundaries() {
+        let scenarios = vec![
+            CompletenessScenario {
+                name: "empty input is computed but neutral",
+                input: CompletenessInput::Profiles(vec![]),
+                config: IsoQualityConfig::default(),
+                expected: expected_completeness(0.0, 100.0, &[], 0),
+            },
+            CompletenessScenario {
+                name: "perfect raw rows",
+                input: CompletenessInput::Rows {
+                    data: column_data(&[("a", &["x", "y"]), ("b", &["1", "2"])]),
+                    total_rows: 2,
+                },
+                config: IsoQualityConfig::default(),
+                expected: expected_completeness(0.0, 100.0, &[], 4),
+            },
+            CompletenessScenario {
+                name: "exact null threshold is not a null column",
+                input: CompletenessInput::Profiles(vec![string_profile("boundary", 100, 25)]),
+                config: null_threshold(25.0),
+                expected: expected_completeness(25.0, 75.0, &[], 100),
+            },
+            CompletenessScenario {
+                name: "degraded profiles expose exact counters",
+                input: CompletenessInput::Profiles(vec![
+                    string_profile("partial", 100, 10),
+                    string_profile("mostly_null", 100, 60),
+                ]),
+                config: IsoQualityConfig::default(),
+                expected: expected_completeness(35.0, 30.0, &["mostly_null"], 200),
+            },
+        ];
+
+        for scenario in scenarios {
+            let calculator = CompletenessCalculator::new(&scenario.config);
+            let actual = match &scenario.input {
+                CompletenessInput::Rows { data, total_rows } => {
+                    calculator.calculate(data, &[], *total_rows)
+                }
+                CompletenessInput::Profiles(profiles) => {
+                    calculator.calculate_from_profiles(profiles)
+                }
+            }
+            .unwrap_or_else(|error| panic!("scenario `{}` failed: {error}", scenario.name));
+
+            assert_completeness(scenario.name, &actual, &scenario.expected);
         }
-    }
-
-    #[test]
-    fn test_calculate_from_profiles_all_complete() {
-        let thresholds = IsoQualityConfig::default();
-        let calc = CompletenessCalculator::new(&thresholds);
-        let profiles = vec![make_profile("a", 100, 0), make_profile("b", 100, 0)];
-
-        let result = calc.calculate_from_profiles(&profiles).unwrap();
-        assert_eq!(result.missing_values_ratio, 0.0);
-        assert_eq!(result.complete_records_ratio, 100.0);
-        assert!(result.null_columns.is_empty());
-    }
-
-    #[test]
-    fn test_calculate_from_profiles_with_nulls() {
-        let thresholds = IsoQualityConfig::default();
-        let calc = CompletenessCalculator::new(&thresholds);
-        let profiles = vec![
-            make_profile("a", 100, 10), // 10% null
-            make_profile("b", 100, 20), // 20% null
-        ];
-
-        let result = calc.calculate_from_profiles(&profiles).unwrap();
-        // 30 null cells out of 200 total = 15%
-        assert!((result.missing_values_ratio - 15.0).abs() < 0.01);
-        // Pessimistic bound: max(0, 100 - 30) / 100 = 70%
-        assert!((result.complete_records_ratio - 70.0).abs() < 0.01);
-        assert!(result.null_columns.is_empty()); // Neither exceeds 50% threshold
-    }
-
-    #[test]
-    fn test_calculate_from_profiles_null_column_detected() {
-        let thresholds = IsoQualityConfig::default();
-        let calc = CompletenessCalculator::new(&thresholds);
-        let profiles = vec![
-            make_profile("good", 100, 0),
-            make_profile("bad", 100, 60), // 60% null → above 50% threshold
-        ];
-
-        let result = calc.calculate_from_profiles(&profiles).unwrap();
-        assert_eq!(result.null_columns, vec!["bad".to_string()]);
-    }
-
-    #[test]
-    fn test_calculate_from_profiles_empty() {
-        let thresholds = IsoQualityConfig::default();
-        let calc = CompletenessCalculator::new(&thresholds);
-        let profiles: Vec<ColumnProfile> = vec![];
-
-        let result = calc.calculate_from_profiles(&profiles).unwrap();
-        assert_eq!(result.missing_values_ratio, 0.0);
-        assert_eq!(result.complete_records_ratio, 100.0);
     }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -52,6 +52,8 @@ mod accuracy;
 mod completeness;
 mod consistency;
 mod precision;
+#[cfg(test)]
+mod testing;
 mod timeliness;
 mod uniqueness;
 mod utils;
@@ -743,6 +745,7 @@ pub struct BifurcatedResult {
 
 #[cfg(test)]
 mod tests {
+    use super::testing::string_profile;
     use super::*;
     use crate::types::{ColumnStats, DataType};
     use dataprof_core::QualityScoreWeights;
@@ -820,6 +823,26 @@ mod tests {
             .expect("quality metrics");
 
         assert_eq!(metrics.score_weights, weights);
+    }
+
+    #[test]
+    fn unrequested_completeness_remains_absent() {
+        let data = HashMap::from([("value".to_string(), vec!["x".to_string()])]);
+        let profiles = vec![string_profile("value", 1, 0)];
+        let requested = [QualityDimension::Consistency];
+
+        let metrics = MetricsCalculator::new()
+            .calculate_comprehensive_metrics(&data, &profiles, Some(&requested))
+            .expect("quality metrics");
+
+        assert!(
+            metrics.completeness.is_none(),
+            "an unrequested dimension must remain absent rather than looking computed"
+        );
+        assert!(
+            metrics.consistency.is_some(),
+            "the requested dimension should still be computed"
+        );
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/metrics/testing.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/testing.rs
@@ -1,0 +1,109 @@
+//! Test-only scenario helpers for quality-dimension calculators.
+//!
+//! Keep these builders small and dimension-neutral. Future uniqueness and
+//! timeliness scenario matrices can reuse `column_data` and `string_profile`,
+//! adding dimension-specific scenario and assertion helpers only when needed.
+
+use super::completeness::CompletenessMetrics;
+use crate::core::config::IsoQualityConfig;
+use crate::types::{ColumnProfile, ColumnStats, DataType, TextStats};
+use std::collections::HashMap;
+
+pub(super) fn column_data(columns: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+    columns
+        .iter()
+        .map(|(name, values)| {
+            (
+                (*name).to_string(),
+                values.iter().map(|value| (*value).to_string()).collect(),
+            )
+        })
+        .collect()
+}
+
+pub(super) fn string_profile(name: &str, total: usize, nulls: usize) -> ColumnProfile {
+    ColumnProfile {
+        name: name.to_string(),
+        data_type: DataType::String,
+        null_count: nulls,
+        total_count: total,
+        unique_count: Some(total.saturating_sub(nulls)),
+        unique_count_is_approximate: Some(false),
+        stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
+        patterns: Some(vec![]),
+    }
+}
+
+pub(super) fn null_threshold(max_null_percentage: f64) -> IsoQualityConfig {
+    IsoQualityConfig {
+        max_null_percentage,
+        ..IsoQualityConfig::default()
+    }
+}
+
+pub(super) enum CompletenessInput {
+    Rows {
+        data: HashMap<String, Vec<String>>,
+        total_rows: usize,
+    },
+    Profiles(Vec<ColumnProfile>),
+}
+
+pub(super) struct CompletenessScenario {
+    pub name: &'static str,
+    pub input: CompletenessInput,
+    pub config: IsoQualityConfig,
+    pub expected: CompletenessMetrics,
+}
+
+pub(super) fn expected_completeness(
+    missing_values_ratio: f64,
+    complete_records_ratio: f64,
+    null_columns: &[&str],
+    total_cells: usize,
+) -> CompletenessMetrics {
+    CompletenessMetrics {
+        missing_values_ratio,
+        complete_records_ratio,
+        null_columns: null_columns
+            .iter()
+            .map(|column| (*column).to_string())
+            .collect(),
+        total_cells,
+    }
+}
+
+pub(super) fn assert_completeness(
+    scenario_name: &str,
+    actual: &CompletenessMetrics,
+    expected: &CompletenessMetrics,
+) {
+    assert_float_field(
+        scenario_name,
+        "missing_values_ratio",
+        actual.missing_values_ratio,
+        expected.missing_values_ratio,
+    );
+    assert_float_field(
+        scenario_name,
+        "complete_records_ratio",
+        actual.complete_records_ratio,
+        expected.complete_records_ratio,
+    );
+    assert_eq!(
+        actual.null_columns, expected.null_columns,
+        "scenario `{scenario_name}` field `null_columns`"
+    );
+    assert_eq!(
+        actual.total_cells, expected.total_cells,
+        "scenario `{scenario_name}` field `total_cells`"
+    );
+}
+
+fn assert_float_field(scenario_name: &str, field: &str, actual: f64, expected: f64) {
+    const EPSILON: f64 = 1e-9;
+    assert!(
+        (actual - expected).abs() <= EPSILON,
+        "scenario `{scenario_name}` field `{field}`: expected {expected}, got {actual}"
+    );
+}

--- a/crates/dataprof-metrics/src/analysis/metrics/testing.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/testing.rs
@@ -22,12 +22,16 @@ pub(super) fn column_data(columns: &[(&str, &[&str])]) -> HashMap<String, Vec<St
 }
 
 pub(super) fn string_profile(name: &str, total: usize, nulls: usize) -> ColumnProfile {
+    let unique_count = total.checked_sub(nulls).unwrap_or_else(|| {
+        panic!("profile `{name}` has {nulls} nulls but only {total} total values")
+    });
+
     ColumnProfile {
         name: name.to_string(),
         data_type: DataType::String,
         null_count: nulls,
         total_count: total,
-        unique_count: Some(total.saturating_sub(nulls)),
+        unique_count: Some(unique_count),
         unique_count_is_approximate: Some(false),
         stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
         patterns: Some(vec![]),
@@ -101,9 +105,9 @@ pub(super) fn assert_completeness(
 }
 
 fn assert_float_field(scenario_name: &str, field: &str, actual: f64, expected: f64) {
-    const EPSILON: f64 = 1e-9;
+    const ABSOLUTE_TOLERANCE: f64 = 0.01;
     assert!(
-        (actual - expected).abs() <= EPSILON,
-        "scenario `{scenario_name}` field `{field}`: expected {expected}, got {actual}"
+        (actual - expected).abs() <= ABSOLUTE_TOLERANCE,
+        "scenario `{scenario_name}` field `{field}`: expected {expected} ± {ABSOLUTE_TOLERANCE}, got {actual}"
     );
 }


### PR DESCRIPTION
## Summary

- add test-only scenario helpers for quality metrics
- migrate completeness coverage to named boundary cases
- preserve coverage for unrequested dimensions remaining absent

## Checks

- `cargo test -p dataprof-metrics`
- `cargo clippy -p dataprof-metrics --all-targets -- -D warnings`
- `cargo fmt --all --check`

Closes #244