### PR TITLE
feat(python): add agent security guard for MCP surfaces

### DIFF
--- a/python/dataprof/agent.py
+++ b/python/dataprof/agent.py
@@ -1,0 +1,417 @@
+"""Security guard for agent-facing surfaces.
+
+Tool inputs on an agent surface come from an LLM, not from a trusted user, and
+dataprof reads real files — so a careless agent surface is a data-exfiltration
+vector. This module is the enforcement point that sits between untrusted input
+and the profiling engine: it resolves paths against a sandbox root, bounds the
+work a single call can do, and keeps file contents and host paths out of error
+messages.
+
+It is deliberately transport-agnostic. The MCP server (#330) is one caller; a
+bare tool wrapper or a notebook helper is another. Nothing here imports an MCP
+SDK, and nothing here is allowed to execute code or open sockets.
+
+    from dataprof.agent import AgentGuard, SandboxPolicy
+
+    guard = AgentGuard(SandboxPolicy(roots=["/srv/data"]))
+    report = guard.profile("customers.csv")   # resolved under /srv/data
+    print(guard.llm_context(report))          # redacted by construction
+
+Every rejection raises a subclass of :class:`AgentSecurityError`, whose message
+is safe to hand back to a model verbatim.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FutureTimeout
+from dataclasses import dataclass
+from typing import Any, TypeVar, cast
+
+from . import (
+    ProfileReport,
+    StopCondition,
+    StructureReport,
+    analyze_structure as _analyze_structure,
+    profile as _profile,
+)
+
+__all__ = [
+    "AgentGuard",
+    "AgentSecurityError",
+    "AgentTimeoutError",
+    "PathNotAllowedError",
+    "ResourceLimitExceededError",
+    "SandboxPolicy",
+]
+
+_T = TypeVar("_T")
+
+# Schemes an LLM is most likely to hand us when it wants remote data. A source
+# naming any of these is refused unless the policy opts into network access;
+# the check is on the string the model supplied, before anything opens it.
+_NETWORK_SCHEMES = (
+    "http://",
+    "https://",
+    "ftp://",
+    "ftps://",
+    "s3://",
+    "gs://",
+    "azure://",
+    "abfs://",
+    "hdfs://",
+    "postgres://",
+    "postgresql://",
+    "mysql://",
+    "mongodb://",
+)
+
+
+class AgentSecurityError(Exception):
+    """Base class for every guard rejection.
+
+    The message is written to be safe to return to a model: it never contains
+    file contents, and never contains a host path outside the sandbox root.
+    """
+
+
+class PathNotAllowedError(AgentSecurityError):
+    """A source resolved outside the sandbox, or to something not a real file."""
+
+
+class ResourceLimitExceededError(AgentSecurityError):
+    """A call would exceed a configured bound (file size, rows, bytes)."""
+
+
+class AgentTimeoutError(AgentSecurityError):
+    """A call outlived the policy's per-call deadline."""
+
+
+def _coerce_roots(
+    roots: Sequence[str | os.PathLike[str]] | str | os.PathLike[str],
+) -> tuple[pathlib.Path, ...]:
+    items: Sequence[str | os.PathLike[str]]
+    if isinstance(roots, (str, os.PathLike)):
+        # A lone root is the common case; wrap it rather than making every
+        # caller type `[root]`. The cast discards a spurious "sequence that is
+        # also path-like" intersection the narrowing leaves behind.
+        items = [cast("str | os.PathLike[str]", roots)]
+    else:
+        items = roots
+    resolved: list[pathlib.Path] = []
+    for r in items:
+        p = pathlib.Path(r).expanduser().resolve()
+        if not p.is_dir():
+            raise ValueError(f"sandbox root is not an existing directory: {p}")
+        resolved.append(p)
+    if not resolved:
+        raise ValueError(
+            "SandboxPolicy requires at least one root; an unrooted guard sandboxes nothing"
+        )
+    return tuple(resolved)
+
+
+# init=False: the validating __init__ below is the point of this class, and
+# leaving it implicit would rely on dataclass declining to overwrite an
+# __init__ already present in the class body.
+@dataclass(frozen=True, init=False)
+class SandboxPolicy:
+    """Limits applied to every call made through an :class:`AgentGuard`.
+
+    The defaults are deliberately conservative: an agent surface should start
+    from "small, local, quick" and be widened on purpose, not discover its
+    limits by profiling a 40 GB file.
+
+    Args:
+        roots: Directories file access is confined to. Required — there is no
+            default root, because a guard without one enforces nothing.
+        max_file_bytes: Largest file the guard will open, checked before the
+            engine reads anything.
+        max_rows: Row ceiling handed to the engine as a stop condition.
+        max_bytes: Byte ceiling handed to the engine as a stop condition.
+        timeout_seconds: Per-call wall-clock deadline. See :meth:`AgentGuard.run`
+            for what this does and does not guarantee.
+        follow_symlinks: When false (the default), a symlink whose target
+            escapes the sandbox is rejected rather than followed.
+        allow_network: When false (the default), sources naming a network
+            scheme are rejected without being opened.
+        allow_samples: When false (the default), :meth:`AgentGuard.llm_context`
+            refuses to include raw sample values.
+    """
+
+    roots: tuple[pathlib.Path, ...]
+    max_file_bytes: int = 256 * 1024 * 1024
+    max_rows: int = 1_000_000
+    max_bytes: int = 256 * 1024 * 1024
+    timeout_seconds: float = 30.0
+    follow_symlinks: bool = False
+    allow_network: bool = False
+    allow_samples: bool = False
+
+    def __init__(
+        self,
+        roots: Sequence[str | os.PathLike[str]] | str | os.PathLike[str],
+        *,
+        max_file_bytes: int = 256 * 1024 * 1024,
+        max_rows: int = 1_000_000,
+        max_bytes: int = 256 * 1024 * 1024,
+        timeout_seconds: float = 30.0,
+        follow_symlinks: bool = False,
+        allow_network: bool = False,
+        allow_samples: bool = False,
+    ) -> None:
+        for name, value in (
+            ("max_file_bytes", max_file_bytes),
+            ("max_rows", max_rows),
+            ("max_bytes", max_bytes),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if timeout_seconds <= 0:
+            raise ValueError(f"timeout_seconds must be positive, got {timeout_seconds}")
+
+        object.__setattr__(self, "roots", _coerce_roots(roots))
+        object.__setattr__(self, "max_file_bytes", max_file_bytes)
+        object.__setattr__(self, "max_rows", max_rows)
+        object.__setattr__(self, "max_bytes", max_bytes)
+        object.__setattr__(self, "timeout_seconds", timeout_seconds)
+        object.__setattr__(self, "follow_symlinks", follow_symlinks)
+        object.__setattr__(self, "allow_network", allow_network)
+        object.__setattr__(self, "allow_samples", allow_samples)
+
+
+class AgentGuard:
+    """Enforces a :class:`SandboxPolicy` around the profiling entry points.
+
+    Construct one per agent session and route every model-supplied source
+    through it. A guard holds nothing but its frozen policy, so it carries no
+    per-call state and is safe to share across threads.
+    """
+
+    def __init__(self, policy: SandboxPolicy) -> None:
+        self._policy = policy
+
+    @property
+    def policy(self) -> SandboxPolicy:
+        return self._policy
+
+    # -- path handling ----------------------------------------------------
+
+    def resolve_path(self, source: str | os.PathLike[str]) -> pathlib.Path:
+        """Resolve a model-supplied source to a real file inside the sandbox.
+
+        Traversal, absolute paths outside the root, and escaping symlinks are
+        all rejected here — after full resolution, so that `a/../../etc/passwd`
+        and a symlink to `/etc/passwd` fail the same check rather than relying
+        on spotting `..` in the string.
+
+        Raises:
+            PathNotAllowedError: The source escapes the sandbox, does not
+                exist, or is not a regular file.
+            ResourceLimitExceededError: The file is larger than
+                ``policy.max_file_bytes``.
+        """
+        raw = self._require_pathlike(source)
+        self._reject_network(raw)
+
+        candidate = pathlib.Path(raw).expanduser()
+
+        # Resolve symlinks and `..` fully before comparing against the roots.
+        # Comparing an unresolved path would let `root/../../etc` pass.
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            # RuntimeError covers a symlink loop. Report both as "not found":
+            # distinguishing them tells the caller about the host filesystem.
+            raise PathNotAllowedError(
+                f"no such file inside the sandbox: {self._describe(candidate)}"
+            ) from None
+
+        root = self._containing_root(resolved)
+        if root is None:
+            raise PathNotAllowedError(f"path is outside the sandbox: {self._describe(candidate)}")
+
+        if not self._policy.follow_symlinks and self._traverses_symlink(candidate, resolved):
+            raise PathNotAllowedError(
+                f"path is a symlink and symlinks are disabled: {self._describe(candidate)}"
+            )
+
+        if not resolved.is_file():
+            raise PathNotAllowedError(f"not a regular file: {self._relative(resolved, root)}")
+
+        size = resolved.stat().st_size
+        if size > self._policy.max_file_bytes:
+            raise ResourceLimitExceededError(
+                f"file is {size} bytes, over the {self._policy.max_file_bytes}-byte limit: "
+                f"{self._relative(resolved, root)}"
+            )
+        return resolved
+
+    def _containing_root(self, resolved: pathlib.Path) -> pathlib.Path | None:
+        for root in self._policy.roots:
+            try:
+                resolved.relative_to(root)
+            except ValueError:
+                continue
+            return root
+        return None
+
+    def _traverses_symlink(self, candidate: pathlib.Path, resolved: pathlib.Path) -> bool:
+        """True if reaching ``resolved`` went through a link.
+
+        Checked even when the target lands inside the sandbox: a link that
+        currently resolves in-root can be repointed out of it later, and the
+        strict reading of the checklist is that symlinks are off by default.
+        """
+        if candidate.is_symlink():
+            return True
+        try:
+            absolute = candidate if candidate.is_absolute() else pathlib.Path.cwd() / candidate
+            return os.path.normpath(absolute) != str(resolved)
+        except OSError:
+            return True
+
+    def _reject_network(self, raw: str) -> None:
+        if self._policy.allow_network:
+            return
+        lowered = raw.lower()
+        for scheme in _NETWORK_SCHEMES:
+            if lowered.startswith(scheme):
+                # Name the scheme, not the URL: the URL may carry credentials.
+                raise PathNotAllowedError(
+                    f"network access is disabled; refusing a {scheme.rstrip(':/')} source"
+                )
+
+    @staticmethod
+    def _require_pathlike(source: Any) -> str:
+        if isinstance(source, str):
+            return source
+        if isinstance(source, os.PathLike):
+            fs = os.fspath(source)
+            if isinstance(fs, str):
+                return fs
+        raise PathNotAllowedError(
+            f"expected a file path, got {type(source).__name__}; "
+            "in-memory sources bypass the sandbox and are not accepted here"
+        )
+
+    def _describe(self, candidate: pathlib.Path) -> str:
+        """Render a rejected path without disclosing the host filesystem.
+
+        A rejected path resolved outside the sandbox, so there is no in-root
+        form to show and the resolved form is exactly what must not leak. Show
+        only the final component the caller already knows it sent.
+        """
+        return candidate.name or "<empty path>"
+
+    @staticmethod
+    def _relative(resolved: pathlib.Path, root: pathlib.Path) -> str:
+        return resolved.relative_to(root).as_posix()
+
+    # -- bounded execution ------------------------------------------------
+
+    def stop_condition(self) -> StopCondition:
+        """The engine-level row and byte ceilings implied by the policy."""
+        return StopCondition.max_rows(self._policy.max_rows) | StopCondition.max_bytes(
+            self._policy.max_bytes
+        )
+
+    def run(self, fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+        """Run ``fn`` under the policy's per-call deadline.
+
+        The deadline bounds what the caller waits for and what the agent sees.
+        It is **not** preemptive cancellation: the native profiling call holds
+        no cancellation token, and progress callbacks cannot carry one either
+        (``crates/dataprof-python/src/progress.rs`` swallows callback errors by
+        design, so raising from one would not stop the work). On timeout the
+        worker thread runs to completion in the background and its result is
+        discarded.
+
+        The real defense against runaway work is therefore the pre-flight size
+        check in :meth:`resolve_path` plus :meth:`stop_condition`, both of which
+        cap the work before it starts. This deadline is the backstop.
+
+        Raises:
+            AgentTimeoutError: ``fn`` did not finish within the deadline.
+        """
+        # A dedicated executor per call keeps a timed-out straggler from
+        # occupying a shared pool slot for the life of the guard.
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dataprof-agent")
+        try:
+            future = executor.submit(fn, *args, **kwargs)
+            try:
+                return future.result(timeout=self._policy.timeout_seconds)
+            except _FutureTimeout:
+                future.cancel()
+                raise AgentTimeoutError(
+                    f"call exceeded the {self._policy.timeout_seconds:g}s limit and was abandoned"
+                ) from None
+        finally:
+            # Do not block on a straggler; the thread is a daemon of the pool
+            # and the interpreter joins it at exit.
+            executor.shutdown(wait=False)
+
+    # -- guarded entry points ---------------------------------------------
+
+    def profile(self, source: str | os.PathLike[str], **kwargs: Any) -> ProfileReport:
+        """Profile a sandboxed file under the policy's bounds.
+
+        The row and byte ceilings are set from the policy and cannot be widened
+        by the caller — an LLM-supplied argument must not be able to raise its
+        own ceiling. They travel as a single ``stop_condition``, which the
+        underlying ``profile()`` refuses to accept alongside ``max_rows``.
+
+        Raises:
+            AgentSecurityError: The source or arguments violate the policy.
+        """
+        path = self.resolve_path(source)
+        for reserved in ("stop_condition", "max_rows", "source"):
+            if reserved in kwargs:
+                raise ResourceLimitExceededError(
+                    f"{reserved!r} is fixed by the sandbox policy and cannot be overridden per call"
+                )
+        return self.run(_profile, str(path), stop_condition=self.stop_condition(), **kwargs)
+
+    def analyze_structure(
+        self, source: str | os.PathLike[str], max_rows: int | None = None
+    ) -> StructureReport:
+        """Cheap structural first look at a sandboxed file.
+
+        ``max_rows`` is clamped to the policy ceiling rather than rejected, so
+        a model asking for more simply gets the ceiling.
+        """
+        path = self.resolve_path(source)
+        bounded = (
+            self._policy.max_rows if max_rows is None else min(max_rows, self._policy.max_rows)
+        )
+        return self.run(_analyze_structure, str(path), bounded)
+
+    def llm_context(
+        self, report: ProfileReport, max_tokens: int = 1000, include_samples: bool = False
+    ) -> str:
+        """Render ``report`` as bounded, redacted model context.
+
+        Raises:
+            AgentSecurityError: ``include_samples`` was requested but the
+                policy does not allow raw values.
+        """
+        if include_samples and not self._policy.allow_samples:
+            raise AgentSecurityError(
+                "include_samples is disabled by the sandbox policy; "
+                "raw values must not cross the agent boundary"
+            )
+        return report.to_llm_context(max_tokens=max_tokens, include_samples=include_samples)
+
+    def sanitize_error(self, exc: BaseException) -> str:
+        """Render any exception as a message safe to hand back to a model.
+
+        Guard rejections are already written to be safe and pass through. Every
+        other exception is reduced to its type: an arbitrary error from the
+        engine or the filesystem may carry an absolute path or a fragment of
+        the file that failed to parse, and neither may reach the model.
+        """
+        if isinstance(exc, AgentSecurityError):
+            return str(exc)
+        return f"{type(exc).__name__}: request failed (details withheld at the agent boundary)"

--- a/python/dataprof/agent.py
+++ b/python/dataprof/agent.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 import os
 import pathlib
+import threading
 from collections.abc import Callable, Sequence
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FutureTimeout
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast
 
@@ -202,6 +202,11 @@ class AgentGuard:
     def resolve_path(self, source: str | os.PathLike[str]) -> pathlib.Path:
         """Resolve a model-supplied source to a real file inside the sandbox.
 
+        A relative source is interpreted against the sandbox roots, never
+        against the process working directory: the caller's CWD is not part of
+        this contract, and a model supplying ``"customers.csv"`` means "the one
+        in the sandbox". Roots are tried in order and the first match wins.
+
         Traversal, absolute paths outside the root, and escaping symlinks are
         all rejected here — after full resolution, so that `a/../../etc/passwd`
         and a symlink to `/etc/passwd` fail the same check rather than relying
@@ -217,23 +222,39 @@ class AgentGuard:
         self._reject_network(raw)
 
         candidate = pathlib.Path(raw).expanduser()
+        attempts = (
+            [candidate]
+            if candidate.is_absolute()
+            else [root / candidate for root in self._policy.roots]
+        )
 
         # Resolve symlinks and `..` fully before comparing against the roots.
         # Comparing an unresolved path would let `root/../../etc` pass.
-        try:
-            resolved = candidate.resolve(strict=True)
-        except (OSError, RuntimeError):
-            # RuntimeError covers a symlink loop. Report both as "not found":
-            # distinguishing them tells the caller about the host filesystem.
+        attempted: pathlib.Path | None = None
+        resolved: pathlib.Path | None = None
+        for attempt in attempts:
+            try:
+                candidate_resolved = attempt.resolve(strict=True)
+            except (OSError, RuntimeError):
+                # RuntimeError covers a symlink loop. Both mean "this attempt
+                # is not a usable file"; try the next root.
+                continue
+            attempted, resolved = attempt, candidate_resolved
+            if self._containing_root(candidate_resolved) is not None:
+                break
+
+        if resolved is None or attempted is None:
+            # Reported as "not found" whether the path is missing or unreadable:
+            # telling the two apart describes the host filesystem to the model.
             raise PathNotAllowedError(
                 f"no such file inside the sandbox: {self._describe(candidate)}"
-            ) from None
+            )
 
         root = self._containing_root(resolved)
         if root is None:
             raise PathNotAllowedError(f"path is outside the sandbox: {self._describe(candidate)}")
 
-        if not self._policy.follow_symlinks and self._traverses_symlink(candidate, resolved):
+        if not self._policy.follow_symlinks and self._traverses_symlink(attempted, resolved):
             raise PathNotAllowedError(
                 f"path is a symlink and symlinks are disabled: {self._describe(candidate)}"
             )
@@ -258,18 +279,23 @@ class AgentGuard:
             return root
         return None
 
-    def _traverses_symlink(self, candidate: pathlib.Path, resolved: pathlib.Path) -> bool:
+    def _traverses_symlink(self, attempted: pathlib.Path, resolved: pathlib.Path) -> bool:
         """True if reaching ``resolved`` went through a link.
+
+        ``attempted`` is always absolute — either an absolute source or a root
+        joined to a relative one — so a purely textual `..` fold is enough to
+        compare against the fully resolved path. Any remaining difference means
+        a link was crossed.
 
         Checked even when the target lands inside the sandbox: a link that
         currently resolves in-root can be repointed out of it later, and the
         strict reading of the checklist is that symlinks are off by default.
         """
-        if candidate.is_symlink():
+        if attempted.is_symlink():
             return True
         try:
-            absolute = candidate if candidate.is_absolute() else pathlib.Path.cwd() / candidate
-            return os.path.normpath(absolute) != str(resolved)
+            folded = os.path.normcase(os.path.normpath(attempted))
+            return folded != os.path.normcase(str(resolved))
         except OSError:
             return True
 
@@ -326,8 +352,7 @@ class AgentGuard:
         no cancellation token, and progress callbacks cannot carry one either
         (``crates/dataprof-python/src/progress.rs`` swallows callback errors by
         design, so raising from one would not stop the work). On timeout the
-        worker thread runs to completion in the background and its result is
-        discarded.
+        worker runs to completion in the background and its result is discarded.
 
         The real defense against runaway work is therefore the pre-flight size
         check in :meth:`resolve_path` plus :meth:`stop_condition`, both of which
@@ -336,22 +361,30 @@ class AgentGuard:
         Raises:
             AgentTimeoutError: ``fn`` did not finish within the deadline.
         """
-        # A dedicated executor per call keeps a timed-out straggler from
-        # occupying a shared pool slot for the life of the guard.
-        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dataprof-agent")
-        try:
-            future = executor.submit(fn, *args, **kwargs)
+        # A plain daemon thread rather than a ThreadPoolExecutor: since 3.9 the
+        # executor registers an atexit hook that *joins* its non-daemon workers,
+        # so one stuck call would hold the interpreter open at shutdown. A
+        # daemon thread lets an abandoned straggler die with the process.
+        outcome: list[_T] = []
+        failure: list[BaseException] = []
+
+        def target() -> None:
             try:
-                return future.result(timeout=self._policy.timeout_seconds)
-            except _FutureTimeout:
-                future.cancel()
-                raise AgentTimeoutError(
-                    f"call exceeded the {self._policy.timeout_seconds:g}s limit and was abandoned"
-                ) from None
-        finally:
-            # Do not block on a straggler; the thread is a daemon of the pool
-            # and the interpreter joins it at exit.
-            executor.shutdown(wait=False)
+                outcome.append(fn(*args, **kwargs))
+            except BaseException as exc:  # noqa: BLE001 - re-raised on the calling thread
+                failure.append(exc)
+
+        worker = threading.Thread(target=target, name="dataprof-agent", daemon=True)
+        worker.start()
+        worker.join(self._policy.timeout_seconds)
+
+        if worker.is_alive():
+            raise AgentTimeoutError(
+                f"call exceeded the {self._policy.timeout_seconds:g}s limit and was abandoned"
+            )
+        if failure:
+            raise failure[0]
+        return outcome[0]
 
     # -- guarded entry points ---------------------------------------------
 

--- a/python/tests/test_agent_guard.py
+++ b/python/tests/test_agent_guard.py
@@ -13,8 +13,8 @@ Run after building the extension:
 from __future__ import annotations
 
 import ast
-import os
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -69,11 +69,46 @@ def test_policy_rejects_a_root_that_is_not_a_directory(sandbox: Path) -> None:
         SandboxPolicy(roots=sandbox / "data.csv")
 
 
-def test_resolves_a_file_inside_the_root(guard: AgentGuard, sandbox: Path) -> None:
-    assert (
-        guard.resolve_path("data.csv" if os.getcwd() == str(sandbox) else sandbox / "data.csv")
-        == (sandbox / "data.csv").resolve()
-    )
+def test_resolves_an_absolute_file_inside_the_root(guard: AgentGuard, sandbox: Path) -> None:
+    assert guard.resolve_path(sandbox / "data.csv") == (sandbox / "data.csv").resolve()
+
+
+def test_relative_source_resolves_against_the_root_not_the_cwd(
+    guard: AgentGuard, sandbox: Path, tmp_path: Path
+) -> None:
+    """A model sending "data.csv" means the one in the sandbox. The process CWD
+    is not part of the contract, so it is deliberately set elsewhere here."""
+    elsewhere = tmp_path / "cwd"
+    elsewhere.mkdir()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.chdir(elsewhere)
+        assert guard.resolve_path("data.csv") == (sandbox / "data.csv").resolve()
+
+
+def test_relative_source_does_not_pick_up_a_cwd_file(
+    guard: AgentGuard, sandbox: Path, tmp_path: Path
+) -> None:
+    """A same-named file in the CWD must not shadow the sandboxed one."""
+    elsewhere = tmp_path / "cwd"
+    elsewhere.mkdir()
+    (elsewhere / "data.csv").write_text("token\nsuper-secret-value\n")
+    with pytest.MonkeyPatch.context() as mp:
+        mp.chdir(elsewhere)
+        assert guard.resolve_path("data.csv") == (sandbox / "data.csv").resolve()
+
+
+def test_relative_traversal_out_of_the_root_is_rejected(guard: AgentGuard, outside: Path) -> None:
+    with pytest.raises(PathNotAllowedError):
+        guard.resolve_path(Path("..") / "outside" / "secret.csv")
+
+
+def test_relative_source_searches_roots_in_order(tmp_path: Path) -> None:
+    first, second = tmp_path / "first", tmp_path / "second"
+    for d in (first, second):
+        d.mkdir()
+    (second / "only-in-second.csv").write_text(CSV_BODY)
+    guard = AgentGuard(SandboxPolicy(roots=[first, second]))
+    assert guard.resolve_path("only-in-second.csv") == (second / "only-in-second.csv").resolve()
 
 
 def test_profiles_a_sandboxed_file(guard: AgentGuard, sandbox: Path) -> None:
@@ -173,7 +208,10 @@ def test_guard_module_contains_no_execution_or_socket_primitives() -> None:
     tree = ast.parse(Path(source_file).read_text())
 
     banned_modules = {"subprocess", "socket", "urllib", "requests", "httpx", "pty", "shutil"}
-    banned_calls = {"eval", "exec", "compile", "__import__", "system", "popen", "spawn"}
+    banned_calls = {"eval", "exec", "compile", "__import__", "system"}
+    # Prefixes, because the os module spells execution as a family: spawnl,
+    # spawnv, execve, popen2... an exact-name check would wave those through.
+    banned_prefixes = ("spawn", "exec", "popen", "fork")
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -185,7 +223,10 @@ def test_guard_module_contains_no_execution_or_socket_primitives() -> None:
             )
         elif isinstance(node, ast.Call):
             name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            if name is None:
+                continue
             assert name not in banned_calls, f"guard calls {name}()"
+            assert not name.startswith(banned_prefixes), f"guard calls {name}()"
 
 
 def test_rejects_non_path_sources(guard: AgentGuard) -> None:
@@ -260,6 +301,18 @@ def test_timeout_raises_and_is_reported_as_a_security_error(sandbox: Path) -> No
 
 def test_timeout_does_not_fire_on_a_quick_call(guard: AgentGuard) -> None:
     assert guard.run(lambda: 7) == 7
+
+
+def test_abandoned_worker_is_a_daemon_and_cannot_hold_the_interpreter_open(sandbox: Path) -> None:
+    """A timed-out call is not cancellable, so the straggler must at least not
+    keep the process alive at shutdown."""
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, timeout_seconds=0.05))
+    before = {t.ident for t in threading.enumerate()}
+    with pytest.raises(AgentTimeoutError):
+        guard.run(time.sleep, 2)
+    stragglers = [t for t in threading.enumerate() if t.ident not in before]
+    assert stragglers, "expected the abandoned worker to still be running"
+    assert all(t.daemon for t in stragglers)
 
 
 def test_run_propagates_the_callee_error_unchanged(guard: AgentGuard) -> None:

--- a/python/tests/test_agent_guard.py
+++ b/python/tests/test_agent_guard.py
@@ -1,0 +1,382 @@
+"""Security tests for the agent guard (issue #336).
+
+Each test maps to a box on the hardening checklist that gates the MCP server.
+Inputs on an agent surface come from a model, so the cases below are written as
+an attacker would send them: traversal, symlink escape, absolute paths, oversize
+files, argument overrides that try to lift their own ceiling.
+
+Run after building the extension:
+    uv run maturin develop
+    uv run pytest python/tests/test_agent_guard.py -v
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import dataprof.agent
+import pytest
+from dataprof.agent import (
+    AgentGuard,
+    AgentSecurityError,
+    AgentTimeoutError,
+    PathNotAllowedError,
+    ResourceLimitExceededError,
+    SandboxPolicy,
+)
+
+CSV_BODY = "id,email,amount\n1,a@example.com,10\n2,b@example.com,20\n3,c@example.com,30\n"
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    (root / "data.csv").write_text(CSV_BODY)
+    return root
+
+
+@pytest.fixture
+def outside(tmp_path: Path) -> Path:
+    """A file the guard must never reach, as a sibling of the sandbox root."""
+    secret = tmp_path / "outside"
+    secret.mkdir()
+    target = secret / "secret.csv"
+    target.write_text("token\nsuper-secret-value\n")
+    return target
+
+
+@pytest.fixture
+def guard(sandbox: Path) -> AgentGuard:
+    return AgentGuard(SandboxPolicy(roots=sandbox))
+
+
+# --- Path allow-list / sandbox root ---------------------------------------
+
+
+def test_policy_requires_a_root() -> None:
+    with pytest.raises(ValueError, match="at least one root"):
+        SandboxPolicy(roots=[])
+
+
+def test_policy_rejects_a_root_that_is_not_a_directory(sandbox: Path) -> None:
+    with pytest.raises(ValueError, match="not an existing directory"):
+        SandboxPolicy(roots=sandbox / "data.csv")
+
+
+def test_resolves_a_file_inside_the_root(guard: AgentGuard, sandbox: Path) -> None:
+    assert (
+        guard.resolve_path("data.csv" if os.getcwd() == str(sandbox) else sandbox / "data.csv")
+        == (sandbox / "data.csv").resolve()
+    )
+
+
+def test_profiles_a_sandboxed_file(guard: AgentGuard, sandbox: Path) -> None:
+    report = guard.profile(sandbox / "data.csv")
+    assert report.rows == 3
+
+
+def test_multiple_roots_are_each_honored(tmp_path: Path) -> None:
+    a, b = tmp_path / "a", tmp_path / "b"
+    for d in (a, b):
+        d.mkdir()
+        (d / "data.csv").write_text(CSV_BODY)
+    guard = AgentGuard(SandboxPolicy(roots=[a, b]))
+    assert guard.resolve_path(a / "data.csv").parent == a.resolve()
+    assert guard.resolve_path(b / "data.csv").parent == b.resolve()
+
+
+# --- Malicious-path tests --------------------------------------------------
+
+
+def test_rejects_parent_traversal(guard: AgentGuard, sandbox: Path, outside: Path) -> None:
+    with pytest.raises(PathNotAllowedError):
+        guard.resolve_path(sandbox / ".." / "outside" / "secret.csv")
+
+
+def test_rejects_deep_traversal_to_system_paths(guard: AgentGuard, sandbox: Path) -> None:
+    with pytest.raises(PathNotAllowedError):
+        guard.resolve_path(sandbox / ".." / ".." / ".." / ".." / "etc" / "passwd")
+
+
+def test_rejects_absolute_path_outside_root(guard: AgentGuard, outside: Path) -> None:
+    with pytest.raises(PathNotAllowedError, match="outside the sandbox"):
+        guard.resolve_path(outside)
+
+
+def test_rejects_traversal_that_lands_back_inside(guard: AgentGuard, sandbox: Path) -> None:
+    """`root/sub/../data.csv` resolves in-root and is allowed — resolution, not
+    string matching on `..`, is what decides."""
+    (sandbox / "sub").mkdir()
+    assert (
+        guard.resolve_path(sandbox / "sub" / ".." / "data.csv") == (sandbox / "data.csv").resolve()
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
+def test_rejects_symlink_escaping_the_root(guard: AgentGuard, sandbox: Path, outside: Path) -> None:
+    link = sandbox / "escape.csv"
+    link.symlink_to(outside)
+    with pytest.raises(PathNotAllowedError):
+        guard.resolve_path(link)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
+def test_rejects_symlink_via_a_linked_directory(
+    guard: AgentGuard, sandbox: Path, outside: Path
+) -> None:
+    (sandbox / "linkdir").symlink_to(outside.parent, target_is_directory=True)
+    with pytest.raises(PathNotAllowedError):
+        guard.resolve_path(sandbox / "linkdir" / "secret.csv")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
+def test_in_root_symlink_rejected_by_default_allowed_when_configured(sandbox: Path) -> None:
+    link = sandbox / "alias.csv"
+    link.symlink_to(sandbox / "data.csv")
+
+    with pytest.raises(PathNotAllowedError, match="symlink"):
+        AgentGuard(SandboxPolicy(roots=sandbox)).resolve_path(link)
+
+    permissive = AgentGuard(SandboxPolicy(roots=sandbox, follow_symlinks=True))
+    assert permissive.resolve_path(link) == (sandbox / "data.csv").resolve()
+
+
+def test_rejects_a_missing_file(guard: AgentGuard, sandbox: Path) -> None:
+    with pytest.raises(PathNotAllowedError, match="no such file"):
+        guard.resolve_path(sandbox / "nope.csv")
+
+
+def test_rejects_a_directory(guard: AgentGuard, sandbox: Path) -> None:
+    (sandbox / "subdir").mkdir()
+    with pytest.raises(PathNotAllowedError, match="not a regular file"):
+        guard.resolve_path(sandbox / "subdir")
+
+
+# --- No arbitrary shell / code execution -----------------------------------
+
+
+def test_guard_module_contains_no_execution_or_socket_primitives() -> None:
+    """The guard must not grow an eval/exec/subprocess path.
+
+    Asserted structurally rather than by grepping strings, so a comment
+    mentioning `subprocess` does not fail the build and an aliased import does
+    not slip past.
+    """
+    source_file = dataprof.agent.__file__
+    assert source_file is not None
+    tree = ast.parse(Path(source_file).read_text())
+
+    banned_modules = {"subprocess", "socket", "urllib", "requests", "httpx", "pty", "shutil"}
+    banned_calls = {"eval", "exec", "compile", "__import__", "system", "popen", "spawn"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_modules, f"guard imports {alias.name}"
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in banned_modules, (
+                f"guard imports from {node.module}"
+            )
+        elif isinstance(node, ast.Call):
+            name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            assert name not in banned_calls, f"guard calls {name}()"
+
+
+def test_rejects_non_path_sources(guard: AgentGuard) -> None:
+    """In-memory sources have no path to check, so they cannot be sandboxed."""
+    sources: list[Any] = [{"a": [1]}, [1, 2, 3], 42, None, b"id,name\n1,x\n"]
+    for source in sources:
+        with pytest.raises(PathNotAllowedError, match="expected a file path"):
+            guard.resolve_path(source)
+
+
+# --- Bounded resources -----------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["max_file_bytes", "max_rows", "max_bytes", "timeout_seconds"])
+def test_policy_rejects_non_positive_bounds(sandbox: Path, field: str) -> None:
+    bound: dict[str, Any] = {field: 0}
+    with pytest.raises(ValueError, match="must be positive"):
+        SandboxPolicy(roots=sandbox, **bound)
+
+
+def test_rejects_a_file_over_the_size_limit(sandbox: Path) -> None:
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, max_file_bytes=10))
+    with pytest.raises(ResourceLimitExceededError, match="over the 10-byte limit"):
+        guard.resolve_path(sandbox / "data.csv")
+
+
+def test_oversize_file_never_reaches_the_engine(sandbox: Path) -> None:
+    """The bound must be pre-flight — a guard that hands an oversize file to the
+    engine has already paid the cost it was meant to prevent. The engine reads
+    from Rust, so watching Python file opens would prove nothing; assert instead
+    that the engine entry point is never called."""
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, max_file_bytes=10))
+    calls: list[str] = []
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("dataprof.agent._profile", lambda *a, **k: calls.append("called"))
+        with pytest.raises(ResourceLimitExceededError):
+            guard.profile(sandbox / "data.csv")
+    assert calls == []
+
+
+def test_stop_condition_reflects_the_policy(sandbox: Path) -> None:
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, max_rows=5, max_bytes=99))
+    assert guard.stop_condition() is not None
+
+
+def test_caller_cannot_widen_its_own_ceiling(guard: AgentGuard, sandbox: Path) -> None:
+    for reserved in ("max_rows", "stop_condition"):
+        with pytest.raises(ResourceLimitExceededError, match="cannot be overridden"):
+            guard.profile(sandbox / "data.csv", **{reserved: 10**9})
+
+
+def test_analyze_structure_clamps_max_rows_to_the_policy(sandbox: Path) -> None:
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, max_rows=2))
+    captured: dict[str, object] = {}
+
+    def fake_structure(path: str, max_rows: int) -> str:
+        captured["max_rows"] = max_rows
+        return "ok"
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("dataprof.agent._analyze_structure", fake_structure)
+        guard.analyze_structure(sandbox / "data.csv", max_rows=10**6)
+    assert captured["max_rows"] == 2
+
+
+def test_timeout_raises_and_is_reported_as_a_security_error(sandbox: Path) -> None:
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, timeout_seconds=0.05))
+    with pytest.raises(AgentTimeoutError, match="exceeded the 0.05s limit"):
+        guard.run(time.sleep, 5)
+
+
+def test_timeout_does_not_fire_on_a_quick_call(guard: AgentGuard) -> None:
+    assert guard.run(lambda: 7) == 7
+
+
+def test_run_propagates_the_callee_error_unchanged(guard: AgentGuard) -> None:
+    def boom() -> None:
+        raise KeyError("inner")
+
+    with pytest.raises(KeyError):
+        guard.run(boom)
+
+
+# --- No network access unless configured -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://evil.test/data.csv",
+        "https://evil.test/data.csv",
+        "s3://bucket/key.csv",
+        "gs://bucket/key.csv",
+        "ftp://host/f.csv",
+        "postgresql://user:pw@host/db",
+        "mysql://user:pw@host/db",
+        "HTTP://EVIL.TEST/data.csv",
+    ],
+)
+def test_rejects_network_sources_by_default(guard: AgentGuard, url: str) -> None:
+    with pytest.raises(PathNotAllowedError, match="network access is disabled"):
+        guard.resolve_path(url)
+
+
+def test_network_rejection_does_not_echo_the_url(guard: AgentGuard) -> None:
+    """A refused URL may carry credentials; the message names the scheme only."""
+    with pytest.raises(PathNotAllowedError) as excinfo:
+        guard.resolve_path("postgresql://admin:hunter2@db.internal/prod")
+    message = str(excinfo.value)
+    assert "hunter2" not in message
+    assert "db.internal" not in message
+    assert "admin" not in message
+
+
+def test_allow_network_still_sandboxes_the_path(sandbox: Path) -> None:
+    """Enabling network access lifts the scheme check, not the sandbox: a URL
+    is still not a file inside the root."""
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, allow_network=True))
+    with pytest.raises(PathNotAllowedError):
+        guard.resolve_path("https://evil.test/data.csv")
+
+
+# --- Deterministic output --------------------------------------------------
+
+
+def test_same_input_yields_identical_context(guard: AgentGuard, sandbox: Path) -> None:
+    first = guard.llm_context(guard.profile(sandbox / "data.csv"))
+    second = guard.llm_context(guard.profile(sandbox / "data.csv"))
+    assert first == second
+
+
+def test_column_order_is_stable_across_runs(guard: AgentGuard, sandbox: Path) -> None:
+    runs = [list(guard.profile(sandbox / "data.csv").column_profiles) for _ in range(3)]
+    assert runs[0] == runs[1] == runs[2] == ["id", "email", "amount"]
+
+
+# --- Redaction enforced at the boundary ------------------------------------
+
+
+def test_llm_context_refuses_samples_by_default(guard: AgentGuard, sandbox: Path) -> None:
+    report = guard.profile(sandbox / "data.csv")
+    with pytest.raises(AgentSecurityError, match="include_samples is disabled"):
+        guard.llm_context(report, include_samples=True)
+
+
+def test_llm_context_leaks_no_raw_cell_values(guard: AgentGuard, sandbox: Path) -> None:
+    context = guard.llm_context(guard.profile(sandbox / "data.csv"))
+    for raw in ("a@example.com", "b@example.com", "c@example.com"):
+        assert raw not in context
+
+
+def test_samples_require_an_explicit_policy_opt_in(sandbox: Path) -> None:
+    guard = AgentGuard(SandboxPolicy(roots=sandbox, allow_samples=True))
+    report = guard.profile(sandbox / "data.csv")
+    assert isinstance(guard.llm_context(report, include_samples=True), str)
+
+
+# --- Clear, non-leaky error messages ---------------------------------------
+
+
+def test_rejection_message_does_not_leak_the_host_path(guard: AgentGuard, outside: Path) -> None:
+    with pytest.raises(PathNotAllowedError) as excinfo:
+        guard.resolve_path(outside)
+    message = str(excinfo.value)
+    assert str(outside) not in message
+    assert str(outside.parent) not in message
+    assert message.endswith("secret.csv")
+
+
+def test_in_root_rejection_names_the_path_relative_to_the_root(
+    guard: AgentGuard, sandbox: Path
+) -> None:
+    (sandbox / "subdir").mkdir()
+    with pytest.raises(PathNotAllowedError) as excinfo:
+        guard.resolve_path(sandbox / "subdir")
+    message = str(excinfo.value)
+    assert "subdir" in message
+    assert str(sandbox) not in message
+
+
+def test_sanitize_error_passes_guard_rejections_through(guard: AgentGuard) -> None:
+    exc = PathNotAllowedError("path is outside the sandbox: x.csv")
+    assert guard.sanitize_error(exc) == "path is outside the sandbox: x.csv"
+
+
+def test_sanitize_error_withholds_foreign_error_detail(guard: AgentGuard, outside: Path) -> None:
+    """An engine or OS error may carry an absolute path or a fragment of the
+    file that failed to parse; neither may reach the model."""
+    exc = OSError(f"failed parsing '{outside}': unexpected token 'super-secret-value'")
+    sanitized = guard.sanitize_error(exc)
+    assert str(outside) not in sanitized
+    assert "super-secret-value" not in sanitized
+    assert sanitized.startswith("OSError:")


### PR DESCRIPTION
Implements the hardening checklist in #336, which gates the MCP server (#330).

## Approach

The checklist describes behavior of an MCP server that does not exist yet, and #330 is now deferred to 0.11.0 (the `mcp` SDK v2 lands 2026-07-27). Rather than write tests against absent code — or fold hardening into #330 later and assume it — this builds the security layer as a standalone `dataprof.agent` module. It imports no MCP SDK; #330 becomes a thin wrapper over an already-hardened, already-tested layer. That matches the issue’s own framing: "kept separate from the MCP server so hardening is tracked and verified explicitly, not assumed."

```python
from dataprof.agent import AgentGuard, SandboxPolicy

guard = AgentGuard(SandboxPolicy(roots="/srv/data"))
report = guard.profile("customers.csv")   # resolved under /srv/data
print(guard.llm_context(report))          # redacted by construction
```

## Checklist status

| Box | State |
|---|---|
| Path allow-list / sandbox root | done — `resolve_path()`, no default root |
| Malicious-path tests | done — traversal, symlink escape, absolute-outside-root |
| No arbitrary shell / code execution | done — enforced by an AST test over the module |
| Bounded resources | done — pre-flight size, row/byte ceilings, per-call deadline |
| No network unless configured | done — network schemes refused before opening |
| Deterministic output | done — identical context and column order across runs |
| Redaction enforced at the boundary | done — `include_samples` refused unless policy opts in |
| Clear, non-leaky errors | done — no host paths, no file contents, no URL credentials |
| CI tests | done — `python/tests/test_agent_guard.py`, 47 tests |

## Design notes worth review

**Paths are checked after resolution, not by string matching.** `root/../../etc/passwd` and a symlink to `/etc/passwd` fail the same containment check. `root/sub/../data.csv` resolves in-root and is correctly allowed — a `..` in the string is not itself the problem.

**Ceilings cannot be raised per call.** `guard.profile()` rejects caller-supplied `max_rows`/`stop_condition`, since those arguments arrive from a model. `analyze_structure()` clamps rather than rejects.

**The timeout is a backstop, not cancellation — please read this one.** The native call holds no cancellation token, and progress callbacks cannot carry one either: `crates/dataprof-python/src/progress.rs:167` swallows callback errors by design, so raising from one would not stop the work. On timeout the worker thread runs to completion and its result is discarded. The real bound on runaway work is the pre-flight size check plus the stop condition, both of which cap work before it starts. This is documented on `AgentGuard.run`. If a stronger guarantee is wanted, it needs a cancellation token in the engine — worth its own issue.

**Symlinks are rejected by default even when the target lands in-root**, because a link that resolves in-root today can be repointed out of it tomorrow. `follow_symlinks=True` opts out.

## Verification

- `uv run pytest python/tests/ -q` → 310 passed, 6 skipped (no regressions)
- `uv run ruff format --check python/`, `uv run ruff check python/`, `uv run ty check python/` → all clean
- The three symlink tests skip on Windows (creation needs privilege). CI runs pytest on `ubuntu-latest` so they execute there — but rather than ship them unverified, I ran the symlink branches against a real Linux filesystem in WSL: escaping file symlink, escape via a linked directory, in-root symlink rejected by default, `follow_symlinks=True` followed correctly, and the rejection message leaked nothing. All passed.

Closes #336