### PR TITLE
fix(metrics): treat quality_dimensions=[] as quality not analyzed

### DIFF
--- a/crates/dataprof-core/src/quality.rs
+++ b/crates/dataprof-core/src/quality.rs
@@ -105,6 +105,36 @@ impl MetricPack {
             Some(p) => p.contains(&Self::Quality),
         }
     }
+
+    /// Resolve the packs to compute, folding in an explicit quality-dimension
+    /// selection.
+    ///
+    /// Requesting an empty set of dimensions (`Some(&[])`) says "assess no
+    /// dimension", which is the same statement as not selecting the quality
+    /// pack: nothing is analyzed, so the report carries no quality. Without
+    /// this, an empty selection produces a quality object whose dimensions are
+    /// all absent — an artifact that reads like a measured result.
+    ///
+    /// This is deliberately about what was *requested*. A caller that asks for
+    /// dimensions and gets none back (an empty dataset, no date column) was
+    /// still analyzed, and keeps a quality object reporting exactly that.
+    pub fn resolve_with_dimensions(
+        packs: Option<&[Self]>,
+        dimensions: Option<&[QualityDimension]>,
+    ) -> Option<Vec<Self>> {
+        if !dimensions.is_some_and(<[QualityDimension]>::is_empty) {
+            return packs.map(<[Self]>::to_vec);
+        }
+        // `None` packs means "all packs"; make that explicit before removing
+        // Quality, so the result still selects everything else.
+        let selected = packs.map_or_else(Self::all, <[Self]>::to_vec);
+        Some(
+            selected
+                .into_iter()
+                .filter(|pack| *pack != Self::Quality)
+                .collect(),
+        )
+    }
 }
 
 impl std::str::FromStr for MetricPack {
@@ -143,6 +173,50 @@ mod tests {
         assert!(MetricPack::include_statistics(None));
         assert!(MetricPack::include_patterns(None));
         assert!(MetricPack::include_quality(None));
+    }
+
+    #[test]
+    fn test_resolve_with_dimensions_empty_selection_drops_quality() {
+        // Requesting no dimension is the same statement as not asking for
+        // quality at all, so the pack must fall out and the report carry no
+        // quality object.
+        let resolved = MetricPack::resolve_with_dimensions(None, Some(&[])).unwrap();
+        assert!(!resolved.contains(&MetricPack::Quality));
+        assert!(!MetricPack::include_quality(Some(&resolved)));
+        // The other packs survive: only quality was deselected.
+        assert!(resolved.contains(&MetricPack::Schema));
+        assert!(resolved.contains(&MetricPack::Statistics));
+        assert!(resolved.contains(&MetricPack::Patterns));
+    }
+
+    #[test]
+    fn test_resolve_with_dimensions_empty_selection_keeps_explicit_packs() {
+        let packs = vec![MetricPack::Schema, MetricPack::Quality];
+        let resolved = MetricPack::resolve_with_dimensions(Some(&packs), Some(&[])).unwrap();
+        assert_eq!(resolved, vec![MetricPack::Schema]);
+    }
+
+    #[test]
+    fn test_resolve_with_dimensions_non_empty_selection_is_untouched() {
+        // A real selection says which dimensions to assess, not whether to.
+        let dims = vec![QualityDimension::Completeness];
+        assert_eq!(MetricPack::resolve_with_dimensions(None, Some(&dims)), None);
+        assert!(MetricPack::include_quality(None));
+
+        let packs = vec![MetricPack::Quality];
+        let resolved = MetricPack::resolve_with_dimensions(Some(&packs), Some(&dims)).unwrap();
+        assert!(MetricPack::include_quality(Some(&resolved)));
+    }
+
+    #[test]
+    fn test_resolve_with_dimensions_absent_selection_is_untouched() {
+        // `None` means "all dimensions", which is not the same as "none".
+        assert_eq!(MetricPack::resolve_with_dimensions(None, None), None);
+        let packs = vec![MetricPack::Quality];
+        assert_eq!(
+            MetricPack::resolve_with_dimensions(Some(&packs), None),
+            Some(packs)
+        );
     }
 
     #[test]

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -365,7 +365,8 @@ pub fn profile_dataframe(
     let start = std::time::Instant::now();
 
     // Extract metric packs and quality dimensions from config
-    let packs = config.and_then(|c| c.metric_packs.as_deref());
+    let resolved_packs = config.and_then(PyProfilerConfig::effective_metric_packs);
+    let packs = resolved_packs.as_deref();
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
     let include_quality = MetricPack::include_quality(packs);
@@ -470,7 +471,8 @@ pub fn profile_arrow(
     let start = std::time::Instant::now();
 
     // Extract metric packs and quality dimensions from config
-    let packs = config.and_then(|c| c.metric_packs.as_deref());
+    let resolved_packs = config.and_then(PyProfilerConfig::effective_metric_packs);
+    let packs = resolved_packs.as_deref();
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
     let include_quality = MetricPack::include_quality(packs);

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -43,7 +43,8 @@ pub fn profile_columns(
 ) -> PyResult<PyProfileReport> {
     let start = std::time::Instant::now();
 
-    let packs = config.and_then(|c| c.metric_packs.as_deref());
+    let resolved_packs = config.and_then(PyProfilerConfig::effective_metric_packs);
+    let packs = resolved_packs.as_deref();
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
     let include_quality = MetricPack::include_quality(packs);

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -305,6 +305,19 @@ impl PyProfilerConfig {
         )
         .with_temporal_columns(self.temporal_columns.clone())
     }
+
+    /// Metric packs with an empty quality-dimension selection folded in.
+    ///
+    /// The in-memory entry points (`profile_columns`, the Arrow exporters) gate
+    /// on packs directly instead of going through `Profiler`, so they resolve
+    /// the same rule here — otherwise `quality_dimensions=[]` would mean one
+    /// thing for a file and another for a DataFrame.
+    pub(crate) fn effective_metric_packs(&self) -> Option<Vec<MetricPack>> {
+        MetricPack::resolve_with_dimensions(
+            self.metric_packs.as_deref(),
+            self.quality_dimensions.as_deref(),
+        )
+    }
 }
 
 fn parse_engine(s: &str) -> PyResult<EngineType> {

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -698,13 +698,25 @@ impl PyDataQualityMetrics {
     }
 
     fn __str__(&self) -> String {
-        format!(
-            "DataQualityMetrics(score={:.1}%, completeness={:.1}%, consistency={:.1}%, uniqueness={:.1}%)",
-            self.inner.overall_score(),
-            self.inner.complete_records_ratio(),
-            self.inner.data_type_consistency(),
-            self.inner.key_uniqueness(),
-        )
+        // Render only what was assessed. The flat accessors below substitute a
+        // perfect 100.0 for an absent dimension (kept for the deprecated
+        // getters), so reading them here would print "consistency=100.0%" for a
+        // dimension that never ran — a reassuring number with nothing behind it.
+        let assessed = self.inner.assessed_dimensions();
+        if assessed.is_empty() {
+            return "DataQualityMetrics(not assessed)".to_string();
+        }
+        let mut parts = vec![format!("score={:.1}%", self.inner.overall_score())];
+        for (label, value) in [
+            ("completeness", self.inner.completeness_score()),
+            ("consistency", self.inner.consistency_score()),
+            ("uniqueness", self.inner.uniqueness_score()),
+        ] {
+            if let Some(v) = value {
+                parts.push(format!("{label}={v:.1}%"));
+            }
+        }
+        format!("DataQualityMetrics({})", parts.join(", "))
     }
 
     fn __repr__(&self) -> String {

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -214,6 +214,13 @@ impl Profiler {
     /// By default all dimensions are evaluated. Call this method with a subset
     /// to skip the rest — dimensions that are not requested will appear as
     /// `None` in the report.
+    ///
+    /// Passing an empty vector requests no dimension, which means quality is
+    /// not analyzed at all: the report carries no quality metrics, exactly as
+    /// if [`metric_packs`](Self::metric_packs) had omitted
+    /// [`MetricPack::Quality`]. That is distinct from requesting dimensions and
+    /// finding none assessable — that still reports quality, with nothing
+    /// assessed.
     pub fn quality_dimensions(mut self, dims: Vec<QualityDimension>) -> Self {
         self.config.quality_dimensions = Some(dims);
         self
@@ -421,6 +428,19 @@ impl Profiler {
         .with_temporal_columns(self.config.temporal_columns.clone())
     }
 
+    /// The metric packs to compute, with an empty quality-dimension selection
+    /// folded in.
+    ///
+    /// Resolved on read rather than in the setters so the outcome does not
+    /// depend on whether `quality_dimensions` or `metric_packs` was called
+    /// first.
+    fn effective_metric_packs(&self) -> Option<Vec<MetricPack>> {
+        MetricPack::resolve_with_dimensions(
+            self.config.metric_packs.as_deref(),
+            self.config.quality_dimensions.as_deref(),
+        )
+    }
+
     /// Reject a stop condition richer than a plain row limit.
     ///
     /// Row-oriented parsers (JSON, Parquet, the Arrow CSV reader) can enforce a
@@ -533,8 +553,8 @@ impl Profiler {
                 if let Some(d) = &self.config.quality_dimensions {
                     profiler = profiler.quality_dimensions(d.clone());
                 }
-                if let Some(p) = &self.config.metric_packs {
-                    profiler = profiler.metric_packs(p.clone());
+                if let Some(p) = self.effective_metric_packs() {
+                    profiler = profiler.metric_packs(p);
                 }
                 if let Some(l) = &self.config.locale {
                     profiler = profiler.locale(l.clone());
@@ -597,8 +617,8 @@ impl Profiler {
         if let Some(d) = &self.config.quality_dimensions {
             profiler = profiler.quality_dimensions(d.clone());
         }
-        if let Some(p) = &self.config.metric_packs {
-            profiler = profiler.metric_packs(p.clone());
+        if let Some(p) = self.effective_metric_packs() {
+            profiler = profiler.metric_packs(p);
         }
         if let Some(l) = &self.config.locale {
             profiler = profiler.locale(l.clone());
@@ -657,8 +677,8 @@ impl Profiler {
             if let Some(d) = &self.config.quality_dimensions {
                 profiler = profiler.quality_dimensions(d.clone());
             }
-            if let Some(p) = &self.config.metric_packs {
-                profiler = profiler.metric_packs(p.clone());
+            if let Some(p) = self.effective_metric_packs() {
+                profiler = profiler.metric_packs(p);
             }
             if let Some(l) = &self.config.locale {
                 profiler = profiler.locale(l.clone());
@@ -819,8 +839,8 @@ impl Profiler {
         if let Some(ref d) = self.config.quality_dimensions {
             profiler = profiler.quality_dimensions(d.clone());
         }
-        if let Some(ref p) = self.config.metric_packs {
-            profiler = profiler.metric_packs(p.clone());
+        if let Some(p) = self.effective_metric_packs() {
+            profiler = profiler.metric_packs(p);
         }
         profiler = profiler.semantic_hints(self.semantic_hints());
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -823,7 +823,10 @@ def profile_file(
         quality_dimensions: List of quality dimensions to evaluate.
             Valid values: "completeness", "consistency", "uniqueness",
             "accuracy", "timeliness", "validity", "precision". None = all
-            dimensions (default).
+            dimensions (default). An empty list requests no dimension, which
+            means quality is not analyzed at all: ``quality`` and
+            ``quality_score`` are None, the same as omitting "quality" from
+            ``metrics``.
         metrics: List of metric packs to compute. Valid values: "schema"
             (always included), "statistics", "patterns", "quality".
             None = all packs (default).
@@ -912,7 +915,10 @@ def profile(
         quality_dimensions: List of quality dimensions to evaluate.
             Valid values: "completeness", "consistency", "uniqueness",
             "accuracy", "timeliness", "validity", "precision". None = all
-            dimensions (default).
+            dimensions (default). An empty list requests no dimension, which
+            means quality is not analyzed at all: ``quality`` and
+            ``quality_score`` are None, the same as omitting "quality" from
+            ``metrics``.
         metrics: List of metric packs to compute. Valid values: "schema"
             (always included), "statistics", "patterns", "quality".
             None = all packs (default). Omitting a pack skips that

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -547,6 +547,83 @@ class TestProfileReport:
         with pytest.warns(DeprecationWarning, match="DataQualityMetrics\\.key_uniqueness"):
             assert q.key_uniqueness == 100.0
 
+    @pytest.mark.parametrize("source", ["file", "dict"])
+    def test_empty_quality_dimensions_means_not_analyzed(self, source, tmp_path):
+        """An empty selection requests no dimension, which is the same as not
+        asking for quality — so nothing was analyzed and there is no quality to
+        report. Must agree for file and in-memory inputs, which reach the gate
+        by different routes."""
+        data = {"id": [1, 2, 3], "name": ["a", "b", None]}
+        if source == "file":
+            path = tmp_path / "d.csv"
+            path.write_text("id,name\n1,a\n2,b\n3,\n")
+            target = str(path)
+        else:
+            target = data
+
+        report = dataprof.profile(target, quality_dimensions=[])
+        assert report.quality is None
+        assert report.quality_score is None
+        assert report.to_dict().get("quality") is None
+
+    @pytest.mark.parametrize("source", ["file", "dict"])
+    def test_empty_quality_dimensions_matches_deselecting_the_pack(self, source, tmp_path):
+        """`quality_dimensions=[]` and `metrics=["schema"]` both say "no quality"
+        and must not disagree about how that looks."""
+        if source == "file":
+            path = tmp_path / "d.csv"
+            path.write_text("id,name\n1,a\n2,b\n3,\n")
+            target = str(path)
+        else:
+            target = {"id": [1, 2, 3], "name": ["a", "b", None]}
+
+        empty_dims = dataprof.profile(target, quality_dimensions=[])
+        no_pack = dataprof.profile(target, metrics=["schema"])
+        assert empty_dims.quality is no_pack.quality is None
+        assert empty_dims.quality_score is no_pack.quality_score is None
+
+    def test_empty_selection_still_profiles_the_data(self):
+        """Dropping quality must not drop the profile with it."""
+        report = dataprof.profile(CSV_FILE, quality_dimensions=[])
+        assert report.rows > 0
+        assert report.columns > 0
+        assert report.quality is None
+
+    def test_analyzed_but_vacuous_is_not_reported_as_unanalyzed(self):
+        """The distinction the whole contract rests on: asking for quality and
+        finding nothing assessable is *not* the same as never asking. The first
+        keeps a quality object saying so; only the second is None."""
+        report = dataprof.profile({"a": []})
+        assert report.quality is not None
+        assert report.quality_score is None
+        assert report.quality.assessed_dimensions() == []
+
+        not_asked = dataprof.profile({"a": []}, quality_dimensions=[])
+        assert not_asked.quality is None
+
+    def test_str_omits_dimensions_that_were_not_assessed(self):
+        """str() read the flat accessors, which substitute a perfect 100.0 for an
+        absent dimension — so an unassessed dimension printed as 100%, a
+        reassuring number with nothing behind it."""
+        q = dataprof.profile(CSV_FILE, quality_dimensions=["completeness"]).quality
+        assert q is not None
+        rendered = str(q)
+        assert "completeness=" in rendered
+        assert "consistency=" not in rendered
+        assert "uniqueness=" not in rendered
+
+    def test_str_reports_dimensions_that_were_assessed(self):
+        q = dataprof.profile(CSV_FILE).quality
+        assert q is not None
+        rendered = str(q)
+        for dimension in ("completeness=", "consistency=", "uniqueness="):
+            assert dimension in rendered
+
+    def test_str_says_so_when_nothing_was_assessed(self):
+        q = dataprof.profile({"a": []}).quality
+        assert q is not None
+        assert str(q) == "DataQualityMetrics(not assessed)"
+
     def test_reloaded_quality_flat_accessors_warn(self, report):
         reloaded = dataprof.ProfileReport.from_json(report.to_json())
         q = reloaded.quality


### PR DESCRIPTION
Closes #384.

## Heads-up for review

Two related changes in one PR (agreed deliberately, but flagging it since it cuts against one-behavior-change-per-PR): the `quality_dimensions=[]` contract, and a display fix for the same bug class. Both are "an absence rendered as a plausible number".

## What #384 actually looks like now

The issue’s evidence is **stale** — worth knowing before reading it. It reports `quality_score == 0.0`; that is already `None` today, presumably fixed during the quality overhaul. What survives:

| Surface | Before | After |
|---|---|---|
| `report.quality_score` | `None` | `None` (unchanged) |
| `report.quality` | object, all dimensions `None` | `None` |
| `to_dict()["quality"]` | `{"overall_score": 0.0, "assessed_dimensions": [], …}` | `null` |
| `str(report.quality)` with `["completeness"]` | `completeness=75.0%, consistency=100.0%, uniqueness=100.0%` | `completeness=75.0%` |

## The contract

**An empty selection means quality was not analyzed** — `quality` and `quality_score` are None, identical to omitting `"quality"` from `metrics`. That option was chosen over rejecting `[]` because the codebase already had the precedent (`metrics=["schema"]` behaves exactly this way) and because it is non-breaking: anyone reading `quality_score` already sees `None`.

The rule lives in `MetricPack::resolve_with_dimensions` in **core**, so Rust and Python cannot drift — which was a real risk, because the in-memory entry points (`profile_columns`, the Arrow exporters) gate on packs directly rather than going through `Profiler`. Before this, `quality_dimensions=[]` was already going to be resolved in two places or none. It is resolved on *read*, not in the setters, so the outcome does not depend on whether `quality_dimensions` or `metric_packs` was called first.

**The distinction that matters, and the trap I avoided:** the tempting fix is "if no dimensions were assessed, report quality as None". That is wrong — it would collapse *not requested* into *requested but nothing was assessable* (an empty dataset, no date column), which is exactly the distinction AGENTS.md:63-64 says to preserve. So the resolution happens at the request level, and `profile({"a": []})` still returns a quality object reporting that nothing was assessed. There is a test pinning this.

## The display fix

`__str__` read the flat accessors, which do `map_or(100.0, …)` — an absent dimension substitutes a **perfect** score. So `print(report.quality)` reported `consistency=100.0%` for a dimension that never ran, on the ordinary partial-selection path, with no warning. `__repr__` had already been taught to check `.is_some()`; `__str__` was left behind.

I deliberately did **not** change the `map_or(100.0)` accessors themselves. That default is intentional, documented, tested (`test_partial_dimensions_flat_accessors_return_defaults`), and reached only through Python getters that already emit a `DeprecationWarning` pointing at the nested properties. Changing it would break a legacy surface that is already on its way out, for no user benefit. `__str__` was the live, non-deprecated leak.

A plausible zero looks alarming and gets investigated; a plausible 100% looks fine and gets trusted. The second is the more dangerous half.

## Verification

- `cargo test -p dataprof-core -p dataprof-metrics -p dataprof` → 289 passed
- `uv run pytest python/tests/` → 324 passed, 6 skipped (no regressions)
- `cargo fmt --all`, `cargo clippy … -D warnings`, `ruff format/check`, `ty check` → clean
- New: 4 Rust tests on the resolver, 9 Python tests covering both source paths (file *and* dict — they reach the gate by different routes and disagreed before this), the analyzed-but-vacuous distinction, and the three `str()` states.