### PR TITLE
feat(report): version the serialized ProfileReport schema

### DIFF
--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -17,7 +17,7 @@ pub use profile_builder::{
     profile_from_stats, profile_from_stats_with_hints, profiles_from_streaming,
     profiles_from_streaming_with_hints, quality_check_samples,
 };
-pub use profile_report::ProfileReport;
+pub use profile_report::{ProfileReport, REPORT_SCHEMA_VERSION};
 pub use report_assembler::ReportAssembler;
 pub use streaming_stats::{
     StreamingColumnCollection, StreamingStatistics, TextLengthStats, WelfordAccumulator,

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -139,7 +139,6 @@ impl<'de> serde::Deserialize<'de> for ProfileReport {
     where
         D: serde::Deserializer<'de>,
     {
-        use serde::Deserialize;
         use serde::de::Error;
 
         let value = serde_json::Value::deserialize(deserializer)?;

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -23,13 +23,12 @@ pub const REPORT_SCHEMA_VERSION: u32 = 1;
 /// Quality assessment informed by ISO 8000/25012 concepts. This is the primary output of all
 /// profiling operations (`Profiler::analyze_file`, `Profiler::analyze_source`,
 /// `Profiler::profile_stream`, etc.).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ProfileReport {
     /// Version of the serialized report schema (see [`REPORT_SCHEMA_VERSION`]).
     ///
     /// `0` means the document predates schema versioning (a 0.9-era report).
     /// Deserialization rejects versions newer than [`REPORT_SCHEMA_VERSION`].
-    #[serde(default, deserialize_with = "deserialize_schema_version")]
     pub schema_version: u32,
     /// Unique identifier for this report (UUID v4)
     pub id: String,
@@ -40,15 +39,9 @@ pub struct ProfileReport {
     /// Column-level profiling results
     pub column_profiles: Vec<ColumnProfile>,
     /// Execution metadata (timing, rows processed, truncation info, etc.)
-    #[serde(alias = "scan_info")]
     pub execution: ExecutionMetadata,
     /// Data quality assessment (optional — partial analysis may skip quality)
-    #[serde(
-        alias = "data_quality_metrics",
-        skip_serializing_if = "Option::is_none",
-        default,
-        deserialize_with = "deserialize_quality_compat"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<QualityAssessment>,
 }
 
@@ -100,23 +93,79 @@ impl ProfileReport {
     }
 }
 
-/// Rejects documents written by a newer schema than this build understands.
-/// Failing here aborts the whole deserialization, so an incompatible report
-/// can never partially decode into a plausible but semantically wrong one.
-fn deserialize_schema_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize;
+/// Mirror of [`ProfileReport`] carrying the field-level deserialization
+/// rules (legacy aliases, quality compat). Kept private: the public entry
+/// point is the manual [`serde::Deserialize`] impl below, which gates on
+/// `schema_version` before any of these fields decode.
+#[derive(serde::Deserialize)]
+struct ProfileReportFields {
+    #[serde(default)]
+    schema_version: u32,
+    id: String,
+    timestamp: String,
+    data_source: DataSource,
+    column_profiles: Vec<ColumnProfile>,
+    #[serde(alias = "scan_info")]
+    execution: ExecutionMetadata,
+    #[serde(
+        alias = "data_quality_metrics",
+        default,
+        deserialize_with = "deserialize_quality_compat"
+    )]
+    quality: Option<QualityAssessment>,
+}
 
-    let version = u32::deserialize(deserializer)?;
-    if version > REPORT_SCHEMA_VERSION {
-        return Err(serde::de::Error::custom(format!(
-            "report schema version {version} is newer than the latest supported \
-             version {REPORT_SCHEMA_VERSION}; upgrade dataprof to read this report"
-        )));
+impl From<ProfileReportFields> for ProfileReport {
+    fn from(fields: ProfileReportFields) -> Self {
+        Self {
+            schema_version: fields.schema_version,
+            id: fields.id,
+            timestamp: fields.timestamp,
+            data_source: fields.data_source,
+            column_profiles: fields.column_profiles,
+            execution: fields.execution,
+            quality: fields.quality,
+        }
     }
-    Ok(version)
+}
+
+/// Manual deserialization so the `schema_version` gate runs before any other
+/// field decodes. A derived deserializer visits fields in document order, so
+/// an unsupported future document that also changed structure could fail with
+/// a confusing structural error instead of the actionable version error; by
+/// buffering the document first, the version check always wins.
+impl<'de> serde::Deserialize<'de> for ProfileReport {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::Deserialize;
+        use serde::de::Error;
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match value.get("schema_version") {
+            // Absent field: legacy pre-0.10 document, defaults to version 0.
+            None => {}
+            Some(serde_json::Value::Number(n)) if n.as_u64().is_some() => {
+                let version = n.as_u64().unwrap_or_default();
+                if version > u64::from(REPORT_SCHEMA_VERSION) {
+                    return Err(D::Error::custom(format!(
+                        "report schema version {version} is newer than the latest supported \
+                         version {REPORT_SCHEMA_VERSION}; upgrade dataprof to read this report"
+                    )));
+                }
+            }
+            // An explicit null or non-integer is malformed, not legacy.
+            Some(other) => {
+                return Err(D::Error::custom(format!(
+                    "report schema_version must be a non-negative integer, got {other}"
+                )));
+            }
+        }
+        ProfileReportFields::deserialize(value)
+            .map(ProfileReport::from)
+            .map_err(D::Error::custom)
+    }
 }
 
 /// Custom deserializer that handles both legacy `DataQualityMetrics` (flat)
@@ -322,5 +371,48 @@ mod tests {
             msg.contains("schema version") && msg.contains("upgrade dataprof"),
             "expected an actionable schema-version error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn test_version_error_wins_over_structural_errors() {
+        // A future document that also broke structure, with schema_version
+        // appearing after the broken field, must still fail with the version
+        // error — not a confusing type error from the field encountered first.
+        let json_text = format!(
+            r#"{{"column_profiles": "not-an-array", "schema_version": {}}}"#,
+            REPORT_SCHEMA_VERSION + 1
+        );
+        let err = serde_json::from_str::<ProfileReport>(&json_text).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("upgrade dataprof"),
+            "expected the schema-version error to win, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_null_schema_version_is_malformed_not_legacy() {
+        let mut json = current_document();
+        json["schema_version"] = json!(null);
+
+        let err = serde_json::from_value::<ProfileReport>(json).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("schema_version must be a non-negative integer"),
+            "expected explicit rejection of null schema_version, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_non_integer_schema_version_is_rejected() {
+        for bad in [json!("1"), json!(1.5), json!(-1), json!(true)] {
+            let mut json = current_document();
+            json["schema_version"] = bad.clone();
+            let err = serde_json::from_value::<ProfileReport>(json).unwrap_err();
+            assert!(
+                err.to_string().contains("non-negative integer"),
+                "expected rejection of {bad}, got: {err}"
+            );
+        }
     }
 }

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -1,6 +1,22 @@
 use dataprof_core::{ColumnProfile, DataSource, ExecutionMetadata};
 use dataprof_metrics::{QualityAssessment, QualityMetrics};
 
+/// Version of the serialized `ProfileReport` schema written by this build.
+///
+/// This is intentionally independent of the package version: the document
+/// format only changes when the schema itself changes, not on every release.
+///
+/// Compatibility policy for readers:
+/// - Documents without a `schema_version` field are legacy pre-0.10 reports
+///   and deserialize with `schema_version == 0`.
+/// - Unknown *additive* fields written by a newer dataprof are ignored, so a
+///   reader accepts any document whose `schema_version` is at most this
+///   constant.
+/// - A document with a `schema_version` greater than this constant fails to
+///   deserialize with an explicit error instead of being partially decoded
+///   into a plausible-but-wrong report.
+pub const REPORT_SCHEMA_VERSION: u32 = 1;
+
 /// Complete profiling report for a data source.
 ///
 /// Contains column-level statistics, execution metadata, and an optional
@@ -9,6 +25,12 @@ use dataprof_metrics::{QualityAssessment, QualityMetrics};
 /// `Profiler::profile_stream`, etc.).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProfileReport {
+    /// Version of the serialized report schema (see [`REPORT_SCHEMA_VERSION`]).
+    ///
+    /// `0` means the document predates schema versioning (a 0.9-era report).
+    /// Deserialization rejects versions newer than [`REPORT_SCHEMA_VERSION`].
+    #[serde(default, deserialize_with = "deserialize_schema_version")]
+    pub schema_version: u32,
     /// Unique identifier for this report (UUID v4)
     pub id: String,
     /// Timestamp when the report was generated (ISO 8601 / RFC 3339)
@@ -39,6 +61,7 @@ impl ProfileReport {
         quality: Option<QualityAssessment>,
     ) -> Self {
         Self {
+            schema_version: REPORT_SCHEMA_VERSION,
             id: uuid::Uuid::new_v4().to_string(),
             timestamp: chrono::Utc::now().to_rfc3339(),
             data_source,
@@ -75,6 +98,25 @@ impl ProfileReport {
     pub fn source_identifier(&self) -> String {
         self.data_source.identifier()
     }
+}
+
+/// Rejects documents written by a newer schema than this build understands.
+/// Failing here aborts the whole deserialization, so an incompatible report
+/// can never partially decode into a plausible but semantically wrong one.
+fn deserialize_schema_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    let version = u32::deserialize(deserializer)?;
+    if version > REPORT_SCHEMA_VERSION {
+        return Err(serde::de::Error::custom(format!(
+            "report schema version {version} is newer than the latest supported \
+             version {REPORT_SCHEMA_VERSION}; upgrade dataprof to read this report"
+        )));
+    }
+    Ok(version)
 }
 
 /// Custom deserializer that handles both legacy `DataQualityMetrics` (flat)
@@ -134,6 +176,29 @@ mod tests {
         assert_eq!(deserialized.source_identifier(), "test.csv");
         assert_eq!(deserialized.execution.rows_processed, 100);
         assert!(deserialized.quality.is_some());
+        assert_eq!(deserialized.schema_version, REPORT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn test_serialized_report_carries_schema_version() {
+        let report = ProfileReport::new(
+            DataSource::File {
+                path: "test.csv".to_string(),
+                format: FileFormat::Csv,
+                size_bytes: 1024,
+                modified_at: None,
+                parquet_metadata: None,
+            },
+            vec![],
+            ExecutionMetadata::new(100, 5, 50),
+            None,
+        );
+
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(
+            value.get("schema_version").and_then(|v| v.as_u64()),
+            Some(u64::from(REPORT_SCHEMA_VERSION))
+        );
     }
 
     #[test]
@@ -190,6 +255,9 @@ mod tests {
         let report: ProfileReport = serde_json::from_value(json).unwrap();
 
         assert_eq!(report.id, "legacy-report");
+        // A document without a schema_version field is a legacy pre-0.10
+        // report; it must load and be identifiable as such.
+        assert_eq!(report.schema_version, 0);
         assert_eq!(report.execution.rows_processed, 10);
         // Legacy metrics predate the assessability denominators: the facts
         // stay readable, but no score is fabricated from them.
@@ -205,5 +273,54 @@ mod tests {
             .expect("legacy completeness facts should deserialize");
         assert!((completeness.complete_records_ratio - 100.0).abs() < 0.01);
         assert!(quality.metrics.assessed_dimensions().is_empty());
+    }
+
+    fn current_document() -> serde_json::Value {
+        json!({
+            "schema_version": REPORT_SCHEMA_VERSION,
+            "id": "current-report",
+            "timestamp": "2026-07-16T10:00:00Z",
+            "data_source": {
+                "type": "file",
+                "path": "test.csv",
+                "format": "csv",
+                "size_bytes": 42
+            },
+            "column_profiles": [],
+            "execution": {
+                "rows_processed": 10,
+                "columns_detected": 2,
+                "scan_time_ms": 5,
+                "error_count": 0,
+                "source_exhausted": true,
+                "sampling_applied": false
+            }
+        })
+    }
+
+    #[test]
+    fn test_additive_fields_from_newer_writer_are_ignored() {
+        // A newer dataprof may add fields within the same schema version;
+        // a compatible reader must not break on them.
+        let mut json = current_document();
+        json["a_future_additive_field"] = json!({"anything": true});
+        json["column_profiles"] = json!([]);
+
+        let report: ProfileReport = serde_json::from_value(json).unwrap();
+        assert_eq!(report.schema_version, REPORT_SCHEMA_VERSION);
+        assert_eq!(report.id, "current-report");
+    }
+
+    #[test]
+    fn test_unsupported_future_schema_version_fails_explicitly() {
+        let mut json = current_document();
+        json["schema_version"] = json!(REPORT_SCHEMA_VERSION + 1);
+
+        let err = serde_json::from_value::<ProfileReport>(json).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("schema version") && msg.contains("upgrade dataprof"),
+            "expected an actionable schema-version error, got: {msg}"
+        );
     }
 }

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -53,7 +53,7 @@ pub use dataprof_parquet::{
     analyze_parquet_with_quality_dims, is_parquet_file,
 };
 pub use dataprof_partial::{analyze_structure, infer_schema, quick_row_count};
-pub use dataprof_runtime::ProfileReport;
+pub use dataprof_runtime::{ProfileReport, REPORT_SCHEMA_VERSION};
 
 #[cfg(feature = "async-streaming")]
 pub use dataprof_engines::streaming::ReqwestSource;

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -457,6 +457,29 @@ reloaded = dp.ProfileReport.from_json(report.to_json())
 reloaded = dp.ProfileReport.from_dict(report.to_dict())
 ```
 
+#### Report schema versioning
+
+Saved reports are durable artifacts — CI baselines, drift references, agent
+inputs — so the document carries its own schema version, independent of the
+package version:
+
+```python
+report.to_dict()["schema_version"]   # == dp.REPORT_SCHEMA_VERSION
+```
+
+The compatibility policy when loading:
+
+| Document | Behavior |
+|---|---|
+| No `schema_version` field | Legacy pre-0.10 report; loads through a compatibility path |
+| `schema_version` ≤ `dp.REPORT_SCHEMA_VERSION` | Loads normally; unknown additive fields from newer writers are ignored |
+| `schema_version` > `dp.REPORT_SCHEMA_VERSION` | Raises `ValueError` immediately — an incompatible report is never partially decoded |
+
+The version only increments when the document format itself changes
+incompatibly, not on every dataprof release. The same field with the same
+semantics appears in reports serialized from Rust (`serde`), where readers
+enforce the identical policy.
+
 ### `compare()`
 
 Detect quality drift or schema changes between two profiles (e.g. the same

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -161,9 +161,18 @@ def capabilities() -> Capabilities:
     )
 
 
+# Version of the serialized report document written by to_dict()/to_json()/
+# save(). Independent of the package version: it only changes when the report
+# schema itself changes. Readers accept any document whose schema_version is
+# at most this value; documents without the field are legacy pre-0.10 reports
+# and load through a compatibility path. See ProfileReport.from_dict().
+REPORT_SCHEMA_VERSION = 1
+
+
 __all__ = [
     "Capabilities",
     "capabilities",
+    "REPORT_SCHEMA_VERSION",
     "analyze_database_async",
     "count_table_rows_async",
     "get_table_schema_async",
@@ -1636,7 +1645,10 @@ class ProfileReport:
         """Convert the report to a nested Python dict.
 
         All floating-point values are rounded (2dp for percentages, 4dp for
-        statistics) to match the Rust report serialization.
+        statistics) to match the Rust report serialization. The document
+        carries ``schema_version`` (``dataprof.REPORT_SCHEMA_VERSION``) so
+        saved reports remain readable across releases; see
+        :meth:`from_dict` for the compatibility policy.
         """
         cols = [column_to_dict(col) for col in self._report.column_profiles]
 
@@ -1675,6 +1687,7 @@ class ProfileReport:
                 quality_dict["precision"] = precision
 
         return {
+            "schema_version": REPORT_SCHEMA_VERSION,
             "source": self._report.source,
             "source_type": self._report.source_type,
             "execution": {
@@ -2092,10 +2105,38 @@ class ProfileReport:
         ``quality_summary``, mapping access, …) work as usual. Useful for
         reloading a report saved yesterday without re-profiling the data.
 
+        Compatibility: the document's ``schema_version`` (see
+        ``dataprof.REPORT_SCHEMA_VERSION``) is checked first. Documents
+        without the field are legacy pre-0.10 reports and load through a
+        compatibility path; unknown additive fields from newer writers are
+        ignored; a document with a newer schema version is rejected outright
+        rather than partially decoded.
+
         Raises:
-            ValueError: if ``data`` is not a mapping produced by ``to_dict()``.
+            ValueError: if ``data`` is not a mapping produced by ``to_dict()``,
+                or was written with a newer report schema than this dataprof
+                can read.
         """
-        if not isinstance(data, dict) or not {"source", "columns", "execution"} <= data.keys():
+        if not isinstance(data, dict):
+            raise ValueError(
+                "from_dict() expects a mapping produced by ProfileReport.to_dict() "
+                "(with 'source', 'columns', and 'execution' keys)."
+            )
+        # Check the schema version before any structural decoding: an
+        # incompatible document must fail explicitly, never load partially.
+        version = data.get("schema_version")
+        if version is not None:
+            if isinstance(version, bool) or not isinstance(version, int):
+                raise ValueError(
+                    f"from_dict(): 'schema_version' must be an integer, got {version!r}."
+                )
+            if version > REPORT_SCHEMA_VERSION:
+                raise ValueError(
+                    f"This report uses schema version {version}, but this dataprof "
+                    f"reads up to version {REPORT_SCHEMA_VERSION}. Upgrade dataprof "
+                    "to load it."
+                )
+        if not {"source", "columns", "execution"} <= data.keys():
             raise ValueError(
                 "from_dict() expects a mapping produced by ProfileReport.to_dict() "
                 "(with 'source', 'columns', and 'execution' keys)."

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -2124,9 +2124,9 @@ class ProfileReport:
             )
         # Check the schema version before any structural decoding: an
         # incompatible document must fail explicitly, never load partially.
-        version = data.get("schema_version")
-        if version is not None:
-            if isinstance(version, bool) or not isinstance(version, int):
+        if "schema_version" in data:
+            version = data["schema_version"]
+            if version is None or isinstance(version, bool) or not isinstance(version, int):
                 raise ValueError(
                     f"from_dict(): 'schema_version' must be an integer, got {version!r}."
                 )
@@ -2136,7 +2136,6 @@ class ProfileReport:
                     f"reads up to version {REPORT_SCHEMA_VERSION}. Upgrade dataprof "
                     "to load it."
                 )
-        if not {"source", "columns", "execution"} <= data.keys():
             raise ValueError(
                 "from_dict() expects a mapping produced by ProfileReport.to_dict() "
                 "(with 'source', 'columns', and 'execution' keys)."

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -2124,6 +2124,8 @@ class ProfileReport:
             )
         # Check the schema version before any structural decoding: an
         # incompatible document must fail explicitly, never load partially.
+        # An explicit null is not the same as a missing field: only documents
+        # written before versioning existed may omit it.
         if "schema_version" in data:
             version = data["schema_version"]
             if version is None or isinstance(version, bool) or not isinstance(version, int):
@@ -2136,6 +2138,7 @@ class ProfileReport:
                     f"reads up to version {REPORT_SCHEMA_VERSION}. Upgrade dataprof "
                     "to load it."
                 )
+        if not {"source", "columns", "execution"} <= data.keys():
             raise ValueError(
                 "from_dict() expects a mapping produced by ProfileReport.to_dict() "
                 "(with 'source', 'columns', and 'execution' keys)."

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -27,6 +27,9 @@ from ._dataprof import (
 
 # --- Primary API ---
 
+REPORT_SCHEMA_VERSION: int
+"""Version of the serialized report document written by to_dict()/save()."""
+
 @dataclass(frozen=True, slots=True)
 class Capabilities:
     """Immutable snapshot of features available in this installation."""
@@ -287,6 +290,7 @@ def _estimate_tokens(text: str) -> int: ...
 __all__ = [
     "Capabilities",
     "capabilities",
+    "REPORT_SCHEMA_VERSION",
     "analyze_database_async",
     "count_table_rows_async",
     "get_table_schema_async",

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -829,6 +829,61 @@ class TestReportErgonomics:
         col = reloaded[d["columns"][0]["name"]]
         assert not hasattr(col, "__evil__")
 
+    # -- Report schema versioning (compatibility contract) --
+
+    def test_to_dict_carries_schema_version(self, report):
+        d = report.to_dict()
+        assert d["schema_version"] == dataprof.REPORT_SCHEMA_VERSION
+        assert json.loads(report.to_json())["schema_version"] == dataprof.REPORT_SCHEMA_VERSION
+
+    def test_save_load_preserves_schema_version(self, report):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            report.save(path)
+            with open(path, encoding="utf-8") as fh:
+                on_disk = json.load(fh)
+            assert on_disk["schema_version"] == dataprof.REPORT_SCHEMA_VERSION
+            loaded = dataprof.ProfileReport.load(path)
+            assert loaded.to_dict()["schema_version"] == dataprof.REPORT_SCHEMA_VERSION
+        finally:
+            os.unlink(path)
+
+    def test_from_dict_accepts_legacy_unversioned_document(self, report):
+        # A 0.9-era save() document has no schema_version field; it must
+        # still load through the legacy compatibility path.
+        legacy = report.to_dict()
+        del legacy["schema_version"]
+        reloaded = dataprof.ProfileReport.from_dict(legacy)
+        assert reloaded.columns == report.columns
+
+    def test_from_dict_ignores_additive_top_level_fields(self, report):
+        # A newer writer on the same schema version may add fields; a
+        # compatible reader must not break on them.
+        d = report.to_dict()
+        d["a_future_additive_field"] = {"anything": True}
+        reloaded = dataprof.ProfileReport.from_dict(d)
+        assert reloaded.columns == report.columns
+
+    def test_from_dict_rejects_newer_schema_version(self, report):
+        d = report.to_dict()
+        d["schema_version"] = dataprof.REPORT_SCHEMA_VERSION + 1
+        with pytest.raises(ValueError, match="Upgrade dataprof"):
+            dataprof.ProfileReport.from_dict(d)
+
+    @pytest.mark.parametrize("bad", ["1", 1.0, True, {}])
+    def test_from_dict_rejects_non_integer_schema_version(self, report, bad):
+        d = report.to_dict()
+        d["schema_version"] = bad
+        with pytest.raises(ValueError, match="schema_version"):
+            dataprof.ProfileReport.from_dict(d)
+
+    def test_newer_schema_version_fails_before_partial_decoding(self):
+        # The version gate must run before structural validation: an
+        # incompatible document is rejected outright, not half-parsed.
+        with pytest.raises(ValueError, match="Upgrade dataprof"):
+            dataprof.ProfileReport.from_dict({"schema_version": dataprof.REPORT_SCHEMA_VERSION + 1})
+
     def test_compare_identical_is_zero(self, report):
         reloaded = dataprof.ProfileReport.from_json(report.to_json())
         delta = report.compare(reloaded)
@@ -1350,6 +1405,7 @@ class TestNamespace:
         expected = {
             "Capabilities",
             "capabilities",
+            "REPORT_SCHEMA_VERSION",
             "profile",
             "profile_file",
             "Profiler",

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -871,7 +871,7 @@ class TestReportErgonomics:
         with pytest.raises(ValueError, match="Upgrade dataprof"):
             dataprof.ProfileReport.from_dict(d)
 
-    @pytest.mark.parametrize("bad", ["1", 1.0, True, {}])
+    @pytest.mark.parametrize("bad", ["1", 1.0, True, {}, None])
     def test_from_dict_rejects_non_integer_schema_version(self, report, bad):
         d = report.to_dict()
         d["schema_version"] = bad


### PR DESCRIPTION
Closes #374.

## What

Saved reports are durable artifacts (CI baselines, drift references, agent inputs), but the serialized document had no schema version: a future field change could turn a stored baseline into an opaque failure or a plausible-but-different report. This adds an explicit, package-version-independent `schema_version` to both serialization dialects and defines the reader policy.

- **Rust**: `REPORT_SCHEMA_VERSION` (= 1) exported from `dataprof-runtime` and the facade; `ProfileReport` serializes the field and its deserializer rejects newer versions with an actionable error. Documents without the field (0.9-era) load as version 0 through the existing legacy aliases.
- **Python**: `dataprof.REPORT_SCHEMA_VERSION` (= 1); `to_dict()`/`to_json()`/`save()` stamp the document; `from_dict()`/`from_json()`/`load()` check the version **before** any structural decoding — legacy documents load, additive unknown fields are ignored, newer versions raise `ValueError` ("Upgrade dataprof to load it"), non-integer versions are rejected.
- **Docs**: compatibility policy table in the Python guide; policy doc comments on the Rust const/field.

## Compatibility semantics

| Document | Reader behavior |
|---|---|
| No `schema_version` (pre-0.10) | Loads via legacy path, identifiable as version 0 |
| `schema_version` ≤ current | Loads; unknown additive fields ignored |
| `schema_version` > current | Explicit failure, never partial decoding |

## Tests

Fixture coverage in both languages for all four document classes (legacy / current / additive-future / incompatible-future), plus non-integer version rejection and a gate-ordering test (version check precedes structural validation).

## Verification

Drove the flow end-to-end through both public surfaces (not just tests): profiled a real CSV, saved, inspected the on-disk document (`schema_version: 1` leads the document), reloaded, then tampered the file on disk — version 99 rejected with the actionable message, field removed loads as legacy, string version rejected, additive unknown field tolerated. Same probes through the Rust facade via `serde_json`.

```
cargo test -p dataprof-runtime      # 41 passed
uv run pytest python/tests/test_python_api.py -q   # 265 passed
cargo fmt --all && cargo clippy -p dataprof-runtime -p dataprof -p dataprof-python --all-targets
uv run ruff format python/ && uv run ruff check python/ && uv run ty check python/
```