### PR TITLE
fix(python): describe() 50% falls back to median when quartiles are absent

### DIFF
--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1762,7 +1762,9 @@ class ProfileReport:
                 "std": _r4(col.std_dev),
                 "min": _r4(col.min),
                 "25%": q["q1"] if q else None,
-                "50%": q["q2"] if q else None,
+                # Small samples compute a median without full quartiles;
+                # fall back so 50% matches the median shown elsewhere.
+                "50%": q["q2"] if q else _r2(col.median),
                 "75%": q["q3"] if q else None,
                 "max": _r4(col.max),
                 "min_length": col.min_length,

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1754,6 +1754,19 @@ class TestDescribe:
         desc = r.describe()
         assert desc is not None
 
+    def test_describe_50pct_falls_back_to_median(self):
+        # Small samples compute a median without full quartiles; describe()
+        # must not show 50% as missing while the median exists.
+        r = dataprof.profile({"age": [29, 31, 42]})
+        col = r["age"]
+        assert col.median is not None
+        desc = r.describe()
+        try:
+            fifty = desc["age"]["50%"]
+        except TypeError:
+            fifty = desc.loc["50%", "age"]
+        assert fifty == pytest.approx(col.median, abs=0.01)
+
 
 # ─────────────────────────────────────────────────
 #  16. quality_summary


### PR DESCRIPTION
Found while dogfooding: on small samples the profiler computes a median but not full quartiles, so `to_markdown()` showed `median=31.0` while `describe()` showed `50%` as NaN for the same column. `describe()` now falls back to the median (2dp, matching quartile rounding) when quartiles were not computed.

Repro before the fix:

~~~python
r = dp.profile({"age": [29, 31, 42]})
r.to_markdown()   # median=31.0
r.describe()      # 50% -> NaN
~~~

Gates: ruff format/check, ty, pytest (256 passed).