### PR TITLE
fix(metrics): track duplicate rows in columnar and record-batch engines

### DIFF
--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -1,4 +1,4 @@
-use crate::record_batch_analyzer::observe_batch_rows;
+use crate::record_batch_analyzer::BatchRowTracker;
 use arrow::array::*;
 use arrow::csv::ReaderBuilder;
 use arrow::datatypes::*;
@@ -10,8 +10,7 @@ use dataprof_csv::CsvParserConfig;
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::{infer_type, is_null_like_token};
 use dataprof_runtime::{
-    ColumnProfileInput, ProfileReport, ReportAssembler, RowUniquenessTracker, TextLengths,
-    build_column_profile,
+    ColumnProfileInput, ProfileReport, ReportAssembler, TextLengths, build_column_profile,
 };
 use std::fs::File;
 use std::path::Path;
@@ -142,7 +141,7 @@ impl ArrowProfiler {
         // reservoirs are misaligned (any column with nulls) would silently
         // skip the duplicate component of the uniqueness dimension — breaking
         // cross-engine score parity with the incremental engine.
-        let mut row_tracker = RowUniquenessTracker::default();
+        let mut row_tracker = BatchRowTracker::default();
 
         // The Arrow CSV reader has no row cap, so enforce it here: stop once the
         // limit is reached and slice the batch that straddles it, keeping the row
@@ -166,11 +165,7 @@ impl ArrowProfiler {
             }
 
             total_rows += batch.num_rows();
-            observe_batch_rows(&mut row_tracker, &batch).map_err(|error| {
-                DataProfilerError::ArrowError {
-                    message: error.to_string(),
-                }
-            })?;
+            row_tracker.observe_batch(&batch);
 
             // Process each column in the batch
             for (col_idx, column) in batch.columns().iter().enumerate() {

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -1,3 +1,4 @@
+use crate::record_batch_analyzer::observe_batch_rows;
 use arrow::array::*;
 use arrow::csv::ReaderBuilder;
 use arrow::datatypes::*;
@@ -9,7 +10,8 @@ use dataprof_csv::CsvParserConfig;
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::{infer_type, is_null_like_token};
 use dataprof_runtime::{
-    ColumnProfileInput, ProfileReport, ReportAssembler, TextLengths, build_column_profile,
+    ColumnProfileInput, ProfileReport, ReportAssembler, RowUniquenessTracker, TextLengths,
+    build_column_profile,
 };
 use std::fs::File;
 use std::path::Path;
@@ -136,6 +138,11 @@ impl ArrowProfiler {
         }
 
         let mut total_rows = 0;
+        // Full-stream duplicate-row tracking: without it, files whose sample
+        // reservoirs are misaligned (any column with nulls) would silently
+        // skip the duplicate component of the uniqueness dimension — breaking
+        // cross-engine score parity with the incremental engine.
+        let mut row_tracker = RowUniquenessTracker::default();
 
         // The Arrow CSV reader has no row cap, so enforce it here: stop once the
         // limit is reached and slice the batch that straddles it, keeping the row
@@ -159,6 +166,11 @@ impl ArrowProfiler {
             }
 
             total_rows += batch.num_rows();
+            observe_batch_rows(&mut row_tracker, &batch).map_err(|error| {
+                DataProfilerError::ArrowError {
+                    message: error.to_string(),
+                }
+            })?;
 
             // Process each column in the batch
             for (col_idx, column) in batch.columns().iter().enumerate() {
@@ -213,7 +225,8 @@ impl ArrowProfiler {
             },
             execution,
         )
-        .columns(column_profiles);
+        .columns(column_profiles)
+        .with_row_duplicates(row_tracker.summary());
 
         if MetricPack::include_quality(packs) {
             assembler = assembler

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -307,6 +307,7 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
         ExecutionMetadata::new(total_rows, num_columns, scan_time_ms),
     )
     .columns(column_profiles)
+    .with_row_duplicates(analyzer.row_duplicate_summary())
     .with_quality_data(sample_columns)
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dims) = quality_dimensions {

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -234,6 +234,7 @@ pub fn analyze_parquet_with_config_dims_and_hints(
         execution,
     )
     .columns(column_profiles)
+    .with_row_duplicates(analyzer.row_duplicate_summary())
     .with_quality_data(sample_columns)
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -16,14 +16,49 @@ use std::fmt::Write as _;
 
 const NUMERIC_SAMPLE_CAP: usize = 10_000;
 
-/// Fold every row of a batch into the tracker as a canonical signature.
+/// Full-stream duplicate-row tracking over Arrow batches.
 ///
-/// Signatures use the same length-prefixed encoding as the incremental
+/// Row signatures use the same length-prefixed encoding as the incremental
 /// engine's `StreamingColumnCollection::process_record`, with a null slot
 /// contributing an empty value — so on inputs both engines can read (CSV),
 /// duplicate counts agree across engines. Columns fold in schema order,
 /// which is stable across the batches of one source.
-pub fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -> Result<()> {
+///
+/// When a column's values cannot be rendered (an Arrow type without a
+/// formatter), tracking disables itself and [`Self::summary`] returns `None`
+/// — the duplicate component reads "not assessed". Substituting placeholder
+/// values instead would fabricate or mask duplicates, which is worse than
+/// admitting the metric was skipped; and the profile as a whole must not
+/// fail over an auxiliary metric.
+#[derive(Default)]
+pub(crate) struct BatchRowTracker {
+    tracker: RowUniquenessTracker,
+    disabled: bool,
+}
+
+impl BatchRowTracker {
+    pub(crate) fn observe_batch(&mut self, batch: &RecordBatch) {
+        if self.disabled {
+            return;
+        }
+        if observe_batch_rows(&mut self.tracker, batch).is_err() {
+            self.disabled = true;
+        }
+    }
+
+    /// Full-stream row-duplicate counts; `None` when no rows were seen or a
+    /// batch could not be signed (partial counts would be misleading).
+    pub(crate) fn summary(&self) -> Option<RowDuplicateSummary> {
+        if self.disabled {
+            return None;
+        }
+        self.tracker.summary()
+    }
+}
+
+/// Fold every row of a batch into the tracker as a canonical signature.
+/// See [`BatchRowTracker`] for the encoding and failure contract.
+fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -> Result<()> {
     use arrow::datatypes::DataType as ArrowDataType;
     use arrow::util::display::{ArrayFormatter, FormatOptions};
 
@@ -65,7 +100,7 @@ pub fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatc
 pub struct RecordBatchAnalyzer {
     column_analyzers: HashMap<String, ColumnAnalyzer>,
     total_rows: usize,
-    row_tracker: RowUniquenessTracker,
+    row_tracker: BatchRowTracker,
 }
 
 impl RecordBatchAnalyzer {
@@ -73,13 +108,13 @@ impl RecordBatchAnalyzer {
         Self {
             column_analyzers: HashMap::new(),
             total_rows: 0,
-            row_tracker: RowUniquenessTracker::default(),
+            row_tracker: BatchRowTracker::default(),
         }
     }
 
     pub fn process_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         self.total_rows += batch.num_rows();
-        observe_batch_rows(&mut self.row_tracker, batch)?;
+        self.row_tracker.observe_batch(batch);
 
         for (column_index, column) in batch.columns().iter().enumerate() {
             let schema = batch.schema();
@@ -101,7 +136,8 @@ impl RecordBatchAnalyzer {
         self.total_rows
     }
 
-    /// Full-stream row-duplicate counts, or `None` when no rows were seen.
+    /// Full-stream row-duplicate counts, or `None` when no rows were seen or
+    /// the batches could not be signed (see [`BatchRowTracker`]).
     pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
         self.row_tracker.summary()
     }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -7,16 +7,65 @@ use arrow::util::display::ArrayFormatter;
 use dataprof_core::{ColumnProfile, DataType, SemanticHints};
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
-use dataprof_metrics::infer_type;
-use dataprof_runtime::{ColumnProfileInput, TextLengths, build_column_profile};
+use dataprof_metrics::{RowDuplicateSummary, infer_type};
+use dataprof_runtime::{
+    ColumnProfileInput, RowUniquenessTracker, TextLengths, build_column_profile,
+};
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 const NUMERIC_SAMPLE_CAP: usize = 10_000;
+
+/// Fold every row of a batch into the tracker as a canonical signature.
+///
+/// Signatures use the same length-prefixed encoding as the incremental
+/// engine's `StreamingColumnCollection::process_record`, with a null slot
+/// contributing an empty value — so on inputs both engines can read (CSV),
+/// duplicate counts agree across engines. Columns fold in schema order,
+/// which is stable across the batches of one source.
+pub fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -> Result<()> {
+    use arrow::datatypes::DataType as ArrowDataType;
+    use arrow::util::display::{ArrayFormatter, FormatOptions};
+
+    // Null must render as an empty field ("0:"), matching the incremental
+    // engine — the default formatter would render a visible placeholder.
+    let options = FormatOptions::default().with_null("");
+    let formatters: Vec<Option<ArrayFormatter>> = batch
+        .columns()
+        .iter()
+        .map(|column| match column.data_type() {
+            // A NullArray has no validity buffer; every slot is null.
+            ArrowDataType::Null => Ok(None),
+            _ => ArrayFormatter::try_new(column.as_ref(), &options).map(Some),
+        })
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|error| anyhow::anyhow!("row signature formatting failed: {error}"))?;
+
+    let mut value_buffer = String::new();
+    for row_index in 0..batch.num_rows() {
+        let mut row_signature = String::new();
+        for (column, formatter) in batch.columns().iter().zip(&formatters) {
+            value_buffer.clear();
+            if let Some(formatter) = formatter
+                && !column.is_null(row_index)
+            {
+                write!(value_buffer, "{}", formatter.value(row_index))
+                    .map_err(|error| anyhow::anyhow!("row signature formatting failed: {error}"))?;
+            }
+            let _ = write!(row_signature, "{}:", value_buffer.len());
+            row_signature.push_str(&value_buffer);
+        }
+        tracker.observe(row_signature);
+    }
+
+    Ok(())
+}
 
 /// Analyzer for processing multiple RecordBatches and building column profiles.
 pub struct RecordBatchAnalyzer {
     column_analyzers: HashMap<String, ColumnAnalyzer>,
     total_rows: usize,
+    row_tracker: RowUniquenessTracker,
 }
 
 impl RecordBatchAnalyzer {
@@ -24,11 +73,13 @@ impl RecordBatchAnalyzer {
         Self {
             column_analyzers: HashMap::new(),
             total_rows: 0,
+            row_tracker: RowUniquenessTracker::default(),
         }
     }
 
     pub fn process_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         self.total_rows += batch.num_rows();
+        observe_batch_rows(&mut self.row_tracker, batch)?;
 
         for (column_index, column) in batch.columns().iter().enumerate() {
             let schema = batch.schema();
@@ -48,6 +99,11 @@ impl RecordBatchAnalyzer {
 
     pub fn total_rows(&self) -> usize {
         self.total_rows
+    }
+
+    /// Full-stream row-duplicate counts, or `None` when no rows were seen.
+    pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
+        self.row_tracker.summary()
     }
 
     pub fn to_profiles(

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -429,7 +429,8 @@ pub fn profile_dataframe(
         },
         exec,
     )
-    .columns(column_profiles);
+    .columns(column_profiles)
+    .with_row_duplicates(analyzer.row_duplicate_summary());
 
     if include_quality {
         assembler = assembler
@@ -534,7 +535,8 @@ pub fn profile_arrow(
         },
         exec,
     )
-    .columns(column_profiles);
+    .columns(column_profiles)
+    .with_row_duplicates(analyzer.row_duplicate_summary());
 
     if include_quality {
         assembler = assembler

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -14,7 +14,9 @@ use dataprof::{
     DataFrameLibrary, DataSource, ExecutionMetadata, MetricPack, TruncationReason, infer_type,
     is_null_like_token,
 };
-use dataprof_runtime::{ColumnProfileInput, ReportAssembler, build_column_profile};
+use dataprof_runtime::{
+    ColumnProfileInput, ReportAssembler, RowUniquenessTracker, build_column_profile,
+};
 
 use super::config::PyProfilerConfig;
 use super::types::PyProfileReport;
@@ -73,9 +75,27 @@ pub fn profile_columns(
     let num_cols = columns.len();
 
     // Analysis is pure Rust over owned data, so the GIL buys us nothing here.
-    let (column_profiles, sample_columns) = py.detach(|| {
+    let (column_profiles, sample_columns, row_duplicates) = py.detach(|| {
         let mut profiles = Vec::with_capacity(num_cols);
         let mut samples = std::collections::HashMap::new();
+
+        // Full-stream duplicate-row tracking over the row-aligned input,
+        // using the same length-prefixed signature encoding as the file
+        // engines. Null cells contribute an empty value, so files and
+        // ad-hoc inputs holding the same data agree on duplicate counts.
+        let mut row_tracker = RowUniquenessTracker::default();
+        if num_cols > 0 {
+            use std::fmt::Write as _;
+            for row_index in 0..num_rows {
+                let mut row_signature = String::new();
+                for (_, cells) in &columns {
+                    let value = cells[row_index].as_deref().unwrap_or("");
+                    let _ = write!(row_signature, "{}:", value.len());
+                    row_signature.push_str(value);
+                }
+                row_tracker.observe(row_signature);
+            }
+        }
 
         for (col_name, cells) in &columns {
             let present: Vec<String> = cells[..num_rows]
@@ -114,7 +134,7 @@ pub fn profile_columns(
             }
         }
 
-        (profiles, samples)
+        (profiles, samples, row_tracker.summary())
     });
 
     let mut exec = ExecutionMetadata::new(num_rows, num_cols, start.elapsed().as_millis());
@@ -142,7 +162,8 @@ pub fn profile_columns(
         },
         exec,
     )
-    .columns(column_profiles);
+    .columns(column_profiles)
+    .with_row_duplicates(row_duplicates);
 
     if include_quality {
         assembler = assembler

--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -20,5 +20,6 @@ pub use profile_builder::{
 pub use profile_report::ProfileReport;
 pub use report_assembler::ReportAssembler;
 pub use streaming_stats::{
-    StreamingColumnCollection, StreamingStatistics, TextLengthStats, WelfordAccumulator,
+    RowUniquenessTracker, StreamingColumnCollection, StreamingStatistics, TextLengthStats,
+    WelfordAccumulator,
 };

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -308,3 +308,64 @@ def test_sqlite_parity(tmp_path):
     assert not mismatches, "sqlite disagrees with the reference profile on:\n" + "\n".join(
         mismatches
     )
+
+
+# ── Duplicate-row detection with nulls (issue #417) ──
+#
+# The columnar engine used to skip duplicate-row detection whenever any column
+# contained nulls: per-column sample reservoirs lose row alignment, the
+# sample-based scan correctly refused to run, and — with no full-stream
+# tracker — the uniqueness dimension silently dropped its duplicate component.
+# Same file, different overall quality score depending on the engine.
+
+
+def _dup_rows_csv(tmp_path):
+    path = tmp_path / "dups_with_nulls.csv"
+    path.write_text(
+        "id,name,value,city\n"
+        "1,Alice,10.5,Rome\n"
+        "2,,20.0,Milan\n"
+        "2,,20.0,Milan\n"  # duplicate row containing a null
+        "3,Bob,,Naples\n"
+        "4,Alice,10.5,\n"
+        "1,Alice,10.5,Rome\n",  # duplicate of the first row
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_duplicate_rows_with_nulls_agree_across_engines(tmp_path):
+    path = _dup_rows_csv(tmp_path)
+    reports = {
+        engine: dataprof.profile(str(path), engine=engine) for engine in ("incremental", "columnar")
+    }
+
+    facts = {}
+    for engine, report in reports.items():
+        uniqueness = report.to_dict()["quality"]["uniqueness"]
+        facts[engine] = (
+            uniqueness["rows_checked"],
+            uniqueness["duplicate_rows"],
+            uniqueness["key_uniqueness"],
+        )
+        assert uniqueness["rows_checked"] == 6, f"{engine} must scan every row"
+        assert uniqueness["duplicate_rows"] == 2, f"{engine} must find both duplicates"
+
+    assert facts["incremental"] == facts["columnar"]
+    assert reports["incremental"].quality_score == pytest.approx(
+        reports["columnar"].quality_score, abs=0.01
+    ), "overall quality must not depend on the engine"
+
+
+def test_duplicate_rows_tracked_for_dataframe_and_arrow_inputs(tmp_path):
+    # The DataFrame/Arrow paths share RecordBatchAnalyzer; duplicates must be
+    # assessed there too, not silently skipped when a column has nulls.
+    pa = pytest.importorskip("pyarrow")
+    data = {
+        "id": [1, 2, 2, 3],
+        "name": ["Alice", None, None, "Bob"],
+    }
+    report = dataprof.profile(pa.table(data))
+    uniqueness = report.to_dict()["quality"]["uniqueness"]
+    assert uniqueness["rows_checked"] == 4
+    assert uniqueness["duplicate_rows"] == 1

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -596,3 +596,88 @@ fn test_profiler_all_dimensions_default() {
     assert!(m.validity.is_some());
     assert!(m.precision.is_some());
 }
+
+/// Regression for #417: the columnar engine used to skip duplicate-row
+/// detection whenever any column contained nulls (misaligned sample
+/// reservoirs), silently dropping the duplicate component of the uniqueness
+/// dimension and producing a different overall quality score than the
+/// incremental engine for the same bytes.
+#[test]
+fn test_duplicate_rows_with_nulls_match_across_engines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "id,name,value,city").unwrap();
+    writeln!(f, "1,Alice,10.5,Rome").unwrap();
+    writeln!(f, "2,,20.0,Milan").unwrap();
+    writeln!(f, "2,,20.0,Milan").unwrap(); // duplicate row containing a null
+    writeln!(f, "3,Bob,,Naples").unwrap();
+    writeln!(f, "4,Alice,10.5,").unwrap();
+    writeln!(f, "1,Alice,10.5,Rome").unwrap(); // duplicate of row 1
+    f.flush().unwrap();
+
+    let incremental = Profiler::new()
+        .engine(EngineType::Incremental)
+        .analyze_file(f.path())
+        .expect("incremental analysis should succeed");
+    let columnar = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(f.path())
+        .expect("columnar analysis should succeed");
+
+    let inc_uniq = incremental
+        .quality
+        .as_ref()
+        .and_then(|q| q.metrics.uniqueness.as_ref())
+        .expect("incremental uniqueness should be assessed");
+    let col_uniq = columnar
+        .quality
+        .as_ref()
+        .and_then(|q| q.metrics.uniqueness.as_ref())
+        .expect("columnar uniqueness should be assessed");
+
+    // Both engines must scan every row and find both duplicates, despite the
+    // nulls that break per-column sample alignment.
+    assert_eq!(inc_uniq.rows_checked, 6, "incremental rows_checked");
+    assert_eq!(col_uniq.rows_checked, 6, "columnar rows_checked");
+    assert_eq!(inc_uniq.duplicate_rows, 2, "incremental duplicate_rows");
+    assert_eq!(col_uniq.duplicate_rows, 2, "columnar duplicate_rows");
+    assert_eq!(
+        inc_uniq.key_uniqueness, col_uniq.key_uniqueness,
+        "key_uniqueness must match across engines"
+    );
+
+    // The contract that actually matters to users: identical overall score.
+    let inc_score = incremental.quality_score().expect("incremental score");
+    let col_score = columnar.quality_score().expect("columnar score");
+    assert!(
+        (inc_score - col_score).abs() < 0.01,
+        "overall quality must not depend on the engine: incremental={inc_score} columnar={col_score}"
+    );
+}
+
+/// Duplicate-row detection must also run on clean files (no nulls) — the
+/// aligned-sample fallback already handled this, so it guards the new
+/// full-stream tracker against regressing the easy case.
+#[test]
+fn test_duplicate_rows_without_nulls_match_across_engines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "id,name").unwrap();
+    writeln!(f, "1,Alice").unwrap();
+    writeln!(f, "2,Bob").unwrap();
+    writeln!(f, "2,Bob").unwrap();
+    writeln!(f, "3,Carol").unwrap();
+    f.flush().unwrap();
+
+    for engine in [EngineType::Incremental, EngineType::Columnar] {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(f.path())
+            .expect("analysis should succeed");
+        let uniq = report
+            .quality
+            .as_ref()
+            .and_then(|q| q.metrics.uniqueness.as_ref())
+            .expect("uniqueness should be assessed");
+        assert_eq!(uniq.rows_checked, 4, "{engine:?} rows_checked");
+        assert_eq!(uniq.duplicate_rows, 1, "{engine:?} duplicate_rows");
+    }
+}


### PR DESCRIPTION
Closes #417.

## Problem

`engine="incremental"` and `engine="columnar"` produced **different quality scores for the same bytes** whenever any column contained nulls (e.g. `sensor_data_outliers.csv`: 83.81 vs 76.41). Only the incremental/async engines fed a full-stream `RowUniquenessTracker`; the columnar paths fell back to the sample-based duplicate scan, which correctly refuses to run on null-misaligned reservoirs — so the uniqueness dimension silently lost its duplicate component and renormalized differently.

## Fix

A shared `observe_batch_rows()` helper (in `record_batch_analyzer`) folds every row of a `RecordBatch` into the existing `RowUniquenessTracker` using the **same length-prefixed signature encoding as the incremental engine** (null → empty field), so duplicate counts agree across engines by construction. Wired into every previously-untracked assembler site:

- `ArrowProfiler` CSV batch loop (the `engine="columnar"` headline)
- Parquet file parser and Parquet-over-HTTP (via `RecordBatchAnalyzer`)
- Python DataFrame and Arrow-capsule bindings (same analyzer)
- the dependency-free dict/rows path (`profile_columns`)

`RowUniquenessTracker` is now exported from `dataprof-runtime`.

The last site was caught by the existing test suite mid-review: wiring the DataFrame path but not the dict path made *those two* disagree (88.94 vs 91.02) — the ad-hoc-vs-pandas parity test failed exactly as designed. All input paths now assess duplicates identically.

## Tests

- `cross_engine_consistency.rs`: nulls+duplicates fixture asserting identical uniqueness facts **and identical overall score** across incremental/columnar, plus a no-nulls regression guard
- `test_engine_parity.py`: same fixture through the Python surface, plus a DataFrame/Arrow-input duplicate-tracking test

## Verification (live, not just tests)

All five input surfaces drove the same 4-row nulls+duplicate dataset to identical facts (`rows_checked=4, duplicate_rows=1, exact`): CSV both engines, dict, parquet file, pandas, polars. Original repro files now MATCH (83.81/83.81, 87.65/87.65). Scale check: 500k rows — columnar 0.37s vs incremental 0.98s with the tracker active, both flagging the HLL spill as approximate.

Gates: `cargo test --workspace` (25 suites), `pytest python/tests/` (326 passed), fmt/clippy/ruff clean.