### PR TITLE
fix(metrics): populate execution.memory_peak_mb in incremental and columnar engines

### DIFF
--- a/crates/dataprof-core/src/execution.rs
+++ b/crates/dataprof-core/src/execution.rs
@@ -30,7 +30,9 @@ pub struct ExecutionMetadata {
     /// Throughput in rows per second, auto-calculated when possible.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub throughput_rows_sec: Option<f64>,
-    /// Peak memory usage in megabytes, if tracked.
+    /// Peak process memory usage (resident set size) in megabytes observed
+    /// during profiling, sampled at chunk/batch boundaries. Absent when the
+    /// platform provided no reading or the input path does not track memory.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_peak_mb: Option<f64>,
     /// Number of errors encountered during profiling.

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod classification;
 pub mod config;
 pub mod errors;
 pub mod execution;
+pub mod memory_sampler;
 pub mod memory_tracker;
 pub mod output;
 pub mod partial;
@@ -25,6 +26,7 @@ pub use config::{
 };
 pub use errors::{DataProfilerError, RecoveryAttempt, RecoveryStrategy, RetryConfig};
 pub use execution::{ExecutionMetadata, TruncationReason};
+pub use memory_sampler::PeakMemorySampler;
 pub use memory_tracker::{MemoryLeak, MemoryTracker};
 pub use output::OutputFormat;
 pub use partial::{

--- a/crates/dataprof-core/src/memory_sampler.rs
+++ b/crates/dataprof-core/src/memory_sampler.rs
@@ -1,0 +1,84 @@
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+/// Tracks the peak resident set size (RSS) of the current process across a
+/// profiling run.
+///
+/// Engines call [`sample`](Self::sample) at chunk/batch boundaries; the peak
+/// observed feeds `ExecutionMetadata::memory_peak_mb`. The reading is the
+/// whole-process RSS, so on embedded surfaces (e.g. the Python extension) it
+/// includes host-process memory — it is an upper bound on what profiling used,
+/// suitable for verifying the bounded-memory claim, not an exact attribution.
+pub struct PeakMemorySampler {
+    system: System,
+    pid: Option<Pid>,
+    peak_bytes: u64,
+}
+
+impl PeakMemorySampler {
+    /// Create a sampler and take an initial reading.
+    pub fn new() -> Self {
+        let mut sampler = Self {
+            system: System::new(),
+            pid: sysinfo::get_current_pid().ok(),
+            peak_bytes: 0,
+        };
+        sampler.sample();
+        sampler
+    }
+
+    /// Refresh the process RSS and fold it into the running peak.
+    pub fn sample(&mut self) {
+        let Some(pid) = self.pid else { return };
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            false,
+            ProcessRefreshKind::nothing().with_memory(),
+        );
+        if let Some(process) = self.system.process(pid) {
+            self.peak_bytes = self.peak_bytes.max(process.memory());
+        }
+    }
+
+    /// Peak RSS observed so far, in megabytes.
+    ///
+    /// `None` when the platform provided no reading — callers should leave
+    /// `memory_peak_mb` absent (not analyzed) rather than report zero.
+    pub fn peak_mb(&self) -> Option<f64> {
+        (self.peak_bytes > 0).then(|| self.peak_bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+impl Default for PeakMemorySampler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sampler_reports_positive_peak() {
+        let sampler = PeakMemorySampler::new();
+        let peak = sampler
+            .peak_mb()
+            .expect("current process RSS should be readable on supported platforms");
+        assert!(peak > 0.0, "peak RSS must be positive, got {peak}");
+    }
+
+    #[test]
+    fn test_peak_is_monotonic_across_samples() {
+        let mut sampler = PeakMemorySampler::new();
+        let first = sampler.peak_mb().expect("initial reading");
+        // Allocate enough that RSS cannot legitimately shrink below the first peak.
+        let ballast = vec![1u8; 4 * 1024 * 1024];
+        sampler.sample();
+        let second = sampler.peak_mb().expect("second reading");
+        assert!(
+            second >= first,
+            "peak must never decrease: {first} -> {second}"
+        );
+        drop(ballast);
+    }
+}

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -150,8 +150,6 @@ impl IncrementalProfiler {
                 break;
             }
 
-            memory_sampler.sample();
-
             // Store headers from first chunk and initialize column collection
             if headers.is_none() && chunk_headers.is_some() {
                 headers = chunk_headers;
@@ -216,6 +214,11 @@ impl IncrementalProfiler {
                     }
                 }
             }
+
+            // Sample after processing, while the chunk buffer and the stats it
+            // grew are both resident, so per-chunk allocation spikes count
+            // toward the peak.
+            memory_sampler.sample();
 
             if hit_row_limit {
                 break;

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use dataprof_core::{
     ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, MetricPack,
-    ProgressSink, QualityDimension, SamplingStrategy, SchemaStabilityTracker, SemanticHints,
-    StopCondition, StopEvaluator,
+    PeakMemorySampler, ProgressSink, QualityDimension, SamplingStrategy, SchemaStabilityTracker,
+    SemanticHints, StopCondition, StopEvaluator,
 };
 use dataprof_csv::{CsvParserConfig, MemoryMappedCsvReader};
 use dataprof_runtime::{
@@ -127,6 +127,7 @@ impl IncrementalProfiler {
 
         progress_tracker.emit_started(Some(estimated_data_rows), Some(file_size_bytes));
 
+        let mut memory_sampler = PeakMemorySampler::new();
         let mut headers = None;
         let mut iterated_rows = 0;
         let mut analyzed_rows = 0;
@@ -148,6 +149,8 @@ impl IncrementalProfiler {
             if records.is_empty() && actual_bytes == 0 {
                 break;
             }
+
+            memory_sampler.sample();
 
             // Store headers from first chunk and initialize column collection
             if headers.is_none() && chunk_headers.is_some() {
@@ -262,6 +265,7 @@ impl IncrementalProfiler {
             }
         }
 
+        memory_sampler.sample();
         progress_tracker.emit_finished(!source_exhausted);
 
         // Convert streaming statistics to column profiles
@@ -290,6 +294,10 @@ impl IncrementalProfiler {
 
         let mut execution = ExecutionMetadata::new(analyzed_rows, num_columns, scan_time_ms)
             .with_bytes_consumed(bytes_consumed);
+
+        if let Some(peak_mb) = memory_sampler.peak_mb() {
+            execution = execution.with_memory_peak_mb(peak_mb);
+        }
 
         // Apply stop condition truncation reason
         if let Some(reason) = stop_eval.truncation_reason() {
@@ -435,6 +443,28 @@ mod tests {
 
         let report = profiler.analyze_file(temp_file.path())?;
         assert_eq!(report.column_profiles.len(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_memory_peak_is_populated() -> Result<()> {
+        // Regression for #419: memory_peak_mb was declared but never set,
+        // so every report shipped null for a headline instrumentation field.
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "id,value")?;
+        for i in 1..=100 {
+            writeln!(temp_file, "{},val_{}", i, i)?;
+        }
+        temp_file.flush()?;
+
+        let report = IncrementalProfiler::new().analyze_file(temp_file.path())?;
+
+        let peak = report
+            .execution
+            .memory_peak_mb
+            .expect("incremental engine must report peak memory");
+        assert!(peak > 0.0, "peak memory must be positive, got {peak}");
 
         Ok(())
     }

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -167,7 +167,6 @@ impl ArrowProfiler {
 
             total_rows += batch.num_rows();
             row_tracker.observe_batch(&batch);
-            memory_sampler.sample();
 
             // Process each column in the batch
             for (col_idx, column) in batch.columns().iter().enumerate() {
@@ -178,6 +177,11 @@ impl ArrowProfiler {
                     analyzer.process_array(column)?;
                 }
             }
+
+            // Sample after processing, while the batch and the analyzer state
+            // it grew are both resident, so per-batch allocation spikes count
+            // toward the peak.
+            memory_sampler.sample();
         }
 
         // Convert analyzers to column profiles and extract samples

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -4,7 +4,7 @@ use arrow::csv::ReaderBuilder;
 use arrow::datatypes::*;
 use dataprof_core::{
     ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata, FileFormat,
-    MetricPack, QualityDimension, SemanticHints, TruncationReason,
+    MetricPack, PeakMemorySampler, QualityDimension, SemanticHints, TruncationReason,
 };
 use dataprof_csv::CsvParserConfig;
 use dataprof_metrics::CardinalityEstimator;
@@ -148,6 +148,7 @@ impl ArrowProfiler {
         // count exact rather than rounding up to a batch boundary.
         let max_rows = self.csv_config.as_ref().and_then(|config| config.max_rows);
         let mut truncated = false;
+        let mut memory_sampler = PeakMemorySampler::new();
 
         for batch_result in csv_reader {
             let mut batch = batch_result.map_err(|error| map_arrow_csv_error(file_path, &error))?;
@@ -166,6 +167,7 @@ impl ArrowProfiler {
 
             total_rows += batch.num_rows();
             row_tracker.observe_batch(&batch);
+            memory_sampler.sample();
 
             // Process each column in the batch
             for (col_idx, column) in batch.columns().iter().enumerate() {
@@ -205,7 +207,11 @@ impl ArrowProfiler {
         let scan_time_ms = start.elapsed().as_millis();
         let num_columns = column_profiles.len();
 
+        memory_sampler.sample();
         let mut execution = ExecutionMetadata::new(total_rows, num_columns, scan_time_ms);
+        if let Some(peak_mb) = memory_sampler.peak_mb() {
+            execution = execution.with_memory_peak_mb(peak_mb);
+        }
         if truncated && let Some(max) = max_rows {
             execution = execution.with_truncation(TruncationReason::MaxRows(max as u64));
         }
@@ -874,6 +880,28 @@ mod tests {
             DataType::Integer,
             "age column should be detected as Integer"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_memory_peak_is_populated() -> Result<(), DataProfilerError> {
+        // Regression for #419: memory_peak_mb was declared but never set,
+        // so every report shipped null for a headline instrumentation field.
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "id,value")?;
+        for i in 1..=100 {
+            writeln!(temp_file, "{},val_{}", i, i)?;
+        }
+        temp_file.flush()?;
+
+        let report = ArrowProfiler::new().analyze_csv_file(temp_file.path())?;
+
+        let peak = report
+            .execution
+            .memory_peak_mb
+            .expect("columnar engine must report peak memory");
+        assert!(peak > 0.0, "peak memory must be positive, got {peak}");
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes #419: `ExecutionMetadata::with_memory_peak_mb` had zero callers, so `execution.memory_peak_mb` was `null` in every report ever produced — broken instrumentation in a product whose core claim is bounded memory.

## Changes

- **`dataprof-core`**: new `PeakMemorySampler` — samples the current process RSS via `sysinfo` (already a core dependency) and tracks the peak. Returns `None` when the platform gives no reading, preserving the *absent = not analyzed* contract instead of reporting zero.
- **`IncrementalProfiler`**: samples once per chunk plus a final sample; populates `memory_peak_mb`.
- **`ArrowProfiler` (columnar)**: samples once per record batch plus a final sample; populates `memory_peak_mb`.

The reading is whole-process RSS, so on embedded surfaces (Python extension) it includes host-process memory — documented on the sampler and the field as an upper bound suitable for verifying the bounded-memory claim, not exact attribution.

The Python surface already plumbs the field through (`report.memory_peak_mb`), so no binding changes were needed.

## Tests

- `test_memory_peak_is_populated` regression tests in both engines (per acceptance criteria)
- Sampler unit tests in core (positive reading, monotonic peak)
- Verified end-to-end through the public facade: Auto, Incremental, and Columnar engines all emit `memory_peak_mb` in the serialized JSON report

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test -p dataprof-core
cargo test -p dataprof-engines
cargo test -p dataprof-parquet --features arrow
cargo test -p dataprof --test cross_engine_consistency --test public_api_facade
```