### PR TITLE
fix(csv): quote-aware delimiter sniffer; absent delimiters can no longer win

### DIFF
--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -79,7 +79,7 @@ impl CsvParserConfig {
 }
 
 /// Count fields in a line for a given delimiter, respecting quoted sections.
-fn count_fields(line: &str, delimiter: char) -> usize {
+pub(crate) fn count_fields(line: &str, delimiter: char) -> usize {
     let mut count = 1;
     let mut in_quotes = false;
     let mut chars = line.chars().peekable();
@@ -97,55 +97,89 @@ fn count_fields(line: &str, delimiter: char) -> usize {
     count
 }
 
+/// Split raw CSV sample text into logical records, honoring quoted sections
+/// so an embedded newline inside quotes does not start a new record.
+fn split_sample_records(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut records = Vec::new();
+    let mut in_quotes = false;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                if in_quotes && bytes.get(i + 1) == Some(&b'"') {
+                    i += 1; // escaped quote inside a quoted section
+                } else {
+                    in_quotes = !in_quotes;
+                }
+            }
+            b'\n' if !in_quotes => {
+                let end = if i > start && bytes[i - 1] == b'\r' {
+                    i - 1
+                } else {
+                    i
+                };
+                records.push(&text[start..end]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if start < text.len() {
+        records.push(text[start..].trim_end_matches('\r'));
+    }
+    records
+}
+
 /// Detect the most likely CSV delimiter by sampling up to 4 KB of data.
 ///
-/// Tests comma, semicolon, tab, and pipe. Returns the delimiter that produces
-/// the most consistent field counts across the first 5 sample lines, preferring
-/// delimiters that yield more than one field.
+/// The sample is split into logical records with quote handling, so quoted
+/// fields containing embedded newlines or delimiter characters do not skew
+/// detection. Tests comma, semicolon, tab, and pipe over the first 5 records:
+/// a delimiter whose modal field count is greater than one always beats one
+/// that only ever yields single-field records, then higher record agreement
+/// and higher field counts win.
 ///
-/// Falls back to comma if no clear winner is found.
+/// Falls back to comma if no candidate splits the sample.
 pub fn detect_delimiter<R: Read>(reader: R) -> std::io::Result<u8> {
+    const SAMPLE_BYTES: u64 = 4096;
     let mut preamble = Vec::new();
-    let mut take = reader.take(4096);
+    let mut take = reader.take(SAMPLE_BYTES);
     take.read_to_end(&mut preamble)?;
+    let truncated = preamble.len() as u64 == SAMPLE_BYTES;
 
     let preamble_str = String::from_utf8_lossy(&preamble);
-    let lines: Vec<String> = preamble_str.lines().map(|line| line.to_string()).collect();
+    let mut records = split_sample_records(&preamble_str);
+    // A full sample buffer usually ends mid-record; never score a fragment.
+    if truncated && records.len() > 1 {
+        records.pop();
+    }
 
     let delimiters = *b",;\t|";
     let mut best_delimiter = b',';
-    let mut max_consistency = 0;
-    let mut max_fields = 0;
+    // (splits records into >1 field, records agreeing on the modal count,
+    //  modal field count) — compared lexicographically, first wins ties.
+    let mut best_score = (false, 0usize, 0usize);
 
     for &delimiter in &delimiters {
-        let delimiter_char = delimiter as char;
         let mut counts = std::collections::HashMap::new();
-        let mut total_fields = 0;
-
-        let sample_lines = std::cmp::min(lines.len(), 5);
-        for line in lines.iter().take(sample_lines) {
-            let count = count_fields(line, delimiter_char);
-            *counts.entry(count).or_insert(0) += 1;
-            total_fields += count;
+        for record in records.iter().take(5) {
+            let fields = count_fields(record, delimiter as char);
+            *counts.entry(fields).or_insert(0usize) += 1;
         }
 
-        // decode-audit: no-data — an empty sample scores 0 consistency for this
-        // delimiter candidate; nothing is fabricated.
-        let consistency = counts.values().max().copied().unwrap_or(0);
-        let avg_fields = total_fields.checked_div(sample_lines).unwrap_or(0);
+        // decode-audit: no-data — an empty sample scores 0 for this delimiter
+        // candidate; nothing is fabricated.
+        let (modal_fields, consistency) = counts
+            .into_iter()
+            .max_by_key(|&(fields, count)| (count, fields))
+            .unwrap_or((0, 0));
 
-        let should_update = if avg_fields > 1 && max_fields <= 1 {
-            true
-        } else if avg_fields <= 1 && max_fields > 1 {
-            false
-        } else {
-            consistency > max_consistency
-                || (consistency == max_consistency && avg_fields > max_fields)
-        };
-
-        if should_update {
-            max_consistency = consistency;
-            max_fields = avg_fields;
+        let score = (modal_fields > 1, consistency, modal_fields);
+        if score > best_score {
+            best_score = score;
             best_delimiter = delimiter;
         }
     }
@@ -628,5 +662,42 @@ mod tests {
     fn test_detect_delimiter_quoted_fields() {
         let data = b"name;desc;val\n\"hello;world\";foo;1\nbar;baz;2\n";
         assert_eq!(detect_delimiter(Cursor::new(data.as_ref())).unwrap(), b';');
+    }
+
+    #[test]
+    fn test_detect_delimiter_quoted_embedded_newline() {
+        // A quoted cell containing a newline must not break record splitting:
+        // before the quote-aware sniffer this file was detected as semicolon
+        // (zero occurrences, "perfectly consistent" single-field records) and
+        // profiled as a single column named "id,comment".
+        let data = b"id,comment\n1,\"line one\nline two\"\n2,\"normal\"\n3,\"has \"\"quotes\"\" inside\"\n";
+        assert_eq!(detect_delimiter(Cursor::new(data.as_ref())).unwrap(), b',');
+    }
+
+    #[test]
+    fn test_detect_delimiter_absent_candidate_never_beats_real_one() {
+        // One ragged record makes comma imperfect (consistency 3/4); an absent
+        // delimiter is uniformly single-field (4/4) and must still lose.
+        let data = b"a,b,c\n1,2,3\nragged line without delimiters\n4,5,6\n";
+        assert_eq!(detect_delimiter(Cursor::new(data.as_ref())).unwrap(), b',');
+    }
+
+    #[test]
+    fn test_detect_delimiter_single_column_falls_back_to_comma() {
+        let data = b"value\n1\n2\n3\n";
+        assert_eq!(detect_delimiter(Cursor::new(data.as_ref())).unwrap(), b',');
+    }
+
+    #[test]
+    fn test_detect_delimiter_two_column_semicolon_with_commas_in_text() {
+        // Free text containing commas must not outvote the true delimiter.
+        let data = b"id;note\n1;hello, world\n2;foo, bar, baz\n3;plain\n";
+        assert_eq!(detect_delimiter(Cursor::new(data.as_ref())).unwrap(), b';');
+    }
+
+    #[test]
+    fn test_split_sample_records_quote_aware() {
+        let records = split_sample_records("a,b\r\n1,\"x\ny\"\n2,z\n");
+        assert_eq!(records, vec!["a,b", "1,\"x\ny\"", "2,z"]);
     }
 }

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -99,7 +99,12 @@ pub(crate) fn count_fields(line: &str, delimiter: char) -> usize {
 
 /// Split raw CSV sample text into logical records, honoring quoted sections
 /// so an embedded newline inside quotes does not start a new record.
-fn split_sample_records(text: &str) -> Vec<&str> {
+///
+/// The returned flag is true when the final record was not terminated by a
+/// newline outside quotes — i.e. the text ends mid-record (or exactly at a
+/// record's end with no trailing newline, which a caller sampling a fixed
+/// byte budget cannot distinguish from a cut).
+fn split_sample_records(text: &str) -> (Vec<&str>, bool) {
     let bytes = text.as_bytes();
     let mut records = Vec::new();
     let mut in_quotes = false;
@@ -127,10 +132,11 @@ fn split_sample_records(text: &str) -> Vec<&str> {
         }
         i += 1;
     }
-    if start < text.len() {
+    let last_unterminated = start < text.len();
+    if last_unterminated {
         records.push(text[start..].trim_end_matches('\r'));
     }
-    records
+    (records, last_unterminated)
 }
 
 /// Detect the most likely CSV delimiter by sampling up to 4 KB of data.
@@ -151,9 +157,10 @@ pub fn detect_delimiter<R: Read>(reader: R) -> std::io::Result<u8> {
     let truncated = preamble.len() as u64 == SAMPLE_BYTES;
 
     let preamble_str = String::from_utf8_lossy(&preamble);
-    let mut records = split_sample_records(&preamble_str);
-    // A full sample buffer usually ends mid-record; never score a fragment.
-    if truncated && records.len() > 1 {
+    let (mut records, last_unterminated) = split_sample_records(&preamble_str);
+    // A full sample buffer that ends mid-record leaves a fragment; never score
+    // it. A sample ending on a clean newline keeps all its records.
+    if truncated && last_unterminated && records.len() > 1 {
         records.pop();
     }
 
@@ -697,7 +704,31 @@ mod tests {
 
     #[test]
     fn test_split_sample_records_quote_aware() {
-        let records = split_sample_records("a,b\r\n1,\"x\ny\"\n2,z\n");
+        let (records, last_unterminated) = split_sample_records("a,b\r\n1,\"x\ny\"\n2,z\n");
         assert_eq!(records, vec!["a,b", "1,\"x\ny\"", "2,z"]);
+        assert!(!last_unterminated);
+
+        let (records, last_unterminated) = split_sample_records("a,b\n1,\"cut mid-fie");
+        assert_eq!(records, vec!["a,b", "1,\"cut mid-fie"]);
+        assert!(last_unterminated);
+    }
+
+    #[test]
+    fn test_detect_delimiter_full_sample_ending_on_record_boundary() {
+        // Exactly 4096 bytes ending with a clean newline: the final record is
+        // complete and must be scored, not dropped as a fragment.
+        let mut data = Vec::from(&b"a;b;c\n"[..]);
+        while data.len() < 4090 {
+            data.extend_from_slice(b"1;2;3\n");
+        }
+        while data.len() < 4095 {
+            data.push(b'#');
+        }
+        data.push(b'\n');
+        assert_eq!(data.len(), 4096);
+        assert_eq!(
+            detect_delimiter(Cursor::new(data.as_slice())).unwrap(),
+            b';'
+        );
     }
 }

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -260,103 +260,11 @@ impl RobustCsvParser {
     }
 
     /// Detect delimiter by sampling the file.
+    ///
+    /// Delegates to the shared quote-aware sniffer so both parsers agree on
+    /// the delimiter for the same file.
     pub fn detect_delimiter(&self, file_path: &Path) -> Result<u8> {
-        let file = std::fs::File::open(file_path)?;
-        let reader = BufReader::new(file);
-
-        let mut lines = Vec::new();
-        for (index, line) in reader.lines().enumerate() {
-            if index >= 5 {
-                break;
-            }
-            lines.push(line?);
-        }
-
-        let delimiters = *b",;\t|";
-        let mut best_delimiter = b',';
-        let mut max_consistency = 0;
-        let mut max_field_count = 0;
-
-        for &delimiter in &delimiters {
-            let consistency = self.measure_delimiter_consistency(&lines, delimiter);
-            let avg_field_count = self.average_field_count(&lines, delimiter);
-
-            let should_update = if avg_field_count > 1 && max_field_count <= 1 {
-                true
-            } else if avg_field_count <= 1 && max_field_count > 1 {
-                false
-            } else {
-                consistency > max_consistency
-                    || (consistency == max_consistency && avg_field_count > max_field_count)
-            };
-
-            if should_update {
-                max_consistency = consistency;
-                max_field_count = avg_field_count;
-                best_delimiter = delimiter;
-            }
-        }
-
-        Ok(best_delimiter)
-    }
-
-    fn measure_delimiter_consistency(&self, lines: &[String], delimiter: u8) -> usize {
-        if lines.is_empty() {
-            return 0;
-        }
-
-        let delimiter_char = delimiter as char;
-        let field_counts: Vec<usize> = lines
-            .iter()
-            .map(|line| self.count_fields_simple(line, delimiter_char))
-            .collect();
-
-        let mut counts = std::collections::HashMap::new();
-        for &count in &field_counts {
-            *counts.entry(count).or_insert(0) += 1;
-        }
-
-        // decode-audit: no-data — an empty sample scores 0 consistency for this
-        // delimiter candidate; nothing is fabricated.
-        counts.values().max().copied().unwrap_or(0)
-    }
-
-    fn average_field_count(&self, lines: &[String], delimiter: u8) -> usize {
-        if lines.is_empty() {
-            return 0;
-        }
-
-        let delimiter_char = delimiter as char;
-        let total_fields: usize = lines
-            .iter()
-            .map(|line| self.count_fields_simple(line, delimiter_char))
-            .sum();
-
-        total_fields / lines.len()
-    }
-
-    fn count_fields_simple(&self, line: &str, delimiter: char) -> usize {
-        let mut field_count = 1;
-        let mut in_quotes = false;
-        let mut chars = line.chars().peekable();
-
-        while let Some(ch) = chars.next() {
-            match ch {
-                '"' => {
-                    if chars.peek() == Some(&'"') {
-                        chars.next();
-                    } else {
-                        in_quotes = !in_quotes;
-                    }
-                }
-                current if current == delimiter && !in_quotes => {
-                    field_count += 1;
-                }
-                _ => {}
-            }
-        }
-
-        field_count
+        Ok(crate::detect_delimiter_from_path(file_path)?)
     }
 
     /// Parse CSV with robust error handling.
@@ -574,7 +482,7 @@ impl RobustCsvParser {
             }
 
             let delimiter = self.delimiter.unwrap_or(b',') as char;
-            let field_count = self.count_fields_simple(&line, delimiter);
+            let field_count = crate::count_fields(&line, delimiter);
             *field_counts.entry(field_count).or_insert(0) += 1;
 
             diagnostics.total_lines += 1;


### PR DESCRIPTION
## Summary

Fixes #423.

The delimiter sniffer split its 4 KB sample on raw newlines, so a quoted cell containing an embedded newline corrupted per-record field counts: comma scored 4/5 consistency while semicolon — which never appears and therefore yields a "perfectly consistent" one field per record — scored 5/5 and won. Valid CSV was profiled as a single column named `id,comment` at quality 100%, through every engine.

## Changes

- `split_sample_records`: quote-aware record splitting for the sample (handles `""` escapes, CRLF, embedded newlines).
- Scoring is now the lexicographic tuple `(modal field count > 1, records agreeing on modal count, modal field count)` — a delimiter that never splits a record can no longer beat one that does, and the old integer-division `avg_fields` guard (which never fired for 2-column files) is gone.
- The trailing record is dropped when the sample budget fills, so a mid-record cut is never scored.
- `RobustCsvParser::detect_delimiter` now delegates to the shared sniffer instead of maintaining a near-copy with the same flaws; its `count_fields_simple` is replaced by the shared `count_fields`.

## Tests

- `cargo test -p dataprof-csv` (34 passed; 6 new sniffer/record-split tests, including the quoted-newline repro and the absent-delimiter-vs-ragged case)
- `cargo test -p dataprof -p dataprof-partial`
- `cargo clippy --all --all-targets -- -D warnings`, `cargo fmt`
- End-to-end via `uv run maturin develop`: the repro file now profiles as `id, comment` / 3 rows; messy/ragged/semicolon/wide fixtures unchanged.
