### PR TITLE
fix(metrics): base numeric stats from exact accumulators; disclose sampled order statistics

### DIFF
--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -517,6 +517,8 @@ impl ColumnAnalyzer {
                 // Utf8 columns often carry numeric content (the Arrow CSV
                 // reader may deliver strings): keep the exact accumulators
                 // fed so numeric stats never fall back to the sample.
+                // decode-audit: no-data — a cell that does not parse is a
+                // non-numeric value, excluded from numeric stats by design.
                 if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }
@@ -541,6 +543,8 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
+                // decode-audit: no-data — a cell that does not parse is a
+                // non-numeric value, excluded from numeric stats by design.
                 if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -10,7 +10,8 @@ use dataprof_csv::CsvParserConfig;
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::{infer_type, is_null_like_token};
 use dataprof_runtime::{
-    ColumnProfileInput, ProfileReport, ReportAssembler, TextLengths, build_column_profile,
+    ColumnProfileInput, ExactNumericAggregates, ProfileReport, ReportAssembler,
+    StreamReservoirSampler, TextLengths, build_column_profile,
 };
 use std::fs::File;
 use std::path::Path;
@@ -281,6 +282,7 @@ struct ColumnAnalyzer {
     max_value: Option<f64>,
     sum: f64,
     sum_squares: f64,
+    numeric_count: usize,
     // Text statistics
     min_length: usize,
     max_length: usize,
@@ -288,8 +290,8 @@ struct ColumnAnalyzer {
     // Boolean statistics
     true_count: usize,
     false_count: usize,
-    // Sample values for pattern detection
-    sample_values: Vec<String>,
+    // Reservoir sample for pattern detection and order statistics
+    sample_values: StreamReservoirSampler,
 }
 
 impl ColumnAnalyzer {
@@ -303,12 +305,13 @@ impl ColumnAnalyzer {
             max_value: None,
             sum: 0.0,
             sum_squares: 0.0,
+            numeric_count: 0,
             min_length: usize::MAX,
             max_length: 0,
             total_length: 0,
             true_count: 0,
             false_count: 0,
-            sample_values: Vec::new(),
+            sample_values: StreamReservoirSampler::new(NUMERIC_SAMPLE_CAP),
         }
     }
 
@@ -454,9 +457,7 @@ impl ColumnAnalyzer {
                 self.cardinality.insert_owned(value.to_string());
 
                 // Keep samples for pattern detection
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -470,9 +471,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert_owned(value.to_string());
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -486,9 +485,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert_owned(value.to_string());
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -502,9 +499,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert_owned(value.to_string());
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -519,12 +514,16 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
+                // Utf8 columns often carry numeric content (the Arrow CSV
+                // reader may deliver strings): keep the exact accumulators
+                // fed so numeric stats never fall back to the sample.
+                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                    self.update_numeric_stats(number);
+                }
 
                 self.cardinality.insert(value);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -542,12 +541,13 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
+                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                    self.update_numeric_stats(number);
+                }
 
                 self.cardinality.insert(value);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -566,9 +566,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(value_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value_str.to_string());
-                }
+                self.sample_values.offer(value_str.to_string());
             }
         }
         Ok(())
@@ -583,9 +581,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&date_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(date_str);
-                }
+                self.sample_values.offer(date_str);
             }
         }
         Ok(())
@@ -600,9 +596,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&date_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(date_str);
-                }
+                self.sample_values.offer(date_str);
             }
         }
         Ok(())
@@ -619,9 +613,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&ts_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(ts_str);
-                }
+                self.sample_values.offer(ts_str);
             }
         }
         Ok(())
@@ -638,9 +630,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&ts_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(ts_str);
-                }
+                self.sample_values.offer(ts_str);
             }
         }
         Ok(())
@@ -657,9 +647,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&ts_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(ts_str);
-                }
+                self.sample_values.offer(ts_str);
             }
         }
         Ok(())
@@ -676,9 +664,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&ts_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(ts_str);
-                }
+                self.sample_values.offer(ts_str);
             }
         }
         Ok(())
@@ -701,9 +687,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&hex_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(hex_str);
-                }
+                self.sample_values.offer(hex_str);
             }
         }
         Ok(())
@@ -729,9 +713,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&hex_str);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(hex_str);
-                }
+                self.sample_values.offer(hex_str);
             }
         }
         Ok(())
@@ -748,9 +730,7 @@ impl ColumnAnalyzer {
                     .unwrap_or_else(|_| format!("<type:{}>", array.data_type()));
                 self.update_text_stats(&value);
 
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.clone());
-                }
+                self.sample_values.offer(value.clone());
 
                 self.cardinality.insert_owned(value);
             }
@@ -761,6 +741,7 @@ impl ColumnAnalyzer {
     fn update_numeric_stats(&mut self, value: f64) {
         self.sum += value;
         self.sum_squares += value * value;
+        self.numeric_count += 1;
 
         self.min_value = Some(match self.min_value {
             Some(min) => min.min(value),
@@ -771,6 +752,32 @@ impl ColumnAnalyzer {
             Some(max) => max.max(value),
             None => value,
         });
+    }
+
+    /// Exact aggregates over every numeric value processed, independent of the
+    /// bounded reservoir sample. `None` when the column saw no numeric values.
+    fn exact_numeric_aggregates(&self) -> Option<ExactNumericAggregates> {
+        let (min, max) = (self.min_value?, self.max_value?);
+        if self.numeric_count == 0 {
+            return None;
+        }
+        let mean = self.sum / self.numeric_count as f64;
+        // Clamp: sum-of-squares variance can go slightly negative from
+        // floating-point cancellation.
+        let variance = dataprof_metrics::stats::numeric::calculate_variance(
+            self.sum_squares,
+            self.sum,
+            self.numeric_count,
+        )
+        .max(0.0);
+        Some(ExactNumericAggregates {
+            min,
+            max,
+            mean,
+            std_dev: variance.sqrt(),
+            variance,
+            count: self.numeric_count,
+        })
     }
 
     fn update_text_stats(&mut self, value: &str) {
@@ -806,7 +813,7 @@ impl ColumnAnalyzer {
             null_count: self.null_count,
             unique_count: Some(self.cardinality.estimate()),
             unique_count_is_approximate: Some(self.cardinality.is_approximate()),
-            sample_values: &self.sample_values,
+            sample_values: self.sample_values.samples(),
             text_lengths: Some(TextLengths {
                 min_length: self.min_length,
                 max_length: self.max_length,
@@ -820,6 +827,7 @@ impl ColumnAnalyzer {
             skip_statistics,
             skip_patterns,
             locale,
+            exact_numeric: self.exact_numeric_aggregates(),
         })
     }
 
@@ -836,7 +844,7 @@ impl ColumnAnalyzer {
             arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8 => {
                 // Reuse the shared inference logic for consistent type detection
                 // across all engines (dates before numerics, 100% match threshold)
-                infer_type(&self.sample_values)
+                infer_type(self.sample_values.samples())
             }
             _ => DataType::String,
         }
@@ -844,7 +852,7 @@ impl ColumnAnalyzer {
 
     /// Get collected sample values for quality metrics calculation
     fn get_sample_values(&self) -> Vec<String> {
-        self.sample_values.clone()
+        self.sample_values.samples().to_vec()
     }
 }
 

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -531,6 +531,8 @@ impl ColumnAnalyzer {
                 // Utf8 columns often carry numeric content (the Arrow CSV
                 // reader may deliver strings): keep the exact accumulators
                 // fed so numeric stats never fall back to the sample.
+                // decode-audit: no-data — a cell that does not parse is a
+                // non-numeric value, excluded from numeric stats by design.
                 if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }
@@ -550,6 +552,8 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
+                // decode-audit: no-data — a cell that does not parse is a
+                // non-numeric value, excluded from numeric stats by design.
                 if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -9,7 +9,8 @@ use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{RowDuplicateSummary, infer_type};
 use dataprof_runtime::{
-    ColumnProfileInput, RowUniquenessTracker, TextLengths, build_column_profile,
+    ColumnProfileInput, ExactNumericAggregates, RowUniquenessTracker, StreamReservoirSampler,
+    TextLengths, build_column_profile,
 };
 use std::collections::HashMap;
 use std::fmt::Write as _;
@@ -179,7 +180,7 @@ impl RecordBatchAnalyzer {
     pub fn create_sample_columns(&self) -> HashMap<String, Vec<String>> {
         let mut samples = HashMap::new();
         for (name, analyzer) in &self.column_analyzers {
-            samples.insert(name.clone(), analyzer.sample_values.clone());
+            samples.insert(name.clone(), analyzer.sample_values.samples().to_vec());
         }
         samples
     }
@@ -200,12 +201,13 @@ pub struct ColumnAnalyzer {
     max_value: Option<f64>,
     sum: f64,
     sum_squares: f64,
+    numeric_count: usize,
     min_length: usize,
     max_length: usize,
     total_length: usize,
     true_count: usize,
     false_count: usize,
-    sample_values: Vec<String>,
+    sample_values: StreamReservoirSampler,
 }
 
 impl ColumnAnalyzer {
@@ -219,12 +221,13 @@ impl ColumnAnalyzer {
             max_value: None,
             sum: 0.0,
             sum_squares: 0.0,
+            numeric_count: 0,
             min_length: usize::MAX,
             max_length: 0,
             total_length: 0,
             true_count: 0,
             false_count: 0,
-            sample_values: Vec::new(),
+            sample_values: StreamReservoirSampler::new(NUMERIC_SAMPLE_CAP),
         }
     }
 
@@ -393,9 +396,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 self.update_numeric_stats(value);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -408,9 +409,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -423,9 +422,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -438,9 +435,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -453,9 +448,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -468,9 +461,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -483,9 +474,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -498,9 +487,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -513,9 +500,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -528,9 +513,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
-                }
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -545,10 +528,14 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
-                self.cardinality.insert(value);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
+                // Utf8 columns often carry numeric content (the Arrow CSV
+                // reader may deliver strings): keep the exact accumulators
+                // fed so numeric stats never fall back to the sample.
+                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                    self.update_numeric_stats(number);
                 }
+                self.cardinality.insert(value);
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -563,10 +550,11 @@ impl ColumnAnalyzer {
                     continue;
                 }
                 self.update_text_stats(value);
-                self.cardinality.insert(value);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value.to_string());
+                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                    self.update_numeric_stats(number);
                 }
+                self.cardinality.insert(value);
+                self.sample_values.offer(value.to_string());
             }
         }
         Ok(())
@@ -583,9 +571,7 @@ impl ColumnAnalyzer {
                 }
                 let value_str = if value { "True" } else { "False" };
                 self.cardinality.insert(value_str);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(value_str.to_string());
-                }
+                self.sample_values.offer(value_str.to_string());
             }
         }
         Ok(())
@@ -598,9 +584,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(days as f64);
                 let date_str = format!("1970-01-01+{}days", days);
                 self.cardinality.insert(&date_str);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(date_str);
-                }
+                self.sample_values.offer(date_str);
             }
         }
         Ok(())
@@ -613,9 +597,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(millis as f64);
                 let datetime_str = format!("1970-01-01T00:00:00.000+{}ms", millis);
                 self.cardinality.insert(&datetime_str);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(datetime_str);
-                }
+                self.sample_values.offer(datetime_str);
             }
         }
         Ok(())
@@ -634,9 +616,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(ts_str);
-                    }
+                    self.sample_values.offer(ts_str);
                 }
             }
         } else if let Some(ts_array) = array
@@ -649,9 +629,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(ts_str);
-                    }
+                    self.sample_values.offer(ts_str);
                 }
             }
         } else if let Some(ts_array) = array
@@ -664,9 +642,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(ts_str);
-                    }
+                    self.sample_values.offer(ts_str);
                 }
             }
         } else if let Some(ts_array) = array
@@ -679,9 +655,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(ts_str);
-                    }
+                    self.sample_values.offer(ts_str);
                 }
             }
         }
@@ -696,9 +670,7 @@ impl ColumnAnalyzer {
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
                 self.cardinality.insert_owned(format!("len:{}", len));
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(format!("<binary:{} bytes>", len));
-                }
+                self.sample_values.offer(format!("<binary:{} bytes>", len));
             }
         }
         Ok(())
@@ -711,9 +683,7 @@ impl ColumnAnalyzer {
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
                 self.cardinality.insert_owned(format!("len:{}", len));
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(format!("<binary:{} bytes>", len));
-                }
+                self.sample_values.offer(format!("<binary:{} bytes>", len));
             }
         }
         Ok(())
@@ -726,9 +696,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(decimal_value as f64);
                 let decimal_str = format!("dec128:{}", decimal_value);
                 self.cardinality.insert(&decimal_str);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(decimal_str);
-                }
+                self.sample_values.offer(decimal_str);
             }
         }
         Ok(())
@@ -740,9 +708,7 @@ impl ColumnAnalyzer {
                 let decimal_str = format!("dec256:value_{}", index);
                 self.update_text_stats(&decimal_str);
                 self.cardinality.insert(&decimal_str);
-                if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                    self.sample_values.push(decimal_str);
-                }
+                self.sample_values.offer(decimal_str);
             }
         }
         Ok(())
@@ -761,9 +727,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}ns", dur_value);
                     self.cardinality.insert(&dur_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(dur_str);
-                    }
+                    self.sample_values.offer(dur_str);
                 }
             }
         } else if let Some(dur_array) = array
@@ -776,9 +740,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}us", dur_value);
                     self.cardinality.insert(&dur_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(dur_str);
-                    }
+                    self.sample_values.offer(dur_str);
                 }
             }
         } else if let Some(dur_array) = array
@@ -791,9 +753,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}ms", dur_value);
                     self.cardinality.insert(&dur_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(dur_str);
-                    }
+                    self.sample_values.offer(dur_str);
                 }
             }
         } else if let Some(dur_array) = array
@@ -806,9 +766,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}s", dur_value);
                     self.cardinality.insert(&dur_str);
-                    if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                        self.sample_values.push(dur_str);
-                    }
+                    self.sample_values.offer(dur_str);
                 }
             }
         }
@@ -823,9 +781,7 @@ impl ColumnAnalyzer {
                     if !array.is_null(index) {
                         let value_str = formatter.value(index).to_string();
                         self.update_text_stats(&value_str);
-                        if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                            self.sample_values.push(value_str.clone());
-                        }
+                        self.sample_values.offer(value_str.clone());
                         self.cardinality.insert_owned(value_str);
                     }
                 }
@@ -835,9 +791,7 @@ impl ColumnAnalyzer {
                     if !array.is_null(index) {
                         let value_str = format!("<{}:value_{}>", array.data_type(), index);
                         self.update_text_stats(&value_str);
-                        if self.sample_values.len() < NUMERIC_SAMPLE_CAP {
-                            self.sample_values.push(value_str.clone());
-                        }
+                        self.sample_values.offer(value_str.clone());
                         self.cardinality.insert_owned(value_str);
                     }
                 }
@@ -849,6 +803,7 @@ impl ColumnAnalyzer {
     fn update_numeric_stats(&mut self, value: f64) {
         self.sum += value;
         self.sum_squares += value * value;
+        self.numeric_count += 1;
 
         self.min_value = Some(match self.min_value {
             Some(min_value) => min_value.min(value),
@@ -859,6 +814,32 @@ impl ColumnAnalyzer {
             Some(max_value) => max_value.max(value),
             None => value,
         });
+    }
+
+    /// Exact aggregates over every numeric value processed, independent of the
+    /// bounded reservoir sample. `None` when the column saw no numeric values.
+    fn exact_numeric_aggregates(&self) -> Option<ExactNumericAggregates> {
+        let (min, max) = (self.min_value?, self.max_value?);
+        if self.numeric_count == 0 {
+            return None;
+        }
+        let mean = self.sum / self.numeric_count as f64;
+        // Clamp: sum-of-squares variance can go slightly negative from
+        // floating-point cancellation.
+        let variance = dataprof_metrics::stats::numeric::calculate_variance(
+            self.sum_squares,
+            self.sum,
+            self.numeric_count,
+        )
+        .max(0.0);
+        Some(ExactNumericAggregates {
+            min,
+            max,
+            mean,
+            std_dev: variance.sqrt(),
+            variance,
+            count: self.numeric_count,
+        })
     }
 
     fn update_text_stats(&mut self, value: &str) {
@@ -894,7 +875,7 @@ impl ColumnAnalyzer {
             null_count: self.null_count,
             unique_count: Some(self.cardinality.estimate()),
             unique_count_is_approximate: Some(self.cardinality.is_approximate()),
-            sample_values: &self.sample_values,
+            sample_values: self.sample_values.samples(),
             text_lengths: Some(TextLengths {
                 min_length: self.min_length,
                 max_length: self.max_length,
@@ -908,6 +889,7 @@ impl ColumnAnalyzer {
             skip_statistics,
             skip_patterns,
             locale,
+            exact_numeric: self.exact_numeric_aggregates(),
         })
     }
 
@@ -932,7 +914,7 @@ impl ColumnAnalyzer {
             arrow::datatypes::DataType::Duration(_) => DataType::Integer,
             arrow::datatypes::DataType::Boolean => DataType::Boolean,
             arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8 => {
-                infer_type(&self.sample_values)
+                infer_type(self.sample_values.samples())
             }
             _ => DataType::String,
         }

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -127,6 +127,9 @@ pub fn profile_columns(
                 skip_statistics,
                 skip_patterns,
                 locale,
+                // `present` is the full column, so the sample-derived stats
+                // are already exact.
+                exact_numeric: None,
             }));
 
             if include_quality {

--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -13,13 +13,13 @@ pub use async_source::ReqwestSource;
 pub use async_source::{AsyncDataSource, AsyncSourceInfo, BytesSource};
 pub use memory_config::MemoryConfig;
 pub use profile_builder::{
-    ColumnProfileInput, TextLengths, build_column_profile, infer_data_type_streaming,
-    profile_from_stats, profile_from_stats_with_hints, profiles_from_streaming,
-    profiles_from_streaming_with_hints, quality_check_samples,
+    ColumnProfileInput, ExactNumericAggregates, TextLengths, build_column_profile,
+    infer_data_type_streaming, profile_from_stats, profile_from_stats_with_hints,
+    profiles_from_streaming, profiles_from_streaming_with_hints, quality_check_samples,
 };
 pub use profile_report::{ProfileReport, REPORT_SCHEMA_VERSION};
 pub use report_assembler::ReportAssembler;
 pub use streaming_stats::{
-    RowUniquenessTracker, StreamingColumnCollection, StreamingStatistics, TextLengthStats,
-    WelfordAccumulator,
+    RowUniquenessTracker, StreamReservoirSampler, StreamingColumnCollection, StreamingStatistics,
+    TextLengthStats, WelfordAccumulator,
 };

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -52,7 +52,7 @@ pub struct ColumnProfileInput<'a> {
     pub exact_numeric: Option<ExactNumericAggregates>,
 }
 
-/// Exact streaming aggregates for a numeric column: O(1)-memory statistics an
+/// Exact streaming aggregates for a numeric column: O(1)-memory statistics that an
 /// engine computed over the entire stream, as opposed to the bounded
 /// `sample_values` it retained.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -13,7 +13,8 @@ use dataprof_core::{
 use dataprof_metrics::{
     analysis::inference::{is_null_like_token, parse_strict_boolean_token},
     analysis::patterns::looks_like_date,
-    calculate_datetime_stats, calculate_numeric_stats, calculate_text_stats, detect_patterns,
+    calculate_datetime_stats, calculate_text_stats, detect_patterns,
+    stats::numeric::{calculate_coefficient_of_variation, compute_numeric_stats},
 };
 
 use crate::streaming_stats::{StreamingColumnCollection, StreamingStatistics};
@@ -41,6 +42,30 @@ pub struct ColumnProfileInput<'a> {
     pub skip_patterns: bool,
     /// Optional locale for pattern detection (e.g. "IT", "US").
     pub locale: Option<&'a str>,
+    /// Exact aggregates over every numeric value the engine streamed.
+    ///
+    /// When present, these override the sample-derived `min`, `max`, `mean`,
+    /// `std_dev`, and `variance` on numeric columns, so those fields stay
+    /// exact even when `sample_values` no longer covers the full stream.
+    /// `None` means `sample_values` *is* the full data (in-memory sources)
+    /// or the engine has no exact accumulators for the column.
+    pub exact_numeric: Option<ExactNumericAggregates>,
+}
+
+/// Exact streaming aggregates for a numeric column: O(1)-memory statistics an
+/// engine computed over the entire stream, as opposed to the bounded
+/// `sample_values` it retained.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ExactNumericAggregates {
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    /// Standard deviation with the unbiased (n-1) denominator.
+    pub std_dev: f64,
+    /// Variance with the unbiased (n-1) denominator.
+    pub variance: f64,
+    /// Number of parsed numeric values covered by these aggregates.
+    pub count: usize,
 }
 
 /// Pre-computed text length stats from streaming/columnar engines.
@@ -61,7 +86,31 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
         ColumnStats::None
     } else {
         match input.data_type {
-            DataType::Integer | DataType::Float => calculate_numeric_stats(input.sample_values),
+            DataType::Integer | DataType::Float => {
+                let mut numeric = compute_numeric_stats(input.sample_values);
+                if let Some(exact) = &input.exact_numeric {
+                    numeric.min = exact.min;
+                    numeric.max = exact.max;
+                    numeric.mean = exact.mean;
+                    numeric.std_dev = exact.std_dev;
+                    numeric.variance = exact.variance;
+                    numeric.coefficient_of_variation =
+                        calculate_coefficient_of_variation(exact.std_dev, exact.mean);
+                    // Order statistics (median, quartiles, mode, skewness,
+                    // kurtosis, outliers) still come from the retained sample;
+                    // disclose that whenever the sample no longer covers every
+                    // numeric value the exact aggregates saw.
+                    let sampled_numeric = input
+                        .sample_values
+                        .iter()
+                        .filter(|s| s.parse::<f64>().ok().is_some_and(|v| v.is_finite()))
+                        .count();
+                    if exact.count > sampled_numeric {
+                        numeric.is_approximate = Some(true);
+                    }
+                }
+                ColumnStats::Numeric(numeric)
+            }
             DataType::Date => {
                 if !input.sample_values.is_empty() {
                     calculate_datetime_stats(input.sample_values)
@@ -227,6 +276,7 @@ pub fn profile_from_stats_with_hints(
         skip_statistics,
         skip_patterns,
         locale,
+        exact_numeric: stats.exact_numeric_aggregates(),
     })
 }
 
@@ -352,6 +402,7 @@ mod tests {
             boolean_counts: Some((2, 1)),
             skip_statistics: false,
             skip_patterns: false,
+            exact_numeric: None,
             locale: None,
         });
 
@@ -384,6 +435,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: false,
             skip_patterns: false,
+            exact_numeric: None,
             locale: None,
         });
 
@@ -412,6 +464,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: true,
             skip_patterns: false,
+            exact_numeric: None,
             locale: None,
         });
 
@@ -434,6 +487,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: false,
             skip_patterns: true,
+            exact_numeric: None,
             locale: None,
         });
 
@@ -461,6 +515,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: false,
             skip_patterns: false,
+            exact_numeric: None,
             locale: None,
         });
 
@@ -482,6 +537,7 @@ mod tests {
             boolean_counts: None,
             skip_statistics: false,
             skip_patterns: false,
+            exact_numeric: None,
             locale: None,
         });
 

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -46,6 +46,12 @@ impl WelfordAccumulator {
         if self.count == 0 { 0.0 } else { self.mean }
     }
 
+    /// Number of values folded into this accumulator.
+    #[inline]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
     pub fn variance(&self) -> f64 {
         if self.count < 2 {
             0.0
@@ -56,6 +62,21 @@ impl WelfordAccumulator {
 
     pub fn std_dev(&self) -> f64 {
         self.variance().sqrt()
+    }
+
+    /// Unbiased sample variance (n-1 denominator), matching the convention of
+    /// the batch numeric stats in `dataprof-metrics`.
+    pub fn sample_variance(&self) -> f64 {
+        if self.count < 2 {
+            0.0
+        } else {
+            (self.m2 / (self.count - 1) as f64).max(0.0)
+        }
+    }
+
+    /// Standard deviation derived from [`Self::sample_variance`].
+    pub fn sample_std_dev(&self) -> f64 {
+        self.sample_variance().sqrt()
     }
 
     pub fn merge(&mut self, other: &WelfordAccumulator) {
@@ -87,7 +108,7 @@ impl Default for WelfordAccumulator {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct StreamReservoirSampler {
+pub struct StreamReservoirSampler {
     reservoir: Vec<String>,
     capacity: usize,
     count: u64,
@@ -338,6 +359,29 @@ impl StreamingStatistics {
 
     pub fn sample_values(&self) -> &[String] {
         self.sampler.samples()
+    }
+
+    /// Exact aggregates over every numeric value this column has streamed,
+    /// or `None` when no value parsed as a finite number.
+    ///
+    /// These come from the O(1)-memory min/max fields and the Welford
+    /// accumulator, so they cover the full stream even when the reservoir
+    /// sample no longer does.
+    pub fn exact_numeric_aggregates(
+        &self,
+    ) -> Option<crate::profile_builder::ExactNumericAggregates> {
+        let count = self.welford.count();
+        if count == 0 {
+            return None;
+        }
+        Some(crate::profile_builder::ExactNumericAggregates {
+            min: self.min,
+            max: self.max,
+            mean: self.welford.mean(),
+            std_dev: self.welford.sample_std_dev(),
+            variance: self.welford.sample_variance(),
+            count: count as usize,
+        })
     }
 
     pub fn text_length_stats(&self) -> TextLengthStats {

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -119,6 +119,7 @@ impl StreamReservoirSampler {
     const DEFAULT_SEED: u64 = 0xDA7A_900D_F00D_5EED;
 
     pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
         Self {
             reservoir: Vec::with_capacity(capacity.min(1024)),
             capacity,
@@ -810,6 +811,14 @@ mod tests {
         }
 
         assert_eq!(left.samples(), right.samples());
+    }
+
+    #[test]
+    fn test_reservoir_zero_capacity_still_retains_a_sample() {
+        let mut sampler = StreamReservoirSampler::new(0);
+        sampler.offer("value".to_string());
+
+        assert_eq!(sampler.samples(), ["value"]);
     }
 
     #[test]

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -12,6 +12,106 @@ use dataprof::{
 use dataprof::{EngineType, Profiler};
 use tempfile::NamedTempFile;
 
+/// 30k rows of *sorted* values — larger than the 10k per-column sample
+/// reservoirs, so any engine that derives base statistics from its retained
+/// sample (or samples a biased prefix) reports wildly wrong min/max/mean.
+fn create_sorted_30k_csv() -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "id,value").unwrap();
+    for i in 0..30_000 {
+        writeln!(f, "{},{:.2}", i, i as f64 / 2.0).unwrap();
+    }
+    f.flush().unwrap();
+    f
+}
+
+/// Base numeric statistics must be exact — computed over every value, not the
+/// bounded sample — and identical across engines, even when the data is
+/// sorted and larger than the sample capacity (#424).
+#[test]
+fn test_base_numeric_stats_exact_beyond_sample_capacity() {
+    let csv = create_sorted_30k_csv();
+    let path = csv.path();
+
+    let std_report = analyze_csv_file(path, &CsvParserConfig::default())
+        .expect("standard CSV analysis should succeed");
+    let arrow_report = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(path)
+        .expect("Arrow CSV analysis should succeed");
+
+    for (engine, report) in [("std", &std_report), ("arrow", &arrow_report)] {
+        let id = report
+            .column_profiles
+            .iter()
+            .find(|c| c.name == "id")
+            .expect("id column");
+        let ColumnStats::Numeric(n) = &id.stats else {
+            panic!("id should have numeric stats");
+        };
+        // Exact analytical values for 0..=29999.
+        assert_eq!(n.min, 0.0, "[{engine}] min must be exact");
+        assert_eq!(n.max, 29_999.0, "[{engine}] max must be exact");
+        assert!(
+            (n.mean - 14_999.5).abs() < 1e-6,
+            "[{engine}] mean must be exact, got {}",
+            n.mean
+        );
+        // Order statistics come from a 10k sample out of 30k values, and the
+        // report must say so.
+        assert_eq!(
+            n.is_approximate,
+            Some(true),
+            "[{engine}] sampled order statistics must be disclosed as approximate"
+        );
+    }
+
+    // And the two engines must agree with each other exactly on base stats.
+    for name in ["id", "value"] {
+        let get = |r: &dataprof::ProfileReport| {
+            let col = r.column_profiles.iter().find(|c| c.name == name).unwrap();
+            match &col.stats {
+                ColumnStats::Numeric(n) => (n.min, n.max, n.mean, n.std_dev),
+                other => panic!("'{name}' should be numeric, got {other:?}"),
+            }
+        };
+        let (min1, max1, mean1, std1) = get(&std_report);
+        let (min2, max2, mean2, std2) = get(&arrow_report);
+        assert_eq!(min1, min2, "'{name}' min must match across engines");
+        assert_eq!(max1, max2, "'{name}' max must match across engines");
+        assert!(
+            (mean1 - mean2).abs() < 1e-9,
+            "'{name}' mean: {mean1} vs {mean2}"
+        );
+        assert!(
+            (std1 - std2).abs() < 1e-6 * std1.abs().max(1.0),
+            "'{name}' std_dev: {std1} vs {std2}"
+        );
+    }
+}
+
+/// Small data (fewer values than the sample capacity) keeps exact order
+/// statistics and must not be flagged approximate.
+#[test]
+fn test_small_data_not_flagged_approximate() {
+    let csv = create_test_csv();
+    let report = analyze_csv_file(csv.path(), &CsvParserConfig::default()).unwrap();
+    let age = report
+        .column_profiles
+        .iter()
+        .find(|c| c.name == "age")
+        .unwrap();
+    let ColumnStats::Numeric(n) = &age.stats else {
+        panic!("age should be numeric");
+    };
+    assert_eq!(
+        n.is_approximate, None,
+        "full-coverage stats are not approximate"
+    );
+    assert_eq!(n.min, 20.0);
+    assert_eq!(n.max, 69.0);
+}
+
 fn create_test_csv() -> NamedTempFile {
     let mut f = NamedTempFile::new().unwrap();
     writeln!(f, "name,age,salary,score").unwrap();


### PR DESCRIPTION
## Summary

Fixes #424.

On files larger than the 10k per-column sample, `min`/`max`/`mean`/`std_dev`/`variance` were computed from the retained sample while the report claimed no sampling (`sampling_applied: false`, no `is_approximate`). The engines also sampled differently — streaming kept a seeded reservoir, the columnar analyzers kept the **first 10k values** — so on a sorted 2M-row column the columnar engine reported `max = 9,999` against a true max of 1,999,999, and the same file produced different quality scores per engine.

## Changes

- **`ColumnProfileInput.exact_numeric`** (new `ExactNumericAggregates`): when an engine provides exact stream aggregates, `build_column_profile` overlays exact `min`/`max`/`mean`/`std_dev`/`variance` (and recomputes CV) over the sample-derived stats. Order statistics (median, quartiles, mode, skewness, kurtosis, outliers) remain sample-based and are now flagged `is_approximate: true` whenever the sample no longer covers every numeric value.
- **Streaming path**: feeds the aggregates from the exact min/max and Welford accumulator it already maintained (and previously threw away). New `WelfordAccumulator::count/sample_variance/sample_std_dev` accessors use the unbiased n−1 denominator to match the batch stats convention.
- **Columnar analyzers** (`arrow_profiler`, `record_batch_analyzer`): track `numeric_count`, expose exact aggregates from their existing sum/sum-squares accumulators, and now also feed those accumulators from Utf8 arrays carrying numeric content (the Arrow CSV reader delivers strings — previously such columns had no exact stats at all). Their first-N prefix sample is replaced with the shared deterministic `StreamReservoirSampler`, removing the sorted-data bias from order statistics and quality sampling.
- In-memory Python column path passes `exact_numeric: None` — its sample *is* the full data, already exact.

## Result on the 2M-row repro

| | before (inc / col) | after (inc / col) |
|---|---|---|
| id max | 1,999,844 / **9,999** | 1,999,999 / 1,999,999 |
| id mean | 999,336.58 / 4,999.5 | 999,999.5 / 999,999.5 |
| is_approximate | absent | true |
| overall quality | 87.28 / 87.24 | 87.28 / 87.28 |

## Tests

- New `test_base_numeric_stats_exact_beyond_sample_capacity`: 30k sorted rows, asserts analytically exact min/max/mean, `is_approximate: Some(true)`, and exact cross-engine agreement; `test_small_data_not_flagged_approximate` guards the no-sampling case.
- `cargo test --workspace` (28 suites), `uv run pytest python/tests` (338 passed), `cargo clippy --all --all-targets -- -D warnings`, `cargo fmt`.
- End-to-end via `maturin develop` on the 124 MB dogfooding file (table above).

Follow-up (out of scope): quality-dimension sample parity across engines uses differently-merged reservoirs; tracked by #363's tolerance-based tests. Per-column invalid-count disclosure is #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)