### PR TITLE
feat(metrics): per-column invalid_count for values excluded from numeric stats

### DIFF
--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -24,6 +24,15 @@ pub struct ColumnProfile {
     /// is unsafe for those checks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_count_is_approximate: Option<bool>,
+    /// Non-null values that failed the column's type parse and were therefore
+    /// excluded from `stats`.
+    ///
+    /// For numeric columns this makes the statistics denominator auditable:
+    /// `mean`/`std_dev` cover `total_count - null_count - invalid_count`
+    /// values. `None` means the check did not run (non-numeric column, or
+    /// statistics skipped) — never "no invalid values", which is `Some(0)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invalid_count: Option<usize>,
     pub stats: ColumnStats,
     /// Detected patterns, or `None` when pattern detection did not run.
     ///
@@ -226,6 +235,7 @@ mod tests {
             total_count: 10,
             unique_count: Some(8),
             unique_count_is_approximate: Some(false),
+            invalid_count: Some(0),
             stats: ColumnStats::Numeric(NumericStats {
                 min: 1.0,
                 max: 100.0,
@@ -278,6 +288,7 @@ mod tests {
             total_count: 3,
             unique_count: Some(3),
             unique_count_is_approximate: Some(false),
+            invalid_count: None,
             stats: ColumnStats::Text(TextStats {
                 min_length: 3,
                 max_length: 7,

--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -24,8 +24,9 @@ pub struct ColumnProfile {
     /// is unsafe for those checks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_count_is_approximate: Option<bool>,
-    /// Non-null values that failed the column's type parse and were therefore
-    /// excluded from `stats`.
+    /// Non-null values that did not parse as a finite number for the column's
+    /// type — parse failures and non-finite tokens like `inf`/`NaN` — and were
+    /// therefore excluded from `stats`.
     ///
     /// For numeric columns this makes the statistics denominator auditable:
     /// `mean`/`std_dev` cover `total_count - null_count - invalid_count`

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -36,6 +36,23 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
     // Infer type (uses same whitespace logic internally)
     let data_type = infer_type(data);
 
+    // Non-null values that fail the numeric parse are excluded from the
+    // statistics; expose that count so denominators stay auditable.
+    let invalid_count = match data_type {
+        DataType::Integer | DataType::Float => {
+            let parsed = data
+                .iter()
+                .filter(|s| s.parse::<f64>().ok().is_some_and(|v| v.is_finite()))
+                .count();
+            Some(
+                total_count
+                    .saturating_sub(null_count)
+                    .saturating_sub(parsed),
+            )
+        }
+        _ => None,
+    };
+
     // Calculate stats
     let stats = match data_type {
         DataType::Integer | DataType::Float => calculate_numeric_stats(data),
@@ -92,6 +109,7 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
         // analyze_column counts distinct values with an exact HashSet, so the
         // count is exact whenever it was computed (never in fast mode).
         unique_count_is_approximate: unique_count.map(|_| false),
+        invalid_count,
         stats,
         patterns,
     }

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -2,7 +2,8 @@ use crate::types::{ColumnProfile, ColumnStats, DataType};
 
 use crate::analysis::inference::{infer_type, is_null_like_token, parse_strict_boolean_token};
 use crate::analysis::patterns::detect_patterns;
-use crate::stats::{calculate_datetime_stats, calculate_numeric_stats, calculate_text_stats};
+use crate::stats::numeric::compute_numeric_stats_with_parsed_count;
+use crate::stats::{calculate_datetime_stats, calculate_text_stats};
 
 /// Analyze a column with full profiling (includes pattern detection and unique counts)
 pub fn analyze_column(name: &str, data: &[String]) -> ColumnProfile {
@@ -36,26 +37,22 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
     // Infer type (uses same whitespace logic internally)
     let data_type = infer_type(data);
 
-    // Non-null values that fail the numeric parse are excluded from the
-    // statistics; expose that count so denominators stay auditable.
-    let invalid_count = match data_type {
+    // Calculate stats. Numeric columns also yield how many values parsed as
+    // finite numbers, so the invalid count comes from the same single pass.
+    let mut invalid_count = None;
+    let stats = match data_type {
         DataType::Integer | DataType::Float => {
-            let parsed = data
-                .iter()
-                .filter(|s| s.parse::<f64>().ok().is_some_and(|v| v.is_finite()))
-                .count();
-            Some(
+            let (numeric, parsed) = compute_numeric_stats_with_parsed_count(data);
+            // Non-null values that fail the finite-numeric parse are excluded
+            // from the statistics; expose the count so denominators stay
+            // auditable.
+            invalid_count = Some(
                 total_count
                     .saturating_sub(null_count)
                     .saturating_sub(parsed),
-            )
+            );
+            ColumnStats::Numeric(numeric)
         }
-        _ => None,
-    };
-
-    // Calculate stats
-    let stats = match data_type {
-        DataType::Integer | DataType::Float => calculate_numeric_stats(data),
         DataType::Date => calculate_datetime_stats(data),
         DataType::Boolean => {
             let tc = data

--- a/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
@@ -239,6 +239,7 @@ mod tests {
             total_count: 0,
             unique_count: None,
             unique_count_is_approximate: None,
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -223,6 +223,7 @@ mod tests {
             total_count: 0,
             unique_count: None,
             unique_count_is_approximate: None,
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -763,6 +763,7 @@ mod tests {
             total_count: 1_000,
             unique_count: Some(100),
             unique_count_is_approximate: Some(false),
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -814,6 +815,7 @@ mod tests {
             total_count: 1,
             unique_count: Some(1),
             unique_count_is_approximate: Some(false),
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -854,6 +856,7 @@ mod tests {
             total_count: 100,
             unique_count: Some(10),
             unique_count_is_approximate: Some(false),
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];

--- a/crates/dataprof-metrics/src/analysis/metrics/precision.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/precision.rs
@@ -100,6 +100,7 @@ mod tests {
             total_count: 4,
             unique_count: Some(4),
             unique_count_is_approximate: Some(false),
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/testing.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/testing.rs
@@ -33,6 +33,7 @@ pub(super) fn string_profile(name: &str, total: usize, nulls: usize) -> ColumnPr
         total_count: total,
         unique_count: Some(unique_count),
         unique_count_is_approximate: Some(false),
+        invalid_count: None,
         stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
         patterns: Some(vec![]),
     }

--- a/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
@@ -206,6 +206,7 @@ mod tests {
             total_count: total,
             unique_count: unique,
             unique_count_is_approximate: unique.map(|_| false),
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/validity.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/validity.rs
@@ -84,6 +84,7 @@ mod tests {
             total_count: 4,
             unique_count: Some(4),
             unique_count_is_approximate: Some(false),
+            invalid_count: None,
             stats: ColumnStats::None,
             patterns,
         }

--- a/crates/dataprof-metrics/src/stats/numeric.rs
+++ b/crates/dataprof-metrics/src/stats/numeric.rs
@@ -10,6 +10,13 @@ pub fn calculate_numeric_stats(data: &[String]) -> ColumnStats {
 
 /// Compute numeric stats and return the inner struct directly.
 pub fn compute_numeric_stats(data: &[String]) -> NumericStats {
+    compute_numeric_stats_with_parsed_count(data).0
+}
+
+/// Compute numeric stats plus the number of values they cover — the count of
+/// cells that parsed as a finite number. Lets callers derive invalid-value
+/// counts without a second parse pass over the data.
+pub fn compute_numeric_stats_with_parsed_count(data: &[String]) -> (NumericStats, usize) {
     // decode-audit: no-data — cells that do not parse are non-numeric values
     // (nulls, tokens like "N/A"), excluded from numeric stats by design.
     let numbers: Vec<f64> = data
@@ -17,9 +24,10 @@ pub fn compute_numeric_stats(data: &[String]) -> NumericStats {
         .filter_map(|s| s.parse::<f64>().ok())
         .filter(|x| x.is_finite())
         .collect();
+    let parsed_count = numbers.len();
 
     if numbers.is_empty() {
-        return NumericStats::empty();
+        return (NumericStats::empty(), 0);
     }
 
     // Single SIMD-accelerated pass for base statistics (min, max, sum, sum_squares)
@@ -76,21 +84,24 @@ pub fn compute_numeric_stats(data: &[String]) -> NumericStats {
     // samples to mirror the global metric's behaviour.
     let outlier_count = count_outliers_iqr(&numbers, quartiles.as_ref(), 4);
 
-    NumericStats {
-        min,
-        max,
-        mean,
-        std_dev,
-        variance,
-        median,
-        quartiles,
-        mode,
-        coefficient_of_variation,
-        skewness,
-        kurtosis,
-        is_approximate,
-        outlier_count,
-    }
+    (
+        NumericStats {
+            min,
+            max,
+            mean,
+            std_dev,
+            variance,
+            median,
+            quartiles,
+            mode,
+            coefficient_of_variation,
+            skewness,
+            kurtosis,
+            is_approximate,
+            outlier_count,
+        },
+        parsed_count,
+    )
 }
 
 /// Count IQR outliers given pre-computed quartiles. Returns `None` when the

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -58,6 +58,11 @@ pub struct PyColumnProfile {
     /// `Some(True)` when it is a HyperLogLog estimate (~1% relative error).
     #[pyo3(get)]
     pub unique_count_is_approximate: Option<bool>,
+    /// Non-null values that failed the column's type parse and are excluded
+    /// from the statistics. `None` = check did not run (non-numeric column);
+    /// `Some(0)` = every non-null value parsed.
+    #[pyo3(get)]
+    pub invalid_count: Option<usize>,
     #[pyo3(get)]
     pub null_percentage: f64,
     #[pyo3(get)]
@@ -210,6 +215,7 @@ impl From<&ColumnProfile> for PyColumnProfile {
             null_count: profile.null_count,
             unique_count: profile.unique_count,
             unique_count_is_approximate: profile.unique_count_is_approximate,
+            invalid_count: profile.invalid_count,
             null_percentage,
             uniqueness_ratio,
             min,

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -58,9 +58,10 @@ pub struct PyColumnProfile {
     /// `Some(True)` when it is a HyperLogLog estimate (~1% relative error).
     #[pyo3(get)]
     pub unique_count_is_approximate: Option<bool>,
-    /// Non-null values that failed the column's type parse and are excluded
-    /// from the statistics. `None` = check did not run (non-numeric column);
-    /// `Some(0)` = every non-null value parsed.
+    /// Non-null values that did not parse as a finite number — parse failures
+    /// and non-finite tokens like `inf`/`NaN` — and are excluded from the
+    /// statistics. `None` = check did not run (non-numeric column, or
+    /// statistics skipped); `Some(0)` = every non-null value parsed.
     #[pyo3(get)]
     pub invalid_count: Option<usize>,
     #[pyo3(get)]

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -14,7 +14,7 @@ use dataprof_metrics::{
     analysis::inference::{is_null_like_token, parse_strict_boolean_token},
     analysis::patterns::looks_like_date,
     calculate_datetime_stats, calculate_text_stats, detect_patterns,
-    stats::numeric::{calculate_coefficient_of_variation, compute_numeric_stats},
+    stats::numeric::{calculate_coefficient_of_variation, compute_numeric_stats_with_parsed_count},
 };
 
 use crate::streaming_stats::{StreamingColumnCollection, StreamingStatistics};
@@ -88,12 +88,8 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
     } else {
         match input.data_type {
             DataType::Integer | DataType::Float => {
-                let mut numeric = compute_numeric_stats(input.sample_values);
-                let sampled_numeric = input
-                    .sample_values
-                    .iter()
-                    .filter(|s| s.parse::<f64>().ok().is_some_and(|v| v.is_finite()))
-                    .count();
+                let (mut numeric, sampled_numeric) =
+                    compute_numeric_stats_with_parsed_count(input.sample_values);
                 // Values the statistics actually cover. With exact stream
                 // aggregates that is the engine's full parsed count; without
                 // them the sample *is* the full data (in-memory sources).

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -82,12 +82,31 @@ pub struct TextLengths {
 /// pre-computed text lengths; this function handles stats calculation
 /// and pattern detection.
 pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
+    let mut invalid_count = None;
     let stats = if input.skip_statistics {
         ColumnStats::None
     } else {
         match input.data_type {
             DataType::Integer | DataType::Float => {
                 let mut numeric = compute_numeric_stats(input.sample_values);
+                let sampled_numeric = input
+                    .sample_values
+                    .iter()
+                    .filter(|s| s.parse::<f64>().ok().is_some_and(|v| v.is_finite()))
+                    .count();
+                // Values the statistics actually cover. With exact stream
+                // aggregates that is the engine's full parsed count; without
+                // them the sample *is* the full data (in-memory sources).
+                let parsed_total = match &input.exact_numeric {
+                    Some(exact) => exact.count,
+                    None => sampled_numeric,
+                };
+                invalid_count = Some(
+                    input
+                        .total_count
+                        .saturating_sub(input.null_count)
+                        .saturating_sub(parsed_total),
+                );
                 if let Some(exact) = &input.exact_numeric {
                     numeric.min = exact.min;
                     numeric.max = exact.max;
@@ -100,11 +119,6 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
                     // kurtosis, outliers) still come from the retained sample;
                     // disclose that whenever the sample no longer covers every
                     // numeric value the exact aggregates saw.
-                    let sampled_numeric = input
-                        .sample_values
-                        .iter()
-                        .filter(|s| s.parse::<f64>().ok().is_some_and(|v| v.is_finite()))
-                        .count();
                     if exact.count > sampled_numeric {
                         numeric.is_approximate = Some(true);
                     }
@@ -177,6 +191,7 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
         total_count: input.total_count,
         unique_count: input.unique_count,
         unique_count_is_approximate: input.unique_count_is_approximate,
+        invalid_count,
         stats,
         patterns,
     }

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -203,6 +203,7 @@ Per-column profiling statistics.
 | `total_count` | `int` | Total number of values |
 | `null_count` | `int` | Number of null/missing values |
 | `unique_count` | `int \| None` | Distinct value count |
+| `invalid_count` | `int \| None` | Non-null values that failed the column's type parse and are excluded from the statistics. `None` = check did not run (non-numeric column); `0` = every non-null value parsed |
 | `null_percentage` | `float` | Null ratio (0.0--100.0) |
 | `uniqueness_ratio` | `float` | Unique values / total values |
 | `min` | `float \| None` | Minimum (numeric columns) |

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -203,7 +203,7 @@ Per-column profiling statistics.
 | `total_count` | `int` | Total number of values |
 | `null_count` | `int` | Number of null/missing values |
 | `unique_count` | `int \| None` | Distinct value count |
-| `invalid_count` | `int \| None` | Non-null values that failed the column's type parse and are excluded from the statistics. `None` = check did not run (non-numeric column); `0` = every non-null value parsed |
+| `invalid_count` | `int \| None` | Non-null values that did not parse as a finite number (parse failures and non-finite tokens like `inf`/`NaN`) and are excluded from the statistics. `None` = check did not run (non-numeric column, or statistics skipped); `0` = every non-null value parsed |
 | `null_percentage` | `float` | Null ratio (0.0--100.0) |
 | `uniqueness_ratio` | `float` | Unique values / total values |
 | `min` | `float \| None` | Minimum (numeric columns) |

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -492,8 +492,9 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
         "unique_count_is_approximate": col.unique_count_is_approximate,
         "uniqueness_ratio": _r2(col.uniqueness_ratio),
     }
-    # Absent (not None) when the parse check did not run, mirroring the Rust
-    # serialization: None = not analyzed, 0 = analyzed and clean.
+    # The key is omitted entirely when the check did not run (non-numeric
+    # column, or statistics skipped), mirroring the Rust serialization; a
+    # clean numeric column serializes 0.
     if col.invalid_count is not None:
         col_data["invalid_count"] = col.invalid_count
     if col.min is not None:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -492,6 +492,10 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
         "unique_count_is_approximate": col.unique_count_is_approximate,
         "uniqueness_ratio": _r2(col.uniqueness_ratio),
     }
+    # Absent (not None) when the parse check did not run, mirroring the Rust
+    # serialization: None = not analyzed, 0 = analyzed and clean.
+    if col.invalid_count is not None:
+        col_data["invalid_count"] = col.invalid_count
     if col.min is not None:
         col_data["stats"] = {
             k: v
@@ -574,6 +578,7 @@ def _column_record(col: ColumnProfile) -> dict[str, Any]:
         "unique_count": col.unique_count,
         "unique_count_is_approximate": col.unique_count_is_approximate,
         "uniqueness_ratio": _r2(col.uniqueness_ratio),
+        "invalid_count": col.invalid_count,
         "min": _r4(col.min),
         "max": _r4(col.max),
         "mean": _r4(col.mean),
@@ -1316,6 +1321,7 @@ class _DictColumn:
         self.unique_count = d.get("unique_count")
         self.unique_count_is_approximate = d.get("unique_count_is_approximate")
         self.uniqueness_ratio = d.get("uniqueness_ratio")
+        self.invalid_count = d.get("invalid_count")
         # Overlay only known stat attributes — never setattr arbitrary keys from
         # (possibly malformed) input, which could inject unexpected/dunder names.
         stats = d.get("stats")

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -149,6 +149,7 @@ class ColumnProfile:
     null_count: int
     unique_count: int | None
     unique_count_is_approximate: bool | None
+    invalid_count: int | None
     null_percentage: float
     uniqueness_ratio: float
     min: float | None

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -2243,3 +2243,47 @@ class TestLowSampleWarning:
         r = dataprof.profile(str(path))
         assert r.low_sample_warning is False
         assert "low_sample_warning" not in r.to_dict()["quality"]
+
+
+class TestInvalidCount:
+    """Per-column invalid_count: non-null values excluded from numeric stats
+    must be disclosed, never silently dropped (#425)."""
+
+    def test_unparseable_numeric_value_is_counted(self, tmp_path):
+        path = tmp_path / "amounts.csv"
+        path.write_text('amount,label\n1.5,a\n2.5,b\n3.5,c\n4.5,d\n5.5,e\n"12,50",f\n,g\n')
+        r = dataprof.profile(str(path))
+
+        amount = r["amount"]
+        assert amount.data_type == "float"
+        assert amount.null_count == 1
+        assert amount.invalid_count == 1
+
+        d = next(c for c in r.to_dict()["columns"] if c["name"] == "amount")
+        assert d["invalid_count"] == 1
+
+    def test_clean_numeric_column_reports_zero_not_none(self, tmp_path):
+        path = tmp_path / "clean.csv"
+        path.write_text("x\n" + "\n".join(str(i) for i in range(20)) + "\n")
+        r = dataprof.profile(str(path))
+        assert r["x"].invalid_count == 0
+
+    def test_non_numeric_column_not_checked(self, tmp_path):
+        path = tmp_path / "text.csv"
+        path.write_text("name\nalice\nbob\ncarol\n")
+        r = dataprof.profile(str(path))
+        assert r["name"].invalid_count is None
+        d = r.to_dict()["columns"][0]
+        assert "invalid_count" not in d
+
+    def test_in_memory_sources_match_file_semantics(self):
+        r = dataprof.profile({"v": ["1", "2", "3", "4", "5", "12,50", None]})
+        assert r["v"].invalid_count == 1
+
+    def test_roundtrip_preserves_invalid_count(self, tmp_path):
+        path = tmp_path / "amounts.csv"
+        path.write_text('amount\n1.5\n2.5\n3.5\n4.5\n5.5\n"12,50"\n')
+        r = dataprof.profile(str(path))
+        r2 = dataprof.ProfileReport.from_json(r.to_json())
+        assert r2["amount"].invalid_count == 1
+        assert r2.to_dict() == r.to_dict()

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -64,6 +64,9 @@ fn test_base_numeric_stats_exact_beyond_sample_capacity() {
             Some(true),
             "[{engine}] sampled order statistics must be disclosed as approximate"
         );
+        // Every value parsed: analyzed and clean is Some(0), never None —
+        // and never a nonzero artifact of comparing against the sample.
+        assert_eq!(id.invalid_count, Some(0), "[{engine}] invalid_count");
     }
 
     // And the two engines must agree with each other exactly on base stats.
@@ -86,6 +89,54 @@ fn test_base_numeric_stats_exact_beyond_sample_capacity() {
         assert!(
             (std1 - std2).abs() < 1e-6 * std1.abs().max(1.0),
             "'{name}' std_dev: {std1} vs {std2}"
+        );
+    }
+}
+
+/// A numeric column with an unparseable non-null value must disclose it via
+/// `invalid_count` — identically through every engine — so the statistics
+/// denominator is auditable instead of silently shrinking (#425).
+#[test]
+fn test_invalid_count_surfaces_unparseable_numeric_values() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "amount,label").unwrap();
+    for i in 0..5 {
+        writeln!(f, "{}.5,row{}", i, i).unwrap();
+    }
+    // Decimal-comma value: non-null, fails the numeric parse.
+    writeln!(f, "\"12,50\",rowx").unwrap();
+    writeln!(f, ",rownull").unwrap();
+    f.flush().unwrap();
+
+    let std_report = analyze_csv_file(f.path(), &CsvParserConfig::default()).unwrap();
+    let arrow_report = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(f.path())
+        .unwrap();
+
+    for (engine, report) in [("std", &std_report), ("arrow", &arrow_report)] {
+        let amount = report
+            .column_profiles
+            .iter()
+            .find(|c| c.name == "amount")
+            .unwrap();
+        assert_eq!(amount.data_type, DataType::Float, "[{engine}]");
+        assert_eq!(amount.total_count, 7, "[{engine}]");
+        assert_eq!(amount.null_count, 1, "[{engine}]");
+        assert_eq!(
+            amount.invalid_count,
+            Some(1),
+            "[{engine}] the unparseable value must be counted, not silently dropped"
+        );
+
+        let label = report
+            .column_profiles
+            .iter()
+            .find(|c| c.name == "label")
+            .unwrap();
+        assert_eq!(
+            label.invalid_count, None,
+            "[{engine}] non-numeric columns are not checked: None, not 0"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #425.

A numeric column with an unparseable non-null value (e.g. the decimal-comma `"1.234,56"`) computed its mean over a silently shrunken denominator: 8 non-null values, statistics over 7, and nothing anywhere in the report saying so. This is the worst bug class for a profiler per AGENTS.md — a silent error that turns into a plausible number.

## Changes

- `ColumnProfile.invalid_count: Option<usize>` — non-null values that failed the column's type parse and are therefore excluded from `stats`. Semantics follow the None/absent contract: `None` = check did not run (non-numeric column, or statistics pack skipped); `Some(0)` = analyzed and clean.
- Computed in `build_column_profile` for numeric columns as `total_count − null_count − parsed_count`, where `parsed_count` is the exact per-engine parsed-numeric count introduced by #432 (`ExactNumericAggregates.count` from Welford / `numeric_count`), or the full-sample parse count for in-memory sources. The legacy `analyze_column` path computes it directly over its full data slice.
- Serialization is additive (`skip_serializing_if`), so it fits `REPORT_SCHEMA_VERSION 1` compatibility rules; old readers ignore the new key, reloaded reports preserve it.
- Exposed end-to-end in Python: `ColumnProfile.invalid_count`, `to_dict()` (present only when analyzed), `to_dataframe()`/flat records, `from_json()` reload path, type stubs, and the Python README field table.

## Verification (original dogfooding repro)

```text
amount: mean 185.0686 | null_count 2 | invalid_count 1  -> stats cover 7 of 10, auditable
order_id: invalid_count 0        (clean numeric column: Some(0), not None)
customer: invalid_count None     (non-numeric: not analyzed)
```

## Tests

- Rust: `test_invalid_count_surfaces_unparseable_numeric_values` — a decimal-comma value must yield `invalid_count == Some(1)` **identically through the standard and columnar engines**, and text columns stay `None`; the 30k exactness test now also asserts `Some(0)` on clean columns.
- Python: 5 new tests covering file/in-memory parity, `Some(0)` vs `None` semantics, `to_dict` presence rules, and JSON round-trip.
- Gates: `cargo test --workspace` (28 suites), `uv run pytest python/tests` (343 passed), clippy `-D warnings`, decode-audit, ruff, ty.

Note for future work: values with surrounding whitespace (`" 1 "`) fail `str::parse` and are counted invalid — accurate disclosure of current parse behavior, but the parse itself could trim; that belongs with #433's parsing work rather than this counter.
