### PR TITLE
fix(hints): make streamed binding evidence exact

### DIFF
--- a/crates/dataprof-core/src/semantic.rs
+++ b/crates/dataprof-core/src/semantic.rs
@@ -160,6 +160,26 @@ impl SemanticHints {
         })
     }
 
+    /// Reject value-driven hints when the Quality metric pack did not run.
+    ///
+    /// Positive and temporal hints only affect quality calculators. Accepting
+    /// them without a quality assessment would make the configuration look
+    /// effective while producing neither metrics nor binding evidence.
+    pub fn validate_quality_usage(&self, quality_computed: bool) -> Result<(), DataProfilerError> {
+        if quality_computed
+            || (self.positive_columns.is_empty() && self.temporal_columns.is_empty())
+        {
+            return Ok(());
+        }
+
+        Err(DataProfilerError::InvalidSemanticHint {
+            message: "positive_columns and temporal_columns require the Quality metric pack"
+                .to_string(),
+            suggestion: "Include MetricPack::Quality (\"quality\" in Python), or remove the value-driven hint. Identifier hints remain usable without quality because they affect column typing."
+                .to_string(),
+        })
+    }
+
     /// Fail loudly when a hint names a real column but bound to nothing.
     ///
     /// Only bindings that were assessed over the full data

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -274,7 +274,7 @@ pub fn analyze_csv_from_reader_with_hints<R: Read>(
             .collect()
     };
 
-    let mut column_stats = StreamingColumnCollection::new();
+    let mut column_stats = StreamingColumnCollection::new().with_semantic_hints(semantic_hints);
     let mut rows_read = 0;
 
     for result in csv_reader.records() {
@@ -378,6 +378,7 @@ pub fn analyze_csv_file_with_dimensions_and_hints(
     .columns(column_profiles)
     .with_quality_data(sample_columns)
     .with_row_duplicates(column_stats.row_duplicate_summary())
+    .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {
         assembler = assembler.with_requested_dimensions(dimensions.to_vec());

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -221,6 +221,7 @@ impl AsyncStreamingProfiler {
             .columns(column_profiles)
             .with_quality_data(sample_columns)
             .with_row_duplicates(column_stats.row_duplicate_summary())
+            .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
             .with_semantic_hints(self.semantic_hints.clone());
         if let Some(ref dims) = self.quality_dimensions {
             assembler = assembler.with_requested_dimensions(dims.clone());
@@ -561,7 +562,8 @@ impl AsyncStreamingProfiler {
         ),
         DataProfilerError,
     > {
-        let mut column_stats = StreamingColumnCollection::memory_limit(self.memory_limit_mb);
+        let mut column_stats = StreamingColumnCollection::memory_limit(self.memory_limit_mb)
+            .with_semantic_hints(&self.semantic_hints);
         let mut progress_tracker =
             ProgressTracker::new(self.progress_sink.clone(), self.progress_interval);
         let mut total_rows: usize = 0;

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -112,7 +112,8 @@ impl IncrementalProfiler {
         let chunk_size_bytes = self.calculate_optimal_chunk_size(file_size_bytes);
 
         // Initialize streaming statistics collection
-        let mut column_stats = StreamingColumnCollection::memory_limit(self.memory.limit_mb);
+        let mut column_stats = StreamingColumnCollection::memory_limit(self.memory.limit_mb)
+            .with_semantic_hints(&self.semantic_hints);
 
         let mut progress_tracker =
             ProgressTracker::new(self.progress_sink.clone(), self.progress_interval);
@@ -339,6 +340,7 @@ impl IncrementalProfiler {
             assembler = assembler
                 .with_quality_data(sample_columns)
                 .with_row_duplicates(column_stats.row_duplicate_summary())
+                .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
                 .with_semantic_hints(self.semantic_hints.clone());
             if let Some(ref dims) = self.quality_dimensions {
                 assembler = assembler.with_requested_dimensions(dims.clone());

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -353,7 +353,7 @@ fn analyze_json_from_reader_full<R: BufRead>(
     ),
     DataProfilerError,
 > {
-    let mut column_stats = StreamingColumnCollection::new();
+    let mut column_stats = StreamingColumnCollection::new().with_semantic_hints(semantic_hints);
     let mut known_columns = Vec::new();
     let mut known_columns_set = HashSet::new();
     let mut rows_seen = 0;
@@ -467,6 +467,7 @@ pub fn analyze_json_file_with_dimensions_and_hints(
         .columns(column_profiles)
         .with_quality_data(sample_columns)
         .with_row_duplicates(column_stats.row_duplicate_summary())
+        .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
         .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {
         assembler = assembler.with_requested_dimensions(dimensions.to_vec());

--- a/crates/dataprof-metrics/src/analysis/metrics/hint_binding.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/hint_binding.rs
@@ -33,7 +33,7 @@ pub fn compute_value_hint_bindings(
     for column in &hints.positive_columns {
         if let Some(values) = data.get(column) {
             // Mirror accuracy.rs: a value counts if it parses as f64.
-            let (checked, matched) = count_matches(values, |v| v.parse::<f64>().is_ok());
+            let (checked, matched) = count_matches(values, SemanticHintKind::Positive);
             bindings.push(binding(
                 column,
                 SemanticHintKind::Positive,
@@ -47,7 +47,7 @@ pub fn compute_value_hint_bindings(
     for column in &hints.temporal_columns {
         if let Some(values) = data.get(column) {
             // Mirror timeliness.rs: a value counts as a date if a year parses.
-            let (checked, matched) = count_matches(values, |v| extract_year(v).is_some());
+            let (checked, matched) = count_matches(values, SemanticHintKind::Temporal);
             bindings.push(binding(
                 column,
                 SemanticHintKind::Temporal,
@@ -85,7 +85,7 @@ fn binding(
 /// `extract_year(value)`), and neither `parse::<f64>()` nor `extract_year`
 /// tolerates surrounding whitespace, so trimming here would let this evidence
 /// accept values the calculators reject (e.g. `" 1"`, `" 2020-01-01"`).
-fn count_matches(values: &[String], pred: impl Fn(&str) -> bool) -> (usize, usize) {
+fn count_matches(values: &[String], kind: SemanticHintKind) -> (usize, usize) {
     let mut checked = 0;
     let mut matched = 0;
     for value in values {
@@ -93,11 +93,27 @@ fn count_matches(values: &[String], pred: impl Fn(&str) -> bool) -> (usize, usiz
             continue;
         }
         checked += 1;
-        if pred(value) {
+        if value_matches_hint(value, kind) {
             matched += 1;
         }
     }
     (checked, matched)
+}
+
+/// Apply the exact value predicate used by the quality calculator for `kind`.
+///
+/// Streaming engines use this helper while values pass through their
+/// full-stream accumulators. Keeping the predicates here prevents exact
+/// binding evidence from drifting away from the sampled quality calculation.
+pub fn value_matches_hint(value: &str, kind: SemanticHintKind) -> bool {
+    match kind {
+        // Mirror accuracy.rs: it parses the original, untrimmed cell.
+        SemanticHintKind::Positive => value.parse::<f64>().is_ok(),
+        // Mirror timeliness.rs: it extracts a year from the original cell.
+        SemanticHintKind::Temporal => extract_year(value).is_some(),
+        // Identifier binding is structural and is not value-driven.
+        SemanticHintKind::Identifier => true,
+    }
 }
 
 #[cfg(test)]

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -61,7 +61,7 @@ mod utils;
 mod validity;
 
 // Re-export public types for backward compatibility
-pub use hint_binding::compute_value_hint_bindings;
+pub use hint_binding::{compute_value_hint_bindings, value_matches_hint};
 pub use utils::{StatisticalValidation, validate_sample_size};
 
 use accuracy::AccuracyCalculator;

--- a/crates/dataprof-metrics/src/analysis/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/mod.rs
@@ -6,5 +6,5 @@ pub(crate) mod validators;
 
 pub use column::{analyze_column, analyze_column_fast};
 pub use inference::{infer_type, is_null_like_token};
-pub use metrics::{MetricsCalculator, compute_value_hint_bindings};
+pub use metrics::{MetricsCalculator, compute_value_hint_bindings, value_matches_hint};
 pub use patterns::{PatternMetadata, detect_patterns, list_patterns};

--- a/crates/dataprof-metrics/src/lib.rs
+++ b/crates/dataprof-metrics/src/lib.rs
@@ -9,6 +9,7 @@ pub mod types;
 pub use analysis::{
     MetricsCalculator, PatternMetadata, analyze_column, analyze_column_fast,
     compute_value_hint_bindings, detect_patterns, infer_type, is_null_like_token, list_patterns,
+    value_matches_hint,
 };
 pub use quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, PrecisionMetrics,

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -11,7 +11,7 @@ use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::{infer_type, is_null_like_token};
 use dataprof_runtime::{
     ColumnProfileInput, ExactNumericAggregates, ProfileReport, ReportAssembler,
-    StreamReservoirSampler, TextLengths, build_column_profile,
+    StreamReservoirSampler, TextLengths, ValueHintBindingAccumulator, build_column_profile,
 };
 use std::fs::File;
 use std::path::Path;
@@ -143,6 +143,7 @@ impl ArrowProfiler {
         // skip the duplicate component of the uniqueness dimension — breaking
         // cross-engine score parity with the incremental engine.
         let mut row_tracker = BatchRowTracker::default();
+        let mut hint_bindings = ValueHintBindingAccumulator::new(&self.semantic_hints);
 
         // The Arrow CSV reader has no row cap, so enforce it here: stop once the
         // limit is reached and slice the batch that straddles it, keeping the row
@@ -176,6 +177,13 @@ impl ArrowProfiler {
 
                 if let Some(analyzer) = column_analyzers.get_mut(field.name()) {
                     analyzer.process_array(column)?;
+                }
+                if let Some(values) = column.as_any().downcast_ref::<StringArray>() {
+                    for row_index in 0..values.len() {
+                        if !values.is_null(row_index) {
+                            hint_bindings.observe(field.name(), values.value(row_index));
+                        }
+                    }
                 }
             }
 
@@ -238,6 +246,7 @@ impl ArrowProfiler {
         if MetricPack::include_quality(packs) {
             assembler = assembler
                 .with_quality_data(sample_columns)
+                .with_exact_value_hint_bindings(hint_bindings.bindings(headers.iter()))
                 .with_semantic_hints(self.semantic_hints.clone());
             if let Some(ref dims) = self.quality_dimensions {
                 assembler = assembler.with_requested_dimensions(dims.clone());
@@ -950,6 +959,32 @@ mod tests {
         let error = (unique as f64 - rows as f64).abs() / rows as f64;
         assert!(error < 0.05, "{rows} distinct ids estimated as {unique}");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_value_hint_binding_covers_full_stream() -> Result<(), DataProfilerError> {
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "value")?;
+        writeln!(temp_file, "1")?;
+        for _ in 0..10_050 {
+            writeln!(temp_file, "not-a-number")?;
+        }
+        temp_file.flush()?;
+
+        let hints = SemanticHints::new(vec!["value".to_string()], vec![]);
+        let report = ArrowProfiler::new()
+            .semantic_hints(hints)
+            .analyze_csv_file(temp_file.path())?;
+        let binding = report
+            .semantic_hint_bindings
+            .iter()
+            .find(|binding| binding.column == "value")
+            .expect("positive hint binding");
+
+        assert_eq!(binding.checked_values, 10_051);
+        assert_eq!(binding.matched_values, 1);
+        assert!(binding.exact);
         Ok(())
     }
 

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -269,7 +269,7 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
             message: format!("Failed to build Parquet stream: {}", e),
         })?;
 
-    let mut analyzer = RecordBatchAnalyzer::new();
+    let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
 
     while let Some(batch_result) = stream.next().await {
         let batch = batch_result.map_err(|e| DataProfilerError::ParquetError {
@@ -309,6 +309,7 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
     .columns(column_profiles)
     .with_row_duplicates(analyzer.row_duplicate_summary())
     .with_quality_data(sample_columns)
+    .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dims) = quality_dimensions {
         assembler = assembler.with_requested_dimensions(dims);

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -190,7 +190,7 @@ pub fn analyze_parquet_with_config_dims_and_hints(
             message: format!("Failed to build Parquet reader: {}", error),
         })?;
 
-    let mut analyzer = RecordBatchAnalyzer::new();
+    let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
     for batch_result in reader {
         let batch = batch_result.map_err(|error| DataProfilerError::ParquetError {
             message: format!("Failed to read Parquet batch: {}", error),
@@ -237,6 +237,7 @@ pub fn analyze_parquet_with_config_dims_and_hints(
     .columns(column_profiles)
     .with_row_duplicates(analyzer.row_duplicate_summary())
     .with_quality_data(sample_columns)
+    .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {
         assembler = assembler.with_requested_dimensions(dimensions.to_vec());

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use arrow::array::*;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::ArrayFormatter;
-use dataprof_core::{ColumnProfile, DataType, SemanticHints};
+use dataprof_core::{
+    ColumnProfile, DataType, SemanticHintBinding, SemanticHintKind, SemanticHints,
+};
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{RowDuplicateSummary, infer_type};
@@ -102,6 +104,7 @@ pub struct RecordBatchAnalyzer {
     column_analyzers: HashMap<String, ColumnAnalyzer>,
     total_rows: usize,
     row_tracker: BatchRowTracker,
+    semantic_hints: SemanticHints,
 }
 
 impl RecordBatchAnalyzer {
@@ -110,7 +113,13 @@ impl RecordBatchAnalyzer {
             column_analyzers: HashMap::new(),
             total_rows: 0,
             row_tracker: BatchRowTracker::default(),
+            semantic_hints: SemanticHints::default(),
         }
+    }
+
+    pub fn with_semantic_hints(mut self, hints: &SemanticHints) -> Self {
+        self.semantic_hints = hints.clone();
+        self
     }
 
     pub fn process_batch(&mut self, batch: &RecordBatch) -> Result<()> {
@@ -121,11 +130,12 @@ impl RecordBatchAnalyzer {
             let schema = batch.schema();
             let field = schema.field(column_index);
             let column_name = field.name().to_string();
+            let positive_hint = self.semantic_hints.is_positive_column(&column_name);
+            let temporal_hint = self.semantic_hints.is_temporal_column(&column_name);
 
-            let analyzer = self
-                .column_analyzers
-                .entry(column_name)
-                .or_insert_with(|| ColumnAnalyzer::new(field.data_type()));
+            let analyzer = self.column_analyzers.entry(column_name).or_insert_with(|| {
+                ColumnAnalyzer::with_value_hints(field.data_type(), positive_hint, temporal_hint)
+            });
 
             analyzer.process_array(column)?;
         }
@@ -184,6 +194,29 @@ impl RecordBatchAnalyzer {
         }
         samples
     }
+
+    /// Exact value-driven semantic-hint evidence over every processed batch.
+    pub fn semantic_hint_bindings(&self) -> Vec<SemanticHintBinding> {
+        let positive = self
+            .semantic_hints
+            .positive_columns
+            .iter()
+            .filter_map(|column| {
+                self.column_analyzers
+                    .get(column)
+                    .map(|analyzer| analyzer.hint_binding(column, SemanticHintKind::Positive))
+            });
+        let temporal = self
+            .semantic_hints
+            .temporal_columns
+            .iter()
+            .filter_map(|column| {
+                self.column_analyzers
+                    .get(column)
+                    .map(|analyzer| analyzer.hint_binding(column, SemanticHintKind::Temporal))
+            });
+        positive.chain(temporal).collect()
+    }
 }
 
 impl Default for RecordBatchAnalyzer {
@@ -208,10 +241,23 @@ pub struct ColumnAnalyzer {
     true_count: usize,
     false_count: usize,
     sample_values: StreamReservoirSampler,
+    positive_hint: bool,
+    temporal_hint: bool,
+    hint_checked_values: usize,
+    positive_matched_values: usize,
+    temporal_matched_values: usize,
 }
 
 impl ColumnAnalyzer {
     pub fn new(data_type: &arrow::datatypes::DataType) -> Self {
+        Self::with_value_hints(data_type, false, false)
+    }
+
+    fn with_value_hints(
+        data_type: &arrow::datatypes::DataType,
+        positive_hint: bool,
+        temporal_hint: bool,
+    ) -> Self {
         Self {
             data_type: data_type.clone(),
             total_count: 0,
@@ -228,6 +274,43 @@ impl ColumnAnalyzer {
             true_count: 0,
             false_count: 0,
             sample_values: StreamReservoirSampler::new(NUMERIC_SAMPLE_CAP),
+            positive_hint,
+            temporal_hint,
+            hint_checked_values: 0,
+            positive_matched_values: 0,
+            temporal_matched_values: 0,
+        }
+    }
+
+    fn offer_sample(&mut self, value: String) {
+        if !is_null_like_token(value.trim()) && (self.positive_hint || self.temporal_hint) {
+            self.hint_checked_values += 1;
+            if self.positive_hint
+                && dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Positive)
+            {
+                self.positive_matched_values += 1;
+            }
+            if self.temporal_hint
+                && dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Temporal)
+            {
+                self.temporal_matched_values += 1;
+            }
+        }
+        self.sample_values.offer(value);
+    }
+
+    fn hint_binding(&self, column: &str, kind: SemanticHintKind) -> SemanticHintBinding {
+        let matched_values = match kind {
+            SemanticHintKind::Positive => self.positive_matched_values,
+            SemanticHintKind::Temporal => self.temporal_matched_values,
+            SemanticHintKind::Identifier => self.hint_checked_values,
+        };
+        SemanticHintBinding {
+            column: column.to_string(),
+            kind,
+            checked_values: self.hint_checked_values,
+            matched_values,
+            exact: true,
         }
     }
 
@@ -396,7 +479,7 @@ impl ColumnAnalyzer {
                 let value = array.value(index);
                 self.update_numeric_stats(value);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -409,7 +492,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -422,7 +505,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -435,7 +518,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -448,7 +531,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -461,7 +544,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -474,7 +557,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -487,7 +570,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -500,7 +583,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -513,7 +596,7 @@ impl ColumnAnalyzer {
                 let value_f64 = value as f64;
                 self.update_numeric_stats(value_f64);
                 self.cardinality.insert_owned(value.to_string());
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -537,7 +620,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(number);
                 }
                 self.cardinality.insert(value);
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -558,7 +641,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(number);
                 }
                 self.cardinality.insert(value);
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -575,7 +658,7 @@ impl ColumnAnalyzer {
                 }
                 let value_str = if value { "True" } else { "False" };
                 self.cardinality.insert(value_str);
-                self.sample_values.offer(value_str.to_string());
+                self.offer_sample(value_str.to_string());
             }
         }
         Ok(())
@@ -588,7 +671,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(days as f64);
                 let date_str = format!("1970-01-01+{}days", days);
                 self.cardinality.insert(&date_str);
-                self.sample_values.offer(date_str);
+                self.offer_sample(date_str);
             }
         }
         Ok(())
@@ -601,7 +684,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(millis as f64);
                 let datetime_str = format!("1970-01-01T00:00:00.000+{}ms", millis);
                 self.cardinality.insert(&datetime_str);
-                self.sample_values.offer(datetime_str);
+                self.offer_sample(datetime_str);
             }
         }
         Ok(())
@@ -620,7 +703,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    self.sample_values.offer(ts_str);
+                    self.offer_sample(ts_str);
                 }
             }
         } else if let Some(ts_array) = array
@@ -633,7 +716,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    self.sample_values.offer(ts_str);
+                    self.offer_sample(ts_str);
                 }
             }
         } else if let Some(ts_array) = array
@@ -646,7 +729,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    self.sample_values.offer(ts_str);
+                    self.offer_sample(ts_str);
                 }
             }
         } else if let Some(ts_array) = array
@@ -659,7 +742,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(ts_value as f64);
                     let ts_str = format!("ts:{}", ts_value);
                     self.cardinality.insert(&ts_str);
-                    self.sample_values.offer(ts_str);
+                    self.offer_sample(ts_str);
                 }
             }
         }
@@ -674,7 +757,7 @@ impl ColumnAnalyzer {
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
                 self.cardinality.insert_owned(format!("len:{}", len));
-                self.sample_values.offer(format!("<binary:{} bytes>", len));
+                self.offer_sample(format!("<binary:{} bytes>", len));
             }
         }
         Ok(())
@@ -687,7 +770,7 @@ impl ColumnAnalyzer {
                 let len = bytes.len();
                 self.update_text_stats(&format!("<binary:{}>", len));
                 self.cardinality.insert_owned(format!("len:{}", len));
-                self.sample_values.offer(format!("<binary:{} bytes>", len));
+                self.offer_sample(format!("<binary:{} bytes>", len));
             }
         }
         Ok(())
@@ -700,7 +783,7 @@ impl ColumnAnalyzer {
                 self.update_numeric_stats(decimal_value as f64);
                 let decimal_str = format!("dec128:{}", decimal_value);
                 self.cardinality.insert(&decimal_str);
-                self.sample_values.offer(decimal_str);
+                self.offer_sample(decimal_str);
             }
         }
         Ok(())
@@ -712,7 +795,7 @@ impl ColumnAnalyzer {
                 let decimal_str = format!("dec256:value_{}", index);
                 self.update_text_stats(&decimal_str);
                 self.cardinality.insert(&decimal_str);
-                self.sample_values.offer(decimal_str);
+                self.offer_sample(decimal_str);
             }
         }
         Ok(())
@@ -731,7 +814,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}ns", dur_value);
                     self.cardinality.insert(&dur_str);
-                    self.sample_values.offer(dur_str);
+                    self.offer_sample(dur_str);
                 }
             }
         } else if let Some(dur_array) = array
@@ -744,7 +827,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}us", dur_value);
                     self.cardinality.insert(&dur_str);
-                    self.sample_values.offer(dur_str);
+                    self.offer_sample(dur_str);
                 }
             }
         } else if let Some(dur_array) = array
@@ -757,7 +840,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}ms", dur_value);
                     self.cardinality.insert(&dur_str);
-                    self.sample_values.offer(dur_str);
+                    self.offer_sample(dur_str);
                 }
             }
         } else if let Some(dur_array) = array
@@ -770,7 +853,7 @@ impl ColumnAnalyzer {
                     self.update_numeric_stats(dur_value as f64);
                     let dur_str = format!("dur:{}s", dur_value);
                     self.cardinality.insert(&dur_str);
-                    self.sample_values.offer(dur_str);
+                    self.offer_sample(dur_str);
                 }
             }
         }
@@ -785,7 +868,7 @@ impl ColumnAnalyzer {
                     if !array.is_null(index) {
                         let value_str = formatter.value(index).to_string();
                         self.update_text_stats(&value_str);
-                        self.sample_values.offer(value_str.clone());
+                        self.offer_sample(value_str.clone());
                         self.cardinality.insert_owned(value_str);
                     }
                 }
@@ -795,7 +878,7 @@ impl ColumnAnalyzer {
                     if !array.is_null(index) {
                         let value_str = format!("<{}:value_{}>", array.data_type(), index);
                         self.update_text_stats(&value_str);
-                        self.sample_values.offer(value_str.clone());
+                        self.offer_sample(value_str.clone());
                         self.cardinality.insert_owned(value_str);
                     }
                 }

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -386,16 +386,16 @@ pub fn profile_dataframe(
 
     let num_rows = batch.num_rows();
     let num_cols = batch.num_columns();
+    // decode-audit: no-data — absent config simply means no semantic hints.
+    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
 
     // Process using existing RecordBatchAnalyzer
-    let mut analyzer = RecordBatchAnalyzer::new();
+    let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
     analyzer
         .process_batch(&batch)
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
     let locale = config.and_then(|c| c.locale.as_deref());
-    // decode-audit: no-data — absent config simply means no semantic hints.
-    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
     let sample_columns = if include_quality {
@@ -435,6 +435,7 @@ pub fn profile_dataframe(
     if include_quality {
         assembler = assembler
             .with_quality_data(sample_columns)
+            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
             .with_semantic_hints(semantic_hints.clone());
         if let Some(dims) = config.and_then(|c| c.quality_dimensions.clone()) {
             assembler = assembler.with_requested_dimensions(dims);
@@ -444,7 +445,7 @@ pub fn profile_dataframe(
     }
 
     let report = assembler.build();
-    super::errors::validate_report_hints(&report, &semantic_hints)?;
+    super::errors::validate_report_hints(&report, &semantic_hints, include_quality)?;
 
     Ok(super::types::PyProfileReport::new(report))
 }
@@ -493,6 +494,8 @@ pub fn profile_arrow(
 
     let num_rows = batch.num_rows();
     let num_cols = batch.num_columns();
+    // decode-audit: no-data — absent config simply means no semantic hints.
+    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
 
     // Estimate memory from pyarrow's nbytes
     // decode-audit: no-data — memory estimate is best-effort metadata; failure
@@ -503,14 +506,12 @@ pub fn profile_arrow(
         .ok();
 
     // Process using existing RecordBatchAnalyzer
-    let mut analyzer = RecordBatchAnalyzer::new();
+    let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
     analyzer
         .process_batch(&batch)
         .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
 
     let locale = config.and_then(|c| c.locale.as_deref());
-    // decode-audit: no-data — absent config simply means no semantic hints.
-    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
     let sample_columns = analyzer.create_sample_columns();
@@ -542,6 +543,7 @@ pub fn profile_arrow(
     if include_quality {
         assembler = assembler
             .with_quality_data(sample_columns)
+            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
             .with_semantic_hints(semantic_hints.clone());
         if let Some(dims) = config.and_then(|c| c.quality_dimensions.clone()) {
             assembler = assembler.with_requested_dimensions(dims);
@@ -551,7 +553,7 @@ pub fn profile_arrow(
     }
 
     let report = assembler.build();
-    super::errors::validate_report_hints(&report, &semantic_hints)?;
+    super::errors::validate_report_hints(&report, &semantic_hints, include_quality)?;
 
     Ok(super::types::PyProfileReport::new(report))
 }

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -181,7 +181,7 @@ pub fn profile_columns(
     }
 
     let report = assembler.build();
-    super::errors::validate_report_hints(&report, &semantic_hints)?;
+    super::errors::validate_report_hints(&report, &semantic_hints, include_quality)?;
 
     Ok(PyProfileReport::new(report))
 }

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -24,10 +24,17 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
 
 /// Enforce the semantic-hint contract against a freshly built report: every
 /// hinted column must exist, and no hint may be proven inert over the full data.
-pub(crate) fn validate_report_hints(report: &ProfileReport, hints: &SemanticHints) -> PyResult<()> {
+pub(crate) fn validate_report_hints(
+    report: &ProfileReport,
+    hints: &SemanticHints,
+    quality_requested: bool,
+) -> PyResult<()> {
     if hints.is_empty() {
         return Ok(());
     }
+    hints
+        .validate_quality_usage(quality_requested)
+        .map_err(|e| analysis_error_to_py(&e))?;
     let names: Vec<&str> = report
         .column_profiles
         .iter()

--- a/crates/dataprof-runtime/src/hint_binding.rs
+++ b/crates/dataprof-runtime/src/hint_binding.rs
@@ -1,0 +1,122 @@
+//! Exact, bounded-memory semantic-hint binding counts for streaming engines.
+
+use dataprof_core::{SemanticHintBinding, SemanticHintKind, SemanticHints};
+use dataprof_metrics::{is_null_like_token, value_matches_hint};
+
+#[derive(Debug, Clone)]
+struct BindingCounter {
+    binding: SemanticHintBinding,
+}
+
+/// Accumulates value-driven hint evidence while an engine scans the full data.
+///
+/// The number of configured hints bounds memory use; no cell values are kept.
+#[derive(Debug, Clone, Default)]
+pub struct ValueHintBindingAccumulator {
+    counters: Vec<BindingCounter>,
+}
+
+impl ValueHintBindingAccumulator {
+    pub fn new(hints: &SemanticHints) -> Self {
+        let positive = hints.positive_columns.iter().map(|column| BindingCounter {
+            binding: SemanticHintBinding {
+                column: column.clone(),
+                kind: SemanticHintKind::Positive,
+                checked_values: 0,
+                matched_values: 0,
+                exact: true,
+            },
+        });
+        let temporal = hints.temporal_columns.iter().map(|column| BindingCounter {
+            binding: SemanticHintBinding {
+                column: column.clone(),
+                kind: SemanticHintKind::Temporal,
+                checked_values: 0,
+                matched_values: 0,
+                exact: true,
+            },
+        });
+        Self {
+            counters: positive.chain(temporal).collect(),
+        }
+    }
+
+    /// Observe one cell using the same null and match predicates as the quality
+    /// calculators and their sample-based binding evidence.
+    pub fn observe(&mut self, column: &str, value: &str) {
+        if is_null_like_token(value.trim()) {
+            return;
+        }
+        for counter in self
+            .counters
+            .iter_mut()
+            .filter(|counter| counter.binding.column == column)
+        {
+            counter.binding.checked_values += 1;
+            if value_matches_hint(value, counter.binding.kind) {
+                counter.binding.matched_values += 1;
+            }
+        }
+    }
+
+    /// Return exact evidence for hints whose columns exist in the source.
+    /// Unknown names remain the schema validator's responsibility.
+    pub fn bindings<'a>(
+        &self,
+        column_names: impl IntoIterator<Item = &'a str>,
+    ) -> Vec<SemanticHintBinding> {
+        let names: std::collections::HashSet<&str> = column_names.into_iter().collect();
+        self.counters
+            .iter()
+            .filter(|counter| names.contains(counter.binding.column.as_str()))
+            .map(|counter| counter.binding.clone())
+            .collect()
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        for other_counter in &other.counters {
+            if let Some(counter) = self.counters.iter_mut().find(|candidate| {
+                candidate.binding.column == other_counter.binding.column
+                    && candidate.binding.kind == other_counter.binding.kind
+            }) {
+                counter.binding.checked_values += other_counter.binding.checked_values;
+                counter.binding.matched_values += other_counter.binding.matched_values;
+            } else {
+                self.counters.push(other_counter.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulates_exact_counts_with_calculator_semantics() {
+        let hints = SemanticHints::new(vec!["amount".to_string()], vec![])
+            .with_temporal_columns(vec!["event".to_string()]);
+        let mut accumulator = ValueHintBindingAccumulator::new(&hints);
+        for value in ["1", " 2", "NULL"] {
+            accumulator.observe("amount", value);
+        }
+        for value in ["2020-01-01", "not-a-date", " 2021-01-01"] {
+            accumulator.observe("event", value);
+        }
+
+        let bindings = accumulator.bindings(["amount", "event"]);
+        assert_eq!(bindings[0].checked_values, 2);
+        assert_eq!(bindings[0].matched_values, 1);
+        assert!(bindings[0].exact);
+        assert_eq!(bindings[1].checked_values, 3);
+        assert_eq!(bindings[1].matched_values, 1);
+        assert!(bindings[1].exact);
+    }
+
+    #[test]
+    fn omits_unknown_columns() {
+        let hints = SemanticHints::new(vec!["missing".to_string()], vec![]);
+        let accumulator = ValueHintBindingAccumulator::new(&hints);
+        assert!(accumulator.bindings(["present"]).is_empty());
+    }
+}

--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "async-streaming")]
 mod async_source;
 
+pub mod hint_binding;
 pub mod memory_config;
 pub mod profile_builder;
 pub mod profile_report;
@@ -11,6 +12,7 @@ pub mod streaming_stats;
 pub use async_source::ReqwestSource;
 #[cfg(feature = "async-streaming")]
 pub use async_source::{AsyncDataSource, AsyncSourceInfo, BytesSource};
+pub use hint_binding::ValueHintBindingAccumulator;
 pub use memory_config::MemoryConfig;
 pub use profile_builder::{
     ColumnProfileInput, ExactNumericAggregates, TextLengths, build_column_profile,

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -28,6 +28,7 @@ pub struct ReportAssembler {
     skip_quality: bool,
     requested_dimensions: Option<Vec<QualityDimension>>,
     semantic_hints: SemanticHints,
+    exact_value_hint_bindings: Option<Vec<SemanticHintBinding>>,
     row_duplicates: Option<RowDuplicateSummary>,
 }
 
@@ -43,6 +44,7 @@ impl ReportAssembler {
             skip_quality: false,
             requested_dimensions: None,
             semantic_hints: SemanticHints::default(),
+            exact_value_hint_bindings: None,
             row_duplicates: None,
         }
     }
@@ -83,6 +85,15 @@ impl ReportAssembler {
         self
     }
 
+    /// Provide full-stream evidence for value-driven semantic hints.
+    ///
+    /// Streaming engines should pass their bounded-memory accumulator output;
+    /// it supersedes evidence recomputed from the retained quality sample.
+    pub fn with_exact_value_hint_bindings(mut self, bindings: Vec<SemanticHintBinding>) -> Self {
+        self.exact_value_hint_bindings = Some(bindings);
+        self
+    }
+
     /// Provide full-stream row-duplicate counts from an engine's row
     /// tracker; they supersede the sample-based duplicate scan.
     pub fn with_row_duplicates(mut self, summary: Option<RowDuplicateSummary>) -> Self {
@@ -109,9 +120,9 @@ impl ReportAssembler {
     ///
     /// Identifier binding is structural — the hint coerces the column's type, so
     /// it is read off the column profiles and is always exact. Positive and
-    /// temporal hints are value-driven; they are measured over the same data the
-    /// quality metrics assessed, tagged `exact` only when that data covers every
-    /// row (see [`Self::is_streaming_context`]).
+    /// temporal hints are value-driven. Streaming engines provide exact
+    /// full-stream counts; callers without those accumulators fall back to the
+    /// quality data and tag the result exact only when it covers every row.
     fn compute_hint_bindings(&self) -> Vec<SemanticHintBinding> {
         if self.semantic_hints.is_empty() {
             return Vec::new();
@@ -136,7 +147,9 @@ impl ReportAssembler {
             }
         }
 
-        if let Some(data) = &self.quality_data {
+        if let Some(exact) = &self.exact_value_hint_bindings {
+            bindings.extend(exact.iter().cloned());
+        } else if let Some(data) = &self.quality_data {
             let sample_size = data.values().map(|v| v.len()).max().unwrap_or(0);
             let exact = !self.is_streaming_context(sample_size);
             bindings.extend(compute_value_hint_bindings(

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -148,7 +148,15 @@ impl ReportAssembler {
         }
 
         if let Some(exact) = &self.exact_value_hint_bindings {
-            bindings.extend(exact.iter().cloned());
+            let full_coverage = self.execution.source_exhausted && !self.execution.sampling_applied;
+            bindings.extend(exact.iter().cloned().map(|mut binding| {
+                // Engine accumulators cover every value they processed. That
+                // is every source row for ordinary reservoir-backed streaming,
+                // but not when row-level sampling skipped records or an early
+                // stop left part of the source unread.
+                binding.exact &= full_coverage;
+                binding
+            }));
         } else if let Some(data) = &self.quality_data {
             let sample_size = data.values().map(|v| v.len()).max().unwrap_or(0);
             let exact = !self.is_streaming_context(sample_size);
@@ -245,7 +253,7 @@ impl ReportAssembler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dataprof_core::FileFormat;
+    use dataprof_core::{FileFormat, TruncationReason};
 
     fn test_source() -> DataSource {
         DataSource::File {
@@ -399,5 +407,43 @@ mod tests {
         assert!(report.quality.is_some());
         let quality = report.quality.unwrap();
         assert!(matches!(quality.confidence, MetricConfidence::Mixed { .. }));
+    }
+
+    fn positive_binding() -> SemanticHintBinding {
+        SemanticHintBinding {
+            column: "col".to_string(),
+            kind: SemanticHintKind::Positive,
+            checked_values: 2,
+            matched_values: 0,
+            exact: true,
+        }
+    }
+
+    #[test]
+    fn exact_hint_binding_stays_exact_for_exhaustive_stream() {
+        let report = ReportAssembler::new(test_source(), ExecutionMetadata::new(2, 1, 10))
+            .with_semantic_hints(SemanticHints::new(vec!["col".to_string()], vec![]))
+            .with_exact_value_hint_bindings(vec![positive_binding()])
+            .build();
+
+        assert!(report.semantic_hint_bindings[0].exact);
+    }
+
+    #[test]
+    fn exact_hint_binding_is_downgraded_for_sampled_or_truncated_execution() {
+        let executions = [
+            ExecutionMetadata::new(2, 1, 10).with_sampling(0.5),
+            ExecutionMetadata::new(2, 1, 10).with_truncation(TruncationReason::MaxRows(2)),
+        ];
+
+        for execution in executions {
+            let report = ReportAssembler::new(test_source(), execution)
+                .with_semantic_hints(SemanticHints::new(vec!["col".to_string()], vec![]))
+                .with_exact_value_hint_bindings(vec![positive_binding()])
+                .build();
+
+            assert!(!report.semantic_hint_bindings[0].exact);
+            assert!(!report.semantic_hint_bindings[0].is_proven_inert());
+        }
     }
 }

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -3,7 +3,8 @@ use rand::{Rng, SeedableRng};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
-use crate::profile_builder::infer_data_type_streaming;
+use crate::{ValueHintBindingAccumulator, profile_builder::infer_data_type_streaming};
+use dataprof_core::{SemanticHintBinding, SemanticHints};
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{CardinalityEstimator, HyperLogLog, RowDuplicateSummary};
 
@@ -472,6 +473,7 @@ pub struct StreamingColumnCollection {
     ordered_names: Vec<String>,
     memory_limit_bytes: usize,
     row_tracker: RowUniquenessTracker,
+    hint_bindings: ValueHintBindingAccumulator,
 }
 
 impl StreamingColumnCollection {
@@ -481,6 +483,7 @@ impl StreamingColumnCollection {
             ordered_names: Vec::new(),
             memory_limit_bytes: 100 * 1024 * 1024,
             row_tracker: RowUniquenessTracker::default(),
+            hint_bindings: ValueHintBindingAccumulator::default(),
         }
     }
 
@@ -490,7 +493,14 @@ impl StreamingColumnCollection {
             ordered_names: Vec::new(),
             memory_limit_bytes: limit_mb * 1024 * 1024,
             row_tracker: RowUniquenessTracker::default(),
+            hint_bindings: ValueHintBindingAccumulator::default(),
         }
+    }
+
+    /// Configure value-driven semantic hints before records are processed.
+    pub fn with_semantic_hints(mut self, hints: &SemanticHints) -> Self {
+        self.hint_bindings = ValueHintBindingAccumulator::new(hints);
+        self
     }
 
     pub fn init_columns(&mut self, headers: &[String]) {
@@ -545,6 +555,7 @@ impl StreamingColumnCollection {
             }
             let stats = self.columns.entry(header.to_string()).or_default();
             stats.update(&value);
+            self.hint_bindings.observe(header, &value);
         }
 
         if !headers.is_empty() {
@@ -555,6 +566,12 @@ impl StreamingColumnCollection {
     /// Full-stream row-duplicate counts, or `None` when no rows were seen.
     pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
         self.row_tracker.summary()
+    }
+
+    /// Exact value-driven semantic-hint evidence over every processed record.
+    pub fn semantic_hint_bindings(&self) -> Vec<SemanticHintBinding> {
+        self.hint_bindings
+            .bindings(self.ordered_names.iter().map(String::as_str))
     }
 
     pub fn get_column_stats(&self, column_name: &str) -> Option<&StreamingStatistics> {
@@ -613,6 +630,7 @@ impl StreamingColumnCollection {
             }
         }
         self.row_tracker.merge(&other.row_tracker);
+        self.hint_bindings.merge(&other.hint_bindings);
     }
 }
 

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -440,6 +440,8 @@ impl Profiler {
         if hints.is_empty() {
             return Ok(());
         }
+        let packs = self.effective_metric_packs();
+        hints.validate_quality_usage(MetricPack::include_quality(packs.as_deref()))?;
         let names: Vec<&str> = report
             .column_profiles
             .iter()

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -129,13 +129,14 @@ cannot bind is now an error instead of a silent no-op:
 
 Reports gained `semantic_hint_bindings`, per-column evidence of how each hint
 bound (`column`, `kind`, `checked_values`, `matched_values`, `exact`).
-Value-driven hints are measured over the same data the quality metrics assessed;
-`exact` states whether that covered every row. A hint that matched nothing is
-only rejected when the evidence is `exact`, so on a sampled stream a zero match
-is recorded as evidence rather than mistaken for proof of absence — surfacing
-that universally would require full-stream binding accounting, which pairs
-naturally with the inferred-date accounting work (#430). The field is additive;
-older readers ignore it.
+Value-driven hints are counted by bounded-memory accumulators over the full
+processed stream, even when quality metrics use a reservoir sample. Their
+evidence is therefore exact, and an inert hint is rejected consistently on
+large streamed sources without risking a false positive when a match exists
+outside the retained sample. Supplying `positive_columns` or
+`temporal_columns` without the Quality metric pack is also an error because
+those hints would have no consumer; `identifier_columns` remains usable because
+it affects column typing. The field is additive; older readers ignore it.
 
 ---
 

--- a/tests/semantic_hints.rs
+++ b/tests/semantic_hints.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use dataprof::{ColumnStats, DataProfilerError, DataType, EngineType, Profiler};
+use dataprof::{ColumnStats, DataProfilerError, DataType, EngineType, MetricPack, Profiler};
 use tempfile::NamedTempFile;
 
 fn write_csv(content: &str) -> NamedTempFile {
@@ -302,4 +302,70 @@ fn multiple_unknown_hint_names_are_reported_together() {
         .temporal_columns(vec!["nope_b".to_string()])
         .analyze_file(csv.path());
     assert_hint_error(result, &["'nope_a'", "'nope_b'"]);
+}
+
+#[test]
+fn inert_positive_hint_is_rejected_beyond_stream_reservoir() {
+    let mut csv = String::from("value\n");
+    for _ in 0..10_050 {
+        csv.push_str("not-a-number\n");
+    }
+    let csv = write_csv(&csv);
+
+    let result = Profiler::new()
+        .engine(EngineType::Incremental)
+        .positive_columns(vec!["value".to_string()])
+        .analyze_file(csv.path());
+
+    assert_hint_error(result, &["'value'", "positive_columns", "0 of 10050"]);
+}
+
+#[test]
+fn full_stream_match_prevents_false_inert_error() {
+    let mut csv = String::from("value\n1\n");
+    for _ in 0..10_050 {
+        csv.push_str("not-a-number\n");
+    }
+    let csv = write_csv(&csv);
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .positive_columns(vec!["value".to_string()])
+        .analyze_file(csv.path())
+        .expect("one full-stream match must make the hint active");
+
+    let binding = report
+        .semantic_hint_bindings
+        .iter()
+        .find(|binding| binding.column == "value")
+        .expect("positive binding");
+    assert_eq!(binding.checked_values, 10_051);
+    assert_eq!(binding.matched_values, 1);
+    assert!(binding.exact);
+}
+
+#[test]
+fn value_driven_hint_without_quality_is_rejected() {
+    let csv = write_csv("value\n1\n2\n");
+    let result = Profiler::new()
+        .engine(EngineType::Incremental)
+        .metric_packs(vec![MetricPack::Schema])
+        .positive_columns(vec!["value".to_string()])
+        .analyze_file(csv.path());
+
+    assert_hint_error(result, &["positive_columns", "Quality metric pack"]);
+}
+
+#[test]
+fn identifier_hint_remains_usable_without_quality() {
+    let csv = write_csv("code\n1\n2\n");
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .metric_packs(vec![MetricPack::Schema])
+        .identifier_columns(vec!["code".to_string()])
+        .analyze_file(csv.path())
+        .expect("identifier hints affect typing without quality");
+
+    assert!(report.quality.is_none());
+    assert_eq!(report.column_profiles[0].data_type, DataType::Identifier);
 }

--- a/tests/semantic_hints.rs
+++ b/tests/semantic_hints.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use dataprof::{ColumnStats, DataProfilerError, DataType, EngineType, MetricPack, Profiler};
+use dataprof::{SamplingStrategy, StopCondition};
 use tempfile::NamedTempFile;
 
 fn write_csv(content: &str) -> NamedTempFile {
@@ -368,4 +369,44 @@ fn identifier_hint_remains_usable_without_quality() {
 
     assert!(report.quality.is_none());
     assert_eq!(report.column_profiles[0].data_type, DataType::Identifier);
+}
+
+#[test]
+fn zero_match_on_row_sample_is_not_treated_as_proven_inert() {
+    let csv = write_csv("value\ntext\n1\nmore-text\n");
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .sampling(SamplingStrategy::Systematic { interval: 2 })
+        .positive_columns(vec!["value".to_string()])
+        .analyze_file(csv.path())
+        .expect("unseen rows may contain a match");
+
+    let binding = report
+        .semantic_hint_bindings
+        .iter()
+        .find(|binding| binding.column == "value")
+        .expect("positive binding");
+    assert_eq!(binding.matched_values, 0);
+    assert!(!binding.exact);
+    assert!(!binding.is_proven_inert());
+}
+
+#[test]
+fn zero_match_before_early_stop_is_not_treated_as_proven_inert() {
+    let csv = write_csv("value\ntext\nmore-text\n1\n");
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .stop_when(StopCondition::MaxRows(2))
+        .positive_columns(vec!["value".to_string()])
+        .analyze_file(csv.path())
+        .expect("unread rows may contain a match");
+
+    let binding = report
+        .semantic_hint_bindings
+        .iter()
+        .find(|binding| binding.column == "value")
+        .expect("positive binding");
+    assert_eq!(binding.matched_values, 0);
+    assert!(!binding.exact);
+    assert!(!binding.is_proven_inert());
 }


### PR DESCRIPTION
Closes #442.

## What changed

- add bounded-memory, per-column full-stream binding counters for `positive_columns` and `temporal_columns`
- feed exact binding evidence through CSV, JSON, incremental/async streaming, Arrow CSV, Parquet, and Arrow-backed Python paths
- keep match predicates shared with the quality calculators so raw-string and null semantics stay identical
- reject value-driven hints when the Quality metric pack is not requested; identifier hints remain valid because they affect typing
- update release notes and add regressions beyond the 10,000-value reservoir boundary

## Why

The semantic-hint validation introduced by #420/#441 recomputed value binding from retained quality samples. On large streams, a genuinely inert hint therefore produced `exact: false` evidence and could not be rejected. Conversely, treating a zero sample match as exact would risk rejecting a hint that matched elsewhere in the stream.

The engines already process each value while building bounded-memory statistics, so the new counters establish exact evidence without retaining the full dataset.

## User impact

- inert positive/temporal hints now fail consistently on large streamed sources
- a match anywhere in the processed stream prevents a false inert-hint error
- streamed `semantic_hint_bindings` now reports `exact: true` for value-driven hints
- unusable value-driven hints without Quality fail loudly instead of silently doing nothing

## Validation

- `cargo test -p dataprof-runtime`
- `cargo test -p dataprof-core`
- `cargo test -p dataprof-metrics`
- `cargo test -p dataprof-engines`
- `cargo test -p dataprof-parquet --features parquet-async`
- `cargo test --test semantic_hints`
- `cargo test -p dataprof-python`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`