### PR TITLE
fix(python): preserve DataFrame column order

### DIFF
--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -15,6 +15,7 @@ use dataprof_runtime::{
     TextLengths, build_column_profile,
 };
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt::Write as _;
 
 const NUMERIC_SAMPLE_CAP: usize = 10_000;
@@ -135,22 +136,17 @@ impl RecordBatchAnalyzer {
             let positive_hint = self.semantic_hints.is_positive_column(&column_name);
             let temporal_hint = self.semantic_hints.is_temporal_column(&column_name);
 
-            if !self.column_analyzers.contains_key(&column_name) {
-                self.column_order.push(column_name.clone());
-                self.column_analyzers.insert(
-                    column_name.clone(),
-                    ColumnAnalyzer::with_value_hints(
+            let analyzer = match self.column_analyzers.entry(column_name.clone()) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    self.column_order.push(column_name);
+                    entry.insert(ColumnAnalyzer::with_value_hints(
                         field.data_type(),
                         positive_hint,
                         temporal_hint,
-                    ),
-                );
-            }
-
-            let analyzer = self
-                .column_analyzers
-                .get_mut(&column_name)
-                .expect("column order and analyzers must stay in sync");
+                    ))
+                }
+            };
 
             analyzer.process_array(column)?;
         }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -102,6 +102,7 @@ fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -
 /// Analyzer for processing multiple RecordBatches and building column profiles.
 pub struct RecordBatchAnalyzer {
     column_analyzers: HashMap<String, ColumnAnalyzer>,
+    column_order: Vec<String>,
     total_rows: usize,
     row_tracker: BatchRowTracker,
     semantic_hints: SemanticHints,
@@ -111,6 +112,7 @@ impl RecordBatchAnalyzer {
     pub fn new() -> Self {
         Self {
             column_analyzers: HashMap::new(),
+            column_order: Vec::new(),
             total_rows: 0,
             row_tracker: BatchRowTracker::default(),
             semantic_hints: SemanticHints::default(),
@@ -133,9 +135,22 @@ impl RecordBatchAnalyzer {
             let positive_hint = self.semantic_hints.is_positive_column(&column_name);
             let temporal_hint = self.semantic_hints.is_temporal_column(&column_name);
 
-            let analyzer = self.column_analyzers.entry(column_name).or_insert_with(|| {
-                ColumnAnalyzer::with_value_hints(field.data_type(), positive_hint, temporal_hint)
-            });
+            if !self.column_analyzers.contains_key(&column_name) {
+                self.column_order.push(column_name.clone());
+                self.column_analyzers.insert(
+                    column_name.clone(),
+                    ColumnAnalyzer::with_value_hints(
+                        field.data_type(),
+                        positive_hint,
+                        temporal_hint,
+                    ),
+                );
+            }
+
+            let analyzer = self
+                .column_analyzers
+                .get_mut(&column_name)
+                .expect("column order and analyzers must stay in sync");
 
             analyzer.process_array(column)?;
         }
@@ -174,17 +189,21 @@ impl RecordBatchAnalyzer {
         locale: Option<&str>,
         semantic_hints: &SemanticHints,
     ) -> Vec<ColumnProfile> {
-        let mut profiles = Vec::new();
-        for (name, analyzer) in &self.column_analyzers {
-            profiles.push(analyzer.to_column_profile(
-                name.clone(),
-                skip_statistics,
-                skip_patterns,
-                locale,
-                semantic_hints,
-            ));
-        }
-        profiles
+        self.column_order
+            .iter()
+            .map(|name| {
+                self.column_analyzers
+                    .get(name)
+                    .expect("column order and analyzers must stay in sync")
+                    .to_column_profile(
+                        name.clone(),
+                        skip_statistics,
+                        skip_patterns,
+                        locale,
+                        semantic_hints,
+                    )
+            })
+            .collect()
     }
 
     pub fn create_sample_columns(&self) -> HashMap<String, Vec<String>> {
@@ -1086,6 +1105,36 @@ mod tests {
         assert_eq!(col.total_count, 5);
         assert_eq!(col.null_count, 5);
         assert_eq!(col.unique_count, Some(0));
+    }
+
+    #[test]
+    fn test_profiles_preserve_record_batch_column_order() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("num", ArrowDataType::Float64, false),
+            Field::new("cat", ArrowDataType::Utf8, false),
+            Field::new("when", ArrowDataType::Date32, false),
+            Field::new("big", ArrowDataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Float64Array::from(vec![1.5])),
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(Date32Array::from(vec![19_723])),
+                Arc::new(Int64Array::from(vec![1_i64 << 40])),
+            ],
+        )
+        .unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        analyzer.process_batch(&batch).unwrap();
+
+        let names: Vec<_> = analyzer
+            .to_profiles(false, false, None)
+            .into_iter()
+            .map(|profile| profile.name)
+            .collect();
+        assert_eq!(names, ["num", "cat", "when", "big"]);
     }
 
     #[test]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recorded but never mistaken for proof of absence. Additive report field —
   older readers ignore it. (#420)
 
+### Fixed
+
+- Python DataFrame and Arrow-backed profiles now preserve source schema column
+  order in report exports. `ProfileReport.compare()` column output is no longer
+  alphabetically sorted: it follows the left report's schema order, then appends
+  right-only columns in their source order. (#427)
+
 ## [0.9.0] - 2026-07-09
 
 See [release-notes.md](release-notes.md) for the narrative 0.9.0 notes and the

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -2104,6 +2104,8 @@ class ProfileReport:
         b_order = list(b_cols)
         a_names = set(a_order)
         b_names = set(b_order)
+        # Preserve the left report's schema order, then append right-only
+        # columns in their source order.
         all_names = [*a_order, *(name for name in b_order if name not in a_names)]
 
         def _null_pct(cols: dict[str, ColumnProfile], name: str) -> float | None:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -2100,15 +2100,18 @@ class ProfileReport:
 
         a_cols = self.column_profiles
         b_cols = other.column_profiles
-        a_names = set(a_cols)
-        b_names = set(b_cols)
+        a_order = list(a_cols)
+        b_order = list(b_cols)
+        a_names = set(a_order)
+        b_names = set(b_order)
+        all_names = [*a_order, *(name for name in b_order if name not in a_names)]
 
         def _null_pct(cols: dict[str, ColumnProfile], name: str) -> float | None:
             col = cols.get(name)
             return _r2(col.null_percentage) if col is not None else None
 
         columns: dict[str, dict[str, float | None]] = {}
-        for name in sorted(a_names | b_names):
+        for name in all_names:
             null_a = _null_pct(a_cols, name)
             null_b = _null_pct(b_cols, name)
             null_delta = None if null_a is None or null_b is None else _r2(null_b - null_a)
@@ -2123,9 +2126,9 @@ class ProfileReport:
             "dimensions": dimensions,
             "columns": columns,
             "schema": {
-                "added": sorted(b_names - a_names),
-                "removed": sorted(a_names - b_names),
-                "common": sorted(a_names & b_names),
+                "added": [name for name in b_order if name not in a_names],
+                "removed": [name for name in a_order if name not in b_names],
+                "common": [name for name in a_order if name in b_names],
             },
         }
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -185,11 +185,19 @@ class TestProfileFile:
 
 class TestProfileDataFrame:
     @staticmethod
-    def assert_column_order(report):
+    def assert_column_order(report, backend):
         expected = ["num", "cat", "when", "big"]
         assert [column["name"] for column in report.to_dict()["columns"]] == expected
-        assert report.to_dataframe()["name"].tolist() == expected
-        assert report.describe().columns.tolist() == expected
+        if backend == "pandas":
+            assert report.to_dataframe()["name"].tolist() == expected
+        else:
+            assert report.to_polars()["name"].to_list() == expected
+
+        described = report.describe()
+        described_columns = (
+            list(described) if isinstance(described, dict) else described.columns.tolist()
+        )
+        assert described_columns == expected
         assert list(report.compare(report)["columns"]) == expected
 
     def test_pandas(self):
@@ -205,7 +213,7 @@ class TestProfileDataFrame:
         r = dataprof.profile(df)
         assert r.rows == 2
         assert r.columns == 4
-        self.assert_column_order(r)
+        self.assert_column_order(r, "pandas")
 
 
 class TestInterop:
@@ -232,7 +240,7 @@ class TestInterop:
         assert batch.num_rows > 0
         assert batch.num_columns > 0
 
-    def test_polars(self):
+    def test_polars(self, monkeypatch):
         pl = pytest.importorskip("polars")
         df = pl.DataFrame(
             {
@@ -245,7 +253,16 @@ class TestInterop:
         r = dataprof.profile(df)
         assert r.rows == 2
         assert r.columns == 4
-        TestProfileDataFrame.assert_column_order(r)
+
+        original_import = builtins.__import__
+
+        def import_without_pandas(name, *args, **kwargs):
+            if name == "pandas":
+                raise ImportError("blocked pandas")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", import_without_pandas)
+        TestProfileDataFrame.assert_column_order(r, "polars")
 
 
 class TestProfileAdHocInputs:

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -159,6 +159,19 @@ class TestProfileFile:
         assert via_profile_file.columns == via_profile.columns
         assert via_profile_file.to_dict()["columns"] == via_profile.to_dict()["columns"]
 
+    def test_csv_preserves_column_order(self, tmp_path):
+        path = tmp_path / "ordered.csv"
+        path.write_text("num,cat,when,big\n1.5,a,2024-01-01,1099511627776\n")
+
+        report = dataprof.profile(path)
+
+        assert [column["name"] for column in report.to_dict()["columns"]] == [
+            "num",
+            "cat",
+            "when",
+            "big",
+        ]
+
     def test_missing_file_raises_file_not_found(self):
         missing = str(FIXTURES / "does_not_exist.csv")
         with pytest.raises(FileNotFoundError, match="does_not_exist.csv") as excinfo:
@@ -171,12 +184,28 @@ class TestProfileFile:
 
 
 class TestProfileDataFrame:
+    @staticmethod
+    def assert_column_order(report):
+        expected = ["num", "cat", "when", "big"]
+        assert [column["name"] for column in report.to_dict()["columns"]] == expected
+        assert report.to_dataframe()["name"].tolist() == expected
+        assert report.describe().columns.tolist() == expected
+        assert list(report.compare(report)["columns"]) == expected
+
     def test_pandas(self):
         pd = pytest.importorskip("pandas")
-        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        df = pd.DataFrame(
+            {
+                "num": [1.5, 2.5],
+                "cat": ["a", "b"],
+                "when": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+                "big": [2**40, 2**40 + 1],
+            }
+        )
         r = dataprof.profile(df)
-        assert r.rows == 3
-        assert r.columns == 2
+        assert r.rows == 2
+        assert r.columns == 4
+        self.assert_column_order(r)
 
 
 class TestInterop:
@@ -205,10 +234,18 @@ class TestInterop:
 
     def test_polars(self):
         pl = pytest.importorskip("polars")
-        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        df = pl.DataFrame(
+            {
+                "num": [1.5, 2.5],
+                "cat": ["a", "b"],
+                "when": ["2024-01-01", "2024-01-02"],
+                "big": [2**40, 2**40 + 1],
+            }
+        )
         r = dataprof.profile(df)
-        assert r.rows == 3
-        assert r.columns == 2
+        assert r.rows == 2
+        assert r.columns == 4
+        TestProfileDataFrame.assert_column_order(r)
 
 
 class TestProfileAdHocInputs:


### PR DESCRIPTION
## Summary

- preserve first-seen Arrow schema order while retaining hash-map lookup for column analyzers
- carry DataFrame order through report exports and order `compare()` output left-first
- add pandas, polars, Rust, and file-based CSV regressions for `num, cat, when, big`

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

Closes #427

## Validation

- `uv run pytest python/tests/test_python_api.py::TestProfileDataFrame::test_pandas python/tests/test_python_api.py::TestInterop::test_polars -q` (2 passed; Polars path explicitly blocks pandas)
- `uv run pytest -q` (356 passed, 3 skipped: optional async/database features not compiled)
- `cargo test -p dataprof-parquet --features arrow` (15 passed)
- `cargo test -p dataprof-core` (89 passed plus 1 doctest)
- `cargo test -p dataprof-python` (package compiled; no Rust unit tests defined)
- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings`
- `uv run ruff check python/ .github/scripts/`
- `uv run ruff format --check python/ .github/scripts/`
- `uv run ty check python/`

## Notes

- This intentionally changes the public `ProfileReport.compare()` column-ordering contract for all report sources: output follows the left report's schema order, then appends right-only columns in their source order instead of sorting alphabetically.
- File-based CSV profiling is now covered by the same source-order regression contract; file parsing and file formats are unchanged.
- AI disclosure: this PR was prepared with OpenAI Codex assistance; the final diff was self-reviewed and validated with the commands above.

## Checklist

- [x] Code builds without warnings
- [x] Relevant tests pass
- [x] Code is formatted
- [x] No linting errors
- [x] Added regression coverage
- [x] Self-reviewed the diff
- [x] No hardcoded secrets or sensitive data