### PR TITLE
fix: assess inferred dates in timeliness

### DIFF
--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -24,14 +24,17 @@ pub struct ColumnProfile {
     /// is unsafe for those checks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_count_is_approximate: Option<bool>,
-    /// Non-null values that did not parse for the column's inferred type and
-    /// were therefore excluded from `stats`: non-finite or malformed numbers
-    /// on numeric columns, and invalid calendar values on date columns.
+    /// Non-null values that failed the column type's raw validity predicate:
+    /// non-finite or malformed numbers on numeric columns, and values that do
+    /// not parse directly as calendar dates on date columns. The date predicate
+    /// intentionally does not trim surrounding whitespace; descriptive date
+    /// statistics may normalize whitespace independently.
     ///
-    /// For numeric and date columns this makes the statistics denominator auditable:
-    /// `mean`/`std_dev` cover `total_count - null_count - invalid_count`
-    /// values. `None` means the check did not run (non-numeric column, or
-    /// statistics skipped) — never "no invalid values", which is `Some(0)`.
+    /// For numeric columns, `mean`/`std_dev` cover
+    /// `total_count - null_count - invalid_count` values. For date columns,
+    /// this count audits the strict raw-value quality predicate. `None` means
+    /// the check did not run (another column type, or statistics skipped) —
+    /// never "no invalid values", which is `Some(0)`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub invalid_count: Option<usize>,
     pub stats: ColumnStats,

--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -24,11 +24,11 @@ pub struct ColumnProfile {
     /// is unsafe for those checks.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_count_is_approximate: Option<bool>,
-    /// Non-null values that did not parse as a finite number for the column's
-    /// type — parse failures and non-finite tokens like `inf`/`NaN` — and were
-    /// therefore excluded from `stats`.
+    /// Non-null values that did not parse for the column's inferred type and
+    /// were therefore excluded from `stats`: non-finite or malformed numbers
+    /// on numeric columns, and invalid calendar values on date columns.
     ///
-    /// For numeric columns this makes the statistics denominator auditable:
+    /// For numeric and date columns this makes the statistics denominator auditable:
     /// `mean`/`std_dev` cover `total_count - null_count - invalid_count`
     /// values. `None` means the check did not run (non-numeric column, or
     /// statistics skipped) — never "no invalid values", which is `Some(0)`.

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -53,7 +53,23 @@ fn analyze_column_with_options(name: &str, data: &[String], fast_mode: bool) -> 
             );
             ColumnStats::Numeric(numeric)
         }
-        DataType::Date => calculate_datetime_stats(data),
+        DataType::Date => {
+            let parsed = data
+                .iter()
+                .filter(|value| {
+                    super::metrics::value_matches_hint(
+                        value,
+                        dataprof_core::SemanticHintKind::Temporal,
+                    )
+                })
+                .count();
+            invalid_count = Some(
+                total_count
+                    .saturating_sub(null_count)
+                    .saturating_sub(parsed),
+            );
+            calculate_datetime_stats(data)
+        }
         DataType::Boolean => {
             let tc = data
                 .iter()

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -75,9 +75,9 @@ use validity::ValidityCalculator;
 use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
 use crate::types::{
-    AccuracyMetrics, ColumnProfile, CompletenessMetrics, ConsistencyMetrics, PrecisionMetrics,
-    QualityDimension, QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
-    ValidityMetrics,
+    AccuracyMetrics, ColumnProfile, CompletenessMetrics, ConsistencyMetrics, DataType,
+    PrecisionMetrics, QualityDimension, QualityMetrics, RowDuplicateSummary, TimelinessMetrics,
+    UniquenessMetrics, ValidityMetrics,
 };
 use dataprof_core::SemanticHints;
 use std::collections::HashMap;
@@ -134,6 +134,22 @@ impl MetricsCalculator {
             None => true,
             Some(dims) => dims.contains(&dim),
         }
+    }
+
+    /// Explicit temporal hints plus columns the profiler itself inferred as dates.
+    /// Hint order wins for ambiguous start/end role matching; inferred columns
+    /// are appended in stable profile order and duplicates are removed.
+    fn effective_temporal_columns(
+        column_profiles: &[ColumnProfile],
+        semantic_hints: &SemanticHints,
+    ) -> Vec<String> {
+        let mut columns = semantic_hints.temporal_columns.clone();
+        for profile in column_profiles {
+            if profile.data_type == DataType::Date && !columns.contains(&profile.name) {
+                columns.push(profile.name.clone());
+            }
+        }
+        columns
     }
 
     /// Calculate comprehensive data quality metrics from column data.
@@ -305,12 +321,15 @@ impl MetricsCalculator {
 
         // Timeliness dimension
         let timeliness = if Self::is_requested(requested, QualityDimension::Timeliness) {
-            let t = TimelinessCalculator::new(&self.thresholds)
-                .calculate(data, &semantic_hints.temporal_columns)?;
+            let temporal_columns =
+                Self::effective_temporal_columns(column_profiles, semantic_hints);
+            let t =
+                TimelinessCalculator::new(&self.thresholds).calculate(data, &temporal_columns)?;
             Some(TimelinessMetrics {
                 future_dates_count: t.future_dates_count,
                 stale_data_ratio: t.stale_data_ratio,
                 temporal_violations: t.temporal_violations,
+                invalid_date_values: t.invalid_date_values,
                 date_values_checked: t.date_values_checked,
                 temporal_pairs_checked: t.temporal_pairs_checked,
             })
@@ -411,6 +430,7 @@ impl MetricsCalculator {
                     future_dates_count: 0,
                     stale_data_ratio: 0.0,
                     temporal_violations: 0,
+                    invalid_date_values: 0,
                     date_values_checked: 0,
                     temporal_pairs_checked: 0,
                 })
@@ -639,14 +659,16 @@ impl MetricsCalculator {
         };
 
         let timeliness = if Self::is_requested(requested, QualityDimension::Timeliness) {
+            let temporal_columns =
+                Self::effective_temporal_columns(column_profiles, semantic_hints);
             let t = if !data.is_empty() {
-                TimelinessCalculator::new(&self.thresholds)
-                    .calculate(data, &semantic_hints.temporal_columns)?
+                TimelinessCalculator::new(&self.thresholds).calculate(data, &temporal_columns)?
             } else {
                 timeliness::TimelinessMetrics {
                     future_dates_count: 0,
                     stale_data_ratio: 0.0,
                     temporal_violations: 0,
+                    invalid_date_values: 0,
                     date_values_checked: 0,
                     temporal_pairs_checked: 0,
                 }
@@ -656,6 +678,7 @@ impl MetricsCalculator {
                 future_dates_count: t.future_dates_count,
                 stale_data_ratio: t.stale_data_ratio,
                 temporal_violations: t.temporal_violations,
+                invalid_date_values: t.invalid_date_values,
                 date_values_checked: t.date_values_checked,
                 temporal_pairs_checked: t.temporal_pairs_checked,
             })

--- a/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
@@ -4,6 +4,7 @@
 //! Key metrics: future dates, stale data ratio, temporal violations.
 
 use super::utils::extract_year;
+use crate::analysis::inference::is_null_like_token;
 use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
 use chrono::Datelike;
@@ -15,6 +16,7 @@ pub(crate) struct TimelinessMetrics {
     pub future_dates_count: usize,
     pub stale_data_ratio: f64,
     pub temporal_violations: usize,
+    pub invalid_date_values: usize,
     pub date_values_checked: usize,
     pub temporal_pairs_checked: usize,
 }
@@ -35,9 +37,8 @@ impl<'a> TimelinessCalculator<'a> {
         data: &HashMap<String, Vec<String>>,
         temporal_columns: &[String],
     ) -> Result<TimelinessMetrics, DataProfilerError> {
-        let future_dates_count = Self::count_future_dates(data, temporal_columns)?;
-        let (stale_data_ratio, date_values_checked) =
-            self.calculate_stale_data_ratio(data, temporal_columns)?;
+        let (future_dates_count, stale_data_ratio, date_values_checked, invalid_date_values) =
+            self.calculate_date_summary(data, temporal_columns);
         let (temporal_violations, temporal_pairs_checked) =
             Self::count_temporal_violations(data, temporal_columns)?;
 
@@ -45,82 +46,61 @@ impl<'a> TimelinessCalculator<'a> {
             future_dates_count,
             stale_data_ratio,
             temporal_violations,
+            invalid_date_values,
             date_values_checked,
             temporal_pairs_checked,
         })
     }
 
-    /// Count dates that are in the future (beyond current date)
-    fn count_future_dates(
-        data: &HashMap<String, Vec<String>>,
-        temporal_columns: &[String],
-    ) -> Result<usize, DataProfilerError> {
-        let mut future_count = 0;
-
-        // Get current year from system time
-        let current_year = chrono::Utc::now().year();
-
-        for (column_name, column_data) in data {
-            if !temporal_columns.contains(column_name) {
-                continue;
-            }
-            for value in column_data {
-                if value.is_empty() {
-                    continue;
-                }
-
-                // Extract year from common date formats
-                if let Some(year) = extract_year(value)
-                    && year > current_year
-                {
-                    future_count += 1;
-                }
-            }
-        }
-
-        Ok(future_count)
-    }
-
-    /// Calculate percentage of stale data (older than threshold); returns
-    /// `(ratio, date values with an extractable year)`.
-    fn calculate_stale_data_ratio(
+    /// Assess every non-null value in the selected temporal columns.
+    ///
+    /// `date_values_checked` is the complete denominator. Values that do not
+    /// parse as real calendar dates remain visible as `invalid_date_values`
+    /// instead of disappearing from both the metric and its score.
+    fn calculate_date_summary(
         &self,
         data: &HashMap<String, Vec<String>>,
         temporal_columns: &[String],
-    ) -> Result<(f64, usize), DataProfilerError> {
-        let mut total_dates = 0;
+    ) -> (usize, f64, usize, usize) {
+        let mut future_count = 0;
         let mut stale_dates = 0;
+        let mut valid_dates = 0;
+        let mut checked = 0;
+        let mut invalid_dates = 0;
 
-        // Get current year from system time
         let current_year = chrono::Utc::now().year();
         let threshold_year = current_year - self.thresholds.max_data_age_years as i32;
 
-        for (column_name, column_data) in data {
-            if !temporal_columns.contains(column_name) {
+        for column_name in temporal_columns {
+            let Some(column_data) = data.get(column_name) else {
                 continue;
-            }
+            };
             for value in column_data {
-                if value.is_empty() {
+                if is_null_like_token(value.trim()) {
                     continue;
                 }
+                checked += 1;
 
                 if let Some(year) = extract_year(value) {
-                    total_dates += 1;
+                    valid_dates += 1;
+                    if year > current_year {
+                        future_count += 1;
+                    }
                     if year < threshold_year {
                         stale_dates += 1;
                     }
+                } else {
+                    invalid_dates += 1;
                 }
             }
         }
 
-        if total_dates == 0 {
-            Ok((0.0, 0))
+        let stale_ratio = if valid_dates == 0 {
+            0.0
         } else {
-            Ok((
-                (stale_dates as f64 / total_dates as f64) * 100.0,
-                total_dates,
-            ))
-        }
+            (stale_dates as f64 / valid_dates as f64) * 100.0
+        };
+        (future_count, stale_ratio, checked, invalid_dates)
     }
 
     /// Count temporal ordering violations (e.g., end_date < start_date);
@@ -163,10 +143,15 @@ impl<'a> TimelinessCalculator<'a> {
 
             if let (Some(start_values), Some(end_values)) = (start_data, end_data) {
                 for (start_val, end_val) in start_values.iter().zip(end_values.iter()) {
-                    if start_val.is_empty() || end_val.is_empty() {
+                    if is_null_like_token(start_val.trim()) || is_null_like_token(end_val.trim()) {
                         continue;
                     }
 
+                    // Invalid calendar values are already reported by
+                    // `invalid_date_values` and cannot form a meaningful pair.
+                    if extract_year(start_val).is_none() || extract_year(end_val).is_none() {
+                        continue;
+                    }
                     pairs_checked += 1;
                     // Compare as sortable strings (works for ISO dates YYYY-MM-DD)
                     if start_val > end_val {
@@ -213,7 +198,25 @@ mod tests {
             .calculate(&data, &["event_value".to_string()])
             .expect("timeliness metrics");
 
-        assert_eq!(metrics.date_values_checked, 1);
+        assert_eq!(metrics.date_values_checked, 2);
+        assert_eq!(metrics.invalid_date_values, 1);
+    }
+
+    #[test]
+    fn invalid_calendar_values_are_not_compared_as_temporal_pairs() {
+        let data = HashMap::from([
+            ("start".to_string(), vec!["2024-13-45".to_string()]),
+            ("end".to_string(), vec!["2024-01-01".to_string()]),
+        ]);
+        let config = IsoQualityConfig::default();
+
+        let metrics = TimelinessCalculator::new(&config)
+            .calculate(&data, &["start".to_string(), "end".to_string()])
+            .expect("timeliness metrics");
+
+        assert_eq!(metrics.invalid_date_values, 1);
+        assert_eq!(metrics.temporal_pairs_checked, 0);
+        assert_eq!(metrics.temporal_violations, 0);
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/metrics/utils.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/utils.rs
@@ -172,7 +172,7 @@ fn identifier_words(column_name: &str) -> Vec<&str> {
 /// Extract year from common date formats
 /// Supports: YYYY-MM-DD, DD/MM/YYYY, DD-MM-YYYY, YYYY/MM/DD
 pub(crate) fn extract_year(date_str: &str) -> Option<i32> {
-    parse_raw_datetime_year(date_str).filter(|year| (1900..=2100).contains(year))
+    parse_raw_datetime_year(date_str)
 }
 
 /// Calculate percentile using linear interpolation (Type 7 - R/Excel default)

--- a/crates/dataprof-metrics/src/analysis/metrics/utils.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/utils.rs
@@ -6,6 +6,8 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
+use crate::stats::datetime::parse_raw_datetime_year;
+
 // Pre-compile date validation regex patterns for better performance
 pub(crate) static DATE_VALIDATION_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     vec![
@@ -170,23 +172,7 @@ fn identifier_words(column_name: &str) -> Vec<&str> {
 /// Extract year from common date formats
 /// Supports: YYYY-MM-DD, DD/MM/YYYY, DD-MM-YYYY, YYYY/MM/DD
 pub(crate) fn extract_year(date_str: &str) -> Option<i32> {
-    // Try YYYY-MM-DD or YYYY/MM/DD format (year first)
-    if date_str.len() >= 4
-        && let Ok(year) = date_str[0..4].parse::<i32>()
-        && (1900..=2100).contains(&year)
-    {
-        return Some(year);
-    }
-
-    // Try DD/MM/YYYY or DD-MM-YYYY format (year last)
-    if date_str.len() >= 10
-        && let Ok(year) = date_str[6..10].parse::<i32>()
-        && (1900..=2100).contains(&year)
-    {
-        return Some(year);
-    }
-
-    None
+    parse_raw_datetime_year(date_str).filter(|year| (1900..=2100).contains(year))
 }
 
 /// Calculate percentile using linear interpolation (Type 7 - R/Excel default)

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -90,7 +90,12 @@ pub struct TimelinessMetrics {
     #[serde(serialize_with = "crate::serde_helpers::round_2")]
     pub stale_data_ratio: f64,
     pub temporal_violations: usize,
-    /// Date values with an extractable year in date-typed columns. 0 means
+    /// Non-null values in inferred or explicitly configured temporal columns
+    /// that failed calendar-date parsing.
+    #[serde(default)]
+    pub invalid_date_values: usize,
+    /// Non-null values examined in inferred or explicitly configured temporal
+    /// columns. 0 means
     /// the dimension had nothing to assess and it is excluded from the
     /// overall score.
     #[serde(default)]
@@ -192,6 +197,7 @@ impl QualityMetrics {
                 future_dates_count: 0,
                 stale_data_ratio: 0.0,
                 temporal_violations: 0,
+                invalid_date_values: 0,
                 date_values_checked: 0,
                 temporal_pairs_checked: 0,
             }),
@@ -288,7 +294,7 @@ impl QualityMetrics {
     }
 
     /// Score for the timeliness dimension (0-100), or `None` when the
-    /// dimension was not computed or no parseable values were found in the
+    /// dimension was not computed or no values were found in inferred or
     /// explicitly configured temporal columns.
     ///
     /// `100 - stale_data_ratio`, penalized by future dates as a share of
@@ -299,14 +305,15 @@ impl QualityMetrics {
         if t.date_values_checked == 0 {
             return None;
         }
-        let future_ratio = t.future_dates_count as f64 / t.date_values_checked as f64;
+        let value_violation_ratio =
+            (t.future_dates_count + t.invalid_date_values) as f64 / t.date_values_checked as f64;
         let temporal_ratio = if t.temporal_pairs_checked > 0 {
             t.temporal_violations as f64 / t.temporal_pairs_checked as f64
         } else {
             0.0
         };
         Some(
-            (100.0 - t.stale_data_ratio - (future_ratio + temporal_ratio) * 100.0)
+            (100.0 - t.stale_data_ratio - (value_violation_ratio + temporal_ratio) * 100.0)
                 .clamp(0.0, 100.0),
         )
     }
@@ -475,6 +482,12 @@ impl QualityMetrics {
             .map_or(0, |t| t.temporal_violations)
     }
 
+    pub fn invalid_date_values(&self) -> usize {
+        self.timeliness
+            .as_ref()
+            .map_or(0, |t| t.invalid_date_values)
+    }
+
     pub fn valid_values_ratio(&self) -> f64 {
         self.validity
             .as_ref()
@@ -602,6 +615,7 @@ mod tests {
                 future_dates_count: 0,
                 stale_data_ratio: 0.0,
                 temporal_violations: 0,
+                invalid_date_values: 0,
                 date_values_checked: 100,
                 temporal_pairs_checked: 100,
             }),

--- a/crates/dataprof-metrics/src/stats/datetime.rs
+++ b/crates/dataprof-metrics/src/stats/datetime.rs
@@ -73,6 +73,13 @@ pub fn compute_datetime_stats(data: &[String]) -> DateTimeStats {
 fn parse_flexible_full(s: &str) -> Option<ParsedDateTime> {
     let trimmed = s.trim();
 
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(trimmed) {
+        return Some(ParsedDateTime {
+            date: dt.date_naive(),
+            datetime: Some(dt.naive_local()),
+        });
+    }
+
     // Try datetime formats first (these have time components)
     if let Ok(dt) = NaiveDateTime::parse_from_str(trimmed, "%Y-%m-%dT%H:%M:%S") {
         return Some(ParsedDateTime {
@@ -124,6 +131,19 @@ fn parse_flexible_full(s: &str) -> Option<ParsedDateTime> {
     }
 
     None
+}
+
+/// Parse a raw quality-metric value and return its calendar year.
+///
+/// Unlike the descriptive datetime statistics path, quality predicates do not
+/// normalize surrounding whitespace: a value must be directly parseable as it
+/// appeared in the source. The calendar parser validates month/day ranges, so
+/// shape-only strings such as `2024-13-45` are rejected.
+pub(crate) fn parse_raw_datetime_year(s: &str) -> Option<i32> {
+    if s != s.trim() {
+        return None;
+    }
+    parse_flexible_full(s).map(|parsed| parsed.date.year())
 }
 
 fn build_year_distribution(dates: &[NaiveDate]) -> HashMap<i32, usize> {
@@ -209,6 +229,15 @@ mod tests {
         let dt = parsed.datetime.unwrap();
         assert_eq!(dt.hour(), 10);
         assert_eq!(dt.minute(), 30);
+    }
+
+    #[test]
+    fn raw_datetime_year_validates_the_complete_calendar_value() {
+        assert_eq!(parse_raw_datetime_year("2024-02-29"), Some(2024));
+        assert_eq!(parse_raw_datetime_year("2024-02-29T10:30:00Z"), Some(2024));
+        assert_eq!(parse_raw_datetime_year("2024-13-45"), None);
+        assert_eq!(parse_raw_datetime_year("2023-02-29"), None);
+        assert_eq!(parse_raw_datetime_year(" 2024-02-29"), None);
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/stats/datetime.rs
+++ b/crates/dataprof-metrics/src/stats/datetime.rs
@@ -140,10 +140,38 @@ fn parse_flexible_full(s: &str) -> Option<ParsedDateTime> {
 /// appeared in the source. The calendar parser validates month/day ranges, so
 /// shape-only strings such as `2024-13-45` are rejected.
 pub(crate) fn parse_raw_datetime_year(s: &str) -> Option<i32> {
-    if s != s.trim() {
+    if !looks_like_raw_datetime_candidate(s) {
         return None;
     }
     parse_flexible_full(s).map(|parsed| parsed.date.year())
+}
+
+/// Cheap shape check before attempting the multi-format chrono parser.
+///
+/// Every supported raw format starts with either `YYYY<sep>MM<sep>DD` or
+/// `DD<sep>MM<sep>YYYY`. Malformed date-shaped values remain candidates so the
+/// calendar parser can reject and count values such as `2024-13-45`.
+fn looks_like_raw_datetime_candidate(s: &str) -> bool {
+    if s != s.trim() || s.len() < 10 {
+        return false;
+    }
+
+    let bytes = s.as_bytes();
+    let ascii_digits = |range: std::ops::Range<usize>| {
+        bytes
+            .get(range)
+            .is_some_and(|slice| slice.iter().all(u8::is_ascii_digit))
+    };
+    let supported_separator = |byte: u8| matches!(byte, b'-' | b'/' | b'.');
+
+    let year_first = ascii_digits(0..4)
+        && bytes.get(4).is_some_and(|byte| supported_separator(*byte))
+        && bytes.get(7) == bytes.get(4);
+    let year_last = ascii_digits(6..10)
+        && bytes.get(2).is_some_and(|byte| supported_separator(*byte))
+        && bytes.get(5) == bytes.get(2);
+
+    year_first || year_last
 }
 
 fn build_year_distribution(dates: &[NaiveDate]) -> HashMap<i32, usize> {
@@ -235,9 +263,12 @@ mod tests {
     fn raw_datetime_year_validates_the_complete_calendar_value() {
         assert_eq!(parse_raw_datetime_year("2024-02-29"), Some(2024));
         assert_eq!(parse_raw_datetime_year("2024-02-29T10:30:00Z"), Some(2024));
+        assert_eq!(parse_raw_datetime_year("1800-01-01"), Some(1800));
+        assert_eq!(parse_raw_datetime_year("2200-01-01"), Some(2200));
         assert_eq!(parse_raw_datetime_year("2024-13-45"), None);
         assert_eq!(parse_raw_datetime_year("2023-02-29"), None);
         assert_eq!(parse_raw_datetime_year(" 2024-02-29"), None);
+        assert_eq!(parse_raw_datetime_year("ordinary text value"), None);
     }
 
     #[test]

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -2,6 +2,7 @@ use crate::record_batch_analyzer::BatchRowTracker;
 use arrow::array::*;
 use arrow::csv::ReaderBuilder;
 use arrow::datatypes::*;
+use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
     ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata, FileFormat,
     MetricPack, PeakMemorySampler, QualityDimension, SemanticHints, TruncationReason,
@@ -302,6 +303,7 @@ struct ColumnAnalyzer {
     false_count: usize,
     // Reservoir sample for pattern detection and order statistics
     sample_values: StreamReservoirSampler,
+    date_matched_values: usize,
 }
 
 impl ColumnAnalyzer {
@@ -322,7 +324,15 @@ impl ColumnAnalyzer {
             true_count: 0,
             false_count: 0,
             sample_values: StreamReservoirSampler::new(NUMERIC_SAMPLE_CAP),
+            date_matched_values: 0,
         }
+    }
+
+    fn offer_sample(&mut self, value: String) {
+        if dataprof_metrics::value_matches_hint(&value, dataprof_core::SemanticHintKind::Temporal) {
+            self.date_matched_values += 1;
+        }
+        self.sample_values.offer(value);
     }
 
     fn process_array(&mut self, array: &dyn Array) -> Result<(), DataProfilerError> {
@@ -467,7 +477,7 @@ impl ColumnAnalyzer {
                 self.cardinality.insert_owned(value.to_string());
 
                 // Keep samples for pattern detection
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -481,7 +491,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert_owned(value.to_string());
 
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -495,7 +505,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert_owned(value.to_string());
 
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -509,7 +519,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert_owned(value.to_string());
 
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -535,7 +545,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(value);
 
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -561,7 +571,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(value);
 
-                self.sample_values.offer(value.to_string());
+                self.offer_sample(value.to_string());
             }
         }
         Ok(())
@@ -580,105 +590,59 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(value_str);
 
-                self.sample_values.offer(value_str.to_string());
+                self.offer_sample(value_str.to_string());
             }
         }
         Ok(())
     }
 
     fn process_date32_array(&mut self, array: &Date32Array) -> Result<(), DataProfilerError> {
-        for i in 0..array.len() {
-            if let Some(value) = array.value(i).into() {
-                // Date32 represents days since epoch
-                let date_str = format!("date32:{}", value);
-                self.update_text_stats(&date_str);
-
-                self.cardinality.insert(&date_str);
-
-                self.sample_values.offer(date_str);
-            }
-        }
-        Ok(())
+        self.process_formatted_temporal_array(array)
     }
 
     fn process_date64_array(&mut self, array: &Date64Array) -> Result<(), DataProfilerError> {
-        for i in 0..array.len() {
-            if let Some(value) = array.value(i).into() {
-                // Date64 represents milliseconds since epoch
-                let date_str = format!("date64:{}", value);
-                self.update_text_stats(&date_str);
-
-                self.cardinality.insert(&date_str);
-
-                self.sample_values.offer(date_str);
-            }
-        }
-        Ok(())
+        self.process_formatted_temporal_array(array)
     }
 
     fn process_timestamp_array(
         &mut self,
         array: &TimestampNanosecondArray,
     ) -> Result<(), DataProfilerError> {
-        for i in 0..array.len() {
-            if let Some(value) = array.value(i).into() {
-                let ts_str = format!("timestamp_ns:{}", value);
-                self.update_text_stats(&ts_str);
-
-                self.cardinality.insert(&ts_str);
-
-                self.sample_values.offer(ts_str);
-            }
-        }
-        Ok(())
+        self.process_formatted_temporal_array(array)
     }
 
     fn process_timestamp_micro_array(
         &mut self,
         array: &TimestampMicrosecondArray,
     ) -> Result<(), DataProfilerError> {
-        for i in 0..array.len() {
-            if let Some(value) = array.value(i).into() {
-                let ts_str = format!("timestamp_us:{}", value);
-                self.update_text_stats(&ts_str);
-
-                self.cardinality.insert(&ts_str);
-
-                self.sample_values.offer(ts_str);
-            }
-        }
-        Ok(())
+        self.process_formatted_temporal_array(array)
     }
 
     fn process_timestamp_milli_array(
         &mut self,
         array: &TimestampMillisecondArray,
     ) -> Result<(), DataProfilerError> {
-        for i in 0..array.len() {
-            if let Some(value) = array.value(i).into() {
-                let ts_str = format!("timestamp_ms:{}", value);
-                self.update_text_stats(&ts_str);
-
-                self.cardinality.insert(&ts_str);
-
-                self.sample_values.offer(ts_str);
-            }
-        }
-        Ok(())
+        self.process_formatted_temporal_array(array)
     }
 
     fn process_timestamp_second_array(
         &mut self,
         array: &TimestampSecondArray,
     ) -> Result<(), DataProfilerError> {
+        self.process_formatted_temporal_array(array)
+    }
+
+    fn process_formatted_temporal_array(
+        &mut self,
+        array: &dyn Array,
+    ) -> Result<(), DataProfilerError> {
+        let formatter = ArrayFormatter::try_new(array, &Default::default())?;
         for i in 0..array.len() {
-            if let Some(value) = array.value(i).into() {
-                let ts_str = format!("timestamp_s:{}", value);
-                self.update_text_stats(&ts_str);
-
-                self.cardinality.insert(&ts_str);
-
-                self.sample_values.offer(ts_str);
+            if !array.is_null(i) {
+                let value = formatter.value(i).to_string();
+                self.update_text_stats(&value);
+                self.cardinality.insert(&value);
+                self.offer_sample(value);
             }
         }
         Ok(())
@@ -701,7 +665,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&hex_str);
 
-                self.sample_values.offer(hex_str);
+                self.offer_sample(hex_str);
             }
         }
         Ok(())
@@ -727,7 +691,7 @@ impl ColumnAnalyzer {
 
                 self.cardinality.insert(&hex_str);
 
-                self.sample_values.offer(hex_str);
+                self.offer_sample(hex_str);
             }
         }
         Ok(())
@@ -744,7 +708,7 @@ impl ColumnAnalyzer {
                     .unwrap_or_else(|_| format!("<type:{}>", array.data_type()));
                 self.update_text_stats(&value);
 
-                self.sample_values.offer(value.clone());
+                self.offer_sample(value.clone());
 
                 self.cardinality.insert_owned(value);
             }
@@ -842,6 +806,7 @@ impl ColumnAnalyzer {
             skip_patterns,
             locale,
             exact_numeric: self.exact_numeric_aggregates(),
+            exact_date_matches: Some(self.date_matched_values),
         })
     }
 

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -329,10 +329,26 @@ impl ColumnAnalyzer {
     }
 
     fn offer_sample(&mut self, value: String) {
-        if dataprof_metrics::value_matches_hint(&value, dataprof_core::SemanticHintKind::Temporal) {
+        if self.should_track_date_matches()
+            && dataprof_metrics::value_matches_hint(
+                &value,
+                dataprof_core::SemanticHintKind::Temporal,
+            )
+        {
             self.date_matched_values += 1;
         }
         self.sample_values.offer(value);
+    }
+
+    fn should_track_date_matches(&self) -> bool {
+        matches!(
+            &self.data_type,
+            arrow::datatypes::DataType::Utf8
+                | arrow::datatypes::DataType::LargeUtf8
+                | arrow::datatypes::DataType::Date32
+                | arrow::datatypes::DataType::Date64
+                | arrow::datatypes::DataType::Timestamp(_, _)
+        )
     }
 
     fn process_array(&mut self, array: &dyn Array) -> Result<(), DataProfilerError> {
@@ -820,6 +836,9 @@ impl ColumnAnalyzer {
             | arrow::datatypes::DataType::Int16
             | arrow::datatypes::DataType::Int8 => DataType::Integer,
             arrow::datatypes::DataType::Boolean => DataType::Boolean,
+            arrow::datatypes::DataType::Date32
+            | arrow::datatypes::DataType::Date64
+            | arrow::datatypes::DataType::Timestamp(_, _) => DataType::Date,
             arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8 => {
                 // Reuse the shared inference logic for consistent type detection
                 // across all engines (dates before numerics, 100% match threshold)

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -246,6 +246,7 @@ pub struct ColumnAnalyzer {
     hint_checked_values: usize,
     positive_matched_values: usize,
     temporal_matched_values: usize,
+    date_matched_values: usize,
 }
 
 impl ColumnAnalyzer {
@@ -279,21 +280,27 @@ impl ColumnAnalyzer {
             hint_checked_values: 0,
             positive_matched_values: 0,
             temporal_matched_values: 0,
+            date_matched_values: 0,
         }
     }
 
     fn offer_sample(&mut self, value: String) {
-        if !is_null_like_token(value.trim()) && (self.positive_hint || self.temporal_hint) {
-            self.hint_checked_values += 1;
-            if self.positive_hint
-                && dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Positive)
-            {
-                self.positive_matched_values += 1;
+        if !is_null_like_token(value.trim()) {
+            let matches_date =
+                dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Temporal);
+            if matches_date {
+                self.date_matched_values += 1;
             }
-            if self.temporal_hint
-                && dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Temporal)
-            {
-                self.temporal_matched_values += 1;
+            if self.positive_hint || self.temporal_hint {
+                self.hint_checked_values += 1;
+                if self.positive_hint
+                    && dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Positive)
+                {
+                    self.positive_matched_values += 1;
+                }
+                if self.temporal_hint && matches_date {
+                    self.temporal_matched_values += 1;
+                }
             }
         }
         self.sample_values.offer(value);
@@ -665,11 +672,12 @@ impl ColumnAnalyzer {
     }
 
     fn process_date32_array(&mut self, array: &Date32Array) -> Result<()> {
+        let formatter = ArrayFormatter::try_new(array, &Default::default())?;
         for index in 0..array.len() {
             if !array.is_null(index) {
                 let days = array.value(index);
                 self.update_numeric_stats(days as f64);
-                let date_str = format!("1970-01-01+{}days", days);
+                let date_str = formatter.value(index).to_string();
                 self.cardinality.insert(&date_str);
                 self.offer_sample(date_str);
             }
@@ -678,11 +686,12 @@ impl ColumnAnalyzer {
     }
 
     fn process_date64_array(&mut self, array: &Date64Array) -> Result<()> {
+        let formatter = ArrayFormatter::try_new(array, &Default::default())?;
         for index in 0..array.len() {
             if !array.is_null(index) {
                 let millis = array.value(index);
                 self.update_numeric_stats(millis as f64);
-                let datetime_str = format!("1970-01-01T00:00:00.000+{}ms", millis);
+                let datetime_str = formatter.value(index).to_string();
                 self.cardinality.insert(&datetime_str);
                 self.offer_sample(datetime_str);
             }
@@ -693,6 +702,8 @@ impl ColumnAnalyzer {
     fn process_timestamp_array(&mut self, array: &dyn Array) -> Result<()> {
         use arrow::array::PrimitiveArray;
 
+        let formatter = ArrayFormatter::try_new(array, &Default::default())?;
+
         if let Some(ts_array) = array
             .as_any()
             .downcast_ref::<PrimitiveArray<arrow::datatypes::TimestampNanosecondType>>()
@@ -701,7 +712,7 @@ impl ColumnAnalyzer {
                 if !ts_array.is_null(index) {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
-                    let ts_str = format!("ts:{}", ts_value);
+                    let ts_str = formatter.value(index).to_string();
                     self.cardinality.insert(&ts_str);
                     self.offer_sample(ts_str);
                 }
@@ -714,7 +725,7 @@ impl ColumnAnalyzer {
                 if !ts_array.is_null(index) {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
-                    let ts_str = format!("ts:{}", ts_value);
+                    let ts_str = formatter.value(index).to_string();
                     self.cardinality.insert(&ts_str);
                     self.offer_sample(ts_str);
                 }
@@ -727,7 +738,7 @@ impl ColumnAnalyzer {
                 if !ts_array.is_null(index) {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
-                    let ts_str = format!("ts:{}", ts_value);
+                    let ts_str = formatter.value(index).to_string();
                     self.cardinality.insert(&ts_str);
                     self.offer_sample(ts_str);
                 }
@@ -740,7 +751,7 @@ impl ColumnAnalyzer {
                 if !ts_array.is_null(index) {
                     let ts_value = ts_array.value(index);
                     self.update_numeric_stats(ts_value as f64);
-                    let ts_str = format!("ts:{}", ts_value);
+                    let ts_str = formatter.value(index).to_string();
                     self.cardinality.insert(&ts_str);
                     self.offer_sample(ts_str);
                 }
@@ -977,6 +988,7 @@ impl ColumnAnalyzer {
             skip_patterns,
             locale,
             exact_numeric: self.exact_numeric_aggregates(),
+            exact_date_matches: Some(self.date_matched_values),
         })
     }
 

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -286,8 +286,8 @@ impl ColumnAnalyzer {
 
     fn offer_sample(&mut self, value: String) {
         if !is_null_like_token(value.trim()) {
-            let matches_date =
-                dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Temporal);
+            let matches_date = self.should_track_date_matches()
+                && dataprof_metrics::value_matches_hint(&value, SemanticHintKind::Temporal);
             if matches_date {
                 self.date_matched_values += 1;
             }
@@ -304,6 +304,17 @@ impl ColumnAnalyzer {
             }
         }
         self.sample_values.offer(value);
+    }
+
+    fn should_track_date_matches(&self) -> bool {
+        matches!(
+            &self.data_type,
+            arrow::datatypes::DataType::Utf8
+                | arrow::datatypes::DataType::LargeUtf8
+                | arrow::datatypes::DataType::Date32
+                | arrow::datatypes::DataType::Date64
+                | arrow::datatypes::DataType::Timestamp(_, _)
+        )
     }
 
     fn hint_binding(&self, column: &str, kind: SemanticHintKind) -> SemanticHintBinding {

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -130,6 +130,7 @@ pub fn profile_columns(
                 // `present` is the full column, so the sample-derived stats
                 // are already exact.
                 exact_numeric: None,
+                exact_date_matches: None,
             }));
 
             if include_quality {

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -376,6 +376,11 @@ impl PyDataQualityMetrics {
         warn_flat_quality_accessor(py, "temporal_violations")?;
         Ok(self.inner.temporal_violations())
     }
+    #[getter]
+    fn invalid_date_values(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_flat_quality_accessor(py, "invalid_date_values")?;
+        Ok(self.inner.invalid_date_values())
+    }
 
     /// True when the underlying sample was below the recommended minimum
     /// (10 rows). Treat quality scores as directional rather than reliable
@@ -591,6 +596,10 @@ impl PyDataQualityMetrics {
                 m.insert(
                     "temporal_violations".into(),
                     t.temporal_violations.into_pyobject(py)?.unbind().into_any(),
+                );
+                m.insert(
+                    "invalid_date_values".into(),
+                    t.invalid_date_values.into_pyobject(py)?.unbind().into_any(),
                 );
                 m.insert(
                     "date_values_checked".into(),

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -60,9 +60,9 @@ pub struct PyColumnProfile {
     #[pyo3(get)]
     pub unique_count_is_approximate: Option<bool>,
     /// Non-null values that did not parse as a finite number — parse failures
-    /// and non-finite tokens like `inf`/`NaN` — and are excluded from the
-    /// statistics. `None` = check did not run (non-numeric column, or
-    /// statistics skipped); `Some(0)` = every non-null value parsed.
+    /// and non-finite tokens like `inf`/`NaN` — or failed the strict raw date
+    /// predicate. `None` = check did not run (another column type, or
+    /// statistics skipped); `Some(0)` = every non-null value was valid.
     #[pyo3(get)]
     pub invalid_count: Option<usize>,
     #[pyo3(get)]

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -50,6 +50,9 @@ pub struct ColumnProfileInput<'a> {
     /// `None` means `sample_values` *is* the full data (in-memory sources)
     /// or the engine has no exact accumulators for the column.
     pub exact_numeric: Option<ExactNumericAggregates>,
+    /// Number of values over the full stream accepted by the temporal parser.
+    /// `None` means `sample_values` is the complete in-memory column.
+    pub exact_date_matches: Option<usize>,
 }
 
 /// Exact streaming aggregates for a numeric column: O(1)-memory statistics that an
@@ -122,6 +125,24 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
                 ColumnStats::Numeric(numeric)
             }
             DataType::Date => {
+                let parsed_dates = input.exact_date_matches.unwrap_or_else(|| {
+                    input
+                        .sample_values
+                        .iter()
+                        .filter(|value| {
+                            dataprof_metrics::value_matches_hint(
+                                value,
+                                dataprof_core::SemanticHintKind::Temporal,
+                            )
+                        })
+                        .count()
+                });
+                invalid_count = Some(
+                    input
+                        .total_count
+                        .saturating_sub(input.null_count)
+                        .saturating_sub(parsed_dates),
+                );
                 if !input.sample_values.is_empty() {
                     calculate_datetime_stats(input.sample_values)
                 } else if let Some(tl) = &input.text_lengths {
@@ -288,6 +309,7 @@ pub fn profile_from_stats_with_hints(
         skip_patterns,
         locale,
         exact_numeric: stats.exact_numeric_aggregates(),
+        exact_date_matches: Some(stats.date_match_count()),
     })
 }
 
@@ -414,6 +436,7 @@ mod tests {
             skip_statistics: false,
             skip_patterns: false,
             exact_numeric: None,
+            exact_date_matches: None,
             locale: None,
         });
 
@@ -447,6 +470,7 @@ mod tests {
             skip_statistics: false,
             skip_patterns: false,
             exact_numeric: None,
+            exact_date_matches: None,
             locale: None,
         });
 
@@ -476,6 +500,7 @@ mod tests {
             skip_statistics: true,
             skip_patterns: false,
             exact_numeric: None,
+            exact_date_matches: None,
             locale: None,
         });
 
@@ -499,6 +524,7 @@ mod tests {
             skip_statistics: false,
             skip_patterns: true,
             exact_numeric: None,
+            exact_date_matches: None,
             locale: None,
         });
 
@@ -527,6 +553,7 @@ mod tests {
             skip_statistics: false,
             skip_patterns: false,
             exact_numeric: None,
+            exact_date_matches: None,
             locale: None,
         });
 
@@ -549,6 +576,7 @@ mod tests {
             skip_statistics: false,
             skip_patterns: false,
             exact_numeric: None,
+            exact_date_matches: None,
             locale: None,
         });
 

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -4,9 +4,11 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 use crate::{ValueHintBindingAccumulator, profile_builder::infer_data_type_streaming};
-use dataprof_core::{SemanticHintBinding, SemanticHints};
+use dataprof_core::{SemanticHintBinding, SemanticHintKind, SemanticHints};
 use dataprof_metrics::analysis::inference::is_null_like_token;
-use dataprof_metrics::{CardinalityEstimator, HyperLogLog, RowDuplicateSummary};
+use dataprof_metrics::{
+    CardinalityEstimator, HyperLogLog, RowDuplicateSummary, value_matches_hint,
+};
 
 /// Incremental statistics computation for streaming data processing.
 ///
@@ -277,6 +279,7 @@ pub struct StreamingStatistics {
     hll: HyperLogLog,
     sampler: StreamReservoirSampler,
     text_length_tracker: TextLengthStats,
+    date_match_count: usize,
 }
 
 impl StreamingStatistics {
@@ -290,6 +293,7 @@ impl StreamingStatistics {
             hll: HyperLogLog::new(),
             sampler: StreamReservoirSampler::new(10_000),
             text_length_tracker: TextLengthStats::new(),
+            date_match_count: 0,
         }
     }
 
@@ -311,6 +315,9 @@ impl StreamingStatistics {
         self.hll.insert(value);
         self.sampler.offer(value.to_string());
         self.text_length_tracker.update(value.len());
+        if value_matches_hint(value, SemanticHintKind::Temporal) {
+            self.date_match_count += 1;
+        }
 
         if let Some(number) = value.parse::<f64>().ok().filter(|num| num.is_finite()) {
             self.welford.update(number);
@@ -334,6 +341,7 @@ impl StreamingStatistics {
         self.hll.merge(&other.hll);
         self.sampler.merge(&other.sampler);
         self.text_length_tracker.merge(&other.text_length_tracker);
+        self.date_match_count += other.date_match_count;
     }
 
     pub fn mean(&self) -> f64 {
@@ -361,6 +369,11 @@ impl StreamingStatistics {
 
     pub fn sample_values(&self) -> &[String] {
         self.sampler.samples()
+    }
+
+    /// Values over the full stream accepted by the temporal calculator.
+    pub fn date_match_count(&self) -> usize {
+        self.date_match_count
     }
 
     /// Exact aggregates over every numeric value this column has streamed,

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -64,10 +64,11 @@ Now:
   violations drive accuracy, future dates and temporal violations drive
   timeliness. Completeness is the mean of cell-level and row-level
   completeness.
-- Timeliness scoring is now opt-in through explicit `temporal_columns` hints.
-  Date inference still describes column types, but inferred dates do not affect
-  the quality score unless selected; this prevents arbitrary date-like fields
-  from silently imposing a freshness policy.
+- Timeliness scoring assesses confidently inferred date columns by default.
+  Explicit `temporal_columns` hints add columns that inference cannot identify,
+  such as mixed-format strings. Non-null values that fail strict calendar
+  parsing are reported as `invalid_date_values` and reduce the timeliness score
+  instead of silently disappearing from its denominator.
 - `UniquenessMetrics.key_column` names the column `key_uniqueness` describes;
   when no key column is identified, key uniqueness carries no signal instead
   of "assume perfect".

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -492,9 +492,9 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
         "unique_count_is_approximate": col.unique_count_is_approximate,
         "uniqueness_ratio": _r2(col.uniqueness_ratio),
     }
-    # The key is omitted entirely when the check did not run (non-numeric
-    # column, or statistics skipped), mirroring the Rust serialization; a
-    # clean numeric column serializes 0.
+    # The key is omitted entirely when the numeric/date check did not run
+    # (another column type, or statistics skipped), mirroring the Rust
+    # serialization; a clean checked column serializes 0.
     if col.invalid_count is not None:
         col_data["invalid_count"] = col.invalid_count
     if col.min is not None:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1447,6 +1447,11 @@ class _DictQuality:
         return self._dimension_value("timeliness", "temporal_violations", 0)
 
     @property
+    def invalid_date_values(self) -> int:
+        self._warn_flat_accessor("invalid_date_values")
+        return self._dimension_value("timeliness", "invalid_date_values", 0)
+
+    @property
     def completeness(self) -> dict[str, Any] | None:
         return self._d.get("completeness")
 

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -196,6 +196,7 @@ class DataQualityMetrics:
     future_dates_count: int
     stale_data_ratio: float
     temporal_violations: int
+    invalid_date_values: int
     low_sample_warning: bool
     score_weights: dict[str, float]
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -448,7 +448,7 @@ class TestProfileReport:
         assert uniqueness["rows_checked"] == 3
         assert uniqueness["duplicate_rows_approximate"] is False
 
-    def test_temporal_columns_gate_timeliness_score(self, tmp_path):
+    def test_inferred_date_columns_drive_timeliness_score(self, tmp_path):
         path = tmp_path / "events.csv"
         path.write_text(
             "observed_on,value\n2020-01-01,1\n2021-01-01,2\n",
@@ -458,7 +458,7 @@ class TestProfileReport:
         without_hint = dataprof.profile(str(path))
         without_quality = without_hint.quality
         assert without_quality is not None
-        assert without_quality.dimension_scores()["timeliness"] is None
+        assert without_quality.dimension_scores()["timeliness"] is not None
 
         with_hint = dataprof.profile(str(path), temporal_columns=["observed_on"])
         with_quality = with_hint.quality
@@ -467,6 +467,28 @@ class TestProfileReport:
         timeliness = with_quality.timeliness
         assert timeliness is not None
         assert timeliness["date_values_checked"] == 2
+
+    def test_invalid_calendar_date_is_visible_in_timeliness(self, tmp_path):
+        path = tmp_path / "invalid_date.csv"
+        path.write_text(
+            "observed_on\n"
+            "2024-01-01\n2024-02-02\n2024-03-03\n2024-04-04\n"
+            "2024-05-05\n2024-06-06\n2024-07-07\n2024-08-08\n2024-13-45\n",
+            encoding="utf-8",
+        )
+
+        report = dataprof.profile(str(path))
+        assert report["observed_on"].data_type == "date"
+        assert report["observed_on"].invalid_count == 1
+        quality = report.quality
+        assert quality is not None
+        timeliness = quality.timeliness
+        assert timeliness is not None
+        assert timeliness["date_values_checked"] == 9
+        assert timeliness["invalid_date_values"] == 1
+        timeliness_score = quality.dimension_scores()["timeliness"]
+        assert timeliness_score is not None
+        assert timeliness_score < 100.0
 
     def test_validity_and_precision_dimensions(self, tmp_path):
         path = tmp_path / "semantic_values.csv"

--- a/tests/semantic_hints.rs
+++ b/tests/semantic_hints.rs
@@ -140,21 +140,21 @@ fn identifier_columns_drive_key_uniqueness_without_name_guessing() {
 }
 
 #[test]
-fn temporal_columns_gate_timeliness_scoring() {
+fn inferred_date_columns_are_assessed_without_a_hint() {
     let csv = write_csv("observed_on,value\n2020-01-01,1\n2021-01-01,2\n2022-01-01,3\n");
 
     let without_hint = Profiler::new()
         .engine(EngineType::Incremental)
         .analyze_file(csv.path())
         .expect("profile should succeed");
-    assert_eq!(
+    assert!(
         without_hint
             .quality
             .as_ref()
             .expect("quality")
             .metrics
-            .timeliness_score(),
-        None
+            .timeliness_score()
+            .is_some()
     );
 
     let with_hint = Profiler::new()
@@ -172,6 +172,53 @@ fn temporal_columns_gate_timeliness_scoring() {
             .date_values_checked,
         3
     );
+}
+
+#[test]
+fn invalid_calendar_date_is_visible_and_lowers_timeliness() {
+    let csv = write_csv(
+        "observed_on\n2024-01-01\n2024-02-02\n2024-03-03\n2024-04-04\n2024-05-05\n2024-06-06\n2024-07-07\n2024-08-08\n2024-13-45\n",
+    );
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .analyze_file(csv.path())
+        .expect("mostly valid date column should profile");
+    let column = report
+        .column_profiles
+        .iter()
+        .find(|column| column.name == "observed_on")
+        .expect("date column");
+    assert_eq!(column.data_type, DataType::Date);
+    assert_eq!(column.invalid_count, Some(1));
+
+    let metrics = &report.quality.as_ref().expect("quality").metrics;
+    let timeliness = metrics.timeliness.as_ref().expect("timeliness metrics");
+    assert_eq!(timeliness.date_values_checked, 9);
+    assert_eq!(timeliness.invalid_date_values, 1);
+    assert!(metrics.timeliness_score().expect("timeliness score") < 100.0);
+}
+
+#[test]
+fn date_invalid_count_covers_values_beyond_stream_reservoir() {
+    let mut csv = String::from("observed_on\n2024-13-45\n");
+    for _ in 0..10_050 {
+        csv.push_str("2024-01-01\n");
+    }
+    let csv = write_csv(&csv);
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .analyze_file(csv.path())
+        .expect("date stream should profile");
+    let column = report
+        .column_profiles
+        .iter()
+        .find(|column| column.name == "observed_on")
+        .expect("date column");
+
+    assert_eq!(column.data_type, DataType::Date);
+    assert_eq!(column.invalid_count, Some(1));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- assess confidently inferred date columns in timeliness without requiring an explicit temporal hint
- validate complete calendar values and report non-null parse failures as `invalid_date_values`
- track exact date parse counts across streaming and Arrow/Parquet paths so `ColumnProfile.invalid_count` is not reservoir-biased
- expose the new timeliness fact through Rust serialization and Python quality APIs

## Root cause

Timeliness only received explicitly configured `temporal_columns`, even when profiling had already inferred a column as `date`. Its year extractor also accepted a four-digit prefix without validating the complete calendar value, so malformed values such as `2024-13-45` could disappear from the assessed denominator and leave a perfect score.

## Impact

Inferred date columns now participate in timeliness by default. Explicit temporal hints remain additive for columns inference misses. Invalid calendar values remain visible in both the date column's `invalid_count` and timeliness metrics, and lower the timeliness score.

Closes #430.

## Validation

- `cargo test -p dataprof-metrics`
- `cargo test -p dataprof-runtime`
- `cargo test --test semantic_hints`
- `cargo test -p dataprof-parquet`
- `cargo test -p dataprof-python`
- `uv run maturin develop`
- `uv run pytest python/tests/test_python_api.py -q`
- `cargo clippy --all --all-targets -- -D warnings`
- `uv run ruff format python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`