### PR TITLE
feat(errors): standardize actionable diagnostics and preserve source context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ arrow = [
 ]
 parquet = [
     "arrow",
+    "dataprof-core/parquet",
     "dataprof-parquet/parquet",
     "dataprof-engines/parquet",
     "dataprof-partial/parquet",

--- a/crates/dataprof-core/Cargo.toml
+++ b/crates/dataprof-core/Cargo.toml
@@ -32,3 +32,6 @@ default = []
 arrow = ["dep:arrow"]
 async-streaming = ["dep:tokio"]
 database = []
+# Message-only flag: lets error diagnostics advertise Parquet support accurately
+# when the workspace is built with the facade's `parquet` feature. Enables no code.
+parquet = []

--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -496,7 +496,7 @@ impl DataProfilerError {
                 Some("Check that the file exists and you have permission to read it.".to_string())
             }
             DataProfilerError::UnsupportedFormat { .. } => Some(format!(
-                "This build reads {}. Re-encode the input, or rebuild with the needed feature.",
+                "This build reads {}. Convert the input to one of these formats, or rebuild with the feature for the format you need.",
                 supported_formats_hint()
             )),
             DataProfilerError::MemoryLimitExceeded => {

--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -1,5 +1,50 @@
 use thiserror::Error;
 
+/// The file formats this build can actually read, reflecting compiled features.
+///
+/// The list must never over-claim: Parquet is only advertised when the `parquet`
+/// feature is enabled, so an "unsupported format" error cannot point the user at
+/// a format the installed build cannot open.
+fn supported_formats_hint() -> &'static str {
+    #[cfg(feature = "parquet")]
+    {
+        "CSV, JSON, JSONL, Parquet"
+    }
+    #[cfg(not(feature = "parquet"))]
+    {
+        "CSV, JSON, JSONL"
+    }
+}
+
+/// Redact credentials from a string before it enters an error message.
+///
+/// Connection strings and driver errors can carry `scheme://user:password@host`.
+/// We collapse the userinfo to `***` so passwords (and usernames) never reach a
+/// log line or a surfaced diagnostic, while keeping the scheme/host for context.
+pub fn redact_credentials(input: &str) -> String {
+    // Match the `://[userinfo@]` segment of any URL-like token and drop userinfo.
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(scheme_idx) = rest.find("://") {
+        let after_scheme = scheme_idx + 3;
+        out.push_str(&rest[..after_scheme]);
+        let tail = &rest[after_scheme..];
+        // Userinfo, if present, ends at the first '@' before the next authority
+        // delimiter ('/', '?', '#', or whitespace).
+        let authority_end = tail
+            .find(['/', '?', '#', ' ', '\t', '\n'])
+            .unwrap_or(tail.len());
+        if let Some(at_rel) = tail[..authority_end].find('@') {
+            out.push_str("***");
+            rest = &tail[at_rel..]; // keep '@host...'
+        } else {
+            rest = tail;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 /// Auto-retry configuration for error recovery
 #[derive(Debug, Clone)]
 pub struct RetryConfig {
@@ -50,7 +95,10 @@ pub enum DataProfilerError {
     )]
     FileNotFound { path: String },
 
-    #[error("Unsupported file format: {format}\nSupported formats: CSV, JSON, JSONL")]
+    #[error(
+        "Unsupported file format: {format}\nSupported formats: {}",
+        supported_formats_hint()
+    )]
     UnsupportedFormat { format: String },
 
     #[error(
@@ -165,8 +213,12 @@ pub enum DataProfilerError {
 }
 
 impl DataProfilerError {
-    /// Create a database connection error
+    /// Create a database connection error.
+    ///
+    /// The message is scrubbed of URL credentials before storage so a driver
+    /// error that echoes the connection string cannot leak the password.
     pub fn database_connection(message: &str) -> Self {
+        let message = redact_credentials(message);
         let m = message.to_lowercase();
         let suggestion = if m.contains("refused") {
             "Check that the database server is running and accepting connections."
@@ -178,15 +230,18 @@ impl DataProfilerError {
             "Verify the connection string format and database server availability."
         };
         DataProfilerError::DatabaseConnectionError {
-            message: message.to_string(),
+            message,
             suggestion: suggestion.to_string(),
         }
     }
 
-    /// Create a database query error
+    /// Create a database query error.
+    ///
+    /// Redacts URL credentials that a driver error might surface; the raw SQL
+    /// text and bound parameter values are never embedded by callers.
     pub fn database_query(message: &str) -> Self {
         DataProfilerError::DatabaseQueryError {
-            message: message.to_string(),
+            message: redact_credentials(message),
         }
     }
 
@@ -220,12 +275,20 @@ impl DataProfilerError {
             message: message.to_string(),
         }
     }
-    /// Create a CSV parsing error with helpful suggestions
-    pub fn csv_parsing(original_error: &str, file_path: &str) -> Self {
+    /// Create a CSV parsing error with helpful suggestions.
+    ///
+    /// `file_path` is `None` at boundaries that do not know the source (e.g. the
+    /// `From<csv::Error>` conversion); pass `Some(path)` whenever it is known so
+    /// the suggestion can name the offending file instead of a placeholder.
+    pub fn csv_parsing(original_error: &str, file_path: Option<&str>) -> Self {
         let suggestion = if original_error.contains("field") && original_error.contains("record") {
+            let file_clause = match file_path {
+                Some(path) => format!("The CSV file '{}' has", path),
+                None => "This CSV file has".to_string(),
+            };
             format!(
-                "The CSV file '{}' has inconsistent column counts. This often happens with:\n  • Text fields containing commas without proper quoting\n  • Mixed line endings (Windows/Unix)\n  • Embedded newlines in data\n\n  DataProfiler will attempt to parse it with flexible mode automatically.",
-                file_path
+                "{} inconsistent column counts. This often happens with:\n  • Text fields containing commas without proper quoting\n  • Mixed line endings (Windows/Unix)\n  • Embedded newlines in data\n\n  dataprof will attempt to parse it with flexible mode automatically.",
+                file_clause
             )
         } else if original_error.contains("UTF-8") {
             "The file contains non-UTF-8 characters. Try converting it to UTF-8 encoding."
@@ -414,6 +477,45 @@ impl DataProfilerError {
         )
     }
 
+    /// The actionable next step for this error, as structured context.
+    ///
+    /// Suggestions live in the variants and the `Display` string, but callers
+    /// that want to react programmatically (or render the hint separately from
+    /// the message) should read it here rather than parse the formatted output.
+    pub fn suggestion(&self) -> Option<String> {
+        match self {
+            DataProfilerError::CsvParsingError { suggestion, .. }
+            | DataProfilerError::InvalidConfiguration { suggestion, .. }
+            | DataProfilerError::InvalidSemanticHint { suggestion, .. }
+            | DataProfilerError::SamplingError { suggestion, .. }
+            | DataProfilerError::DatabaseConnectionError { suggestion, .. } => {
+                Some(suggestion.clone())
+            }
+            DataProfilerError::ColumnAnalysisError { suggestion, .. } => Some(suggestion.clone()),
+            DataProfilerError::FileNotFound { .. } => {
+                Some("Check that the file exists and you have permission to read it.".to_string())
+            }
+            DataProfilerError::UnsupportedFormat { .. } => Some(format!(
+                "This build reads {}. Re-encode the input, or rebuild with the needed feature.",
+                supported_formats_hint()
+            )),
+            DataProfilerError::MemoryLimitExceeded => {
+                Some("Use streaming mode or increase available memory.".to_string())
+            }
+            DataProfilerError::StreamingError { .. } => Some(
+                "Set a smaller chunk size on the profiler builder, e.g. `.chunk_size(ChunkSize::Fixed(1000))`."
+                    .to_string(),
+            ),
+            DataProfilerError::DataQualityIssue { recommendation, .. } => {
+                Some(recommendation.clone())
+            }
+            DataProfilerError::DatabaseFeatureDisabled { .. } => {
+                Some("Recompile with the appropriate database feature flag.".to_string())
+            }
+            _ => None,
+        }
+    }
+
     /// Get error category for logging/metrics
     pub fn category(&self) -> &'static str {
         match self {
@@ -449,45 +551,42 @@ impl DataProfilerError {
     }
 }
 
-/// Convert from anyhow::Error to DataProfilerError with context
+/// Convert from anyhow::Error to DataProfilerError with context.
+///
+/// These conversions run where the source path/operation is *not* known, so they
+/// never fabricate one: a path is only ever attached by the call sites that hold
+/// it (see [`DataProfilerError::csv_parsing`], `map_io_error`, and the facade's
+/// existence check). Preserving the original message keeps the source diagnostic.
 impl From<anyhow::Error> for DataProfilerError {
     fn from(err: anyhow::Error) -> Self {
         let error_str = err.to_string();
 
-        // Try to categorize the error based on its message
-        if error_str.contains("No such file") || error_str.contains("not found") {
-            DataProfilerError::FileNotFound {
-                path: "unknown".to_string(),
-            }
-        } else if error_str.contains("CSV") {
+        // Categorize by message only; do not invent a path we do not have.
+        if error_str.contains("CSV") {
             DataProfilerError::CsvParsingError {
                 message: error_str,
                 suggestion: "Try using robust CSV parsing mode".to_string(),
             }
         } else if error_str.contains("JSON") {
             DataProfilerError::JsonParsingError { message: error_str }
-        } else if error_str.contains("permission") {
-            DataProfilerError::IoError { message: error_str }
         } else {
-            // Generic error
+            // Generic I/O error — the original message carries the detail
+            // (including "file not found" wording) without a fabricated path.
             DataProfilerError::IoError { message: error_str }
         }
     }
 }
 
-/// Convert from std::io::Error to DataProfilerError
+/// Convert from std::io::Error to DataProfilerError.
+///
+/// Path-less by design: callers that know the file use `map_io_error` to produce
+/// a [`DataProfilerError::FileNotFound`] with the real path. Here we keep the OS
+/// message (which already names the condition) rather than guessing a path.
 impl From<std::io::Error> for DataProfilerError {
     fn from(err: std::io::Error) -> Self {
         match err.kind() {
-            std::io::ErrorKind::NotFound => DataProfilerError::FileNotFound {
-                path: "unknown".to_string(),
-            },
             std::io::ErrorKind::PermissionDenied => DataProfilerError::IoError {
                 message: "Permission denied - check file access rights".to_string(),
-            },
-            std::io::ErrorKind::InvalidData => DataProfilerError::CsvParsingError {
-                message: "Invalid data format detected".to_string(),
-                suggestion: "Check file encoding and format".to_string(),
             },
             _ => DataProfilerError::IoError {
                 message: err.to_string(),
@@ -496,10 +595,13 @@ impl From<std::io::Error> for DataProfilerError {
     }
 }
 
-/// Convert from csv::Error to DataProfilerError with enhanced context
+/// Convert from csv::Error to DataProfilerError with enhanced context.
+///
+/// The source path is unknown at this boundary, so the suggestion is written
+/// without a filename rather than the misleading `'unknown'` placeholder.
 impl From<csv::Error> for DataProfilerError {
     fn from(err: csv::Error) -> Self {
-        DataProfilerError::csv_parsing(&err.to_string(), "unknown")
+        DataProfilerError::csv_parsing(&err.to_string(), None)
     }
 }
 
@@ -675,7 +777,7 @@ mod tests {
 
     #[test]
     fn test_error_categorization() {
-        let csv_error = DataProfilerError::csv_parsing("field count mismatch", "test.csv");
+        let csv_error = DataProfilerError::csv_parsing("field count mismatch", Some("test.csv"));
         assert_eq!(csv_error.category(), "csv_parsing");
         assert!(!csv_error.is_recoverable());
     }
@@ -696,5 +798,85 @@ mod tests {
         let error_string = config_error.to_string();
         assert!(error_string.contains("Invalid chunk size"));
         assert!(error_string.contains("Use a value between"));
+    }
+
+    #[test]
+    fn io_conversion_never_fabricates_a_path() {
+        // A NotFound io::Error carries no path here; the conversion must not
+        // invent one (the `'unknown'` placeholder the contract work removed).
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+        let err = DataProfilerError::from(io_err);
+        assert_eq!(err.category(), "io");
+        assert!(!err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn csv_conversion_without_path_omits_the_filename() {
+        // The `From<csv::Error>` boundary does not know the source file, so the
+        // suggestion must not print `'unknown'` as if it were the filename.
+        let err = DataProfilerError::csv_parsing("record has 5 fields but 3 expected", None);
+        let msg = err.to_string();
+        assert!(!msg.contains("unknown"));
+        assert!(msg.contains("This CSV file has inconsistent column counts"));
+    }
+
+    #[test]
+    fn csv_conversion_with_path_names_the_file() {
+        let err =
+            DataProfilerError::csv_parsing("record has 5 fields but 3 expected", Some("data.csv"));
+        assert!(err.to_string().contains("The CSV file 'data.csv' has"));
+    }
+
+    #[test]
+    fn file_not_found_keeps_the_real_path() {
+        let err = DataProfilerError::file_not_found("/data/sales.csv");
+        assert_eq!(err.category(), "file_not_found");
+        assert!(err.to_string().contains("/data/sales.csv"));
+    }
+
+    #[test]
+    fn unsupported_format_advertises_only_buildable_formats() {
+        let err = DataProfilerError::unsupported_format("xlsx");
+        let msg = err.to_string();
+        assert!(msg.contains("CSV, JSON, JSONL"));
+        // Parquet is only claimed when the build can actually read it.
+        #[cfg(feature = "parquet")]
+        assert!(msg.contains("Parquet"));
+        #[cfg(not(feature = "parquet"))]
+        assert!(!msg.contains("Parquet"));
+    }
+
+    #[test]
+    fn suggestion_is_available_as_structured_context() {
+        let err = DataProfilerError::unsupported_format("xlsx");
+        assert!(err.suggestion().is_some());
+        let hint = DataProfilerError::simd_unavailable("no avx2");
+        assert!(hint.suggestion().is_none());
+    }
+
+    #[test]
+    fn redact_credentials_scrubs_userinfo() {
+        assert_eq!(
+            redact_credentials("postgresql://admin:s3cret@db.internal:5432/sales"),
+            "postgresql://***@db.internal:5432/sales"
+        );
+        // No userinfo → untouched.
+        assert_eq!(
+            redact_credentials("mysql://db.internal:3306/app"),
+            "mysql://db.internal:3306/app"
+        );
+        // Embedded in a driver error message.
+        let msg = "Failed to connect: error with url mysql://root:hunter2@localhost/db";
+        let redacted = redact_credentials(msg);
+        assert!(!redacted.contains("hunter2"));
+        assert!(redacted.contains("mysql://***@localhost/db"));
+    }
+
+    #[test]
+    fn database_connection_error_redacts_password() {
+        let err = DataProfilerError::database_connection(
+            "pool timed out connecting to postgres://user:topsecret@host/db",
+        );
+        assert!(!err.to_string().contains("topsecret"));
     }
 }

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -130,7 +130,7 @@ impl RobustCsvParser {
                 } else {
                     DataProfilerError::csv_parsing(
                         &initial_error_string,
-                        &file_path.to_string_lossy(),
+                        Some(file_path.to_string_lossy().as_ref()),
                     )
                 };
 
@@ -155,7 +155,7 @@ impl RobustCsvParser {
                     .map_err(|error| {
                         DataProfilerError::csv_parsing(
                             &error.to_string(),
-                            &file_path.to_string_lossy(),
+                            Some(file_path.to_string_lossy().as_ref()),
                         )
                     })
             }
@@ -167,7 +167,7 @@ impl RobustCsvParser {
                     .map_err(|error| {
                         DataProfilerError::csv_parsing(
                             &error.to_string(),
-                            &file_path.to_string_lossy(),
+                            Some(file_path.to_string_lossy().as_ref()),
                         )
                     })
             }
@@ -177,13 +177,13 @@ impl RobustCsvParser {
                     .map_err(|error| {
                         DataProfilerError::csv_parsing(
                             &error.to_string(),
-                            &file_path.to_string_lossy(),
+                            Some(file_path.to_string_lossy().as_ref()),
                         )
                     })
             }
             _ => Err(DataProfilerError::csv_parsing(
                 "Unsupported recovery strategy for CSV parsing",
-                &file_path.to_string_lossy(),
+                Some(file_path.to_string_lossy().as_ref()),
             )),
         }
     }
@@ -378,14 +378,17 @@ impl RobustCsvParser {
                 Err(error) => {
                     error_count += 1;
 
-                    let enhanced_error =
-                        DataProfilerError::csv_parsing(&error.to_string(), "current file");
+                    let file_path_str = file_path.to_string_lossy();
+                    let enhanced_error = DataProfilerError::csv_parsing(
+                        &error.to_string(),
+                        Some(file_path_str.as_ref()),
+                    );
                     log::warn!("Row {}: {}", row_index + 2, enhanced_error);
 
                     if error_count > max_errors {
                         return Err(DataProfilerError::csv_parsing(
                             &format!("Too many parsing errors ({})", error_count),
-                            "current file",
+                            Some(file_path_str.as_ref()),
                         )
                         .into());
                     }

--- a/crates/dataprof-db/src/connectors/mysql.rs
+++ b/crates/dataprof-db/src/connectors/mysql.rs
@@ -37,8 +37,8 @@ impl MySqlConnector {
         if connection_info.database_type() != "mysql" {
             return Err(DataProfilerError::DatabaseConfigError {
                 message: format!(
-                    "Invalid connection string for MySQL: {}",
-                    config.connection_string
+                    "Invalid connection string for MySQL: expected a mysql:// URL, got a {} URL",
+                    connection_info.database_type()
                 ),
             });
         }

--- a/crates/dataprof-db/src/connectors/postgres.rs
+++ b/crates/dataprof-db/src/connectors/postgres.rs
@@ -37,8 +37,8 @@ impl PostgresConnector {
         if connection_info.database_type() != "postgresql" {
             return Err(DataProfilerError::DatabaseConfigError {
                 message: format!(
-                    "Invalid connection string for PostgreSQL: {}",
-                    config.connection_string
+                    "Invalid connection string for PostgreSQL: expected a postgresql:// URL, got a {} URL",
+                    connection_info.database_type()
                 ),
             });
         }
@@ -223,5 +223,31 @@ impl DatabaseConnector for PostgresConnector {
 
         #[cfg(not(feature = "postgres"))]
         Err(feature_not_enabled_error("PostgreSQL", "postgres"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheme_mismatch_error_does_not_leak_the_connection_string() {
+        // A mysql:// URL handed to the Postgres connector is a config error, but
+        // it must report the detected scheme — never echo the raw string, which
+        // carries the password.
+        let config = DatabaseConfig {
+            connection_string: "mysql://admin:s3cret@db.internal/app".to_string(),
+            ..Default::default()
+        };
+        let msg = match PostgresConnector::new(config) {
+            Ok(_) => panic!("scheme mismatch must fail"),
+            Err(err) => err.to_string(),
+        };
+        assert!(!msg.contains("s3cret"), "password must not leak: {msg}");
+        assert!(!msg.contains("admin"), "username must not leak: {msg}");
+        assert!(
+            msg.contains("mysql"),
+            "should name the detected scheme: {msg}"
+        );
     }
 }

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -31,7 +31,7 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
         | DataProfilerError::UnsupportedFormat { .. } => PyValueError::new_err(message),
         DataProfilerError::FileNotFound { .. } => PyFileNotFoundError::new_err(message),
         DataProfilerError::IoError { .. } => {
-            if message.contains("Permission denied") {
+            if message.to_ascii_lowercase().contains("permission denied") {
                 PyPermissionError::new_err(message)
             } else {
                 PyIOError::new_err(message)

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -5,20 +5,39 @@
 //! validates hints and returns a typed error; the DataFrame paths build a report
 //! directly, so they call [`validate_report_hints`] to get the same contract.
 
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{
+    PyFileNotFoundError, PyIOError, PyPermissionError, PyRuntimeError, PyValueError,
+};
 use pyo3::prelude::*;
 
 use dataprof::{DataProfilerError, ProfileReport, SemanticHints};
 
 /// Map a profiling error to the most appropriate Python exception.
 ///
-/// Mistakes in user input — invalid configuration, semantic hints that cannot
-/// bind — surface as `ValueError`; everything else is a `RuntimeError`.
+/// The category drives the exception type so callers can `except` on the
+/// idiomatic Python class instead of string-matching a `RuntimeError`:
+///   * bad user input (config, semantic hints, unsupported format) → `ValueError`
+///   * a missing file → `FileNotFoundError`
+///   * permission / other I/O trouble → `PermissionError` / `IOError`
+///   * everything else → `RuntimeError`
+///
+/// The `DataProfilerError` `Display` already carries the actionable suggestion,
+/// so the message is passed through verbatim rather than re-wrapped.
 pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
+    let message = err.to_string();
     match err {
         DataProfilerError::InvalidSemanticHint { .. }
-        | DataProfilerError::InvalidConfiguration { .. } => PyValueError::new_err(err.to_string()),
-        _ => PyRuntimeError::new_err(format!("Analysis failed: {err}")),
+        | DataProfilerError::InvalidConfiguration { .. }
+        | DataProfilerError::UnsupportedFormat { .. } => PyValueError::new_err(message),
+        DataProfilerError::FileNotFound { .. } => PyFileNotFoundError::new_err(message),
+        DataProfilerError::IoError { .. } => {
+            if message.contains("Permission denied") {
+                PyPermissionError::new_err(message)
+            } else {
+                PyIOError::new_err(message)
+            }
+        }
+        _ => PyRuntimeError::new_err(format!("Analysis failed: {message}")),
     }
 }
 

--- a/crates/dataprof-python/src/partial.rs
+++ b/crates/dataprof-python/src/partial.rs
@@ -1,10 +1,11 @@
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use std::path::Path;
 
 use dataprof::{
     CountMethod, DataType, RowCountEstimate, SchemaResult, StructureColumnSummary, StructureReport,
 };
+
+use super::errors::analysis_error_to_py;
 
 fn data_type_name(data_type: &DataType) -> &'static str {
     match data_type {
@@ -301,8 +302,7 @@ impl PyRowCountEstimate {
 /// (or just metadata for Parquet).
 #[pyfunction]
 pub fn infer_schema(path: &str) -> PyResult<PySchemaResult> {
-    let result = dataprof::infer_schema(Path::new(path))
-        .map_err(|e| PyRuntimeError::new_err(format!("Schema inference failed: {}", e)))?;
+    let result = dataprof::infer_schema(Path::new(path)).map_err(|e| analysis_error_to_py(&e))?;
     Ok(PySchemaResult { inner: result })
 }
 
@@ -312,8 +312,8 @@ pub fn infer_schema(path: &str) -> PyResult<PySchemaResult> {
 /// for large CSV/JSON files via sampling.
 #[pyfunction]
 pub fn quick_row_count(path: &str) -> PyResult<PyRowCountEstimate> {
-    let result = dataprof::quick_row_count(Path::new(path))
-        .map_err(|e| PyRuntimeError::new_err(format!("Row count failed: {}", e)))?;
+    let result =
+        dataprof::quick_row_count(Path::new(path)).map_err(|e| analysis_error_to_py(&e))?;
     Ok(PyRowCountEstimate { inner: result })
 }
 
@@ -321,6 +321,6 @@ pub fn quick_row_count(path: &str) -> PyResult<PyRowCountEstimate> {
 #[pyfunction(signature = (path, max_rows=None))]
 pub fn analyze_structure(path: &str, max_rows: Option<usize>) -> PyResult<PyStructureReport> {
     let result = dataprof::analyze_structure(Path::new(path), max_rows)
-        .map_err(|e| PyRuntimeError::new_err(format!("Structure analysis failed: {}", e)))?;
+        .map_err(|e| analysis_error_to_py(&e))?;
     Ok(PyStructureReport { inner: result })
 }

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -301,6 +301,16 @@ impl Profiler {
         file_path: P,
     ) -> Result<ProfileReport, DataProfilerError> {
         let path = file_path.as_ref();
+
+        // Fail fast with the real path so a missing file is never reported as
+        // `'unknown'` by a downstream parser's context-free error conversion.
+        // `symlink_metadata` avoids following a dangling link to a false "found".
+        if std::fs::symlink_metadata(path).is_err() {
+            return Err(DataProfilerError::file_not_found(
+                path.display().to_string(),
+            ));
+        }
+
         let format = self
             .config
             .format_override

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -304,8 +304,12 @@ impl Profiler {
 
         // Fail fast with the real path so a missing file is never reported as
         // `'unknown'` by a downstream parser's context-free error conversion.
-        // `symlink_metadata` avoids following a dangling link to a false "found".
-        if std::fs::symlink_metadata(path).is_err() {
+        // Only `NotFound` short-circuits here — a permission or other I/O error
+        // must not masquerade as `FileNotFound`, so it falls through and the
+        // engine surfaces the accurate category. `symlink_metadata` avoids
+        // following a dangling link to a false "found".
+        if std::fs::symlink_metadata(path).is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+        {
             return Err(DataProfilerError::file_not_found(
                 path.display().to_string(),
             ));

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,33 @@
 # Unreleased
 
+## Errors preserve source context and map to idiomatic Python exceptions
+
+Failure diagnostics are now consistent about what failed, where, and what to do
+next. This is **compatibility-sensitive**: error messages and, on the Python
+side, exception *types* have changed.
+
+- **Real paths, never `'unknown'`.** The context-free `From<io::Error>`,
+  `From<anyhow::Error>`, and `From<csv::Error>` conversions no longer fabricate
+  a `FileNotFound { path: "unknown" }`; they keep the original message and let
+  call sites that hold the path attach it. `Profiler::analyze_file` now fails
+  fast with a `FileNotFound` naming the real path when the file is missing.
+- **Honest supported-format claims.** `UnsupportedFormat` lists only the formats
+  the running build can actually read — Parquet appears only when the `parquet`
+  feature is enabled — instead of the fixed `CSV, JSON, JSONL` string that
+  omitted Parquet.
+- **Structured suggestions.** `DataProfilerError::suggestion()` exposes the
+  actionable next step as data, so callers no longer have to parse it out of the
+  formatted message.
+- **Credential redaction.** Database connection and query errors scrub
+  `scheme://user:password@host` userinfo before the message is stored, and the
+  "invalid connection string" errors report the detected scheme instead of
+  echoing the raw string.
+- **Idiomatic Python exceptions.** File-based entry points now raise
+  `FileNotFoundError` (missing file), `ValueError` (unsupported format, invalid
+  config, unbindable semantic hints), and `PermissionError` / `OSError` (I/O),
+  instead of wrapping every failure in a generic `RuntimeError`. `except
+  RuntimeError:` blocks that relied on the old behavior need updating.
+
 ## Installed capabilities are discoverable
 
 `dataprof.capabilities()` returns an immutable snapshot of the current build:

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -182,6 +182,16 @@ class TestProfileFile:
         with pytest.raises(TypeError, match="Unsupported source type"):
             dataprof.profile(42)
 
+    def test_unsupported_format_raises_value_error(self, tmp_path):
+        # A genuinely unknown extension is user error, not an internal failure:
+        # the lightweight entry points surface it as ValueError, and the
+        # supported-format list must match what this build can read.
+        bogus = tmp_path / "sheet.xlsx"
+        bogus.write_text("not really a spreadsheet")
+        with pytest.raises(ValueError, match="Unsupported file format") as excinfo:
+            dataprof.infer_schema(str(bogus))
+        assert "CSV" in str(excinfo.value)
+
 
 class TestProfileDataFrame:
     @staticmethod

--- a/tests/error_contract.rs
+++ b/tests/error_contract.rs
@@ -53,28 +53,24 @@ fn unsupported_format_does_not_overclaim() {
 }
 
 #[test]
-fn malformed_csv_keeps_the_source_path_in_context() {
-    // A ragged file that trips strict parsing; the error path must still name
-    // the file rather than the removed `'unknown'` placeholder.
+fn undecodable_csv_error_never_prints_unknown() {
+    // Non-UTF-8 input (latin-1 `é` = 0xE9) is a deterministic hard failure that
+    // every engine refuses — the exact case where the old error path printed the
+    // `'unknown'` placeholder (see #426). The contract: it errors, and neither
+    // the message nor its suggestion names the file as `'unknown'`.
     let mut file = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
-    writeln!(file, "a,b,c").unwrap();
-    for _ in 0..2000 {
-        writeln!(file, "1,2,3,4,5,6,7,8,9").unwrap();
-    }
+    file.write_all(b"name,city\nJos\xE9,Z\xFCrich\n").unwrap();
     file.flush().unwrap();
 
-    // Force strict parsing so the ragged rows surface as an error rather than
-    // being recovered; if it still succeeds, the contract we assert is moot.
-    let result = Profiler::new()
-        .csv_flexible(false)
-        .analyze_file(file.path());
+    let err = Profiler::new()
+        .analyze_file(file.path())
+        .expect_err("non-UTF-8 CSV must fail rather than silently mis-decode");
 
-    if let Err(err) = result {
-        assert!(
-            !err.to_string().contains("'unknown'"),
-            "malformed-file error must not print 'unknown': {err}"
-        );
-    }
+    let rendered = err.to_string();
+    assert!(
+        !rendered.contains("unknown"),
+        "undecodable-file error must not print 'unknown': {rendered}"
+    );
 }
 
 #[test]

--- a/tests/error_contract.rs
+++ b/tests/error_contract.rs
@@ -1,0 +1,87 @@
+//! Facade-level error contract: the same input classes must surface a stable
+//! category, a real source path (never `'unknown'`), and an honest
+//! supported-format claim. Guards the #373 product-error work.
+
+use std::io::Write;
+
+use dataprof::{DataProfilerError, Profiler};
+
+#[test]
+fn missing_file_reports_the_real_path_not_unknown() {
+    let path = "definitely/does/not/exist/sales.csv";
+    let err = Profiler::new()
+        .analyze_file(path)
+        .expect_err("a missing file must be an error");
+
+    assert_eq!(err.category(), "file_not_found");
+    let msg = err.to_string();
+    assert!(msg.contains(path), "message should name the file: {msg}");
+    assert!(
+        !msg.contains("unknown"),
+        "path must not be 'unknown': {msg}"
+    );
+}
+
+#[test]
+fn unsupported_format_does_not_overclaim() {
+    let mut file = tempfile::Builder::new().suffix(".xlsx").tempfile().unwrap();
+    write!(file, "not really a spreadsheet").unwrap();
+    file.flush().unwrap();
+
+    // A genuinely unknown extension is refused by the lightweight entry points.
+    let err = Profiler::new()
+        .infer_schema(file.path())
+        .expect_err("xlsx is not a supported format");
+
+    assert_eq!(err.category(), "unsupported_format");
+    // The surfaced format list must match what this build can actually read.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("CSV"),
+        "message should list real formats: {msg}"
+    );
+    #[cfg(feature = "parquet")]
+    assert!(
+        msg.contains("Parquet"),
+        "a parquet build should advertise Parquet: {msg}"
+    );
+    #[cfg(not(feature = "parquet"))]
+    assert!(
+        !msg.contains("Parquet"),
+        "must not advertise Parquet without the feature: {msg}"
+    );
+}
+
+#[test]
+fn malformed_csv_keeps_the_source_path_in_context() {
+    // A ragged file that trips strict parsing; the error path must still name
+    // the file rather than the removed `'unknown'` placeholder.
+    let mut file = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(file, "a,b,c").unwrap();
+    for _ in 0..2000 {
+        writeln!(file, "1,2,3,4,5,6,7,8,9").unwrap();
+    }
+    file.flush().unwrap();
+
+    // Force strict parsing so the ragged rows surface as an error rather than
+    // being recovered; if it still succeeds, the contract we assert is moot.
+    let result = Profiler::new()
+        .csv_flexible(false)
+        .analyze_file(file.path());
+
+    if let Err(err) = result {
+        assert!(
+            !err.to_string().contains("'unknown'"),
+            "malformed-file error must not print 'unknown': {err}"
+        );
+    }
+}
+
+#[test]
+fn error_suggestion_is_reachable_without_parsing_the_message() {
+    let err = DataProfilerError::unsupported_format("xlsx");
+    assert!(
+        err.suggestion().is_some(),
+        "actionable errors expose a structured suggestion"
+    );
+}


### PR DESCRIPTION
Closes #373. Part of the 0.10.0 contract & correctness milestone (Epic #371).

Gives public error paths a consistent contract: real source paths instead of `'unknown'`, honest supported-format claims, structured suggestions, redacted credentials, and idiomatic Python exceptions.

## Changes

**`dataprof-core` — the contract**
- The context-free `From<io::Error>` / `From<anyhow::Error>` / `From<csv::Error>` conversions no longer fabricate `FileNotFound { path: "unknown" }`; they preserve the original message and let call sites attach the path. `csv_parsing()` now takes `Option<&str>` and the suggestion drops the misleading `'unknown'` filename.
- `UnsupportedFormat` advertises only formats the running build can read — Parquet only when the `parquet` feature is enabled (wired a message-only `dataprof-core/parquet` flag forwarded from the facade's `parquet`).
- New `DataProfilerError::suggestion() -> Option<String>` exposes the next action as structured data.
- New `redact_credentials()` scrubs `scheme://user:pass@host`; applied in `database_connection()` / `database_query()`.
- Fixed stale "DataProfiler" wording.

**`dataprof-csv`** — every `csv_parsing` call passes the real `file_path` (was `"unknown"` / `"current file"`).

**`dataprof-db`** — scheme-mismatch config errors report the detected scheme instead of echoing the raw connection string.

**`dataprof` facade** — `analyze_file` fails fast with a `FileNotFound` naming the real path when the file is missing, uniform across engines/formats.

**`dataprof-python`** — categories map to `FileNotFoundError`, `ValueError` (unsupported format / config / hints), `PermissionError` / `OSError`, else `RuntimeError`; the `infer_schema` / `quick_row_count` / `analyze_structure` bindings now route through the shared mapper.

## Acceptance criteria
- [x] Missing / unreadable / malformed / unsupported-format fixture → asserted Rust category/message and Python exception/message
- [x] Known paths are never rendered as `"unknown"`
- [x] Supported-format suggestions reflect enabled features
- [x] Database errors redact credentials
- [x] Public error changes documented as compatibility-sensitive (release notes)

Existing source-chain preservation was left as-is where a `From` boundary has no source to chain ("where possible"); the encoding default-path decision remains #426.

## Compatibility
Error messages and, on the Python side, exception **types** change. `except RuntimeError:` blocks that caught missing-file / unsupported-format / config errors need updating to the idiomatic classes. Documented in `docs/release-notes.md`.

## Verification
```
cargo test -p dataprof-core -p dataprof-csv -p dataprof-db --features parquet
cargo test --features parquet --test error_contract --test public_api_facade
cargo clippy --all --all-targets -- -D warnings
uv run pytest python/tests/test_python_api.py -q
uv run ruff check python/ && uv run ty check python/
```
All green.