### PR TITLE
feat(input): enforce duplicate column-name policy across engines (#381)

### DIFF
--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -181,6 +181,15 @@ pub enum DataProfilerError {
     #[error("Metrics calculation failed: {message}")]
     MetricsCalculationError { message: String },
 
+    #[error(
+        "Duplicate column name{plural}: {names}\nSource: {source_label}. Column names must be unique after normalization; rename or drop the duplicate column(s) before profiling."
+    )]
+    DuplicateColumnName {
+        names: String,
+        plural: String,
+        source_label: String,
+    },
+
     #[error("Configuration validation failed: {message}")]
     ConfigValidationError { message: String },
 
@@ -275,6 +284,25 @@ impl DataProfilerError {
             message: message.to_string(),
         }
     }
+    /// Create a duplicate-column-name error from the already-collected list of
+    /// repeated names and a short transport label.
+    ///
+    /// Only the offending names and the source are embedded — never row values —
+    /// so the diagnostic cannot leak cell data.
+    pub fn duplicate_column_name(duplicates: &[String], source: &str) -> Self {
+        let plural = if duplicates.len() == 1 { "" } else { "s" };
+        let names = duplicates
+            .iter()
+            .map(|n| format!("'{}'", n))
+            .collect::<Vec<_>>()
+            .join(", ");
+        DataProfilerError::DuplicateColumnName {
+            names,
+            plural: plural.to_string(),
+            source_label: source.to_string(),
+        }
+    }
+
     /// Create a CSV parsing error with helpful suggestions.
     ///
     /// `file_path` is `None` at boundaries that do not know the source (e.g. the
@@ -539,6 +567,7 @@ impl DataProfilerError {
             DataProfilerError::UnsupportedDataSource { .. } => "unsupported_data_source",
             DataProfilerError::AllEnginesFailed { .. } => "all_engines_failed",
             DataProfilerError::MetricsCalculationError { .. } => "metrics_calculation",
+            DataProfilerError::DuplicateColumnName { .. } => "duplicate_column_name",
             DataProfilerError::ConfigValidationError { .. } => "config_validation",
             DataProfilerError::DatabaseConnectionError { .. } => "database_connection",
             DataProfilerError::DatabaseQueryError { .. } => "database_query",

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -51,4 +51,4 @@ pub use source::{
 pub use stop_condition::{
     SchemaStabilityTracker, StopCondition, StopEvaluator, schema_stable_threshold,
 };
-pub use validation::{InputValidator, ValidationError, exit_codes};
+pub use validation::{InputValidator, ValidationError, exit_codes, validate_unique_column_names};

--- a/crates/dataprof-core/src/validation.rs
+++ b/crates/dataprof-core/src/validation.rs
@@ -1,5 +1,43 @@
+use crate::errors::DataProfilerError;
 use anyhow::Result;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+
+/// Reject repeated names in an ordered column-name list, before any per-column
+/// state is built.
+///
+/// Every engine keys its per-column accumulators by name, so a repeated name is
+/// otherwise silently merged (file/Arrow paths) or shadowed at mapping access
+/// (columnar path), yielding a report where `total_count` can exceed the row
+/// count or a column simply disappears. Rejecting up front is the only behavior
+/// all engines can share.
+///
+/// `names` is the final list each engine uses as profile keys, so the check runs
+/// on already-normalized names (the caller's stringification is the normalization
+/// step). `source` is a short transport label — e.g. `"CSV header"`, `"CSV bytes"`,
+/// `"Arrow/Parquet schema"` — surfaced to the user. Duplicates are reported in
+/// first-seen order, deduped; no cell values are ever embedded.
+pub fn validate_unique_column_names(
+    names: &[String],
+    source: &str,
+) -> Result<(), DataProfilerError> {
+    let mut seen: HashSet<&str> = HashSet::with_capacity(names.len());
+    let mut reported: HashSet<&str> = HashSet::new();
+    let mut duplicates: Vec<String> = Vec::new();
+    for name in names {
+        if !seen.insert(name.as_str()) && reported.insert(name.as_str()) {
+            duplicates.push(name.clone());
+        }
+    }
+    if duplicates.is_empty() {
+        Ok(())
+    } else {
+        Err(DataProfilerError::duplicate_column_name(
+            &duplicates,
+            source,
+        ))
+    }
+}
 
 /// Enhanced input validation with helpful error messages and suggestions
 pub struct InputValidator;
@@ -533,5 +571,42 @@ mod tests {
         write!(f, "[settings]").unwrap();
         f.flush().unwrap();
         assert!(InputValidator::validate_config_file(f.path()).is_ok());
+    }
+
+    // -- unique column names --
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn unique_column_names_pass() {
+        assert!(validate_unique_column_names(&names(&["x", "y", "z"]), "CSV header").is_ok());
+        assert!(validate_unique_column_names(&[], "CSV header").is_ok());
+    }
+
+    #[test]
+    fn duplicate_first_middle_last_rejected() {
+        for cols in [
+            names(&["x", "x", "y"]), // first
+            names(&["a", "x", "x"]), // last
+            names(&["a", "x", "b", "x", "c"]),
+        ] {
+            let err = validate_unique_column_names(&cols, "CSV header").unwrap_err();
+            assert!(matches!(err, DataProfilerError::DuplicateColumnName { .. }));
+        }
+    }
+
+    #[test]
+    fn duplicate_error_names_offender_and_source_only() {
+        let cols = names(&["id", "amount", "id", "amount", "note"]);
+        let err = validate_unique_column_names(&cols, "CSV bytes").unwrap_err();
+        let msg = err.to_string();
+        // Each offender named once, source present, no cell values.
+        assert!(msg.contains("'id'"));
+        assert!(msg.contains("'amount'"));
+        assert_eq!(msg.matches("'id'").count(), 1);
+        assert!(msg.contains("CSV bytes"));
+        assert!(msg.contains("Duplicate column names:")); // plural "s"
     }
 }

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -266,7 +266,11 @@ pub fn analyze_csv_from_reader_with_hints<R: Read>(
 
     let header_names: Vec<String> = if config.has_header {
         let headers = csv_reader.headers()?;
-        headers.iter().map(|header| header.to_string()).collect()
+        let names: Vec<String> = headers.iter().map(|header| header.to_string()).collect();
+        // Reject duplicate headers before profiling: process_record keys on name,
+        // so a repeat would merge two source columns into one inflated profile.
+        dataprof_core::validate_unique_column_names(&names, "CSV header")?;
+        names
     } else {
         let headers = csv_reader.headers()?;
         (0..headers.len())

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -134,6 +134,13 @@ impl RobustCsvParser {
                     )
                 };
 
+                // Duplicate headers are deterministic across strategies; recovery
+                // cannot resolve them, so surface the clear error instead of
+                // burying it under "auto-recovery failed".
+                if matches!(dp_error, DataProfilerError::DuplicateColumnName { .. }) {
+                    return Err(dp_error.into());
+                }
+
                 recovery_manager
                     .attempt_recovery(&dp_error, |strategy| {
                         self.try_recovery_strategy(file_path, strategy)
@@ -276,17 +283,21 @@ impl RobustCsvParser {
                 .context("Failed to detect delimiter")?
         };
 
-        match self.try_strict_parsing(file_path, delimiter) {
-            Ok(result) => return Ok(result),
+        let result = match self.try_strict_parsing(file_path, delimiter) {
+            Ok(result) => result,
             Err(error) => {
                 if self.verbosity >= 2 {
                     log::info!("Using flexible CSV parsing (strict mode failed: {})", error);
                 }
+                self.try_flexible_parsing(file_path, delimiter)
+                    .context("Both strict and flexible CSV parsing failed")?
             }
-        }
+        };
 
-        self.try_flexible_parsing(file_path, delimiter)
-            .context("Both strict and flexible CSV parsing failed")
+        // Duplicate headers are a property of the file, identical across parse
+        // strategies, so reject once here rather than in each leaf parser.
+        dataprof_core::validate_unique_column_names(&result.0, "CSV header")?;
+        Ok(result)
     }
 
     fn try_strict_parsing(
@@ -426,14 +437,14 @@ impl RobustCsvParser {
             })
             .from_reader(Cursor::new(data));
 
-        let headers = if has_headers {
-            Some(
-                reader
-                    .headers()?
-                    .iter()
-                    .map(|value| value.to_string())
-                    .collect(),
-            )
+        let headers: Option<Vec<String>> = if has_headers {
+            let names: Vec<String> = reader
+                .headers()?
+                .iter()
+                .map(|value| value.to_string())
+                .collect();
+            dataprof_core::validate_unique_column_names(&names, "CSV header")?;
+            Some(names)
         } else {
             None
         };

--- a/crates/dataprof-engines/src/adaptive.rs
+++ b/crates/dataprof-engines/src/adaptive.rs
@@ -101,6 +101,12 @@ impl AdaptiveProfiler {
         match result {
             Ok(report) => Ok(report),
             Err(primary_err) => {
+                // Duplicate column names are a deterministic property of the file;
+                // no engine can resolve them, so surface the clear, categorized
+                // error instead of burying it under "All engines failed".
+                if matches!(primary_err, DataProfilerError::DuplicateColumnName { .. }) {
+                    return Err(primary_err);
+                }
                 #[cfg(feature = "arrow")]
                 let fallback = match engine {
                     InternalEngineType::Arrow => InternalEngineType::Incremental,

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -157,6 +157,10 @@ impl IncrementalProfiler {
                 headers = chunk_headers;
                 if let Some(ref h) = headers {
                     let names: Vec<String> = h.iter().map(|s| s.to_string()).collect();
+                    // Reject duplicate headers before any per-column state is built:
+                    // init_columns keys on name, so a repeat would otherwise merge
+                    // two source columns into one profile with an inflated count.
+                    dataprof_core::validate_unique_column_names(&names, "CSV header")?;
                     column_stats.init_columns(&names);
                     progress_tracker.emit_schema(names);
                 }

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -103,6 +103,10 @@ impl ArrowProfiler {
 
         // Get headers to create Arrow schema
         let headers = reader.headers()?.clone();
+        // Reject duplicate headers before building the name-keyed analyzer map,
+        // which would otherwise merge two columns into one profile.
+        let header_names: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
+        dataprof_core::validate_unique_column_names(&header_names, "CSV header")?;
         let mut fields = Vec::new();
         for header in headers.iter() {
             // Start with string type, Arrow will convert during processing

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -126,6 +126,20 @@ impl RecordBatchAnalyzer {
     }
 
     pub fn process_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        // Reject duplicate field names before building analyzers: they key on
+        // name, so a repeat would silently merge two columns into one profile and
+        // drop the other from column_order. The schema is fixed for the whole
+        // stream, so checking until the first non-empty batch is sufficient.
+        if self.column_order.is_empty() {
+            let names: Vec<String> = batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().to_string())
+                .collect();
+            dataprof_core::validate_unique_column_names(&names, "Arrow/Parquet schema")?;
+        }
+
         self.total_rows += batch.num_rows();
         self.row_tracker.observe_batch(batch);
 
@@ -1101,6 +1115,33 @@ mod tests {
             }
             _ => panic!("Expected Numeric stats for rank column"),
         }
+    }
+
+    #[test]
+    fn test_duplicate_field_names_rejected_before_merge() {
+        // Two fields named "x" would otherwise collapse into one analyzer,
+        // dropping a column and inflating the survivor's counts. Reject up front.
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("x", ArrowDataType::Int64, true),
+            Field::new("x", ArrowDataType::Int64, true),
+            Field::new("y", ArrowDataType::Int64, true),
+        ]));
+        let a = Int64Array::from(vec![1, 3]);
+        let b = Int64Array::from(vec![2, 4]);
+        let c = Int64Array::from(vec![5, 6]);
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(a), Arc::new(b), Arc::new(c)]).unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        let err = analyzer
+            .process_batch(&batch)
+            .expect_err("duplicate field names must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("'x'"), "names the offender: {msg}");
+        assert!(
+            msg.contains("Arrow/Parquet schema"),
+            "names the source: {msg}"
+        );
     }
 
     #[test]

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -317,7 +317,7 @@ pub fn analyze_csv_to_arrow(path: &str) -> PyResult<PyRecordBatch> {
         .engine(EngineType::Columnar)
         .format(FileFormat::Csv)
         .analyze_file(Path::new(path))
-        .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
+        .map_err(|e| crate::errors::analysis_error_to_py(&e))?;
 
     // Convert column profiles to RecordBatch
     let batch = profiles_to_record_batch(&report.column_profiles)
@@ -333,7 +333,7 @@ pub fn analyze_parquet_to_arrow(path: &str) -> PyResult<PyRecordBatch> {
     use std::path::Path;
 
     let report = analyze_parquet_with_quality(Path::new(path))
-        .map_err(|e| PyRuntimeError::new_err(format!("Parquet analysis failed: {}", e)))?;
+        .map_err(|e| crate::errors::analysis_error_to_py(&e))?;
 
     let batch = profiles_to_record_batch(&report.column_profiles)
         .map_err(|e| PyRuntimeError::new_err(format!("Batch conversion failed: {}", e)))?;
@@ -393,7 +393,7 @@ pub fn profile_dataframe(
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
     analyzer
         .process_batch(&batch)
-        .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
+        .map_err(crate::errors::analyzer_error_to_py)?;
 
     let locale = config.and_then(|c| c.locale.as_deref());
     let column_profiles =
@@ -509,7 +509,7 @@ pub fn profile_arrow(
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
     analyzer
         .process_batch(&batch)
-        .map_err(|e| PyRuntimeError::new_err(format!("Analysis failed: {}", e)))?;
+        .map_err(crate::errors::analyzer_error_to_py)?;
 
     let locale = config.and_then(|c| c.locale.as_deref());
     let column_profiles =

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -68,6 +68,13 @@ pub fn profile_columns(
         )));
     }
 
+    // Backstop: the Python transport wrappers reject collisions with a precise
+    // source label, but this entry is reachable directly, so keep the invariant
+    // (one profile per name, never merged or shadowed) enforced here too.
+    let column_names: Vec<String> = columns.iter().map(|(n, _)| n.clone()).collect();
+    dataprof::validate_unique_column_names(&column_names, "columns")
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
     let num_rows = effective_max_rows
         .map(|cap| cap.min(source_rows))
         .unwrap_or(source_rows);

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -28,6 +28,7 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
     match err {
         DataProfilerError::InvalidSemanticHint { .. }
         | DataProfilerError::InvalidConfiguration { .. }
+        | DataProfilerError::DuplicateColumnName { .. }
         | DataProfilerError::UnsupportedFormat { .. } => PyValueError::new_err(message),
         DataProfilerError::FileNotFound { .. } => PyFileNotFoundError::new_err(message),
         DataProfilerError::IoError { .. } => {
@@ -38,6 +39,20 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
             }
         }
         _ => PyRuntimeError::new_err(format!("Analysis failed: {message}")),
+    }
+}
+
+/// Map an analyzer error (an `anyhow::Error` that usually wraps a
+/// [`DataProfilerError`]) onto a Python exception.
+///
+/// The columnar analyzers return `anyhow::Result`, which would otherwise
+/// flatten every failure into a `RuntimeError`. Recovering the typed error
+/// keeps input problems — notably duplicate column names — as `ValueError`, so
+/// the Arrow/Parquet input paths agree with the CSV and dict/list paths.
+pub(crate) fn analyzer_error_to_py(err: anyhow::Error) -> PyErr {
+    match err.downcast::<DataProfilerError>() {
+        Ok(typed) => analysis_error_to_py(&typed),
+        Err(other) => PyRuntimeError::new_err(format!("Analysis failed: {other}")),
     }
 }
 

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -30,7 +30,7 @@ pub use dataprof_core::{
     Pattern, PatternCategory, ProgressEvent, ProgressSink, QualityDimension, QualityScoreWeights,
     Quartiles, QueryEngine, RowCountEstimate, SamplingStrategy, SchemaResult, SemanticHintBinding,
     SemanticHintKind, SemanticHints, StopCondition, StopEvaluator, StructureColumnSummary,
-    StructureReport, TextStats, TruncationReason, ValidationError,
+    StructureReport, TextStats, TruncationReason, ValidationError, validate_unique_column_names,
 };
 pub use dataprof_csv::{
     CsvDiagnostics, CsvParserConfig, analyze_csv_file, analyze_csv_from_reader,

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -415,9 +415,17 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
         return []
 
     # Reject duplicate headers before profiling: name-keyed mapping access would
-    # otherwise shadow one column and silently drop its profile.
-    if len(set(header)) != len(header):
-        collisions = sorted(name for name in set(header) if header.count(name) > 1)
+    # otherwise shadow one column and silently drop its profile. Single pass,
+    # first-seen order, matching the Rust-side validate_unique_column_names.
+    seen: set[str] = set()
+    collisions: list[str] = []
+    for name in header:
+        if name in seen:
+            if name not in collisions:
+                collisions.append(name)
+        else:
+            seen.add(name)
+    if collisions:
         raise ValueError(
             "csv bytes input: duplicate column name(s): "
             f"{collisions!r}. Column names must be unique."

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -414,6 +414,15 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
     except StopIteration:
         return []
 
+    # Reject duplicate headers before profiling: name-keyed mapping access would
+    # otherwise shadow one column and silently drop its profile.
+    if len(set(header)) != len(header):
+        collisions = sorted(name for name in set(header) if header.count(name) > 1)
+        raise ValueError(
+            "csv bytes input: duplicate column name(s): "
+            f"{collisions!r}. Column names must be unique."
+        )
+
     cells: list[list[str | None]] = [[] for _ in header]
     for row_num, row in enumerate(reader, start=2):
         if len(row) != len(header):

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -369,3 +369,43 @@ def test_duplicate_rows_tracked_for_dataframe_and_arrow_inputs(tmp_path):
     uniqueness = report.to_dict()["quality"]["uniqueness"]
     assert uniqueness["rows_checked"] == 4
     assert uniqueness["duplicate_rows"] == 1
+
+
+def test_duplicate_column_names_rejected_across_all_inputs(tmp_path):
+    # The same duplicate-header source must be rejected identically regardless of
+    # transport, so no path can silently merge or shadow a column (#381).
+    path = tmp_path / "dup.csv"
+    path.write_text("x,x,y\n1,2,a\n3,4,b\n")
+
+    inputs = [
+        ("csv file", lambda: dataprof.profile(str(path))),
+        ("csv bytes", lambda: dataprof.profile(b"x,x,y\n1,2,a\n3,4,b\n", format="csv")),
+        # dict/list-of-dicts collide only after str() normalization (1 vs "1").
+        ("list-of-dicts", lambda: dataprof.profile([{1: "a", "1": "b"}])),
+    ]
+    pa = pytest.importorskip("pyarrow", reason="pyarrow optional")
+    inputs.append((
+        "arrow",
+        lambda: dataprof.profile(
+            pa.table(
+                [pa.array([1, 3]), pa.array([2, 4])],
+                schema=pa.schema([("x", pa.int64()), ("x", pa.int64())]),
+            )
+        ),
+    ))
+
+    for label, call in inputs:
+        with pytest.raises(ValueError):
+            call()
+
+
+def test_rectangular_source_has_one_profile_per_column(tmp_path):
+    # The invariant duplicate-rejection protects: columns == len(profiles) and
+    # every column's total_count equals the row count.
+    path = tmp_path / "rect.csv"
+    path.write_text("a,b,c\n1,2,3\n4,5,6\n")
+    for engine in ("auto", "incremental", "columnar"):
+        report = dataprof.profile(str(path), engine=engine)
+        assert report.columns == len(list(report.column_profiles)) == 3, engine
+        for col in report.column_profiles:
+            assert report[col].total_count == report.rows, f"{engine} {col}"

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -384,15 +384,17 @@ def test_duplicate_column_names_rejected_across_all_inputs(tmp_path):
         ("list-of-dicts", lambda: dataprof.profile([{1: "a", "1": "b"}])),
     ]
     pa = pytest.importorskip("pyarrow", reason="pyarrow optional")
-    inputs.append((
-        "arrow",
-        lambda: dataprof.profile(
-            pa.table(
-                [pa.array([1, 3]), pa.array([2, 4])],
-                schema=pa.schema([("x", pa.int64()), ("x", pa.int64())]),
-            )
-        ),
-    ))
+    inputs.append(
+        (
+            "arrow",
+            lambda: dataprof.profile(
+                pa.table(
+                    [pa.array([1, 3]), pa.array([2, 4])],
+                    schema=pa.schema([("x", pa.int64()), ("x", pa.int64())]),
+                )
+            ),
+        )
+    )
 
     for label, call in inputs:
         with pytest.raises(ValueError):

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -434,6 +434,41 @@ class TestProfileAdHocInputs:
         with pytest.raises(ValueError, match="row 2 has 3 fields"):
             dataprof.profile(b"a,b\n1,2,3\n", format="csv")
 
+    def test_csv_bytes_reject_duplicate_headers(self):
+        # Would otherwise report 3 columns but shadow one 'x' at mapping access.
+        with pytest.raises(ValueError, match="duplicate column name"):
+            dataprof.profile(b"x,x,y\n1,2,a\n3,4,b\n", format="csv")
+
+    def test_csv_file_reject_duplicate_headers(self, tmp_path):
+        path = tmp_path / "dup.csv"
+        path.write_text("x,x,y\n1,2,a\n3,4,b\n")
+        with pytest.raises(ValueError) as excinfo:
+            dataprof.profile(str(path))
+        msg = str(excinfo.value)
+        assert "'x'" in msg  # names the offender
+        assert "1" not in msg  # never echoes cell values
+
+    def test_arrow_reject_duplicate_columns(self):
+        pa = pytest.importorskip("pyarrow")
+        # Two fields named "x"; a name-keyed analyzer would merge them.
+        table = pa.table(
+            [pa.array([1, 3]), pa.array([2, 4]), pa.array([5, 6])],
+            schema=pa.schema(
+                [("x", pa.int64()), ("x", pa.int64()), ("y", pa.int64())]
+            ),
+        )
+        with pytest.raises(ValueError, match="[Dd]uplicate column name"):
+            dataprof.profile(table)
+
+    def test_raw_extension_rejects_duplicate_column_names(self):
+        # profile_columns is importable directly, so it enforces uniqueness too.
+        from dataprof import _dataprof
+
+        with pytest.raises(ValueError, match="[Dd]uplicate column name"):
+            _dataprof.profile_columns(
+                [("x", ["1", "3"]), ("x", ["2", "4"])], "t", None, None
+            )
+
     def test_json_bytes_accept_columns_or_records(self):
         by_column = dataprof.profile(b'{"a": [1, 2]}', format="json")
         by_record = dataprof.profile(b'[{"a": 1}, {"a": 2}]', format="json")

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -453,9 +453,7 @@ class TestProfileAdHocInputs:
         # Two fields named "x"; a name-keyed analyzer would merge them.
         table = pa.table(
             [pa.array([1, 3]), pa.array([2, 4]), pa.array([5, 6])],
-            schema=pa.schema(
-                [("x", pa.int64()), ("x", pa.int64()), ("y", pa.int64())]
-            ),
+            schema=pa.schema([("x", pa.int64()), ("x", pa.int64()), ("y", pa.int64())]),
         )
         with pytest.raises(ValueError, match="[Dd]uplicate column name"):
             dataprof.profile(table)
@@ -465,9 +463,7 @@ class TestProfileAdHocInputs:
         from dataprof import _dataprof
 
         with pytest.raises(ValueError, match="[Dd]uplicate column name"):
-            _dataprof.profile_columns(
-                [("x", ["1", "3"]), ("x", ["2", "4"])], "t", None, None
-            )
+            _dataprof.profile_columns([("x", ["1", "3"]), ("x", ["2", "4"])], "t", None, None)
 
     def test_json_bytes_accept_columns_or_records(self):
         by_column = dataprof.profile(b'{"a": [1, 2]}', format="json")

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -832,3 +832,64 @@ fn test_duplicate_rows_without_nulls_match_across_engines() {
         assert_eq!(uniq.duplicate_rows, 1, "{engine:?} duplicate_rows");
     }
 }
+
+/// Duplicate column names are a deterministic file property that no engine can
+/// resolve; every CSV engine must reject them before profiling rather than
+/// silently merging two columns into one profile (#381).
+#[test]
+fn test_duplicate_headers_rejected_across_csv_engines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "x,x,y").unwrap();
+    writeln!(f, "1,2,a").unwrap();
+    writeln!(f, "3,4,b").unwrap();
+    f.flush().unwrap();
+
+    // Standard (simple) CSV engine.
+    let err = analyze_csv_file(f.path(), &CsvParserConfig::default())
+        .expect_err("standard engine must reject duplicate headers");
+    assert_eq!(err.category(), "duplicate_column_name");
+    let msg = err.to_string();
+    assert!(msg.contains("'x'"), "names the offender: {msg}");
+    assert!(!msg.contains('1'), "must not echo cell values: {msg}");
+
+    // Auto (incremental) and Columnar (Arrow) engines: a clear, categorized error,
+    // never buried under "All engines failed".
+    for engine in [
+        EngineType::Auto,
+        EngineType::Incremental,
+        EngineType::Columnar,
+    ] {
+        let err = Profiler::new()
+            .engine(engine)
+            .analyze_file(f.path())
+            .expect_err("engine must reject duplicate headers");
+        assert_eq!(
+            err.category(),
+            "duplicate_column_name",
+            "{engine:?} should surface the duplicate-column error directly"
+        );
+    }
+}
+
+/// The reason duplicates must be rejected: a rectangular source must yield one
+/// profile per column, each with `total_count == rows` — never a merged column
+/// whose count exceeds the row count.
+#[test]
+fn test_unique_headers_preserve_column_count_and_totals() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "a,b,c").unwrap();
+    writeln!(f, "1,2,3").unwrap();
+    writeln!(f, "4,5,6").unwrap();
+    f.flush().unwrap();
+
+    for engine in [EngineType::Incremental, EngineType::Columnar] {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(f.path())
+            .expect("unique headers should profile");
+        assert_eq!(report.column_profiles.len(), 3, "{engine:?} column count");
+        for col in &report.column_profiles {
+            assert_eq!(col.total_count, 2, "{engine:?} {} total_count", col.name);
+        }
+    }
+}


### PR DESCRIPTION
Closes #381.

## Problem

The same CSV with duplicate headers behaved three different ways:

- **CSV file / incremental** merged both `x` fields into one profile with `total_count = 4` on a 2-row dataset.
- **CSV bytes / columnar** reported 3 columns but shadowed one `x` at name-keyed mapping access, silently dropping a profile.
- **Arrow / Parquet** merged the same way (shared `HashMap`-keyed collapse).
- **dict / list-of-dicts** already rejected collisions.

Root cause: every engine keys per-column state by name, so a repeat is merged or shadowed. There was no enforced contract, and a post-profiling warning is too late.

## Change

Reject duplicate normalized column names **before** profiling, uniformly:

- New `DataProfilerError::DuplicateColumnName` + shared `validate_unique_column_names()` in `dataprof-core`.
- Wired into every header/schema read point: CSV incremental, simple, and robust parsers; `RecordBatchAnalyzer` and the Arrow CSV profiler; the Python columnar entry; and Python CSV-bytes input.
- The adaptive-engine fallback and robust-CSV recovery short-circuit this deterministic error so it surfaces cleanly instead of being buried under "All engines failed".
- Surfaces as `ValueError` in Python (an `analyzer_error_to_py` helper recovers the typed error from the Arrow paths), matching the existing dict/list-of-dicts behavior. Errors name the duplicate and source, never cell values.

## Acceptance criteria

- [x] CSV file, CSV bytes, Arrow/Parquet, dict, list-of-dicts share the normalized-name check.
- [x] Error identifies the duplicate name + source type without printing row values.
- [x] No report can have `columns != len(column_profiles)`.
- [x] Every column profile satisfies `total_count == report.rows` for a rectangular source.
- [x] Exports/mapping access never rely on a shadow warning.
- [x] Regression tests cover exact duplicates (first/middle/last) and `str()` normalization collisions.

## Verification

```
cargo test -p dataprof-core -p dataprof-csv -p dataprof-engines -p dataprof-parquet --features arrow
cargo test --test cross_engine_consistency --features arrow
uv run pytest python/tests/test_engine_parity.py python/tests/test_python_api.py -q
cargo clippy --features arrow --all-targets
cargo fmt --check
```

All green (323 passed / 1 skipped on the Python side; DB test skipped without DB features).