### PR TITLE
feat(json): unify malformed-record policy across file/bytes/async JSONL (#382)

### DIFF
--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -46,7 +46,8 @@ pub use sampling::{
 };
 pub use semantic::{SemanticHintBinding, SemanticHintKind, SemanticHints};
 pub use source::{
-    DataFrameLibrary, DataSource, FileFormat, ParquetMetadata, QueryEngine, StreamSourceSystem,
+    DataFrameLibrary, DataSource, FileFormat, JsonErrorPolicy, ParquetMetadata, QueryEngine,
+    StreamSourceSystem,
 };
 pub use stop_condition::{
     SchemaStabilityTracker, StopCondition, StopEvaluator, schema_stable_threshold,

--- a/crates/dataprof-core/src/source.rs
+++ b/crates/dataprof-core/src/source.rs
@@ -22,6 +22,22 @@ impl std::fmt::Display for FileFormat {
     }
 }
 
+/// How JSON/JSONL parsing reacts to a malformed record.
+///
+/// Shared across the file, in-memory, and async byte input paths so callers get
+/// the same recovery behavior regardless of transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JsonErrorPolicy {
+    /// Skip the malformed record, count it, and keep scanning. The profile is
+    /// reported as partial via `execution.error_count`.
+    #[default]
+    Skip,
+    /// Abort on the first malformed record with a `JsonParsingError` carrying
+    /// line/column context (never the record contents).
+    Strict,
+}
+
 /// Supported query engines for SQL-based profiling
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -1,11 +1,10 @@
-use std::io::Read;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
 use dataprof_core::{
-    ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, MetricPack,
-    ProgressSink, QualityDimension, SamplingStrategy, SchemaStabilityTracker, SemanticHints,
-    StopCondition, StopEvaluator, StreamSourceSystem, TruncationReason,
+    ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, JsonErrorPolicy,
+    MetricPack, ProgressSink, QualityDimension, SamplingStrategy, SchemaStabilityTracker,
+    SemanticHints, StopCondition, StopEvaluator, StreamSourceSystem, TruncationReason,
 };
 use dataprof_runtime::{
     ProfileReport, ReportAssembler, StreamingColumnCollection, profile_builder,
@@ -46,6 +45,7 @@ pub struct AsyncStreamingProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     semantic_hints: SemanticHints,
+    json_error_policy: JsonErrorPolicy,
 }
 
 impl AsyncStreamingProfiler {
@@ -61,6 +61,7 @@ impl AsyncStreamingProfiler {
             quality_dimensions: None,
             metric_packs: None,
             semantic_hints: SemanticHints::default(),
+            json_error_policy: JsonErrorPolicy::default(),
         }
     }
 
@@ -110,6 +111,12 @@ impl AsyncStreamingProfiler {
         self
     }
 
+    /// Set how malformed JSON/JSONL records are handled (default: skip and count).
+    pub fn json_error_policy(mut self, policy: JsonErrorPolicy) -> Self {
+        self.json_error_policy = policy;
+        self
+    }
+
     /// Profile data from an async source, returning a [`ProfileReport`].
     ///
     /// Supports CSV, JSON, and JSONL formats. Parquet async support is tracked separately.
@@ -142,10 +149,13 @@ impl AsyncStreamingProfiler {
         let sync_reader = tokio_util::io::SyncIoBridge::new(reader);
 
         // Spawn the reader on a blocking thread — format determines the parser.
+        // The task reports how many malformed records were skipped (0 for CSV,
+        // and always 0 in strict JSON mode since the first one aborts).
+        let json_error_policy = self.json_error_policy;
         let reader_handle = tokio::task::spawn_blocking(move || match format {
-            FileFormat::Csv => Self::reader_task(sync_reader, tx, rows_per_chunk),
+            FileFormat::Csv => Self::reader_task(sync_reader, tx, rows_per_chunk).map(|()| 0usize),
             FileFormat::Json | FileFormat::Jsonl => {
-                Self::json_reader_task(sync_reader, tx, rows_per_chunk, format)
+                Self::json_reader_task(sync_reader, tx, rows_per_chunk, format, json_error_policy)
             }
             _ => unreachable!(),
         });
@@ -153,29 +163,35 @@ impl AsyncStreamingProfiler {
         // Process chunks on the current task
         let process_result = self.process_chunks(rx, source_info.size_hint).await;
 
-        // If processing failed, abort the reader task to avoid leaking it
+        // If processing failed, prefer the reader's error when it also failed:
+        // a strict-mode malformed record aborts the reader before any data
+        // reaches the processor, which would otherwise surface only as a generic
+        // "empty input" error and mask the real cause.
         let (_headers, column_stats, total_rows, sampled_rows, total_bytes, truncation_reason) =
             match process_result {
                 Ok(result) => result,
-                Err(e) => {
-                    reader_handle.abort();
-                    return Err(e);
+                Err(process_err) => {
+                    return match reader_handle.await {
+                        Ok(Err(reader_err)) => Err(reader_err),
+                        _ => Err(process_err),
+                    };
                 }
             };
 
         // Wait for the reader task to finish and propagate any errors
-        match reader_handle.await {
-            Ok(Ok(())) => {}
+        let malformed_records = match reader_handle.await {
+            Ok(Ok(count)) => count,
             Ok(Err(e)) => return Err(e),
             Err(join_err) if join_err.is_cancelled() => {
                 // We cancelled it ourselves — fine
+                0
             }
             Err(join_err) => {
                 return Err(DataProfilerError::StreamingError {
                     message: format!("Reader task panicked: {}", join_err),
                 });
             }
-        }
+        };
 
         // Build the report
         let packs = self.metric_packs.as_deref();
@@ -208,7 +224,10 @@ impl AsyncStreamingProfiler {
 
         let mut execution = ExecutionMetadata::new(sampled_rows, num_columns, scan_time_ms)
             .with_engine("incremental")
-            .with_bytes_consumed(total_bytes);
+            .with_bytes_consumed(total_bytes)
+            // Tolerant JSONL scans surface skipped malformed records so callers
+            // can distinguish a partial profile from a clean one.
+            .with_error_count(malformed_records);
 
         if let Some(reason) = truncation_reason {
             execution = execution.with_truncation(reason);
@@ -316,7 +335,8 @@ impl AsyncStreamingProfiler {
         tx: mpsc::Sender<ParsedChunk>,
         rows_per_chunk: usize,
         format: FileFormat,
-    ) -> Result<(), DataProfilerError> {
+        error_policy: JsonErrorPolicy,
+    ) -> Result<usize, DataProfilerError> {
         use serde_json::Value;
         use std::io::BufRead;
 
@@ -327,6 +347,8 @@ impl AsyncStreamingProfiler {
             std::collections::HashSet::new();
         let mut bytes_in_chunk: u64 = 0;
         let mut headers_sent = false;
+        let mut malformed_records: usize = 0;
+        let mut emitted_records: usize = 0;
 
         // Helper closure: convert a JSON object into a row aligned to known_columns.
         // New columns are only registered before headers are sent; once headers have
@@ -399,13 +421,32 @@ impl AsyncStreamingProfiler {
 
         match format {
             FileFormat::Jsonl => {
-                // True streaming: line-by-line
-                let mut reader = buf_reader.take(u64::MAX); // Use take to get a Read trait object
-                let de = serde_json::Deserializer::from_reader(&mut reader);
-                for value in de.into_iter::<Value>() {
-                    let v = value.map_err(|e| DataProfilerError::JsonParsingError {
-                        message: e.to_string(),
-                    })?;
+                // True streaming: deserialize one record at a time so a malformed
+                // record can be recovered from (skip to next line) or reported,
+                // matching the sync `scan_json_from_reader` contract.
+                loop {
+                    let parsed = {
+                        let mut de = serde_json::Deserializer::from_reader(&mut buf_reader);
+                        <Value as serde::Deserialize>::deserialize(&mut de)
+                    };
+                    let v = match parsed {
+                        Ok(v) => v,
+                        Err(e) if e.classify() == serde_json::error::Category::Eof => break,
+                        Err(e) => {
+                            if error_policy == JsonErrorPolicy::Strict {
+                                return Err(DataProfilerError::JsonParsingError {
+                                    message: format!("malformed JSON record: {e}"),
+                                });
+                            }
+                            malformed_records += 1;
+                            // Recover by discarding the rest of the offending line.
+                            let mut discard = Vec::new();
+                            buf_reader
+                                .read_until(b'\n', &mut discard)
+                                .map_err(DataProfilerError::from)?;
+                            continue;
+                        }
+                    };
 
                     if let Value::Object(obj) = v {
                         let row = process_object(
@@ -416,6 +457,7 @@ impl AsyncStreamingProfiler {
                         );
                         bytes_in_chunk += row.iter().map(|s| s.len() as u64 + 4).sum::<u64>();
                         current_chunk.push(row);
+                        emitted_records += 1;
 
                         if current_chunk.len() >= rows_per_chunk
                             && !send_chunk(
@@ -426,7 +468,7 @@ impl AsyncStreamingProfiler {
                                 &tx,
                             )?
                         {
-                            return Ok(());
+                            return Ok(malformed_records);
                         }
                     }
                 }
@@ -503,6 +545,7 @@ impl AsyncStreamingProfiler {
                                     bytes_in_chunk +=
                                         row.iter().map(|s| s.len() as u64 + 4).sum::<u64>();
                                     current_chunk.push(row);
+                                    emitted_records += 1;
 
                                     if current_chunk.len() >= rows_per_chunk
                                         && !send_chunk(
@@ -513,14 +556,23 @@ impl AsyncStreamingProfiler {
                                             &tx,
                                         )?
                                     {
-                                        return Ok(());
+                                        return Ok(malformed_records);
                                     }
                                 }
                                 Ok(_) => {
                                     // Skip non-object items, approximate 10 bytes progress
                                     bytes_in_chunk += 10;
                                 }
-                                Err(_) => {
+                                Err(e) => {
+                                    // A corrupt element leaves the array parser unable
+                                    // to resync, so we stop here either way; strict mode
+                                    // surfaces the failure instead of a partial profile.
+                                    if error_policy == JsonErrorPolicy::Strict {
+                                        return Err(DataProfilerError::JsonParsingError {
+                                            message: format!("malformed JSON record: {e}"),
+                                        });
+                                    }
+                                    malformed_records += 1;
                                     break;
                                 }
                             }
@@ -528,6 +580,14 @@ impl AsyncStreamingProfiler {
                     }
                 }
             }
+        }
+
+        // Input made up entirely of malformed records must fail, matching the
+        // file/bytes paths, rather than surfacing a generic "empty stream" error.
+        if emitted_records == 0 && malformed_records > 0 {
+            return Err(DataProfilerError::JsonParsingError {
+                message: "No valid JSON records found (all records were malformed)".to_string(),
+            });
         }
 
         // Flush remaining
@@ -541,7 +601,7 @@ impl AsyncStreamingProfiler {
             );
         }
 
-        Ok(())
+        Ok(malformed_records)
     }
 
     /// Receive parsed chunks and feed them into StreamingColumnCollection.
@@ -876,5 +936,57 @@ mod tests {
             report.execution.truncation_reason,
             Some(TruncationReason::MaxRows(100))
         ));
+    }
+
+    fn jsonl_source(data: &'static [u8]) -> BytesSource {
+        BytesSource::new(
+            bytes::Bytes::from_static(data),
+            AsyncSourceInfo::new("test", FileFormat::Jsonl).size_hint(Some(data.len() as u64)),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_async_jsonl_tolerant_skips_and_counts() {
+        // Malformed record in the middle: default policy skips and counts it.
+        let source = jsonl_source(b"{\"id\":1}\nnot-json\n{\"id\":2}\n");
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.error_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_async_jsonl_strict_aborts() {
+        for data in [
+            b"not-json\n{\"id\":1}\n{\"id\":2}\n".as_ref(),
+            b"{\"id\":1}\nnot-json\n{\"id\":2}\n".as_ref(),
+            b"{\"id\":1}\n{\"id\":2}\nnot-json\n".as_ref(),
+        ] {
+            let source = BytesSource::new(
+                bytes::Bytes::from_static(data),
+                AsyncSourceInfo::new("test", FileFormat::Jsonl),
+            );
+            let result = AsyncStreamingProfiler::new()
+                .json_error_policy(JsonErrorPolicy::Strict)
+                .analyze_stream(source)
+                .await;
+            let err = result.expect_err("strict mode must reject malformed records");
+            let message = err.to_string();
+            assert!(message.to_lowercase().contains("malformed json record"));
+            assert!(!message.contains("not-json"), "leaked record: {message}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_jsonl_clean_has_zero_error_count() {
+        let source = jsonl_source(b"{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n");
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+        assert_eq!(report.execution.rows_processed, 3);
+        assert_eq!(report.execution.error_count, 0);
     }
 }

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -2,11 +2,11 @@ use std::collections::{HashMap, HashSet};
 use std::io::BufRead;
 use std::path::Path;
 
+pub use dataprof_core::JsonErrorPolicy;
 use dataprof_core::{
     ColumnProfile, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, QualityDimension,
     SemanticHints, TruncationReason,
 };
-pub use dataprof_core::JsonErrorPolicy;
 use dataprof_runtime::{
     ProfileReport, ReportAssembler, StreamingColumnCollection, profile_builder,
 };
@@ -722,7 +722,10 @@ mod tests {
             let message = err.to_string().to_lowercase();
             assert!(message.contains("malformed json record"), "got: {message}");
             // The offending record text must never be echoed back.
-            assert!(!err.to_string().contains("not-json"), "leaked record: {err}");
+            assert!(
+                !err.to_string().contains("not-json"),
+                "leaked record: {err}"
+            );
         }
     }
 
@@ -730,8 +733,7 @@ mod tests {
     fn test_tolerant_policy_counts_skipped_records() {
         let data = b"{\"x\":1}\nnot-json\n{\"x\":2}\n";
         let config = JsonParserConfig::jsonl(); // default Skip
-        let summary =
-            scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
+        let summary = scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
         assert_eq!(summary.rows_read, 2);
         assert_eq!(summary.malformed_lines, 1);
     }
@@ -787,7 +789,11 @@ mod tests {
         let config = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
         let err = analyze_json_file(file.path(), &config)
             .expect_err("strict mode must reject the malformed record");
-        assert!(err.to_string().to_lowercase().contains("malformed json record"));
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("malformed json record")
+        );
     }
 
     #[test]

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -6,6 +6,7 @@ use dataprof_core::{
     ColumnProfile, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, QualityDimension,
     SemanticHints, TruncationReason,
 };
+pub use dataprof_core::JsonErrorPolicy;
 use dataprof_runtime::{
     ProfileReport, ReportAssembler, StreamingColumnCollection, profile_builder,
 };
@@ -28,12 +29,20 @@ pub struct JsonParserConfig {
     pub format: Option<JsonFormat>,
     /// Maximum rows to process (None = all rows).
     pub max_rows: Option<usize>,
+    /// How to react to a malformed record (default: skip).
+    pub error_policy: JsonErrorPolicy,
 }
 
 impl JsonParserConfig {
     /// Set the maximum number of rows to process.
     pub fn with_max_rows(mut self, max_rows: usize) -> Self {
         self.max_rows = Some(max_rows);
+        self
+    }
+
+    /// Set how malformed records are handled.
+    pub fn with_error_policy(mut self, policy: JsonErrorPolicy) -> Self {
+        self.error_policy = policy;
         self
     }
 
@@ -110,7 +119,10 @@ where
             let value: Value = match Value::deserialize(&mut deserializer) {
                 Ok(v) => v,
                 Err(err) if err.classify() == serde_json::error::Category::Eof => break,
-                Err(_) => {
+                Err(err) => {
+                    if config.error_policy == JsonErrorPolicy::Strict {
+                        return Err(malformed_record_error(&err));
+                    }
                     malformed_lines += 1;
                     skip_to_next_line(&mut reader)?;
                     continue;
@@ -201,7 +213,10 @@ where
                                 rows_read += 1;
                             }
                             Ok(_) => {}
-                            Err(_) => {
+                            Err(err) => {
+                                if config.error_policy == JsonErrorPolicy::Strict {
+                                    return Err(malformed_record_error(&err));
+                                }
                                 malformed_lines += 1;
                                 break;
                             }
@@ -219,6 +234,15 @@ where
         format,
         truncated,
     })
+}
+
+/// Build a strict-mode parse error from a serde failure. The serde message
+/// carries line/column context but never the record contents, so it is safe to
+/// surface directly.
+fn malformed_record_error(err: &serde_json::Error) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!("malformed JSON record: {err}"),
+    }
 }
 
 fn consume_leading_whitespace<R: BufRead>(reader: &mut R) -> Result<Option<u8>, DataProfilerError> {
@@ -455,8 +479,11 @@ pub fn analyze_json_file_with_dimensions_and_hints(
     let scan_time_ms = start.elapsed().as_millis();
     let num_columns = column_profiles.len();
 
-    let mut execution =
-        ExecutionMetadata::new(rows_read, num_columns, scan_time_ms).with_engine("json");
+    let mut execution = ExecutionMetadata::new(rows_read, num_columns, scan_time_ms)
+        .with_engine("json")
+        // Tolerant scans surface skipped malformed records here so callers can
+        // tell a partial profile from a clean one.
+        .with_error_count(malformed_lines);
     // `truncated` is set only when a record still remained at the cap, so a source
     // holding exactly `max_rows` records is reported as fully read, not cut short.
     if truncated && let Some(max) = config.max_rows {
@@ -679,6 +706,88 @@ mod tests {
         assert_eq!(format, FileFormat::Jsonl);
         assert_eq!(rows, 2);
         assert_eq!(profiles[0].total_count, 2);
+    }
+
+    #[test]
+    fn test_strict_policy_errors_on_malformed_jsonl() {
+        // Malformed in first / middle / last position all abort under Strict.
+        for data in [
+            b"not-json\n{\"x\":1}\n{\"x\":2}\n".as_ref(),
+            b"{\"x\":1}\nnot-json\n{\"x\":2}\n".as_ref(),
+            b"{\"x\":1}\n{\"x\":2}\nnot-json\n".as_ref(),
+        ] {
+            let config = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
+            let err = scan_json_from_reader(Cursor::new(data), &config, |_| {})
+                .expect_err("strict mode must reject malformed records");
+            let message = err.to_string().to_lowercase();
+            assert!(message.contains("malformed json record"), "got: {message}");
+            // The offending record text must never be echoed back.
+            assert!(!err.to_string().contains("not-json"), "leaked record: {err}");
+        }
+    }
+
+    #[test]
+    fn test_tolerant_policy_counts_skipped_records() {
+        let data = b"{\"x\":1}\nnot-json\n{\"x\":2}\n";
+        let config = JsonParserConfig::jsonl(); // default Skip
+        let summary =
+            scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
+        assert_eq!(summary.rows_read, 2);
+        assert_eq!(summary.malformed_lines, 1);
+    }
+
+    #[test]
+    fn test_blank_lines_are_not_counted_as_malformed() {
+        let data = b"{\"x\":1}\n\n   \n{\"x\":2}\n";
+        for policy in [JsonErrorPolicy::Skip, JsonErrorPolicy::Strict] {
+            let config = JsonParserConfig::jsonl().with_error_policy(policy);
+            let summary =
+                scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
+            assert_eq!(summary.rows_read, 2, "policy {policy:?}");
+            assert_eq!(summary.malformed_lines, 0, "policy {policy:?}");
+        }
+    }
+
+    #[test]
+    fn test_truncated_final_record_is_treated_as_eof() {
+        // serde classifies an incomplete trailing object as EOF, not a parse
+        // error, so it is silently dropped rather than counted or raised.
+        let data = b"{\"x\":1}\n{\"x\":2";
+        for policy in [JsonErrorPolicy::Skip, JsonErrorPolicy::Strict] {
+            let config = JsonParserConfig::jsonl().with_error_policy(policy);
+            let summary =
+                scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
+            assert_eq!(summary.rows_read, 1, "policy {policy:?}");
+            assert_eq!(summary.malformed_lines, 0, "policy {policy:?}");
+        }
+    }
+
+    #[test]
+    fn test_all_malformed_file_fails() {
+        let file = write_file("not-json\nalso-bad\n");
+        let config = JsonParserConfig::jsonl();
+        let err = analyze_json_file(file.path(), &config)
+            .expect_err("a file with no valid records must fail");
+        let message = err.to_string().to_lowercase();
+        assert!(message.contains("no valid json records"), "got: {message}");
+    }
+
+    #[test]
+    fn test_tolerant_file_reports_error_count() {
+        let file = write_file("{\"x\":1}\nnot-json\n{\"x\":2}\n");
+        let config = JsonParserConfig::jsonl();
+        let report = analyze_json_file(file.path(), &config).unwrap();
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.error_count, 1);
+    }
+
+    #[test]
+    fn test_strict_file_errors_on_malformed() {
+        let file = write_file("{\"x\":1}\nnot-json\n{\"x\":2}\n");
+        let config = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
+        let err = analyze_json_file(file.path(), &config)
+            .expect_err("strict mode must reject the malformed record");
+        assert!(err.to_string().to_lowercase().contains("malformed json record"));
     }
 
     #[test]

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -35,13 +35,14 @@ pub type PyColumn = (String, Vec<Option<String>>);
 ///
 /// Raises `ValueError` when the columns do not all have the same length.
 #[pyfunction]
-#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None))]
+#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0))]
 pub fn profile_columns(
     py: Python<'_>,
     columns: Vec<PyColumn>,
     name: String,
     max_rows: Option<usize>,
     config: Option<&PyProfilerConfig>,
+    error_count: usize,
 ) -> PyResult<PyProfileReport> {
     let start = std::time::Instant::now();
 
@@ -149,7 +150,10 @@ pub fn profile_columns(
     });
 
     let mut exec = ExecutionMetadata::new(num_rows, num_cols, start.elapsed().as_millis())
-        .with_engine("columnar");
+        .with_engine("columnar")
+        // Malformed records skipped upstream (e.g. tolerant JSONL byte parsing)
+        // are reported here so a partial profile is distinguishable from a clean one.
+        .with_error_count(error_count);
     if truncated {
         exec = exec.with_truncation(TruncationReason::MaxRows(
             effective_max_rows.unwrap_or(0) as u64

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dataprof::{
-    ChunkSize, EngineType, FileFormat, MetricPack, Profiler, QualityDimension, SemanticHints,
-    StopCondition,
+    ChunkSize, EngineType, FileFormat, JsonErrorPolicy, MetricPack, Profiler, QualityDimension,
+    SemanticHints, StopCondition,
 };
 
 use super::progress::py_callback_to_sink;
@@ -26,6 +26,7 @@ pub struct PyProfilerConfig {
     pub(crate) max_rows: Option<u64>,
     pub(crate) csv_delimiter: Option<u8>,
     pub(crate) csv_flexible: Option<bool>,
+    pub(crate) json_error_policy: JsonErrorPolicy,
     pub(crate) sampling: Option<PySamplingStrategy>,
     pub(crate) stop_condition: Option<PyStopCondition>,
     pub(crate) on_progress: Option<Arc<Py<PyAny>>>,
@@ -49,6 +50,7 @@ impl PyProfilerConfig {
         max_rows = None,
         csv_delimiter = None,
         csv_flexible = None,
+        jsonl_on_error = None,
         sampling = None,
         stop_condition = None,
         on_progress = None,
@@ -69,6 +71,7 @@ impl PyProfilerConfig {
         max_rows: Option<u64>,
         csv_delimiter: Option<&str>,
         csv_flexible: Option<bool>,
+        jsonl_on_error: Option<&str>,
         sampling: Option<PySamplingStrategy>,
         stop_condition: Option<PyStopCondition>,
         on_progress: Option<Py<PyAny>>,
@@ -82,6 +85,7 @@ impl PyProfilerConfig {
     ) -> PyResult<Self> {
         let engine = parse_engine(engine)?;
         let format_override = format.map(parse_format).transpose()?;
+        let json_error_policy = jsonl_on_error.map(parse_json_error_policy).transpose()?.unwrap_or_default();
         let csv_delimiter = csv_delimiter
             .map(|d| {
                 if d.len() != 1 {
@@ -138,6 +142,7 @@ impl PyProfilerConfig {
             max_rows,
             csv_delimiter,
             csv_flexible,
+            json_error_policy,
             sampling,
             stop_condition,
             on_progress: on_progress.map(Arc::new),
@@ -195,6 +200,15 @@ impl PyProfilerConfig {
     #[getter]
     fn csv_flexible(&self) -> Option<bool> {
         self.csv_flexible
+    }
+
+    /// How malformed JSON/JSONL records are handled ("skip" or "strict")
+    #[getter]
+    fn jsonl_on_error(&self) -> &str {
+        match self.json_error_policy {
+            JsonErrorPolicy::Skip => "skip",
+            JsonErrorPolicy::Strict => "strict",
+        }
     }
 
     /// Locale for pattern detection
@@ -270,6 +284,7 @@ impl PyProfilerConfig {
         if let Some(f) = self.csv_flexible {
             profiler = profiler.csv_flexible(f);
         }
+        profiler = profiler.json_error_policy(self.json_error_policy);
         if let Some(ref cb) = self.on_progress {
             profiler = profiler.progress_sink(py_callback_to_sink(Arc::clone(cb)));
         }
@@ -340,6 +355,17 @@ fn parse_format(s: &str) -> PyResult<FileFormat> {
         "parquet" => Ok(FileFormat::Parquet),
         _ => Err(PyValueError::new_err(format!(
             "Unknown format '{}'. Valid: csv, json, jsonl, parquet",
+            s
+        ))),
+    }
+}
+
+fn parse_json_error_policy(s: &str) -> PyResult<JsonErrorPolicy> {
+    match s.to_lowercase().as_str() {
+        "skip" => Ok(JsonErrorPolicy::Skip),
+        "strict" => Ok(JsonErrorPolicy::Strict),
+        _ => Err(PyValueError::new_err(format!(
+            "Unknown jsonl_on_error '{}'. Valid: skip, strict",
             s
         ))),
     }

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -85,7 +85,10 @@ impl PyProfilerConfig {
     ) -> PyResult<Self> {
         let engine = parse_engine(engine)?;
         let format_override = format.map(parse_format).transpose()?;
-        let json_error_policy = jsonl_on_error.map(parse_json_error_policy).transpose()?.unwrap_or_default();
+        let json_error_policy = jsonl_on_error
+            .map(parse_json_error_policy)
+            .transpose()?
+            .unwrap_or_default();
         let csv_delimiter = csv_delimiter
             .map(|d| {
                 if d.len() != 1 {

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -29,6 +29,7 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
         DataProfilerError::InvalidSemanticHint { .. }
         | DataProfilerError::InvalidConfiguration { .. }
         | DataProfilerError::DuplicateColumnName { .. }
+        | DataProfilerError::JsonParsingError { .. }
         | DataProfilerError::UnsupportedFormat { .. } => PyValueError::new_err(message),
         DataProfilerError::FileNotFound { .. } => PyFileNotFoundError::new_err(message),
         DataProfilerError::IoError { .. } => {

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -36,7 +36,7 @@ pub use dataprof_csv::{
     CsvDiagnostics, CsvParserConfig, analyze_csv_file, analyze_csv_from_reader,
 };
 pub use dataprof_json::{
-    JsonFormat, JsonParserConfig, analyze_json_file, analyze_json_from_reader,
+    JsonErrorPolicy, JsonFormat, JsonParserConfig, analyze_json_file, analyze_json_from_reader,
 };
 pub use dataprof_metrics::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, MetricsCalculator,

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -40,6 +40,8 @@ pub struct ProfilerConfig {
     pub csv_delimiter: Option<u8>,
     /// Allow ragged CSV rows (None = use parser default).
     pub csv_flexible: Option<bool>,
+    /// How JSON/JSONL malformed records are handled (default: skip and count).
+    pub json_error_policy: dataprof_json::JsonErrorPolicy,
     /// Which quality dimensions to compute. `None` = all (default).
     pub quality_dimensions: Option<Vec<QualityDimension>>,
     /// Which metric packs to compute. `None` = all (default).
@@ -77,6 +79,7 @@ impl Default for ProfilerConfig {
             progress_interval: Duration::from_millis(500),
             csv_delimiter: None,
             csv_flexible: None,
+            json_error_policy: dataprof_json::JsonErrorPolicy::default(),
             quality_dimensions: None,
             metric_packs: None,
             locale: None,
@@ -189,6 +192,17 @@ impl Profiler {
     /// Set whether to allow ragged CSV rows. None = use parser default.
     pub fn csv_flexible(mut self, flexible: bool) -> Self {
         self.config.csv_flexible = Some(flexible);
+        self
+    }
+
+    /// Set how malformed JSON/JSONL records are handled.
+    ///
+    /// Default is [`JsonErrorPolicy::Skip`](dataprof_json::JsonErrorPolicy::Skip):
+    /// malformed records are skipped and counted in `execution.error_count`.
+    /// [`JsonErrorPolicy::Strict`](dataprof_json::JsonErrorPolicy::Strict) aborts
+    /// on the first malformed record.
+    pub fn json_error_policy(mut self, policy: dataprof_json::JsonErrorPolicy) -> Self {
+        self.config.json_error_policy = policy;
         self
     }
 
@@ -507,9 +521,10 @@ impl Profiler {
         self.config.stop_condition.max_rows().map(|n| n as usize)
     }
 
-    /// A JSON parser config carrying the configured row cap, if any.
+    /// A JSON parser config carrying the configured row cap and error policy.
     fn json_config_for_stop(&self) -> dataprof_json::JsonParserConfig {
-        let config = dataprof_json::JsonParserConfig::default();
+        let config = dataprof_json::JsonParserConfig::default()
+            .with_error_policy(self.config.json_error_policy);
         match self.stop_max_rows() {
             Some(max) => config.with_max_rows(max),
             None => config,
@@ -869,6 +884,7 @@ impl Profiler {
             .chunk_size(self.config.chunk_size.clone())
             .sampling(self.config.sampling.clone())
             .stop_condition(self.config.stop_condition.clone())
+            .json_error_policy(self.config.json_error_policy)
             .progress(self.progress_sink.clone(), self.config.progress_interval);
 
         if let Some(mb) = self.config.memory_limit_mb {
@@ -1060,9 +1076,9 @@ impl Profiler {
 
                 #[cfg(not(feature = "parquet-async"))]
                 {
-                    return Err(DataProfilerError::UnsupportedDataSource {
+                    Err(DataProfilerError::UnsupportedDataSource {
                         message: "Remote Parquet profiling requires the 'parquet-async' feature. Rebuild with 'parquet-async' to read Parquet over HTTP.".to_string(),
-                    });
+                    })
                 }
             }
             FileFormat::Csv | FileFormat::Json | FileFormat::Jsonl => {

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -444,6 +444,34 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
     return [(str(name), cells[i]) for i, name in enumerate(header)]
 
 
+def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
+    """Scan JSONL text into row objects, honoring the malformed-record policy.
+
+    Mirrors the file/async JSONL scanners: blank lines are ignored, only object
+    records become rows (other JSON values are skipped without counting), and a
+    malformed record is either skipped-and-counted ("skip") or raised on
+    ("strict"). Error messages carry the 1-based line number, never the record
+    contents. Input that yields no valid record but had malformed lines fails.
+    """
+    rows: list[dict] = []
+    skipped = 0
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            if on_error == "strict":
+                raise ValueError(f"jsonl bytes: malformed JSON record on line {lineno}.") from None
+            skipped += 1
+            continue
+        if isinstance(value, dict):
+            rows.append(value)
+    if not rows and skipped:
+        raise ValueError("jsonl bytes: no valid JSON records found (all records were malformed).")
+    return rows, skipped
+
+
 def _normalize_existing_file(path: str | os.PathLike[str], *, arg_name: str = "path") -> str:
     normalized = _normalize_pathlike(path, arg_name=arg_name)
     try:
@@ -830,6 +858,7 @@ def profile_file(
     max_rows: int | None = None,
     csv_delimiter: str | None = None,
     csv_flexible: bool | None = None,
+    jsonl_on_error: str = "skip",
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
     on_progress: Callable[[ProgressEvent], None] | None = None,
@@ -855,6 +884,10 @@ def profile_file(
         max_rows: Maximum rows to process before stopping.
         csv_delimiter: Single-character CSV delimiter (default: comma).
         csv_flexible: Allow variable-length CSV records.
+        jsonl_on_error: How to handle a malformed JSON/JSONL record: "skip"
+            (default) skips it, counts it in ``report.execution.error_count``,
+            and returns a partial profile; "strict" raises ValueError on the
+            first malformed record. A file with no valid records always fails.
         sampling: Sampling strategy (e.g. SamplingStrategy.random(1000)).
         stop_condition: Early stop condition (e.g. StopCondition.max_rows(5000)).
             Cannot be used together with max_rows.
@@ -894,6 +927,7 @@ def profile_file(
         max_rows=max_rows,
         csv_delimiter=csv_delimiter,
         csv_flexible=csv_flexible,
+        jsonl_on_error=jsonl_on_error,
         sampling=sampling,
         stop_condition=stop_condition,
         on_progress=on_progress,
@@ -920,6 +954,7 @@ def profile(
     name: str | None = None,
     csv_delimiter: str | None = None,
     csv_flexible: bool | None = None,
+    jsonl_on_error: str = "skip",
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
     on_progress: Callable[[ProgressEvent], None] | None = None,
@@ -947,6 +982,11 @@ def profile(
         name: Name for DataFrame sources in the report.
         csv_delimiter: Single-character CSV delimiter (default: comma).
         csv_flexible: Allow variable-length CSV records.
+        jsonl_on_error: How to handle a malformed JSON/JSONL record, applied
+            identically to file, bytes, and async byte inputs: "skip" (default)
+            skips it, counts it in ``report.execution.error_count``, and returns
+            a partial profile; "strict" raises ValueError on the first malformed
+            record. Input with no valid records always raises.
         sampling: Sampling strategy (e.g. SamplingStrategy.random(1000)).
         stop_condition: Early stop condition (e.g. StopCondition.max_rows(5000)).
             Cannot be used together with max_rows.
@@ -979,6 +1019,9 @@ def profile(
     Returns:
         ProfileReport with analysis results and quality metrics.
     """
+    if jsonl_on_error not in ("skip", "strict"):
+        raise ValueError(f"jsonl_on_error must be 'skip' or 'strict', got {jsonl_on_error!r}.")
+
     # File path — build config and delegate to Rust
     if isinstance(source, (str, pathlib.PurePath)):
         return profile_file(
@@ -990,6 +1033,7 @@ def profile(
             max_rows=max_rows,
             csv_delimiter=csv_delimiter,
             csv_flexible=csv_flexible,
+            jsonl_on_error=jsonl_on_error,
             sampling=sampling,
             stop_condition=stop_condition,
             on_progress=on_progress,
@@ -1055,8 +1099,12 @@ def profile(
         rust_report = _profile_dataframe(df, name or default_name, max_rows, _df_config())
         return ProfileReport(rust_report)
 
-    def _profile_python_columns(columns: list[_Column], default_name: str) -> ProfileReport:
-        rust_report = _profile_columns(columns, name or default_name, max_rows, _df_config())
+    def _profile_python_columns(
+        columns: list[_Column], default_name: str, error_count: int = 0
+    ) -> ProfileReport:
+        rust_report = _profile_columns(
+            columns, name or default_name, max_rows, _df_config(), error_count
+        )
         return ProfileReport(rust_report)
 
     if isinstance(source, dict):
@@ -1076,14 +1124,22 @@ def profile(
         fmt = format.lower()
         buffer = _bytes_buffer(source)
 
+        skipped = 0
         if fmt == "csv":
             columns = _columns_from_csv_bytes(buffer, csv_delimiter)
-        elif fmt in ("json", "jsonl"):
+        elif fmt == "jsonl":
             text = buffer.getvalue().decode("utf-8")
-            if fmt == "jsonl":
-                rows = [json.loads(line) for line in text.splitlines() if line.strip()]
-            else:
+            rows, skipped = _scan_jsonl_records(text, jsonl_on_error)
+            columns = _columns_from_records(rows, max_rows, sort_keys=True)
+        elif fmt == "json":
+            text = buffer.getvalue().decode("utf-8")
+            try:
                 rows = json.loads(text)
+            except json.JSONDecodeError as exc:
+                # Surface a dataprof error category, not a bare decoder exception.
+                raise ValueError(
+                    f"json bytes: malformed JSON (line {exc.lineno}, column {exc.colno})."
+                ) from None
             if isinstance(rows, dict):
                 if all(isinstance(values, (list, tuple)) for values in rows.values()):
                     columns = _columns_from_dict(rows)
@@ -1103,7 +1159,7 @@ def profile(
         else:
             raise ValueError("Unsupported bytes format. Use 'csv', 'json', 'jsonl', or 'parquet'.")
 
-        return _profile_python_columns(columns, f"{fmt}_bytes")
+        return _profile_python_columns(columns, f"{fmt}_bytes", skipped)
 
     # DataFrame detection via module name
     source_module = type(source).__module__ or ""
@@ -1694,6 +1750,17 @@ class ProfileReport:
     @property
     def source_exhausted(self) -> bool:
         return self._report.source_exhausted
+
+    @property
+    def error_count(self) -> int:
+        """Number of records skipped because they could not be parsed.
+
+        Nonzero means the profile is partial: for tolerant JSON/JSONL parsing
+        (``jsonl_on_error="skip"``, the default) each malformed record is
+        skipped and counted here rather than aborting the run. Zero means every
+        record parsed cleanly.
+        """
+        return self._report.error_count
 
     @property
     def ragged_row_count(self) -> int:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -460,9 +460,14 @@ def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
             continue
         try:
             value = json.loads(line)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
             if on_error == "strict":
-                raise ValueError(f"jsonl bytes: malformed JSON record on line {lineno}.") from None
+                # ``lineno`` is the record's position in the input; ``exc.colno``
+                # locates the fault within that line. The record text is never
+                # included.
+                raise ValueError(
+                    f"jsonl bytes: malformed JSON record on line {lineno}, column {exc.colno}."
+                ) from None
             skipped += 1
             continue
         if isinstance(value, dict):
@@ -918,6 +923,8 @@ def profile_file(
     Returns:
         ProfileReport with analysis results and quality metrics.
     """
+    if jsonl_on_error not in ("skip", "strict"):
+        raise ValueError(f"jsonl_on_error must be 'skip' or 'strict', got {jsonl_on_error!r}.")
     normalized_path = _normalize_existing_file(path, arg_name="path")
     config = ProfilerConfig(
         engine=engine,

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -66,6 +66,7 @@ def profile(
     name: str | None = None,
     csv_delimiter: str | None = None,
     csv_flexible: bool | None = None,
+    jsonl_on_error: str = "skip",
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
     on_progress: Callable[[ProgressEvent], None] | None = None,
@@ -90,6 +91,7 @@ def profile_file(
     max_rows: int | None = None,
     csv_delimiter: str | None = None,
     csv_flexible: bool | None = None,
+    jsonl_on_error: str = "skip",
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
     on_progress: Callable[[ProgressEvent], None] | None = None,
@@ -203,6 +205,8 @@ class ProfileReport:
     def truncation_reason(self) -> str | None: ...
     @property
     def source_exhausted(self) -> bool: ...
+    @property
+    def error_count(self) -> int: ...
     @property
     def ragged_row_count(self) -> int: ...
     @property

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -27,6 +27,7 @@ class ProfilerConfig:
         max_rows: int | None = None,
         csv_delimiter: str | None = None,
         csv_flexible: bool | None = None,
+        jsonl_on_error: str | None = None,
         sampling: SamplingStrategy | None = None,
         stop_condition: StopCondition | None = None,
         on_progress: Callable[[ProgressEvent], None] | None = None,
@@ -56,6 +57,8 @@ class ProfilerConfig:
     def identifier_columns(self) -> list[str]: ...
     @property
     def temporal_columns(self) -> list[str]: ...
+    @property
+    def jsonl_on_error(self) -> str: ...
 
 # --- Sampling ---
 
@@ -378,6 +381,7 @@ def profile_columns(
     name: str,
     max_rows: int | None,
     config: ProfilerConfig | None,
+    error_count: int = 0,
 ) -> ProfileReport: ...
 def infer_schema(path: str) -> SchemaResult: ...
 def quick_row_count(path: str) -> RowCountEstimate: ...

--- a/python/tests/test_jsonl_error_policy.py
+++ b/python/tests/test_jsonl_error_policy.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-import tempfile
+from pathlib import Path
 
 import dataprof
 import pytest
@@ -33,12 +33,14 @@ requires_async = pytest.mark.skipif(
 )
 
 
-def _write(data: bytes) -> str:
-    tmp = tempfile.NamedTemporaryFile(mode="wb", suffix=".jsonl", delete=False)
-    tmp.write(data)
-    tmp.flush()
-    tmp.close()
-    return tmp.name
+def _write(tmp_path: Path, data: bytes) -> str:
+    """Write ``data`` to a JSONL file under pytest's per-test ``tmp_path``.
+
+    Using the fixture directory means pytest cleans the files up automatically.
+    """
+    target = tmp_path / "data.jsonl"
+    target.write_bytes(data)
+    return str(target)
 
 
 def _async_bytes(data: bytes, **kwargs):
@@ -53,8 +55,8 @@ def _async_bytes(data: bytes, **kwargs):
 # --- Tolerant (default) parity ---------------------------------------------
 
 
-def test_file_tolerant_reports_partial_and_error_count():
-    path = _write(MIXED)
+def test_file_tolerant_reports_partial_and_error_count(tmp_path):
+    path = _write(tmp_path, MIXED)
     report = dataprof.profile(path, format="jsonl")
     assert report.rows == 2
     assert report.error_count == 1
@@ -84,8 +86,8 @@ def test_async_bytes_tolerant_reports_partial_and_error_count():
         b'{"id":1}\n{"id":2}\nnot-json\n',  # last
     ],
 )
-def test_file_strict_raises_valueerror(data):
-    path = _write(data)
+def test_file_strict_raises_valueerror(tmp_path, data):
+    path = _write(tmp_path, data)
     with pytest.raises(ValueError) as excinfo:
         dataprof.profile(path, format="jsonl", jsonl_on_error="strict")
     # A dataprof error category, not a raw decoder exception.
@@ -113,8 +115,8 @@ def test_async_bytes_strict_raises_valueerror():
 # --- Edge cases -------------------------------------------------------------
 
 
-def test_all_malformed_file_and_bytes_fail():
-    path = _write(ALL_BAD)
+def test_all_malformed_file_and_bytes_fail(tmp_path):
+    path = _write(tmp_path, ALL_BAD)
     with pytest.raises(ValueError):
         dataprof.profile(path, format="jsonl")
     with pytest.raises(ValueError):

--- a/python/tests/test_jsonl_error_policy.py
+++ b/python/tests/test_jsonl_error_policy.py
@@ -5,8 +5,10 @@ default (skip) yields a partial profile with ``execution.error_count`` set;
 ``jsonl_on_error="strict"`` raises a ValueError carrying line context, never a
 raw ``json.JSONDecodeError`` and never the record contents.
 
+The async cases are skipped when the extension is built without async support.
+
 Run after building the extension:
-    maturin develop --features python
+    maturin develop --features python,python-async,async-streaming
     pytest python/tests/test_jsonl_error_policy.py -v
 """
 
@@ -22,6 +24,13 @@ import pytest
 # Malformed record in the middle position.
 MIXED = b'{"id":1,"x":10}\nnot-json\n{"id":2,"x":20}\n'
 ALL_BAD = b"not-json\nalso-bad\n"
+
+_HAS_ASYNC = dataprof.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
 
 
 def _write(data: bytes) -> str:
@@ -57,6 +66,7 @@ def test_bytes_tolerant_reports_partial_and_error_count():
     assert report.error_count == 1
 
 
+@requires_async
 def test_async_bytes_tolerant_reports_partial_and_error_count():
     report = _async_bytes(MIXED)
     assert report.rows == 2
@@ -92,6 +102,7 @@ def test_bytes_strict_raises_valueerror_with_line_and_no_record():
     assert "not-json" not in message
 
 
+@requires_async
 def test_async_bytes_strict_raises_valueerror():
     with pytest.raises(ValueError) as excinfo:
         _async_bytes(MIXED, jsonl_on_error="strict")
@@ -102,12 +113,16 @@ def test_async_bytes_strict_raises_valueerror():
 # --- Edge cases -------------------------------------------------------------
 
 
-def test_all_malformed_always_fails_across_transports():
+def test_all_malformed_file_and_bytes_fail():
     path = _write(ALL_BAD)
     with pytest.raises(ValueError):
         dataprof.profile(path, format="jsonl")
     with pytest.raises(ValueError):
         dataprof.profile(ALL_BAD, format="jsonl")
+
+
+@requires_async
+def test_all_malformed_async_fails():
     with pytest.raises(ValueError):
         _async_bytes(ALL_BAD)
 
@@ -126,9 +141,14 @@ def test_invalid_policy_value_rejected():
 
 def test_clean_input_has_zero_error_count():
     data = b'{"id":1}\n{"id":2}\n{"id":3}\n'
-    for report in (
-        dataprof.profile(data, format="jsonl"),
-        _async_bytes(data),
-    ):
-        assert report.rows == 3
-        assert report.error_count == 0
+    report = dataprof.profile(data, format="jsonl")
+    assert report.rows == 3
+    assert report.error_count == 0
+
+
+@requires_async
+def test_clean_input_async_has_zero_error_count():
+    data = b'{"id":1}\n{"id":2}\n{"id":3}\n'
+    report = _async_bytes(data)
+    assert report.rows == 3
+    assert report.error_count == 0

--- a/python/tests/test_jsonl_error_policy.py
+++ b/python/tests/test_jsonl_error_policy.py
@@ -1,0 +1,134 @@
+"""JSONL malformed-record policy parity across file, bytes, and async inputs (#382).
+
+The same malformed input must behave identically regardless of transport:
+default (skip) yields a partial profile with ``execution.error_count`` set;
+``jsonl_on_error="strict"`` raises a ValueError carrying line context, never a
+raw ``json.JSONDecodeError`` and never the record contents.
+
+Run after building the extension:
+    maturin develop --features python
+    pytest python/tests/test_jsonl_error_policy.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+
+import dataprof
+import pytest
+
+# Malformed record in the middle position.
+MIXED = b'{"id":1,"x":10}\nnot-json\n{"id":2,"x":20}\n'
+ALL_BAD = b"not-json\nalso-bad\n"
+
+
+def _write(data: bytes) -> str:
+    tmp = tempfile.NamedTemporaryFile(mode="wb", suffix=".jsonl", delete=False)
+    tmp.write(data)
+    tmp.flush()
+    tmp.close()
+    return tmp.name
+
+
+def _async_bytes(data: bytes, **kwargs):
+    from dataprof.asyncio import profile_bytes
+
+    async def _inner():
+        return await profile_bytes(data, format="jsonl", **kwargs)
+
+    return asyncio.run(_inner())
+
+
+# --- Tolerant (default) parity ---------------------------------------------
+
+
+def test_file_tolerant_reports_partial_and_error_count():
+    path = _write(MIXED)
+    report = dataprof.profile(path, format="jsonl")
+    assert report.rows == 2
+    assert report.error_count == 1
+
+
+def test_bytes_tolerant_reports_partial_and_error_count():
+    report = dataprof.profile(MIXED, format="jsonl")
+    assert report.rows == 2
+    assert report.error_count == 1
+
+
+def test_async_bytes_tolerant_reports_partial_and_error_count():
+    report = _async_bytes(MIXED)
+    assert report.rows == 2
+    assert report.error_count == 1
+
+
+# --- Strict parity ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'not-json\n{"id":1}\n{"id":2}\n',  # first
+        b'{"id":1}\nnot-json\n{"id":2}\n',  # middle
+        b'{"id":1}\n{"id":2}\nnot-json\n',  # last
+    ],
+)
+def test_file_strict_raises_valueerror(data):
+    path = _write(data)
+    with pytest.raises(ValueError) as excinfo:
+        dataprof.profile(path, format="jsonl", jsonl_on_error="strict")
+    # A dataprof error category, not a raw decoder exception.
+    assert not isinstance(excinfo.value, json.JSONDecodeError)
+
+
+def test_bytes_strict_raises_valueerror_with_line_and_no_record():
+    with pytest.raises(ValueError) as excinfo:
+        dataprof.profile(MIXED, format="jsonl", jsonl_on_error="strict")
+    message = str(excinfo.value)
+    assert not isinstance(excinfo.value, json.JSONDecodeError)
+    assert "line 2" in message
+    # The offending record text must never be echoed back.
+    assert "not-json" not in message
+
+
+def test_async_bytes_strict_raises_valueerror():
+    with pytest.raises(ValueError) as excinfo:
+        _async_bytes(MIXED, jsonl_on_error="strict")
+    assert not isinstance(excinfo.value, json.JSONDecodeError)
+    assert "not-json" not in str(excinfo.value)
+
+
+# --- Edge cases -------------------------------------------------------------
+
+
+def test_all_malformed_always_fails_across_transports():
+    path = _write(ALL_BAD)
+    with pytest.raises(ValueError):
+        dataprof.profile(path, format="jsonl")
+    with pytest.raises(ValueError):
+        dataprof.profile(ALL_BAD, format="jsonl")
+    with pytest.raises(ValueError):
+        _async_bytes(ALL_BAD)
+
+
+def test_blank_lines_are_not_counted():
+    data = b'{"id":1}\n\n   \n{"id":2}\n'
+    report = dataprof.profile(data, format="jsonl")
+    assert report.rows == 2
+    assert report.error_count == 0
+
+
+def test_invalid_policy_value_rejected():
+    with pytest.raises(ValueError):
+        dataprof.profile(MIXED, format="jsonl", jsonl_on_error="lenient")
+
+
+def test_clean_input_has_zero_error_count():
+    data = b'{"id":1}\n{"id":2}\n{"id":3}\n'
+    for report in (
+        dataprof.profile(data, format="jsonl"),
+        _async_bytes(data),
+    ):
+        assert report.rows == 3
+        assert report.error_count == 0

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1704,6 +1704,7 @@ class TestNamespace:
             "name",
             "csv_delimiter",
             "csv_flexible",
+            "jsonl_on_error",
             "sampling",
             "stop_condition",
             "on_progress",


### PR DESCRIPTION
Closes #382.

## Problem

A malformed JSONL record behaved differently depending on transport, even though all three are documented as JSONL input:

- **File** — tolerant (skipped the bad line) but never surfaced the skip: `execution.error_count` stayed 0.
- **Bytes** — `json.loads(line)` in a list comprehension leaked a raw `json.JSONDecodeError`.
- **Async bytes** — aborted the whole scan on the first malformed record.

Callers could not choose a predictable recovery policy independent of transport.

## Change

One explicit default — **tolerant (skip)** — with an opt-in **strict** policy applied identically across file, bytes, and async byte inputs, via a shared `JsonErrorPolicy` enum in `dataprof-core`.

- **skip** (default): malformed records are skipped and counted in `execution.error_count`; the profile is partial. Input with **no valid record always fails**.
- **strict**: aborts on the first malformed record with a `JsonParsingError` carrying serde line/column context — never the record contents.

### Python
- `profile(..., jsonl_on_error="skip"|"strict")` and same on `profile_file()`; async `profile_bytes` honors it through `**kwargs`.
- The bytes path no longer leaks `json.JSONDecodeError`; `DataProfilerError::JsonParsingError` now maps to `ValueError`.
- New `ProfileReport.error_count` accessor reports skipped records. Stubs updated.

## Tests
- Rust: core scanner (strict on malformed first/middle/last, blank lines ignored, truncated-final = EOF, all-malformed fails, tolerant error_count) and async reader (skip/strict/clean).
- Python: `test_jsonl_error_policy.py` asserts file/bytes/async parity for both policies, line context without record leakage, and cross-transport all-malformed failure.
- Full suite: `cargo test` + `clippy` clean (also fixed a pre-existing `needless_return`), `pytest`, `ruff`, `ty` all green.

## Non-goals (per issue)
Treating malformed JSON as null; repairing input; unbounded buffering.