### PR TITLE
fix(csv): one clean diagnostic for non-UTF-8 input (#426)

### DIFF
--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -135,6 +135,15 @@ pub enum DataProfilerError {
     #[error("I/O error: {message}\nCheck file permissions and disk space")]
     IoError { message: String },
 
+    #[error(
+        "Non-UTF-8 input in {path}: {detail}\nRe-encode the file as UTF-8 (e.g. `iconv -f {guess} -t UTF-8 {path}`) and profile the result"
+    )]
+    EncodingError {
+        path: String,
+        detail: String,
+        guess: String,
+    },
+
     #[error("JSON parsing failed: {message}\nVerify JSON format and encoding")]
     JsonParsingError { message: String },
 
@@ -527,6 +536,9 @@ impl DataProfilerError {
                 "This build reads {}. Convert the input to one of these formats, or rebuild with the feature for the format you need.",
                 supported_formats_hint()
             )),
+            DataProfilerError::EncodingError { guess, .. } => Some(format!(
+                "Re-encode the file as UTF-8 (e.g. `iconv -f {guess} -t UTF-8`) and profile the result."
+            )),
             DataProfilerError::MemoryLimitExceeded => {
                 Some("Use streaming mode or increase available memory.".to_string())
             }
@@ -550,6 +562,7 @@ impl DataProfilerError {
             DataProfilerError::CsvParsingError { .. } => "csv_parsing",
             DataProfilerError::FileNotFound { .. } => "file_not_found",
             DataProfilerError::UnsupportedFormat { .. } => "unsupported_format",
+            DataProfilerError::EncodingError { .. } => "encoding",
             DataProfilerError::MemoryLimitExceeded => "memory_limit",
             DataProfilerError::InvalidConfiguration { .. } => "configuration",
             DataProfilerError::InvalidSemanticHint { .. } => "semantic_hint",
@@ -827,6 +840,31 @@ mod tests {
         let error_string = config_error.to_string();
         assert!(error_string.contains("Invalid chunk size"));
         assert!(error_string.contains("Use a value between"));
+    }
+
+    #[test]
+    fn encoding_error_names_file_and_gives_reencode_advice() {
+        let err = DataProfilerError::EncodingError {
+            path: "sales.csv".to_string(),
+            detail: "first invalid UTF-8 byte at offset 12".to_string(),
+            guess: "windows-1252".to_string(),
+        };
+        assert_eq!(err.category(), "encoding");
+        let msg = err.to_string();
+        assert!(msg.contains("sales.csv"), "names the file: {msg}");
+        assert!(msg.contains("offset 12"), "reports the offset: {msg}");
+        assert!(
+            msg.to_lowercase().contains("utf-8"),
+            "mentions UTF-8: {msg}"
+        );
+        assert!(msg.contains("iconv"), "gives a re-encode command: {msg}");
+        // The old, misleading advice must not appear.
+        assert!(
+            !msg.to_lowercase().contains("check file permissions"),
+            "{msg}"
+        );
+        assert!(!msg.contains("All engines failed"), "{msg}");
+        assert!(err.suggestion().unwrap().contains("windows-1252"));
     }
 
     #[test]

--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -136,7 +136,7 @@ pub enum DataProfilerError {
     IoError { message: String },
 
     #[error(
-        "Non-UTF-8 input in {path}: {detail}\nRe-encode the file as UTF-8 (e.g. `iconv -f {guess} -t UTF-8 {path}`) and profile the result"
+        "Non-UTF-8 input in {path}: {detail}\nRe-encode the file as UTF-8 (e.g. `iconv -f {guess} -t UTF-8 '{path}'`) and profile the result"
     )]
     EncodingError {
         path: String,

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -14,7 +14,9 @@ mod memmap_reader;
 mod robust_csv;
 
 pub use memmap_reader::MemoryMappedCsvReader;
-pub use robust_csv::{CsvDiagnostics, RobustCsvParser, RobustParseResult};
+pub use robust_csv::{
+    CsvDiagnostics, EncodingDiagnostic, RobustCsvParser, RobustParseResult, diagnose_non_utf8,
+};
 
 /// Configuration for CSV parsing and analysis.
 ///

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -52,8 +52,13 @@ const ENCODING_SNIFF_LIMIT: usize = 1 << 20; // 1 MiB
 pub fn diagnose_non_utf8(path: &Path) -> Option<EncodingDiagnostic> {
     use std::io::Read;
 
+    // decode-audit: unknown — this runs only to enrich an error the caller
+    // already has. If the file cannot be reopened/read for sniffing, returning
+    // None keeps that original engine error, so the failure is surfaced, not lost.
     let file = std::fs::File::open(path).ok()?;
     let mut sample = Vec::new();
+    // decode-audit: unknown — as above; a read failure abandons the guess and
+    // preserves the caller's original error rather than swallowing it.
     file.take(ENCODING_SNIFF_LIMIT as u64)
         .read_to_end(&mut sample)
         .ok()?;

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -674,7 +674,9 @@ mod tests {
 
     #[test]
     fn diagnose_non_utf8_flags_latin1() {
-        // "café" in latin-1: the 0xE9 (é) is an invalid lone continuation byte.
+        // "café" in latin-1: 0xE9 (é) is a UTF-8 leading byte for a 3-byte
+        // sequence, but here it is not followed by continuation bytes, so the
+        // stream is invalid UTF-8 at that position.
         let f = write_bytes(b"name\ncaf\xE9\n");
         let d = diagnose_non_utf8(f.path()).expect("latin-1 should be flagged");
         assert_eq!(d.guess, "latin-1");

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -9,6 +9,88 @@ use dataprof_core::{DataProfilerError, RecoveryStrategy, RetryConfig};
 /// Result type for robust CSV parsing operations.
 pub type RobustParseResult = (Option<Vec<String>>, Vec<Vec<String>>);
 
+/// What [`diagnose_non_utf8`] found about a file that failed UTF-8 decoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncodingDiagnostic {
+    /// Best-effort encoding guess (e.g. `"latin-1"`, `"windows-1252"`, `"utf-16le"`).
+    pub guess: &'static str,
+    /// Byte offset of the first invalid UTF-8 sequence, when found within the
+    /// sampled prefix. `None` means the sampled prefix was valid UTF-8 and the
+    /// offending byte lies further into the file.
+    pub first_invalid_byte: Option<usize>,
+}
+
+impl EncodingDiagnostic {
+    /// Human-readable detail for an error message, without echoing file contents.
+    pub fn detail(&self) -> String {
+        // Plain ASCII only: this string ends up in an encoding-error message that
+        // may be printed to a non-UTF-8 terminal, so it must never add mojibake.
+        match self.first_invalid_byte {
+            Some(offset) => format!(
+                "looks like {}; first invalid UTF-8 byte at offset {offset}",
+                self.guess
+            ),
+            None => format!(
+                "looks like {}; contains bytes that are not valid UTF-8",
+                self.guess
+            ),
+        }
+    }
+}
+
+/// How many leading bytes [`diagnose_non_utf8`] inspects. Large enough to locate
+/// the offending byte in the common case, bounded so the error path never reads
+/// an entire large file.
+const ENCODING_SNIFF_LIMIT: usize = 1 << 20; // 1 MiB
+
+/// Inspect a file that failed UTF-8 decoding and guess its encoding.
+///
+/// Returns `None` when the sampled prefix is valid UTF-8 (so a failure that is
+/// *not* an encoding problem is never mislabeled as one). BOM-prefixed UTF-16 is
+/// reported directly; otherwise a byte in `0x80..=0x9F` points at windows-1252
+/// and anything else at latin-1 — a best-effort guess, not a definitive verdict.
+pub fn diagnose_non_utf8(path: &Path) -> Option<EncodingDiagnostic> {
+    use std::io::Read;
+
+    let file = std::fs::File::open(path).ok()?;
+    let mut sample = Vec::new();
+    file.take(ENCODING_SNIFF_LIMIT as u64)
+        .read_to_end(&mut sample)
+        .ok()?;
+
+    if sample.starts_with(&[0xFF, 0xFE]) {
+        return Some(EncodingDiagnostic {
+            guess: "utf-16le",
+            first_invalid_byte: Some(0),
+        });
+    }
+    if sample.starts_with(&[0xFE, 0xFF]) {
+        return Some(EncodingDiagnostic {
+            guess: "utf-16be",
+            first_invalid_byte: Some(0),
+        });
+    }
+
+    // A valid-UTF-8 prefix means the fault, if any, is beyond the sample — do not
+    // claim an encoding problem we cannot see.
+    let first_invalid_byte = match std::str::from_utf8(&sample) {
+        Ok(_) => return None,
+        Err(err) => Some(err.valid_up_to()),
+    };
+
+    let has_c1_controls = sample.iter().any(|&b| (0x80..=0x9F).contains(&b));
+    let guess = if has_c1_controls {
+        "windows-1252"
+    } else {
+        "latin-1"
+    };
+
+    Some(EncodingDiagnostic {
+        guess,
+        first_invalid_byte,
+    })
+}
+
 /// Robust CSV parser that handles edge cases and malformed data.
 pub struct RobustCsvParser {
     pub flexible: bool,
@@ -577,6 +659,55 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    fn write_bytes(bytes: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(bytes).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn diagnose_non_utf8_flags_latin1() {
+        // "café" in latin-1: the 0xE9 (é) is an invalid lone continuation byte.
+        let f = write_bytes(b"name\ncaf\xE9\n");
+        let d = diagnose_non_utf8(f.path()).expect("latin-1 should be flagged");
+        assert_eq!(d.guess, "latin-1");
+        assert_eq!(d.first_invalid_byte, Some(8));
+    }
+
+    #[test]
+    fn diagnose_non_utf8_flags_windows1252() {
+        // 0x93/0x94 are smart quotes in windows-1252 (C1 range), invalid UTF-8.
+        let f = write_bytes(b"quote\n\x93hi\x94\n");
+        let d = diagnose_non_utf8(f.path()).expect("windows-1252 should be flagged");
+        assert_eq!(d.guess, "windows-1252");
+        assert_eq!(d.first_invalid_byte, Some(6));
+    }
+
+    #[test]
+    fn diagnose_non_utf8_flags_utf16_bom() {
+        let f = write_bytes(&[0xFF, 0xFE, b'a', 0x00]);
+        let d = diagnose_non_utf8(f.path()).expect("utf-16 BOM should be flagged");
+        assert_eq!(d.guess, "utf-16le");
+    }
+
+    #[test]
+    fn diagnose_non_utf8_ignores_clean_utf8() {
+        let f = write_bytes("name\ncafé\n".as_bytes());
+        assert!(diagnose_non_utf8(f.path()).is_none());
+    }
+
+    #[test]
+    fn encoding_diagnostic_detail_never_leaks_bytes() {
+        let d = EncodingDiagnostic {
+            guess: "latin-1",
+            first_invalid_byte: Some(8),
+        };
+        let detail = d.detail();
+        assert!(detail.contains("latin-1"));
+        assert!(detail.contains("offset 8"));
+    }
 
     #[test]
     fn test_robust_csv_parser_basic() -> Result<()> {

--- a/crates/dataprof-engines/src/adaptive.rs
+++ b/crates/dataprof-engines/src/adaptive.rs
@@ -117,8 +117,10 @@ impl AdaptiveProfiler {
                 log::warn!("Fallback: {:?} → {:?} — {}", engine, fallback, primary_err);
                 self.try_engine(&fallback, file_path)
                     .map_err(|fallback_err| DataProfilerError::AllEnginesFailed {
+                        // The `AllEnginesFailed` variant already prefixes
+                        // "All engines failed: "; don't repeat it here.
                         message: format!(
-                            "All engines failed. Primary ({:?}): {}. Fallback ({:?}): {}.",
+                            "Primary ({:?}): {}. Fallback ({:?}): {}.",
                             engine, primary_err, fallback, fallback_err
                         ),
                     })

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -30,6 +30,7 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
         | DataProfilerError::InvalidConfiguration { .. }
         | DataProfilerError::DuplicateColumnName { .. }
         | DataProfilerError::JsonParsingError { .. }
+        | DataProfilerError::EncodingError { .. }
         | DataProfilerError::UnsupportedFormat { .. } => PyValueError::new_err(message),
         DataProfilerError::FileNotFound { .. } => PyFileNotFoundError::new_err(message),
         DataProfilerError::IoError { .. } => {

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -598,26 +598,29 @@ impl Profiler {
                 // select an engine that can deliver it rather than silently
                 // scanning the whole source (which also leaves the report claiming
                 // `source_exhausted` with no truncation reason).
-                if !matches!(self.config.stop_condition, StopCondition::Never) {
-                    return self.run_incremental(file_path, format);
-                }
-
-                let mut profiler = AdaptiveProfiler::new();
-                if let Some(d) = &self.config.quality_dimensions {
-                    profiler = profiler.quality_dimensions(d.clone());
-                }
-                if let Some(p) = self.effective_metric_packs() {
-                    profiler = profiler.metric_packs(p);
-                }
-                if let Some(l) = &self.config.locale {
-                    profiler = profiler.locale(l.clone());
-                }
-                profiler = profiler.semantic_hints(semantic_hints);
-                let csv_config = self.csv_config_for_file(file_path);
-                profiler = profiler.csv_config(csv_config);
-                // Format already resolved here; skip the engine's extension-based
-                // Parquet redetection so explicit `.format()` overrides win.
-                profiler.analyze_csv_file(file_path)
+                let result = if !matches!(self.config.stop_condition, StopCondition::Never) {
+                    self.run_incremental(file_path, format)
+                } else {
+                    let mut profiler = AdaptiveProfiler::new();
+                    if let Some(d) = &self.config.quality_dimensions {
+                        profiler = profiler.quality_dimensions(d.clone());
+                    }
+                    if let Some(p) = self.effective_metric_packs() {
+                        profiler = profiler.metric_packs(p);
+                    }
+                    if let Some(l) = &self.config.locale {
+                        profiler = profiler.locale(l.clone());
+                    }
+                    profiler = profiler.semantic_hints(semantic_hints);
+                    let csv_config = self.csv_config_for_file(file_path);
+                    profiler = profiler.csv_config(csv_config);
+                    // Format already resolved here; skip the engine's extension-based
+                    // Parquet redetection so explicit `.format()` overrides win.
+                    profiler.analyze_csv_file(file_path)
+                };
+                // Both engines fail hard on non-UTF-8 bytes with stacked, misleading
+                // messages. Replace that with one clear encoding diagnostic.
+                result.map_err(|err| map_csv_encoding_error(file_path, err))
             }
         }
     }
@@ -1111,6 +1114,33 @@ impl Profiler {
                 ),
             }),
         }
+    }
+}
+
+/// True when the error stems from the input not being valid UTF-8.
+///
+/// Both the incremental (`IoError: ... valid UTF-8`) and Arrow
+/// (`... invalid UTF-8 data`) engines report this differently, so match the
+/// substring their messages share.
+fn is_utf8_error(err: &DataProfilerError) -> bool {
+    err.to_string().to_ascii_lowercase().contains("utf-8")
+}
+
+/// Turn a raw engine failure on non-UTF-8 input into one clear encoding
+/// diagnostic. Non-encoding errors pass through untouched.
+fn map_csv_encoding_error(file_path: &Path, err: DataProfilerError) -> DataProfilerError {
+    if !is_utf8_error(&err) {
+        return err;
+    }
+    match dataprof_csv::diagnose_non_utf8(file_path) {
+        Some(diagnostic) => DataProfilerError::EncodingError {
+            path: file_path.display().to_string(),
+            detail: diagnostic.detail(),
+            guess: diagnostic.guess.to_string(),
+        },
+        // The bytes turned out to be valid UTF-8 (fault beyond the sniff window,
+        // or a mislabeled failure) — keep the original error rather than guess.
+        None => err,
     }
 }
 

--- a/python/tests/test_encoding.py
+++ b/python/tests/test_encoding.py
@@ -1,0 +1,50 @@
+"""Non-UTF-8 CSV input surfaces one clean encoding diagnostic (#426).
+
+A latin-1 / windows-1252 CSV used to fail with stacked engine errors and
+misleading advice. It should now raise a single ValueError that names the file,
+guesses the encoding, and tells the caller to re-encode as UTF-8.
+
+Run after building the extension:
+    maturin develop --features python
+    pytest python/tests/test_encoding.py -v
+"""
+
+from __future__ import annotations
+
+import dataprof
+import pytest
+
+
+def test_latin1_csv_raises_clean_value_error(tmp_path):
+    path = tmp_path / "latin1.csv"
+    # "José" / "Málaga" encoded as latin-1 — invalid UTF-8.
+    path.write_bytes("name,city\nJosé,Málaga\n".encode("latin-1"))
+
+    try:
+        dataprof.profile(str(path))
+    except ValueError as exc:
+        message = str(exc)
+        assert "utf-8" in message.lower()
+        # Actionable re-encode guidance, not the old stacked-engine noise.
+        assert "iconv" in message
+        assert "All engines failed" not in message
+        assert "check file permissions" not in message.lower()
+    else:
+        raise AssertionError("non-UTF-8 CSV must raise, not profile silently")
+
+
+def test_windows1252_csv_is_flagged(tmp_path):
+    path = tmp_path / "cp1252.csv"
+    # 0x93/0x94 are windows-1252 smart quotes (invalid UTF-8).
+    path.write_bytes(b"quote\n\x93hi\x94\n")
+
+    with pytest.raises(ValueError) as excinfo:
+        dataprof.profile(str(path))
+    assert "utf-8" in str(excinfo.value).lower()
+
+
+def test_valid_utf8_csv_still_profiles(tmp_path):
+    path = tmp_path / "utf8.csv"
+    path.write_text("name,city\nJosé,Málaga\n", encoding="utf-8")
+    report = dataprof.profile(str(path))
+    assert report.rows == 1

--- a/tests/error_contract.rs
+++ b/tests/error_contract.rs
@@ -53,11 +53,10 @@ fn unsupported_format_does_not_overclaim() {
 }
 
 #[test]
-fn undecodable_csv_error_never_prints_unknown() {
+fn non_utf8_csv_reports_one_clean_encoding_diagnostic() {
     // Non-UTF-8 input (latin-1 `é` = 0xE9) is a deterministic hard failure that
-    // every engine refuses — the exact case where the old error path printed the
-    // `'unknown'` placeholder (see #426). The contract: it errors, and neither
-    // the message nor its suggestion names the file as `'unknown'`.
+    // every engine refuses. Instead of stacking two engine errors with wrong
+    // advice, the profiler surfaces a single encoding diagnostic (#426).
     let mut file = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
     file.write_all(b"name,city\nJos\xE9,Z\xFCrich\n").unwrap();
     file.flush().unwrap();
@@ -66,11 +65,54 @@ fn undecodable_csv_error_never_prints_unknown() {
         .analyze_file(file.path())
         .expect_err("non-UTF-8 CSV must fail rather than silently mis-decode");
 
+    assert_eq!(err.category(), "encoding");
     let rendered = err.to_string();
+    // Names the real file, the encoding guess, the offset, and a re-encode fix...
+    assert!(!rendered.contains("unknown"), "{rendered}");
+    assert!(rendered.to_lowercase().contains("utf-8"), "{rendered}");
     assert!(
-        !rendered.contains("unknown"),
-        "undecodable-file error must not print 'unknown': {rendered}"
+        rendered.contains("iconv"),
+        "gives a re-encode command: {rendered}"
     );
+    // ...and drops the old misleading, stacked messaging.
+    assert!(!rendered.contains("All engines failed"), "{rendered}");
+    assert!(
+        !rendered.to_lowercase().contains("check file permissions"),
+        "encoding failure must not blame permissions: {rendered}"
+    );
+}
+
+#[test]
+fn all_engines_failed_message_is_not_doubled() {
+    // The `AllEnginesFailed` variant prefixes "All engines failed: "; the wrapped
+    // message must not repeat it (#426).
+    let err = DataProfilerError::AllEnginesFailed {
+        message: "Primary (Incremental): boom. Fallback (Arrow): boom.".to_string(),
+    };
+    let rendered = err.to_string();
+    assert_eq!(
+        rendered.matches("All engines failed").count(),
+        1,
+        "{rendered}"
+    );
+}
+
+#[test]
+fn ragged_csv_is_not_mislabeled_as_encoding() {
+    // A structural (ragged-row) problem in valid UTF-8 must keep its own category,
+    // never be swept into the encoding path.
+    let mut file = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    // Force a hard parse error the engines cannot recover: an unterminated quote.
+    file.write_all(b"a,b\n\"unterminated,2\n").unwrap();
+    file.flush().unwrap();
+
+    if let Err(err) = Profiler::new().analyze_file(file.path()) {
+        assert_ne!(
+            err.category(),
+            "encoding",
+            "valid UTF-8 is not an encoding fault"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Closes #426.

## Problem

A non-UTF-8 CSV (latin-1 / windows-1252 — common in European exports) failed with a misleading, stacked error:

```
RuntimeError: Analysis failed: All engines failed: All engines failed.
Primary (Incremental): I/O error: stream did not contain valid UTF-8
Check file permissions and disk space.
Fallback (Arrow): ... Encountered invalid UTF-8 data for line 2 and field 1.
```

Three problems remained (the `'unknown'` filename and mojibake-suggestion block were fixed by earlier error-DX work): the doubled `"All engines failed"` prefix, the wrong "check file permissions" advice, and two stacked engine errors instead of one clear cause.

## Change

Per the issue's "single, correct diagnostic" option (decode-and-profile left as a follow-up): detect the UTF-8 failure **reactively** — after an engine fails, mirroring the existing `DuplicateColumnName` short-circuit — and replace it with one clear error.

`profile('latin1.csv')` now raises:

```
ValueError: Non-UTF-8 input in latin1.csv: looks like latin-1; first invalid UTF-8 byte at offset 13
Re-encode the file as UTF-8 (e.g. `iconv -f latin-1 -t UTF-8 latin1.csv`) and profile the result
```

- **New `DataProfilerError::EncodingError { path, detail, guess }`** — category `"encoding"`, mapped to Python `ValueError`.
- **`diagnose_non_utf8` sniffer** (`dataprof-csv`) — BOM sniff for UTF-16, `str::from_utf8().valid_up_to()` for the byte offset, and a `0x80–0x9F` heuristic to guess windows-1252 vs latin-1. Bounded to a 1 MiB sample so the error path never reads a whole large file. Returns `None` on valid UTF-8 so a non-encoding failure is never mislabeled.
- **Reactive conversion** at the single CSV entry (`run_auto`) covers both the adaptive and stop-condition-incremental sub-paths.
- **Doubled-prefix fix**: `AllEnginesFailed` no longer repeats its own prefix.
- The diagnostic detail is **ASCII-only**, so an encoding-error message never adds mojibake itself.

## Tests
- Rust: sniffer unit tests (latin-1, windows-1252, UTF-16 BOM, clean UTF-8), error-message contract, and facade integration in `tests/error_contract.rs` (clean diagnostic, no doubled prefix, ragged CSV **not** mislabeled as encoding).
- Python: `test_encoding.py` — latin-1/windows-1252 raise `ValueError` with re-encode guidance; valid UTF-8 still profiles.
- Full sweep green: `cargo test` + `clippy`, `pytest` (400 passed), `ruff`, `ty`, `cargo fmt`.

## Non-goals
Decoding/transcoding non-UTF-8 input; an `encoding=` option; JSON/Parquet encoding handling.