### PR TITLE
fix: harden profiling contracts before 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,8 @@ homepage = "https://andreabozzo.github.io/dataprof/"
 exclude = [
     "assets/animations/*",
     "assets/images/*.png",
-    "examples/*",
+    "examples/test_data/*",
+    "examples/test_datasets/*",
     ".venv/*",
     ".mypy_cache/*",
     "python/*",

--- a/crates/dataprof-core/src/stop_condition.rs
+++ b/crates/dataprof-core/src/stop_condition.rs
@@ -66,7 +66,8 @@ impl StopCondition {
     /// The row count at which this condition can first trigger on rows alone,
     /// if any.
     ///
-    /// Mirrors [`evaluate`]: `Any` fires as soon as one child fires, so it takes
+    /// Mirrors the internal `evaluate` method: `Any` fires as soon as one child
+    /// fires, so it takes
     /// the *minimum* of the children that a row count can trigger. `All` fires
     /// only once every child has fired, so it takes the *maximum*, and yields
     /// `None` if any child cannot be triggered by rows at all (a byte cap,

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -260,7 +260,8 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
         .map(|i| parquet_meta.row_group(i).compressed_size() as u64)
         .sum();
 
-    let schema_summary = format!("{}", builder.schema());
+    let arrow_schema = builder.schema().clone();
+    let schema_summary = format!("{arrow_schema}");
 
     let mut stream = builder
         .with_batch_size(config.batch_size)
@@ -270,6 +271,7 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
         })?;
 
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
+    analyzer.initialize_schema(arrow_schema.as_ref())?;
 
     while let Some(batch_result) = stream.next().await {
         let batch = batch_result.map_err(|e| DataProfilerError::ParquetError {

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -178,7 +178,8 @@ pub fn analyze_parquet_with_config_dims_and_hints(
         .map(|index| parquet_meta.row_group(index).compressed_size() as u64)
         .sum();
 
-    let schema_summary = format!("{}", builder.schema());
+    let arrow_schema = builder.schema().clone();
+    let schema_summary = format!("{arrow_schema}");
 
     let mut reader_builder = builder.with_batch_size(config.batch_size);
     if let Some(max) = config.max_rows {
@@ -191,6 +192,7 @@ pub fn analyze_parquet_with_config_dims_and_hints(
         })?;
 
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
+    analyzer.initialize_schema(arrow_schema.as_ref())?;
     for batch_result in reader {
         let batch = batch_result.map_err(|error| DataProfilerError::ParquetError {
             message: format!("Failed to read Parquet batch: {}", error),
@@ -385,6 +387,38 @@ mod tests {
     fn test_analyze_parquet_empty_file() {
         let result = analyze_parquet_with_quality(Path::new("nonexistent.parquet"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_zero_row_parquet_preserves_schema() -> Result<()> {
+        let temp_file = NamedTempFile::new()?;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("label", DataType::Utf8, true),
+        ]));
+        let file = File::create(temp_file.path())?;
+        let writer = ArrowWriter::try_new(file, schema, None)?;
+        writer.close()?;
+
+        let report = analyze_parquet_with_quality(temp_file.path())?;
+        assert_eq!(report.execution.rows_processed, 0);
+        assert_eq!(report.execution.columns_detected, 2);
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["id", "label"]
+        );
+        assert!(
+            report
+                .column_profiles
+                .iter()
+                .all(|column| column.total_count == 0 && column.null_count == 0)
+        );
+        assert_eq!(report.quality_score(), None);
+        Ok(())
     }
 
     #[test]

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -125,21 +125,39 @@ impl RecordBatchAnalyzer {
         self
     }
 
-    pub fn process_batch(&mut self, batch: &RecordBatch) -> Result<()> {
-        // Reject duplicate field names before building analyzers: they key on
-        // name, so a repeat would silently merge two columns into one profile and
-        // drop the other from column_order. The schema is fixed for the whole
-        // stream, so checking until the first non-empty batch is sufficient.
-        if self.column_order.is_empty() {
-            let names: Vec<String> = batch
-                .schema()
-                .fields()
-                .iter()
-                .map(|f| f.name().to_string())
-                .collect();
-            dataprof_core::validate_unique_column_names(&names, "Arrow/Parquet schema")?;
-        }
+    /// Initialize column analyzers from a known Arrow schema.
+    ///
+    /// Parquet readers may yield no record batch for a zero-row file. Seeding
+    /// from metadata preserves that file's columns with zero counts instead of
+    /// collapsing a schema-bearing dataset into a zero-column report.
+    pub fn initialize_schema(&mut self, schema: &arrow::datatypes::Schema) -> Result<()> {
+        let names: Vec<String> = schema
+            .fields()
+            .iter()
+            .map(|field| field.name().to_string())
+            .collect();
+        dataprof_core::validate_unique_column_names(&names, "Arrow/Parquet schema")?;
 
+        for field in schema.fields() {
+            let column_name = field.name().to_string();
+            let positive_hint = self.semantic_hints.is_positive_column(&column_name);
+            let temporal_hint = self.semantic_hints.is_temporal_column(&column_name);
+            if let Entry::Vacant(entry) = self.column_analyzers.entry(column_name.clone()) {
+                self.column_order.push(column_name);
+                entry.insert(ColumnAnalyzer::with_value_hints(
+                    field.data_type(),
+                    positive_hint,
+                    temporal_hint,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn process_batch(&mut self, batch: &RecordBatch) -> Result<()> {
+        if self.column_order.is_empty() {
+            self.initialize_schema(batch.schema().as_ref())?;
+        }
         self.total_rows += batch.num_rows();
         self.row_tracker.observe_batch(batch);
 
@@ -147,20 +165,10 @@ impl RecordBatchAnalyzer {
             let schema = batch.schema();
             let field = schema.field(column_index);
             let column_name = field.name().to_string();
-            let positive_hint = self.semantic_hints.is_positive_column(&column_name);
-            let temporal_hint = self.semantic_hints.is_temporal_column(&column_name);
-
-            let analyzer = match self.column_analyzers.entry(column_name.clone()) {
-                Entry::Occupied(entry) => entry.into_mut(),
-                Entry::Vacant(entry) => {
-                    self.column_order.push(column_name);
-                    entry.insert(ColumnAnalyzer::with_value_hints(
-                        field.data_type(),
-                        positive_hint,
-                        temporal_hint,
-                    ))
-                }
-            };
+            let analyzer = self
+                .column_analyzers
+                .get_mut(&column_name)
+                .expect("schema initialization creates every column analyzer");
 
             analyzer.process_array(column)?;
         }
@@ -173,7 +181,7 @@ impl RecordBatchAnalyzer {
     }
 
     /// Full-stream row-duplicate counts, or `None` when no rows were seen or
-    /// the batches could not be signed (see [`BatchRowTracker`]).
+    /// the batches could not be signed (see the internal `BatchRowTracker`).
     pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
         self.row_tracker.summary()
     }
@@ -524,7 +532,18 @@ impl ColumnAnalyzer {
         for index in 0..array.len() {
             if !array.is_null(index) {
                 let value = array.value(index);
-                self.update_numeric_stats(value);
+                // Match the textual/ad-hoc paths: NaN is a null-like value,
+                // while infinities are present but invalid numeric values.
+                // Neither may enter the exact accumulators — one non-finite
+                // value would otherwise poison sum/sum_squares and serialize
+                // as plausible zero variance with a missing mean.
+                if value.is_nan() {
+                    self.null_count += 1;
+                    continue;
+                }
+                if value.is_finite() {
+                    self.update_numeric_stats(value);
+                }
                 self.cardinality.insert_owned(value.to_string());
                 self.offer_sample(value.to_string());
             }
@@ -537,7 +556,13 @@ impl ColumnAnalyzer {
             if !array.is_null(index) {
                 let value = array.value(index);
                 let value_f64 = value as f64;
-                self.update_numeric_stats(value_f64);
+                if value_f64.is_nan() {
+                    self.null_count += 1;
+                    continue;
+                }
+                if value_f64.is_finite() {
+                    self.update_numeric_stats(value_f64);
+                }
                 self.cardinality.insert_owned(value.to_string());
                 self.offer_sample(value.to_string());
             }
@@ -939,6 +964,7 @@ impl ColumnAnalyzer {
     }
 
     fn update_numeric_stats(&mut self, value: f64) {
+        debug_assert!(value.is_finite());
         self.sum += value;
         self.sum_squares += value * value;
         self.numeric_count += 1;
@@ -1114,6 +1140,40 @@ mod tests {
                 assert!((stats.mean - 8.0).abs() < 1e-9, "mean was {}", stats.mean);
             }
             _ => panic!("Expected Numeric stats for rank column"),
+        }
+    }
+
+    #[test]
+    fn test_non_finite_floats_do_not_corrupt_numeric_stats() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            ArrowDataType::Float64,
+            true,
+        )]));
+        let values =
+            Float64Array::from(vec![1.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY, 3.25]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(values)]).unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        analyzer.process_batch(&batch).unwrap();
+        let profiles = analyzer.to_profiles(false, false, None);
+        let column = profiles.iter().find(|p| p.name == "value").unwrap();
+
+        // NaN follows the textual/ad-hoc null-like contract. Infinities are
+        // present values, but are invalid for finite numeric statistics.
+        assert_eq!(column.total_count, 5);
+        assert_eq!(column.null_count, 1);
+        assert_eq!(column.unique_count, Some(4));
+        assert_eq!(column.invalid_count, Some(2));
+        match &column.stats {
+            ColumnStats::Numeric(stats) => {
+                assert!((stats.min - 1.5).abs() < 1e-9);
+                assert!((stats.max - 3.25).abs() < 1e-9);
+                assert!((stats.mean - 2.375).abs() < 1e-9);
+                assert!(stats.std_dev.is_finite());
+                assert!(stats.std_dev > 0.0);
+            }
+            _ => panic!("Expected Numeric stats for value column"),
         }
     }
 

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -3,7 +3,8 @@
 //!
 //! The file-based entry points go through `dataprof::Profiler`, which already
 //! validates hints and returns a typed error; the DataFrame paths build a report
-//! directly, so they call [`validate_report_hints`] to get the same contract.
+//! directly, so they call the internal `validate_report_hints` helper to get
+//! the same contract.
 
 use pyo3::exceptions::{
     PyFileNotFoundError, PyIOError, PyPermissionError, PyRuntimeError, PyValueError,

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -160,8 +160,11 @@ impl Profiler {
     /// Set a stop condition for early termination.
     ///
     /// Fully evaluated for CSV sources by `EngineType::Auto` (which routes to the
-    /// incremental engine) and `EngineType::Incremental`, and by
-    /// [`Profiler::profile_stream`].
+    /// incremental engine) and `EngineType::Incremental`.
+    #[cfg_attr(
+        feature = "async-streaming",
+        doc = "It is also fully evaluated by [`Profiler::profile_stream`]."
+    )]
     ///
     /// The columnar engine and the JSON/Parquet parsers cannot evaluate a
     /// condition per chunk, so they honour a plain row limit
@@ -334,12 +337,21 @@ impl Profiler {
             .format_override
             .clone()
             .unwrap_or_else(|| Self::detect_format(path));
+        let is_csv = matches!(format, FileFormat::Csv);
 
-        let report = match self.config.engine {
+        let result = match self.config.engine {
             EngineType::Auto => self.run_auto(path, format),
             EngineType::Incremental => self.run_incremental(path, format),
             EngineType::Columnar => self.run_columnar(path, format),
-        }?;
+        };
+        // Every CSV engine ultimately requires UTF-8, but their raw errors use
+        // different variants and wording. Normalize at the shared file boundary
+        // so an explicit engine choice cannot regress the product error contract.
+        let report = if is_csv {
+            result.map_err(|err| map_csv_encoding_error(path, err))?
+        } else {
+            result?
+        };
         self.validate_semantic_hints(&report)?;
         Ok(report)
     }
@@ -598,7 +610,7 @@ impl Profiler {
                 // select an engine that can deliver it rather than silently
                 // scanning the whole source (which also leaves the report claiming
                 // `source_exhausted` with no truncation reason).
-                let result = if !matches!(self.config.stop_condition, StopCondition::Never) {
+                if !matches!(self.config.stop_condition, StopCondition::Never) {
                     self.run_incremental(file_path, format)
                 } else {
                     let mut profiler = AdaptiveProfiler::new();
@@ -617,10 +629,7 @@ impl Profiler {
                     // Format already resolved here; skip the engine's extension-based
                     // Parquet redetection so explicit `.format()` overrides win.
                     profiler.analyze_csv_file(file_path)
-                };
-                // Both engines fail hard on non-UTF-8 bytes with stacked, misleading
-                // messages. Replace that with one clear encoding diagnostic.
-                result.map_err(|err| map_csv_encoding_error(file_path, err))
+                }
             }
         }
     }

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -97,9 +97,12 @@ Measures how much data is present vs. missing.
 
 - `missing_values_ratio` -- fraction of null/empty values across all columns
 - `complete_records_ratio` -- fraction of rows with zero nulls
-- `null_columns` -- columns that are entirely null
+- `null_columns` -- columns past the configured null threshold (50% by default)
 
-A completeness score of 0.95 means 95% of expected values are present.
+The completeness score is on the same 0–100 scale as the other dimensions. It
+combines cell completeness (`100 - missing_values_ratio`) and row completeness
+(`complete_records_ratio`), so inspect both underlying values when setting a
+quality gate.
 
 ### Consistency
 
@@ -127,9 +130,11 @@ Measures whether values fall within expected ranges.
 
 ### Timeliness
 
-Measures whether explicitly selected date/time values are current and
-consistent. Pass `temporal_columns=["created_at", "updated_at"]` in Python or
-call `.temporal_columns(...)` on the Rust profiler to opt columns into scoring.
+Measures whether confidently inferred date/time values are current and
+consistent. Inferred date columns participate automatically. Pass
+`temporal_columns=["created_at", "updated_at"]` in Python or call
+`.temporal_columns(...)` on the Rust profiler to add columns whose dates cannot
+be inferred confidently, such as mixed-format strings.
 
 - `future_dates_count` -- dates that are in the future
 - `stale_data_ratio` -- fraction of temporal data that appears outdated

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -350,9 +350,9 @@ if q.completeness is not None:
 does not infer positive-only domains from column names. `identifier_columns`
 marks numeric-looking IDs as semantic strings so numeric stats and outlier
 metrics do not treat them as measures.
-Timeliness scoring is opt-in through `temporal_columns`; inferred date columns
-remain visible in column profiles but do not affect the quality score unless
-their names are explicitly selected.
+Timeliness scoring assesses confidently inferred date columns by default.
+`temporal_columns` adds columns that inference cannot identify confidently, such
+as mixed-format date strings.
 
 Hints are validated, never silently dropped. A hint that names a missing column
 raises `ValueError` listing the unmatched names and the available columns; a

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,10 +16,11 @@ field: reports written before this release deserialize with `ragged_row_count`
 of `0`.
 
 Scope: this is surfaced by the incremental engine, which drives the default CSV
-path. The columnar (Arrow) engine and the async reader reject ragged rows
-outright rather than recovering them, so they never produced the silent-clean
-result; unifying that recovery behavior across engines is tracked separately.
-Ragged rows do not yet influence the consistency dimension's score.
+path. The columnar (Arrow) engine rejects ragged rows outright. The async reader
+currently recovers them without incrementing `ragged_row_count`; that remaining
+silent-clean path is a 0.10 blocker tracked in
+[#462](https://github.com/AndreaBozzo/dataprof/issues/462). Ragged rows do not
+yet influence the consistency dimension's score.
 
 ## Errors preserve source context and map to idiomatic Python exceptions
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -2023,25 +2023,29 @@ class ProfileReport:
             ``self`` for fluent chaining.
         """
         path = _normalize_pathlike(path)
-        if path.endswith(".json"):
+        lower_path = path.lower()
+        if lower_path.endswith(".json"):
             with open(path, "w", encoding="utf-8") as f:
                 f.write(self.to_json())
-        elif path.endswith(".csv"):
+        elif lower_path.endswith(".csv"):
             records = self._records()
-            if records:
-                with open(path, "w", encoding="utf-8", newline="") as f:
+            # Opening unconditionally matters for a zero-column report: save()
+            # must either create the requested artifact or fail, never return
+            # success while leaving no file behind.
+            with open(path, "w", encoding="utf-8", newline="") as f:
+                if records:
                     writer = _csv.DictWriter(f, fieldnames=records[0].keys())
                     writer.writeheader()
                     writer.writerows(records)
-        elif path.endswith(".parquet"):
+        elif lower_path.endswith(".parquet"):
             table = self.to_arrow()
             import pyarrow.parquet as pq
 
             pq.write_table(table, path)
-        elif path.endswith(".html"):
+        elif lower_path.endswith(".html"):
             with open(path, "w", encoding="utf-8") as f:
                 f.write(self.to_html())
-        elif path.endswith((".md", ".markdown")):
+        elif lower_path.endswith((".md", ".markdown")):
             with open(path, "w", encoding="utf-8") as f:
                 f.write(self.to_markdown())
         else:
@@ -2388,10 +2392,11 @@ class ProfileReport:
             FileNotFoundError: if the file does not exist.
         """
         path = _normalize_pathlike(path)
-        if path.endswith(".json"):
+        lower_path = path.lower()
+        if lower_path.endswith(".json"):
             with open(path, encoding="utf-8") as f:
                 return cls.from_json(f.read())
-        if path.endswith((".csv", ".parquet")):
+        if lower_path.endswith((".csv", ".parquet")):
             raise ValueError(
                 f"Cannot reload a full report from '{path}': .csv/.parquet store "
                 "only column profiles. Save and load with .json to round-trip a report."

--- a/python/tests/test_encoding.py
+++ b/python/tests/test_encoding.py
@@ -15,13 +15,14 @@ import dataprof
 import pytest
 
 
-def test_latin1_csv_raises_clean_value_error(tmp_path):
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_latin1_csv_raises_clean_value_error(tmp_path, engine):
     path = tmp_path / "latin1.csv"
     # "José" / "Málaga" encoded as latin-1 — invalid UTF-8.
     path.write_bytes("name,city\nJosé,Málaga\n".encode("latin-1"))
 
     try:
-        dataprof.profile(str(path))
+        dataprof.profile(str(path), engine=engine)
     except ValueError as exc:
         message = str(exc)
         assert "utf-8" in message.lower()

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -2108,6 +2108,20 @@ class TestSaveFormats:
         assert result is report
         assert dataprof.ProfileReport.load(path).to_dict() == report.to_dict()
 
+    def test_save_empty_report_csv_creates_artifact(self, tmp_path):
+        report = dataprof.profile({})
+        path = tmp_path / "empty.csv"
+
+        assert report.save(path) is report
+        assert path.exists()
+        assert path.read_bytes() == b""
+
+    def test_save_and_load_extensions_are_case_insensitive(self, report, tmp_path):
+        path = tmp_path / "REPORT.JSON"
+
+        assert report.save(path) is report
+        assert dataprof.ProfileReport.load(path).to_dict() == report.to_dict()
+
     def test_save_parquet(self, report):
         pytest.importorskip("pyarrow")
         pq = pytest.importorskip("pyarrow.parquet")
@@ -2508,6 +2522,28 @@ class TestZeroRowSemantics:
         assert batch.column("null_percentage").to_pylist() == [None, None]
         assert batch.column("uniqueness_ratio").to_pylist() == [None, None]
 
+    def test_zero_row_parquet_preserves_schema(self, tmp_path):
+        pa = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+        path = tmp_path / "empty.parquet"
+        pq.write_table(
+            pa.table(
+                {
+                    "id": pa.array([], type=pa.int64()),
+                    "label": pa.array([], type=pa.string()),
+                }
+            ),
+            path,
+        )
+
+        report = dataprof.profile(path)
+        assert report.rows == 0
+        assert report.columns == 2
+        assert list(report) == ["id", "label"]
+        assert report["id"].total_count == 0
+        assert report["id"].null_percentage is None
+        assert report.quality_score is None
+
 
 class TestInvalidCount:
     """Per-column invalid_count: non-null values excluded from numeric stats
@@ -2543,6 +2579,22 @@ class TestInvalidCount:
     def test_in_memory_sources_match_file_semantics(self):
         r = dataprof.profile({"v": ["1", "2", "3", "4", "5", "12,50", None]})
         assert r["v"].invalid_count == 1
+
+    def test_arrow_non_finite_values_do_not_poison_statistics(self):
+        pa = pytest.importorskip("pyarrow")
+        r = dataprof.profile(
+            pa.table({"v": [1.5, float("nan"), float("inf"), float("-inf"), 3.25]})
+        )
+        v = r["v"]
+
+        assert v.data_type == "float"
+        assert v.null_count == 1
+        assert v.unique_count == 4
+        assert v.invalid_count == 2
+        assert v.min == 1.5
+        assert v.max == 3.25
+        assert v.mean == pytest.approx(2.375)
+        assert v.std_dev is not None and v.std_dev > 0.0
 
     def test_roundtrip_preserves_invalid_count(self, tmp_path):
         path = tmp_path / "amounts.csv"

--- a/tests/error_contract.rs
+++ b/tests/error_contract.rs
@@ -4,7 +4,7 @@
 
 use std::io::Write;
 
-use dataprof::{DataProfilerError, Profiler};
+use dataprof::{DataProfilerError, EngineType, Profiler};
 
 #[test]
 fn missing_file_reports_the_real_path_not_unknown() {
@@ -61,25 +61,32 @@ fn non_utf8_csv_reports_one_clean_encoding_diagnostic() {
     file.write_all(b"name,city\nJos\xE9,Z\xFCrich\n").unwrap();
     file.flush().unwrap();
 
-    let err = Profiler::new()
-        .analyze_file(file.path())
-        .expect_err("non-UTF-8 CSV must fail rather than silently mis-decode");
+    for engine in [
+        EngineType::Auto,
+        EngineType::Incremental,
+        EngineType::Columnar,
+    ] {
+        let err = Profiler::new()
+            .engine(engine)
+            .analyze_file(file.path())
+            .expect_err("non-UTF-8 CSV must fail rather than silently mis-decode");
 
-    assert_eq!(err.category(), "encoding");
-    let rendered = err.to_string();
-    // Names the real file, the encoding guess, the offset, and a re-encode fix...
-    assert!(!rendered.contains("unknown"), "{rendered}");
-    assert!(rendered.to_lowercase().contains("utf-8"), "{rendered}");
-    assert!(
-        rendered.contains("iconv"),
-        "gives a re-encode command: {rendered}"
-    );
-    // ...and drops the old misleading, stacked messaging.
-    assert!(!rendered.contains("All engines failed"), "{rendered}");
-    assert!(
-        !rendered.to_lowercase().contains("check file permissions"),
-        "encoding failure must not blame permissions: {rendered}"
-    );
+        assert_eq!(err.category(), "encoding");
+        let rendered = err.to_string();
+        // Names the real file, the encoding guess, the offset, and a re-encode fix...
+        assert!(!rendered.contains("unknown"), "{rendered}");
+        assert!(rendered.to_lowercase().contains("utf-8"), "{rendered}");
+        assert!(
+            rendered.contains("iconv"),
+            "gives a re-encode command: {rendered}"
+        );
+        // ...and drops the old misleading, stacked messaging.
+        assert!(!rendered.contains("All engines failed"), "{rendered}");
+        assert!(
+            !rendered.to_lowercase().contains("check file permissions"),
+            "encoding failure must not blame permissions: {rendered}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR applies the safe, self-contained fixes found during the pre-0.10 dogfooding session.

- keep Arrow/Parquet non-finite floats out of exact numeric accumulators while preserving the established NaN/null and infinity/invalid contract
- preserve Parquet schema for zero-row files, including the async HTTP path
- normalize non-UTF-8 CSV diagnostics across auto, incremental, and columnar engines
- make report save/load extensions case-insensitive and ensure empty CSV saves create the requested artifact
- correct completeness, timeliness, and async ragged-row documentation
- remove feature-dependent broken rustdoc links
- ship the declared Rust examples in the crate archive without shipping their fixture directories

## Why

The release dogfooding pass exercised equivalent datasets across path, bytes, DataFrame, Arrow/Polars, sync, async, engine, report, and installed-package surfaces. These issues were small enough to fix directly and had clear compatibility-preserving behavior.

The larger architectural findings remain tracked separately:

- #459 sampling strategy correctness and capability coverage
- #460 execution controls and provenance invariants
- #462 async ragged CSV diagnostics
- #464 all-feature security advisory coverage

## Root causes

- Arrow floating-point arrays admitted NaN and infinities into sum/sum-of-squares, poisoning derived statistics.
- Parquet analyzers initialized columns only after receiving a record batch; zero-row files may yield none.
- UTF-8 error normalization lived only in the auto-engine branch.
- CSV saving opened the destination only when at least one column record existed.
- Package exclusions removed the complete `examples/` tree.

## Validation

- `cargo test --workspace --all-features --lib --tests -j 1`
- targeted Rust regressions for UTF-8 errors, zero-row Parquet, and non-finite Arrow values
- default Python build: 395 passed, 10 expected skips
- all-feature Python build: 422 passed, 4 expected skips
- `cargo fmt --all -- --check`
- `cargo clippy --lib --tests --all-features -- -D warnings`
- `uv run ruff format --check python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`
- default and all-feature rustdoc builds
- `cargo +1.96 check --workspace --all-features`
- workspace Cargo package dry-run
- isolated CPython 3.12 and 3.13 wheel installs
- isolated sdist build and smoke profile
- all Rust and Python examples exercised during the dogfooding baseline

## Notes

The full monolithic workspace rerun later encountered transient Windows linker locks while re-linking example executables. The examples had already run successfully, and the final library/integration and changed-path suites were green.