### PR TITLE
fix(patterns): require locale evidence for summary claims

### DIFF
--- a/crates/dataprof-metrics/src/analysis/patterns.rs
+++ b/crates/dataprof-metrics/src/analysis/patterns.rs
@@ -132,7 +132,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
             specificity: 75,
             locale: None,
             min_threshold: 5.0,
-            validator: None,
+            validator: Some(validators::validate_coordinates),
         },
         PatternDef {
             name: "IBAN",
@@ -477,13 +477,21 @@ pub fn list_patterns(locale: Option<&str>) -> Vec<PatternMetadata> {
 /// # Arguments
 /// * `data` - Slice of string values to analyze
 /// * `locale` - Optional ISO 3166-1 alpha-2 locale (e.g. "IT", "US", "GB").
-///   When set, locale-matching patterns receive a confidence boost and
-///   non-matching locale patterns are suppressed (unless match rate is very high).
+///   Matching is case-insensitive. When set, locale-matching patterns receive
+///   a confidence boost and non-matching locale patterns are suppressed.
+///   Without a locale, locale-specific candidates remain available as evidence
+///   but receive a confidence penalty, with a further penalty for ambiguous
+///   matches shared by patterns from different locales.
 ///
 /// # Returns
 /// Vector of detected patterns sorted by confidence descending, after overlap
 /// suppression and locale filtering.
 pub fn detect_patterns(data: &[String], locale: Option<&str>) -> Vec<Pattern> {
+    let normalized_locale = locale
+        .map(str::trim)
+        .filter(|locale| !locale.is_empty())
+        .map(str::to_ascii_uppercase);
+
     // Filter empty and whitespace-only strings for robust analysis
     let non_empty: Vec<&str> = data
         .iter()
@@ -538,13 +546,18 @@ pub fn detect_patterns(data: &[String], locale: Option<&str>) -> Vec<Pattern> {
                 None => 1.0,
             };
 
-            candidates.push(PatternMatch {
-                def,
-                match_count,
-                match_percentage,
-                matched_rows: std::mem::take(&mut match_bitmaps[pat_idx]),
-                validator_pass_rate,
-            });
+            // A semantic validator rejecting every regex match means this is
+            // not evidence for the pattern. Exclude it before overlap
+            // suppression so it cannot hide another, genuinely valid pattern.
+            if validator_pass_rate > 0.0 {
+                candidates.push(PatternMatch {
+                    def,
+                    match_count,
+                    match_percentage,
+                    matched_rows: std::mem::take(&mut match_bitmaps[pat_idx]),
+                    validator_pass_rate,
+                });
+            }
         }
     }
 
@@ -601,34 +614,55 @@ pub fn detect_patterns(data: &[String], locale: Option<&str>) -> Vec<Pattern> {
         }
     }
 
-    // Phase 3: Build results with locale-adjusted confidence
+    // Phase 3: Build results with locale-adjusted confidence.
+    //
+    // Locale-specific patterns without an explicit locale are useful evidence,
+    // but not strong enough by themselves to become an asserted semantic type.
+    // Identical row matches from multiple locales (for example CAP and ZIP on
+    // five-digit order IDs) are especially ambiguous and are penalized once per
+    // competing locale.
     let mut results: Vec<Pattern> = candidates
         .iter()
         .enumerate()
         .filter(|(i, _)| !suppressed[*i])
-        .filter_map(|(_, pm)| {
+        .filter_map(|(candidate_idx, pm)| {
             let mut confidence = compute_confidence(
                 pm.def.specificity,
                 pm.match_percentage,
                 pm.validator_pass_rate,
             );
 
-            // Locale adjustments (Phase 4)
-            if let Some(configured_locale) = locale {
+            if let Some(configured_locale) = normalized_locale.as_deref() {
                 match pm.def.locale {
-                    Some(pattern_locale) if pattern_locale == configured_locale => {
-                        // Boost locale-matching patterns (cap at 1.0)
+                    Some(pattern_locale)
+                        if pattern_locale.eq_ignore_ascii_case(configured_locale) =>
+                    {
                         confidence = (confidence * 1.2).min(1.0);
-                    }
-                    Some(_)
-                        // Suppress non-matching locale patterns with low confidence,
-                        // unless the match rate is very high (data speaks for itself)
-                        if confidence < 0.5 && pm.match_percentage <= 80.0 => {
-                            return None;
+                        if pm.match_percentage >= 80.0 && pm.validator_pass_rate >= 0.8 {
+                            confidence = confidence.max(0.5);
                         }
-                    Some(_) => {}
-                    None => {} // Universal patterns — no adjustment
+                    }
+                    Some(_) => return None,
+                    None => {}
                 }
+            } else if pm.def.locale.is_some() {
+                let distinct_matching_locales = candidates
+                    .iter()
+                    .enumerate()
+                    .filter(|(other_idx, other)| {
+                        !suppressed[*other_idx]
+                            && (candidate_idx == *other_idx
+                                || (other.def.locale != pm.def.locale
+                                    && other.def.locale.is_some()
+                                    && other.def.category == pm.def.category
+                                    && other.matched_rows == pm.matched_rows))
+                    })
+                    .filter_map(|(_, other)| other.def.locale)
+                    .collect::<std::collections::HashSet<_>>()
+                    .len()
+                    .max(1);
+
+                confidence *= 0.75 / distinct_matching_locales as f64;
             }
 
             Some(Pattern {
@@ -879,7 +913,7 @@ mod tests {
     fn test_detect_coordinates_pattern() {
         let data = vec![
             "41.9028, 12.4964".to_string(),   // Rome
-            "40.7128, -74.0060".to_string(),  // New York
+            "40.7128,-74.0060".to_string(),   // New York
             "-33.8688, 151.2093".to_string(), // Sydney
         ];
         let patterns = detect_patterns(&data, None);
@@ -887,6 +921,23 @@ mod tests {
         assert_eq!(patterns.len(), 1);
         assert_eq!(patterns[0].name, "Geographic Coordinates");
         assert_eq!(patterns[0].category, PatternCategory::Geographic);
+    }
+
+    #[test]
+    fn test_decimal_comma_numbers_are_not_coordinates() {
+        let data = vec![
+            "1.234,56".to_string(),
+            "2.345,67".to_string(),
+            "3.456,78".to_string(),
+        ];
+        let patterns = detect_patterns(&data, None);
+
+        assert!(
+            patterns
+                .iter()
+                .all(|pattern| pattern.name != "Geographic Coordinates"),
+            "locale-formatted decimal values must not be detected as coordinates"
+        );
     }
 
     #[test]
@@ -919,11 +970,11 @@ mod tests {
 
     #[test]
     fn test_detect_piva_pattern() {
-        // 100% 11-digit numbers — well above 25% threshold
+        // Valid identifiers at 100% — well above the 25% threshold.
         let data = vec![
-            "12345678901".to_string(),
-            "98765432109".to_string(),
-            "11111111111".to_string(),
+            "12345678903".to_string(),
+            "00000000000".to_string(),
+            "12345678903".to_string(),
         ];
         let patterns = detect_patterns(&data, None);
 
@@ -1032,15 +1083,15 @@ mod tests {
     #[test]
     fn test_equal_specificity_no_suppression() {
         // CAP (IT) and ZIP Code (US) both have specificity 35.
-        // Pure 5-digit data should return both (no suppression at equal specificity).
+        // Pure 5-digit data retains both as inspectable candidates, but the
+        // cross-locale ambiguity keeps either from becoming a confident claim.
         let data: Vec<String> = (10000..10020).map(|n| n.to_string()).collect();
         let patterns = detect_patterns(&data, None);
-        let cap = patterns.iter().any(|p| p.name == "CAP (IT)");
-        let zip = patterns.iter().any(|p| p.name == "ZIP Code (US)");
-        assert!(
-            cap && zip,
-            "Both CAP and ZIP should survive at equal specificity"
-        );
+        let cap = patterns.iter().find(|p| p.name == "CAP (IT)");
+        let zip = patterns.iter().find(|p| p.name == "ZIP Code (US)");
+        assert!(cap.is_some() && zip.is_some());
+        assert!(cap.unwrap().confidence < 0.5);
+        assert!(zip.unwrap().confidence < 0.5);
     }
 
     // ---- Confidence scoring tests ----
@@ -1183,17 +1234,11 @@ mod tests {
         let cap_valid = p_valid.iter().find(|p| p.name == "CAP (IT)");
         let cap_invalid = p_invalid.iter().find(|p| p.name == "CAP (IT)");
 
-        // Valid CAPs should have higher confidence than invalid ones
-        if let (Some(v), Some(iv)) = (cap_valid, cap_invalid) {
-            assert!(
-                v.confidence > iv.confidence,
-                "Valid CAPs ({:.3}) should have higher confidence than invalid ({:.3})",
-                v.confidence,
-                iv.confidence,
-            );
-        }
-        // At minimum, valid CAPs should be detected
         assert!(cap_valid.is_some(), "Valid CAPs should be detected");
+        assert!(
+            cap_invalid.is_none(),
+            "CAP must be absent when its validator rejects every match"
+        );
     }
 
     #[test]
@@ -1220,15 +1265,10 @@ mod tests {
         let piva_invalid = p_invalid.iter().find(|p| p.name == "P.IVA (IT)");
 
         assert!(piva_valid.is_some(), "Valid P.IVA should be detected");
-        // Both should be detected (regex matches), but valid should have higher confidence
-        if let (Some(v), Some(iv)) = (piva_valid, piva_invalid) {
-            assert!(
-                v.confidence > iv.confidence,
-                "Valid P.IVA ({:.3}) should have higher confidence than invalid ({:.3})",
-                v.confidence,
-                iv.confidence,
-            );
-        }
+        assert!(
+            piva_invalid.is_none(),
+            "P.IVA must be absent when every check digit is invalid"
+        );
     }
 
     // ---- Phase 3 pattern tests ----
@@ -1510,35 +1550,54 @@ mod tests {
     }
 
     #[test]
-    fn test_locale_high_match_rate_keeps_non_matching() {
-        // Even with non-matching locale, very high match rate (>80%) keeps the pattern
+    fn test_explicit_locale_suppresses_non_matching_even_at_high_match_rate() {
         let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
         let with_us = detect_patterns(&data, Some("US"));
 
-        // CAP (IT) has 100% match rate, so it survives despite US locale
         let cap_us = with_us.iter().find(|p| p.name == "CAP (IT)");
         assert!(
-            cap_us.is_some(),
-            "CAP (IT) should survive with US locale when match rate >80% (data speaks for itself)"
+            cap_us.is_none(),
+            "an explicit US locale must suppress CAP even at a 100% regex match"
         );
+        let zip_us = with_us
+            .iter()
+            .find(|p| p.name == "ZIP Code (US)")
+            .expect("the matching US pattern should remain");
+        assert!(zip_us.confidence >= 0.5);
     }
 
     #[test]
-    fn test_locale_none_keeps_all() {
-        // Without locale, both CAP and ZIP should be present (equal specificity)
+    fn test_locale_is_case_insensitive() {
+        let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
+        let uppercase = detect_patterns(&data, Some("IT"));
+        let lowercase = detect_patterns(&data, Some("it"));
+
+        let uppercase_cap = uppercase
+            .iter()
+            .find(|p| p.name == "CAP (IT)")
+            .expect("uppercase locale should detect CAP");
+        let lowercase_cap = lowercase
+            .iter()
+            .find(|p| p.name == "CAP (IT)")
+            .expect("lowercase locale should detect CAP");
+        assert_eq!(uppercase_cap.confidence, lowercase_cap.confidence);
+        assert!(lowercase.iter().all(|p| p.name != "ZIP Code (US)"));
+    }
+
+    #[test]
+    fn test_locale_none_keeps_ambiguous_evidence_below_summary_threshold() {
         let data: Vec<String> = (10001..=10050).map(|n| format!("{}", n)).collect();
         let patterns = detect_patterns(&data, None);
 
-        // At least one 5-digit pattern should survive
-        let has_five_digit = patterns.iter().any(|p| {
-            p.name == "CAP (IT)"
-                || p.name == "ZIP Code (US)"
-                || p.name == "German PLZ"
-                || p.name == "French Code Postal"
-        });
+        let locale_candidates: Vec<&Pattern> = patterns
+            .iter()
+            .filter(|p| p.name == "CAP (IT)" || p.name == "ZIP Code (US)")
+            .collect();
+        assert_eq!(locale_candidates.len(), 2);
         assert!(
-            has_five_digit,
-            "Some 5-digit pattern should be detected without locale"
+            locale_candidates
+                .iter()
+                .all(|pattern| pattern.confidence < 0.5)
         );
     }
 

--- a/crates/dataprof-metrics/src/analysis/validators.rs
+++ b/crates/dataprof-metrics/src/analysis/validators.rs
@@ -10,6 +10,44 @@
 //! Validators are pure functions; some implementations may use small temporary
 //! allocations while validating.
 
+/// Validate a latitude/longitude pair without confusing decimal-comma numbers.
+///
+/// A compact value with a three-digit group after a dot and an unsigned,
+/// two-digit suffix after the comma (for example `1.234,56`) is much stronger
+/// evidence for a locale-formatted decimal number than a coordinate. Other
+/// coordinate forms, including compact integer components, remain valid.
+pub fn validate_coordinates(s: &str) -> bool {
+    let Some((latitude, longitude)) = s.split_once(',') else {
+        return false;
+    };
+
+    let has_separator_whitespace = longitude.starts_with(char::is_whitespace);
+    let latitude = latitude.trim();
+    let longitude = longitude.trim();
+
+    if !has_separator_whitespace
+        && !longitude.starts_with(['+', '-'])
+        && longitude.len() == 2
+        && longitude.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        let unsigned_latitude = latitude.trim_start_matches(['+', '-']);
+        if let Some((whole, fractional)) = unsigned_latitude.split_once('.')
+            && (1..=3).contains(&whole.len())
+            && whole.bytes().all(|byte| byte.is_ascii_digit())
+            && fractional.len() == 3
+            && fractional.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return false;
+        }
+    }
+
+    let (Ok(latitude), Ok(longitude)) = (latitude.parse::<f64>(), longitude.parse::<f64>()) else {
+        return false;
+    };
+
+    (-90.0..=90.0).contains(&latitude) && (-180.0..=180.0).contains(&longitude)
+}
+
 /// Validate an Italian CAP (Codice di Avviamento Postale).
 ///
 /// Valid range: 00010–98168. The regex `^\d{5}$` matches any 5-digit string;
@@ -230,6 +268,19 @@ pub fn validate_ssn_us(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_coordinates_require_unambiguous_separator_evidence() {
+        assert!(validate_coordinates("41.9028,12.4964"));
+        assert!(validate_coordinates("41.9028, 12.4964"));
+        assert!(validate_coordinates("41, 12"));
+        assert!(validate_coordinates("40.7128,-74"));
+        assert!(validate_coordinates("0,0"));
+        assert!(!validate_coordinates("1.234,56"));
+        assert!(!validate_coordinates("-12.345,67"));
+        assert!(!validate_coordinates("91.0, 12.0"));
+        assert!(!validate_coordinates("41.0, 181.0"));
+    }
 
     // ---- CAP (IT) validator ----
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -22,6 +22,24 @@ silent-clean path is a 0.10 blocker tracked in
 [#462](https://github.com/AndreaBozzo/dataprof/issues/462). Ragged rows do not
 yet influence the consistency dimension's score.
 
+## Locale patterns require locale evidence before becoming report claims
+
+Ambiguous locale-specific shapes remain available in each column's detailed
+`patterns` evidence, but no longer appear as a top pattern in text, Markdown,
+HTML, tabular, or LLM-oriented summaries unless their confidence is at least
+0.5. For example, a five-digit order ID column without a configured locale can
+still show both Italian CAP and US ZIP as low-confidence candidates, but neither
+is presented as the column's semantic type.
+
+An explicit `locale=` is now case-insensitive and strict: its matching patterns
+receive enough evidence to be reportable at a strong match rate, while patterns
+for other locales are suppressed even when the broad regex matches every row.
+Coordinate validation also distinguishes compact latitude/longitude pairs from
+decimal-comma numbers such as `1.234,56`. More generally, a pattern is no longer
+returned when its semantic validator rejects every regex match, and such a
+candidate cannot suppress another pattern during overlap resolution. This
+resolves [#429](https://github.com/AndreaBozzo/dataprof/issues/429).
+
 ## Errors preserve source context and map to idiomatic Python exceptions
 
 Failure diagnostics are now consistent about what failed, where, and what to do

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -17,7 +17,14 @@ import warnings
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass as _dataclass
 from importlib import util as _importlib_util
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from ._dataprof import Pattern as _NativePattern
+else:
+    # Pattern objects are returned by the extension and described by its stub,
+    # but the class itself is not exported as a runtime module attribute.
+    _NativePattern = Any
 
 from ._dataprof import (
     ColumnProfile,
@@ -697,7 +704,7 @@ def _stats_cell(col: ColumnProfile) -> str:
 _MIN_SUMMARY_PATTERN_CONFIDENCE = 0.5
 
 
-def _dominant_pattern(col: ColumnProfile) -> Any | None:
+def _dominant_pattern(col: ColumnProfile) -> _NativePattern | _DictPattern | None:
     """Return the strongest pattern that clears the summary evidence threshold."""
     if not col.patterns:
         return None

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -624,8 +624,8 @@ def _column_record(col: ColumnProfile) -> dict[str, Any]:
     top_pattern_pct = None
     top_pattern_category = None
     top_pattern_confidence = None
-    if col.patterns:
-        best = max(col.patterns, key=lambda p: p.confidence)
+    best = _dominant_pattern(col)
+    if best is not None:
         top_pattern = best.name
         top_pattern_pct = _r2(best.match_percentage)
         top_pattern_category = best.category
@@ -691,10 +691,26 @@ def _stats_cell(col: ColumnProfile) -> str:
     return ", ".join(parts)
 
 
+#: A pattern below this confidence remains available in detailed evidence but
+#: is not strong enough to become a report-level semantic claim. This mirrors
+#: the threshold used by the validity quality dimension.
+_MIN_SUMMARY_PATTERN_CONFIDENCE = 0.5
+
+
+def _dominant_pattern(col: ColumnProfile) -> Any | None:
+    """Return the strongest pattern that clears the summary evidence threshold."""
+    if not col.patterns:
+        return None
+    candidates = [
+        pattern for pattern in col.patterns if pattern.confidence >= _MIN_SUMMARY_PATTERN_CONFIDENCE
+    ]
+    return max(candidates, key=lambda pattern: pattern.confidence, default=None)
+
+
 def _pattern_cell(col: ColumnProfile) -> str:
-    """Highest-confidence detected pattern for a column, as "Name (pct%)"."""
-    if col.patterns:
-        best = max(col.patterns, key=lambda p: p.confidence)
+    """Highest-confidence reportable pattern, formatted as "Name (pct%)"."""
+    best = _dominant_pattern(col)
+    if best is not None:
         return f"{best.name} ({_r2(best.match_percentage):.0f}%)"
     return ""
 
@@ -2181,9 +2197,11 @@ class ProfileReport:
                 line += f" [{_one_line(col.min)} .. {_one_line(col.max)}]"
             schema_items.append(line)
 
-        pattern_items = [
-            f"- {_one_line(col.name)}: {_pattern_cell(col)}" for col in cols if col.patterns
-        ]
+        pattern_items = []
+        for col in cols:
+            pattern = _pattern_cell(col)
+            if pattern:
+                pattern_items.append(f"- {_one_line(col.name)}: {pattern}")
 
         # Flags are the reason an agent asked; schema is context; patterns are a
         # bonus. Unused budget rolls forward, so a clean dataset spends its flag
@@ -2433,8 +2451,8 @@ class ProfileReport:
                 parts.append(f"true={col.true_count}({pct:.0f}%)")
             elif col.avg_length is not None:
                 parts.append(f"avg_len={_r4(col.avg_length)}")
-            if col.patterns:
-                best = max(col.patterns, key=lambda p: p.confidence)
+            best = _dominant_pattern(col)
+            if best is not None:
                 parts.append(f"{best.name}({_r2(best.match_percentage):.0f}%)")
             lines.append("   ".join(parts))
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1170,8 +1170,9 @@ class TestToLlmContext:
         assert patterns["ZIP Code (US)"].confidence < 0.5
         assert "CAP (IT)" not in report.to_llm_context()
         assert "ZIP Code (US)" not in report.to_llm_context()
-        assert "CAP (IT)" not in repr(report)
-        assert "ZIP Code (US)" not in report.to_markdown()
+        for summary in (repr(report), report.to_markdown(), report.to_html()):
+            assert "CAP (IT)" not in summary
+            assert "ZIP Code (US)" not in summary
         if dataprof.capabilities().pandas_installed:
             dataframe = report.to_dataframe().set_index("name")
             assert dataframe.loc["order_id", "top_pattern"] is None

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1155,6 +1155,60 @@ class TestToLlmContext:
     def test_reports_detected_pattern_names(self, messy):
         assert "email: Email" in messy.to_llm_context()
 
+    def test_ambiguous_order_ids_stay_detailed_but_not_in_summaries(self, tmp_path):
+        path = tmp_path / "orders.csv"
+        rows = ["order_id"] + [str(value) for value in range(20100, 20200)]
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        report = dataprof.profile(str(path))
+        column = report["order_id"]
+        assert column.patterns is not None
+        patterns = {pattern.name: pattern for pattern in column.patterns}
+
+        assert {"CAP (IT)", "ZIP Code (US)"}.issubset(patterns)
+        assert patterns["CAP (IT)"].confidence < 0.5
+        assert patterns["ZIP Code (US)"].confidence < 0.5
+        assert "CAP (IT)" not in report.to_llm_context()
+        assert "ZIP Code (US)" not in report.to_llm_context()
+        assert "CAP (IT)" not in repr(report)
+        assert "ZIP Code (US)" not in report.to_markdown()
+        if dataprof.capabilities().pandas_installed:
+            dataframe = report.to_dataframe().set_index("name")
+            assert dataframe.loc["order_id", "top_pattern"] is None
+
+        detailed_names = {pattern["name"] for pattern in report.to_dict()["columns"][0]["patterns"]}
+        assert {"CAP (IT)", "ZIP Code (US)"}.issubset(detailed_names)
+
+    def test_explicit_locale_is_case_insensitive_and_strict(self, tmp_path):
+        path = tmp_path / "italian_postcodes.csv"
+        rows = ["postcode"] + [str(value) for value in range(20100, 20200)]
+        path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        report = dataprof.profile(str(path), locale="it")
+        column = report["postcode"]
+        assert column.patterns is not None
+        patterns = {pattern.name: pattern for pattern in column.patterns}
+
+        assert patterns["CAP (IT)"].confidence >= 0.5
+        assert "ZIP Code (US)" not in patterns
+        assert "postcode: CAP (IT)" in report.to_llm_context()
+        if dataprof.capabilities().pandas_installed:
+            dataframe = report.to_dataframe().set_index("name")
+            assert dataframe.loc["postcode", "top_pattern"] == "CAP (IT)"
+
+    def test_decimal_comma_values_are_not_reported_as_coordinates(self, tmp_path):
+        path = tmp_path / "prices.csv"
+        path.write_text(
+            'price\n"1.234,56"\n"2.345,67"\n"3.456,78"\n',
+            encoding="utf-8",
+        )
+
+        report = dataprof.profile(str(path))
+        assert report["price"].patterns is not None
+        names = {pattern.name for pattern in report["price"].patterns}
+        assert "Geographic Coordinates" not in names
+        assert "Geographic Coordinates" not in report.to_llm_context()
+
     @staticmethod
     def _header_tokens(report):
         """Cost of the always-emitted header, which is the effective budget floor."""


### PR DESCRIPTION
## Summary

- keep ambiguous locale-specific matches as low-confidence detailed evidence instead of presenting them as semantic claims
- make explicit locale matching strict and case-insensitive, suppressing patterns from other locales even at a 100% regex match
- require semantic validators to accept at least one match before a pattern can participate in overlap resolution
- reject decimal-comma monetary values such as `1.234,56` as coordinates while preserving compact valid coordinates
- apply the validity dimension's `0.5` evidence threshold consistently to Python text, Markdown, HTML, tabular, and LLM-oriented summaries

## Root cause

Equal-specificity locale patterns such as Italian CAP and US ZIP were intentionally retained after overlap resolution, but the detector did not discount their ambiguity when no locale was supplied. Python summary surfaces then selected the maximum pattern without considering confidence, turning weak candidates into definitive user-facing claims. The coordinate regex also had enough shape overlap with decimal-comma numbers to report prices as geographic coordinates.

## User impact

Five-digit order IDs no longer appear as 100% Italian postal codes or US ZIP codes in condensed reports and agent context. The candidates remain available in `columns[].patterns` for inspection. Supplying `locale="it"` or `locale="US"` now produces one strict, reportable locale match. Patterns rejected by every semantic validation check are no longer returned or allowed to suppress other candidates.

## Validation

- `cargo test --workspace`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `uv run maturin develop`
- `uv run pytest python/tests/test_python_api.py -q` (308 passed)
- `uv run ruff format --check python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`
- manual CSV/DataFrame parity checks for absent, lowercase Italian, and US locales
- manual coordinate checks for `1.234,56`, `40.7128,-74`, and `0,0`

Closes #429