### PR TITLE
perf(ci): parallelize database integration builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,11 +419,7 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           cache-prefix: rust-db
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.10'
+          components: ''
 
       - name: Initialize test databases
         run: |
@@ -433,11 +429,35 @@ jobs:
           mysql -h 127.0.0.1 -u dataprof -pdev_password_123 dataprof_test \
             < .devcontainer/init-scripts/mysql/01-init-schema.sql || true
 
-      - name: Run Rust database tests (SQLite only)
-        run: cargo test --test database_integration --features "sqlite"
-
+      # all-db already includes the SQLite feature and its tests. Running a
+      # SQLite-only command first forces Cargo to build two feature graphs and
+      # can prevent a cold job from reaching the post-job cache save.
       - name: Run Rust database tests (all DBs)
         run: cargo test --test database_integration --features "all-db"
+
+  # The Python extension uses a different Cargo profile and feature graph.
+  # Build it in parallel so neither cold build blocks the other's cache save.
+  python-db-tests:
+    name: Python Database Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          token: ${{ github.token }}
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          cache-prefix: rust-python-db
+          components: ''
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -448,7 +468,11 @@ jobs:
             uv.lock
 
       - name: Build Python bindings with database support
-        run: uv run maturin develop --features "python,python-async,database,sqlite"
+        run: uv run maturin develop --features "python,python-async,sqlite"
 
       - name: Run Python database tests
-        run: uv run pytest python/tests/test_database_api.py python/tests/test_engine_parity.py -v -ra
+        run: >-
+          uv run pytest
+          python/tests/test_database_api.py
+          python/tests/test_engine_parity.py::test_sqlite_parity
+          -v -ra


### PR DESCRIPTION
## Summary

- remove the standalone SQLite Rust test invocation because `all-db` already includes the SQLite feature and runs the same integration tests
- move the Python SQLite extension build and database API tests into a parallel, service-free job
- give Rust all-DB and Python SQLite feature graphs separate cache prefixes so both successful jobs can persist reusable artifacts
- skip unused `rustfmt` and `clippy` components in both database jobs
- run only the database-specific SQLite parity case here; the full engine-parity module remains covered by the main Python test job

## Root cause

The database job serialized three different Cargo feature/profile builds under a 20-minute timeout. On run `30018614237`, the SQLite-only Rust build took 6m38s, the all-DB rebuild took another 4m48s, and the Python binding build was cancelled after a further 7m51s. Because the job timed out, its post-job Rust cache never saved; the next cold branch repeated the same work.

The database assertions themselves are fast: the all-DB Rust binary runs 26 tests in about 0.2s once built, and the targeted Python suite runs 17 tests in about 1.7s locally.

## Expected impact

The two cold feature graphs now build concurrently instead of serially. Each job can finish and save its own cache even when the other build is cold, preventing the timeout/cache-miss loop. Rust coverage is unchanged because `all-db` includes SQLite, PostgreSQL, and MySQL; Python database coverage remains all database API tests plus the SQLite cross-engine parity assertion.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- parsed `.github/workflows/ci.yml` and asserted both database job structures with PyYAML
- `cargo test --test database_integration --features "all-db"` (26 passed)
- `uv run maturin develop --features "python,python-async,sqlite"`
- `uv run pytest python/tests/test_database_api.py python/tests/test_engine_parity.py::test_sqlite_parity -v -ra` (17 passed)
- `git diff --check`