### PR TITLE
fix(async): count ragged CSV rows and honor CSV options (#462)

### DIFF
--- a/crates/dataprof-engines/src/adaptive.rs
+++ b/crates/dataprof-engines/src/adaptive.rs
@@ -107,6 +107,14 @@ impl AdaptiveProfiler {
                 if matches!(primary_err, DataProfilerError::DuplicateColumnName { .. }) {
                     return Err(primary_err);
                 }
+                // Likewise when the caller asked for strict CSV parsing: they
+                // opted out of recovery, so retrying under a second parser only
+                // trades their actionable diagnostic for "all engines failed".
+                if self.csv_config.as_ref().is_some_and(|c| !c.flexible)
+                    && matches!(primary_err, DataProfilerError::CsvParsingError { .. })
+                {
+                    return Err(primary_err);
+                }
                 #[cfg(feature = "arrow")]
                 let fallback = match engine {
                     InternalEngineType::Arrow => InternalEngineType::Incremental,

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -21,6 +21,20 @@ struct ParsedChunk {
     bytes_read: u64,
 }
 
+/// Structural violations the blocking reader task observed while parsing.
+///
+/// Both counters describe what the *reader* saw, so an early-stopped scan
+/// reports the violations within the data it actually read.
+#[derive(Default)]
+struct ReaderOutcome {
+    /// Malformed JSON/JSONL records skipped under the tolerant policy
+    /// (always 0 for CSV, and in strict mode where the first one aborts).
+    malformed_records: usize,
+    /// CSV records whose field count differed from the header (always 0 for
+    /// JSON/JSONL, whose rows are aligned to the column set by construction).
+    ragged_rows: usize,
+}
+
 /// Async streaming profiler that accepts [`AsyncDataSource`] instead of file paths.
 ///
 /// Uses a bounded channel between a blocking CSV reader task and an async
@@ -46,7 +60,15 @@ pub struct AsyncStreamingProfiler {
     metric_packs: Option<Vec<MetricPack>>,
     semantic_hints: SemanticHints,
     json_error_policy: JsonErrorPolicy,
+    csv_flexible: bool,
+    csv_delimiter: Option<u8>,
 }
+
+/// Bytes sniffed from the head of a stream to detect its CSV delimiter.
+///
+/// Matches the file path's sample size so the same data yields the same
+/// delimiter whether it is read from disk or off a socket.
+const DELIMITER_SAMPLE_BYTES: u64 = 4096;
 
 impl AsyncStreamingProfiler {
     pub fn new() -> Self {
@@ -62,6 +84,8 @@ impl AsyncStreamingProfiler {
             metric_packs: None,
             semantic_hints: SemanticHints::default(),
             json_error_policy: JsonErrorPolicy::default(),
+            csv_flexible: true,
+            csv_delimiter: None,
         }
     }
 
@@ -117,6 +141,27 @@ impl AsyncStreamingProfiler {
         self
     }
 
+    /// Set how CSV records whose field count differs from the header are handled.
+    ///
+    /// `true` (default) recovers them — extra fields dropped, missing fields
+    /// padded to null — and counts every one in
+    /// [`ExecutionMetadata::ragged_row_count`], matching the incremental file
+    /// path. `false` rejects the first such record with a CSV parsing error.
+    pub fn csv_flexible(mut self, flexible: bool) -> Self {
+        self.csv_flexible = flexible;
+        self
+    }
+
+    /// Set the CSV field delimiter.
+    ///
+    /// When unset, it is detected from the head of the stream the same way the
+    /// file path detects it, so a semicolon- or tab-separated source profiles
+    /// identically over either transport.
+    pub fn csv_delimiter(mut self, delimiter: u8) -> Self {
+        self.csv_delimiter = Some(delimiter);
+        self
+    }
+
     /// Profile data from an async source, returning a [`ProfileReport`].
     ///
     /// Supports CSV, JSON, and JSONL formats. Parquet async support is tracked separately.
@@ -149,13 +194,21 @@ impl AsyncStreamingProfiler {
         let sync_reader = tokio_util::io::SyncIoBridge::new(reader);
 
         // Spawn the reader on a blocking thread — format determines the parser.
-        // The task reports how many malformed records were skipped (0 for CSV,
-        // and always 0 in strict JSON mode since the first one aborts).
+        // The task reports the structural violations it recovered from, so a
+        // report can never describe a repaired scan as a clean one.
         let json_error_policy = self.json_error_policy;
+        let csv_flexible = self.csv_flexible;
+        let csv_delimiter = self.csv_delimiter;
         let reader_handle = tokio::task::spawn_blocking(move || match format {
-            FileFormat::Csv => Self::reader_task(sync_reader, tx, rows_per_chunk).map(|()| 0usize),
+            FileFormat::Csv => {
+                Self::reader_task(sync_reader, tx, rows_per_chunk, csv_flexible, csv_delimiter)
+            }
             FileFormat::Json | FileFormat::Jsonl => {
                 Self::json_reader_task(sync_reader, tx, rows_per_chunk, format, json_error_policy)
+                    .map(|malformed_records| ReaderOutcome {
+                        malformed_records,
+                        ragged_rows: 0,
+                    })
             }
             _ => unreachable!(),
         });
@@ -179,12 +232,12 @@ impl AsyncStreamingProfiler {
             };
 
         // Wait for the reader task to finish and propagate any errors
-        let malformed_records = match reader_handle.await {
-            Ok(Ok(count)) => count,
+        let reader_outcome = match reader_handle.await {
+            Ok(Ok(outcome)) => outcome,
             Ok(Err(e)) => return Err(e),
             Err(join_err) if join_err.is_cancelled() => {
                 // We cancelled it ourselves — fine
-                0
+                ReaderOutcome::default()
             }
             Err(join_err) => {
                 return Err(DataProfilerError::StreamingError {
@@ -227,7 +280,10 @@ impl AsyncStreamingProfiler {
             .with_bytes_consumed(total_bytes)
             // Tolerant JSONL scans surface skipped malformed records so callers
             // can distinguish a partial profile from a clean one.
-            .with_error_count(malformed_records);
+            .with_error_count(reader_outcome.malformed_records)
+            // Ragged CSV records are recovered, never silently: the count is the
+            // same signal the incremental file path reports.
+            .with_ragged_row_count(reader_outcome.ragged_rows);
 
         if let Some(reason) = truncation_reason {
             execution = execution.with_truncation(reason);
@@ -248,35 +304,79 @@ impl AsyncStreamingProfiler {
         Ok(assembler.build())
     }
 
+    /// Map a `csv` crate error, pointing a strict-mode field-count failure at
+    /// the option that would have recovered it instead.
+    fn csv_error(err: &csv::Error, flexible: bool) -> DataProfilerError {
+        let suggestion = if !flexible && matches!(err.kind(), csv::ErrorKind::UnequalLengths { .. })
+        {
+            "Set csv_flexible=true to recover ragged rows; every recovered row is \
+             reported in execution.ragged_row_count."
+        } else {
+            "Check CSV formatting in the stream data"
+        };
+        DataProfilerError::CsvParsingError {
+            message: err.to_string(),
+            suggestion: suggestion.to_string(),
+        }
+    }
+
     /// Blocking reader task: uses the `csv` crate's RFC 4180-compliant parser
     /// over a `SyncIoBridge` to correctly handle quoted fields with embedded newlines.
+    ///
+    /// Records whose field count differs from the header are counted and
+    /// returned so the report can carry the structural signal; the alignment
+    /// itself (padding short rows, dropping extra fields) happens downstream in
+    /// `StreamingColumnCollection::process_record`, which keys on the header.
     fn reader_task(
         sync_reader: tokio_util::io::SyncIoBridge<
             std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
         >,
         tx: mpsc::Sender<ParsedChunk>,
         rows_per_chunk: usize,
-    ) -> Result<(), DataProfilerError> {
-        let mut csv_reader = csv::ReaderBuilder::new()
-            .has_headers(true)
-            .flexible(true)
-            .from_reader(sync_reader);
+        flexible: bool,
+        delimiter: Option<u8>,
+    ) -> Result<ReaderOutcome, DataProfilerError> {
+        use std::io::Read;
+
+        let mut builder = csv::ReaderBuilder::new();
+        builder.has_headers(true).flexible(flexible);
+
+        // A stream cannot be rewound, so detection reads the head into memory
+        // and chains it back in front of the rest — the parser still sees the
+        // whole source, byte for byte.
+        let source: Box<dyn Read> = match delimiter {
+            Some(delimiter) => {
+                builder.delimiter(delimiter);
+                Box::new(sync_reader)
+            }
+            None => {
+                let mut preamble = Vec::new();
+                let mut head = sync_reader.take(DELIMITER_SAMPLE_BYTES);
+                head.read_to_end(&mut preamble)
+                    .map_err(DataProfilerError::from)?;
+                let detected =
+                    dataprof_csv::detect_delimiter(std::io::Cursor::new(&preamble)).unwrap_or(b',');
+                builder.delimiter(detected);
+                Box::new(std::io::Cursor::new(preamble).chain(head.into_inner()))
+            }
+        };
+
+        let mut csv_reader = builder.from_reader(source);
 
         // Send headers as the first chunk
         let headers = csv_reader
             .headers()
-            .map_err(|e| DataProfilerError::CsvParsingError {
-                message: e.to_string(),
-                suggestion: "Check CSV formatting in the stream data".to_string(),
-            })?;
+            .map_err(|e| Self::csv_error(&e, flexible))?;
 
         let header_fields: Vec<String> = headers.iter().map(|f| f.to_string()).collect();
+        let header_len = header_fields.len();
         let header_chunk = ParsedChunk {
             records: vec![header_fields],
             bytes_read: 0,
         };
+        let mut outcome = ReaderOutcome::default();
         if tx.blocking_send(header_chunk).is_err() {
-            return Ok(());
+            return Ok(outcome);
         }
 
         // Read data records in chunks
@@ -284,10 +384,14 @@ impl AsyncStreamingProfiler {
         let mut bytes_in_chunk: u64 = 0;
 
         for result in csv_reader.records() {
-            let record = result.map_err(|e| DataProfilerError::CsvParsingError {
-                message: e.to_string(),
-                suggestion: "Check CSV formatting in the stream data".to_string(),
-            })?;
+            let record = result.map_err(|e| Self::csv_error(&e, flexible))?;
+
+            // A field count differing from the header is a structural violation.
+            // Counted here, before the row is queued, so the signal covers every
+            // record read rather than only the ones that survive sampling.
+            if record.len() != header_len {
+                outcome.ragged_rows += 1;
+            }
 
             bytes_in_chunk += record.as_slice().len() as u64 + 1;
             let fields: Vec<String> = record.iter().map(|f| f.to_string()).collect();
@@ -304,7 +408,7 @@ impl AsyncStreamingProfiler {
                 bytes_in_chunk = 0;
 
                 if tx.blocking_send(chunk).is_err() {
-                    return Ok(());
+                    return Ok(outcome);
                 }
             }
         }
@@ -318,7 +422,7 @@ impl AsyncStreamingProfiler {
             let _ = tx.blocking_send(chunk);
         }
 
-        Ok(())
+        Ok(outcome)
     }
 
     /// Blocking reader task for JSON/JSONL streams.
@@ -936,6 +1040,130 @@ mod tests {
             report.execution.truncation_reason,
             Some(TruncationReason::MaxRows(100))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_ragged_rows_are_counted() {
+        // Row 2 is short, row 3 is over-long: both differ from the 3-column
+        // header, both are recovered, and neither may vanish from the report.
+        let source =
+            csv_source(b"name,age,city\nAlice,25,NYC\nBob,30\nCarol,35,LA,EXTRA\nDave,40,SF\n");
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.execution.rows_processed, 4);
+        assert_eq!(
+            report.execution.ragged_row_count, 2,
+            "one short and one over-long row must both count as ragged"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_clean_reports_zero_ragged_rows() {
+        let source = csv_source(b"name,age,city\nAlice,25,NYC\nBob,30,LA\n");
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.ragged_row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_strict_rejects_ragged_rows() {
+        let source = csv_source(b"a,b,c\n1,2,3\n4,5\n6,7,8,9\n");
+        let err = AsyncStreamingProfiler::new()
+            .csv_flexible(false)
+            .analyze_stream(source)
+            .await
+            .expect_err("strict mode must reject a ragged record");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("csv_flexible"),
+            "strict failure must name the recovering option: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_ragged_counted_across_chunk_boundaries() {
+        // Ragged rows are counted by the reader task, so the count must not
+        // depend on how the stream happens to be split into chunks.
+        let mut data = String::from("a,b,c\n");
+        for i in 0..500 {
+            if i % 100 == 0 {
+                data.push_str(&format!("{i},short\n"));
+            } else {
+                data.push_str(&format!("{i},{i},{i}\n"));
+            }
+        }
+
+        let source = BytesSource::new(
+            bytes::Bytes::from(data),
+            AsyncSourceInfo::new("chunked-ragged", FileFormat::Csv),
+        );
+        let report = AsyncStreamingProfiler::new()
+            .channel_capacity(1)
+            .chunk_size(ChunkSize::Fixed(5_000))
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.execution.rows_processed, 500);
+        assert_eq!(report.execution.ragged_row_count, 5);
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_detects_non_comma_delimiter() {
+        // Unset delimiter must be sniffed, not assumed: a semicolon file read
+        // as comma-separated collapses into one column and profiles as clean.
+        let source = csv_source(b"name;age;city\nAlice;25;NYC\nBob;30;LA\n");
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.column_profiles.len(), 3);
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.ragged_row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_explicit_delimiter_is_honored() {
+        let source = csv_source(b"a|b\n1|2\n3|4\n");
+        let report = AsyncStreamingProfiler::new()
+            .csv_delimiter(b'|')
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.column_profiles.len(), 2);
+        assert_eq!(report.execution.rows_processed, 2);
+    }
+
+    #[tokio::test]
+    async fn test_async_csv_sniffing_keeps_every_row() {
+        // The sniffed head is chained back in front of the stream; a source
+        // longer than the sample must not lose the rows it was sniffed from.
+        let mut data = String::from("id\tvalue\n");
+        for i in 0..2_000 {
+            data.push_str(&format!("{i}\tvalue_{i}\n"));
+        }
+
+        let source = BytesSource::new(
+            bytes::Bytes::from(data),
+            AsyncSourceInfo::new("sniffed", FileFormat::Csv),
+        );
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.column_profiles.len(), 2);
+        assert_eq!(report.execution.rows_processed, 2_000);
     }
 
     fn jsonl_source(data: &'static [u8]) -> BytesSource {

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -18,6 +18,7 @@ use dataprof::{DataProfilerError, ProfileReport, SemanticHints};
 /// The category drives the exception type so callers can `except` on the
 /// idiomatic Python class instead of string-matching a `RuntimeError`:
 ///   * bad user input (config, semantic hints, unsupported format) → `ValueError`
+///   * malformed data — CSV *and* JSON alike → `ValueError`
 ///   * a missing file → `FileNotFoundError`
 ///   * permission / other I/O trouble → `PermissionError` / `IOError`
 ///   * everything else → `RuntimeError`
@@ -31,6 +32,7 @@ pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
         | DataProfilerError::InvalidConfiguration { .. }
         | DataProfilerError::DuplicateColumnName { .. }
         | DataProfilerError::JsonParsingError { .. }
+        | DataProfilerError::CsvParsingError { .. }
         | DataProfilerError::EncodingError { .. }
         | DataProfilerError::UnsupportedFormat { .. } => PyValueError::new_err(message),
         DataProfilerError::FileNotFound { .. } => PyFileNotFoundError::new_err(message),

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -902,6 +902,12 @@ impl Profiler {
         if let Some(mb) = self.config.memory_limit_mb {
             profiler = profiler.memory_limit_mb(mb);
         }
+        if let Some(flexible) = self.config.csv_flexible {
+            profiler = profiler.csv_flexible(flexible);
+        }
+        if let Some(delimiter) = self.config.csv_delimiter {
+            profiler = profiler.csv_delimiter(delimiter);
+        }
         if let Some(ref d) = self.config.quality_dimensions {
             profiler = profiler.quality_dimensions(d.clone());
         }

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -153,7 +153,7 @@ Returned by `profile()` and all analysis functions.
 | `memory_peak_mb` | `float \| None` | Peak memory usage |
 | `truncation_reason` | `str \| None` | Why processing stopped early |
 | `source_exhausted` | `bool` | Whether the entire source was read |
-| `ragged_row_count` | `int` | Rows whose field count differed from the header (`0` = clean parse) |
+| `ragged_row_count` | `int` | Rows whose field count differed from the header (`0` = clean parse). Reported for file and async CSV inputs; not by `engine="columnar"` |
 | `sampling_applied` | `bool` | Whether sampling was used |
 | `sampling_ratio` | `float \| None` | Fraction of data sampled |
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -23,11 +23,18 @@ now also reaches that path — previously it was accepted and ignored there — 
 rejects the first ragged record instead of repairing it.
 
 Scope: the count is surfaced by the incremental engine, which drives the default
-CSV path, and by the async reader. The columnar (Arrow) engine rejects ragged
-rows outright. Byte inputs to the synchronous `profile()` still reject rather
-than recover, since they are read without the flexible engine; write the data to
-a file to profile it leniently. Ragged rows do not yet influence the consistency
-dimension's score.
+CSV path, and by the async reader. Byte inputs to the synchronous `profile()`
+still reject rather than recover, since they are read without the flexible
+engine; write the data to a file to profile it leniently.
+
+The explicitly selected columnar (Arrow) engine is not yet covered. It rejects a
+row with *extra* fields, but pads a row with *missing* fields to null and still
+reports `ragged_row_count: 0` — so `engine="columnar"` remains a silent-clean
+path for short rows. Prefer the default `engine="auto"` when a source may be
+structurally broken; the gap is tracked in
+[#470](https://github.com/AndreaBozzo/dataprof/issues/470).
+
+Ragged rows do not yet influence the consistency dimension's score.
 
 ## Async CSV detects its delimiter instead of assuming a comma
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,12 +15,41 @@ and in `to_dict()["execution"]["ragged_row_count"]`. It is an additive report
 field: reports written before this release deserialize with `ragged_row_count`
 of `0`.
 
-Scope: this is surfaced by the incremental engine, which drives the default CSV
-path. The columnar (Arrow) engine rejects ragged rows outright. The async reader
-currently recovers them without incrementing `ragged_row_count`; that remaining
-silent-clean path is a 0.10 blocker tracked in
-[#462](https://github.com/AndreaBozzo/dataprof/issues/462). Ragged rows do not
-yet influence the consistency dimension's score.
+The async reader follows the same policy
+([#462](https://github.com/AndreaBozzo/dataprof/issues/462)): byte streams and
+URLs recover ragged rows and report the same count, so the transport can no
+longer launder a broken source into a clean-looking report. `csv_flexible=False`
+now also reaches that path — previously it was accepted and ignored there — and
+rejects the first ragged record instead of repairing it.
+
+Scope: the count is surfaced by the incremental engine, which drives the default
+CSV path, and by the async reader. The columnar (Arrow) engine rejects ragged
+rows outright. Byte inputs to the synchronous `profile()` still reject rather
+than recover, since they are read without the flexible engine; write the data to
+a file to profile it leniently. Ragged rows do not yet influence the consistency
+dimension's score.
+
+## Async CSV detects its delimiter instead of assuming a comma
+
+`csv_delimiter` was accepted and ignored on every async path, which always
+parsed on commas. A semicolon- or tab-separated stream therefore collapsed into
+a single column and profiled as perfectly clean. The async reader now honors an
+explicit `csv_delimiter`, and when none is given it detects one from the head of
+the stream using the same sample size and scoring as the file path — so the same
+bytes yield the same columns whether they are read from disk, from memory, or
+off a URL.
+
+## Malformed CSV raises `ValueError`, like malformed JSON
+
+A CSV parse failure reached Python as a `RuntimeError` while the equivalent JSON
+failure raised `ValueError`, so callers could not catch bad input as one
+category. Malformed data of either format is now a `ValueError`.
+
+Relatedly, a rejection under `csv_flexible=False` keeps its own diagnostic. The
+auto engine used to retry the file under its fallback parser and report
+`All engines failed: ...` with both parsers' messages; asking for strict parsing
+means opting out of recovery, so the original error — naming the row and the
+expected field count — is returned directly.
 
 ## Locale patterns require locale evidence before becoming report claims
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -910,8 +910,12 @@ def profile_file(
         memory_limit_mb: Memory limit in MB.
         format: Override format detection ("csv", "json", "jsonl", "parquet").
         max_rows: Maximum rows to process before stopping.
-        csv_delimiter: Single-character CSV delimiter (default: comma).
-        csv_flexible: Allow variable-length CSV records.
+        csv_delimiter: Single-character CSV delimiter (default: detected
+            from the data).
+        csv_flexible: Allow variable-length CSV records. When True (default) a
+            row whose field count differs from the header is recovered and
+            counted in ``report.ragged_row_count``; False raises ValueError on
+            the first such row.
         jsonl_on_error: How to handle a malformed JSON/JSONL record: "skip"
             (default) skips it, counts it in ``report.execution.error_count``,
             and returns a partial profile; "strict" raises ValueError on the
@@ -1010,8 +1014,12 @@ def profile(
         format: Override format detection ("csv", "json", "jsonl", "parquet").
         max_rows: Maximum rows to process before stopping.
         name: Name for DataFrame sources in the report.
-        csv_delimiter: Single-character CSV delimiter (default: comma).
-        csv_flexible: Allow variable-length CSV records.
+        csv_delimiter: Single-character CSV delimiter (default: detected
+            from the data).
+        csv_flexible: Allow variable-length CSV records. When True (default) a
+            row whose field count differs from the header is recovered and
+            counted in ``report.ragged_row_count``; False raises ValueError on
+            the first such row.
         jsonl_on_error: How to handle a malformed JSON/JSONL record, applied
             identically to file, bytes, and async byte inputs: "skip" (default)
             skips it, counts it in ``report.execution.error_count``, and returns

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -912,10 +912,12 @@ def profile_file(
         max_rows: Maximum rows to process before stopping.
         csv_delimiter: Single-character CSV delimiter (default: detected
             from the data).
-        csv_flexible: Allow variable-length CSV records. When True (default) a
-            row whose field count differs from the header is recovered and
-            counted in ``report.ragged_row_count``; False raises ValueError on
-            the first such row.
+        csv_flexible: Allow variable-length CSV records. Applies to file and
+            async inputs, where True (default) recovers a row whose field count
+            differs from the header and counts it in
+            ``report.ragged_row_count``, and False raises ValueError on the
+            first such row. CSV bytes are always parsed strictly, and
+            ``engine="columnar"`` does not report the count.
         jsonl_on_error: How to handle a malformed JSON/JSONL record: "skip"
             (default) skips it, counts it in ``report.execution.error_count``,
             and returns a partial profile; "strict" raises ValueError on the
@@ -1016,10 +1018,12 @@ def profile(
         name: Name for DataFrame sources in the report.
         csv_delimiter: Single-character CSV delimiter (default: detected
             from the data).
-        csv_flexible: Allow variable-length CSV records. When True (default) a
-            row whose field count differs from the header is recovered and
-            counted in ``report.ragged_row_count``; False raises ValueError on
-            the first such row.
+        csv_flexible: Allow variable-length CSV records. Applies to file and
+            async inputs, where True (default) recovers a row whose field count
+            differs from the header and counts it in
+            ``report.ragged_row_count``, and False raises ValueError on the
+            first such row. CSV bytes are always parsed strictly, and
+            ``engine="columnar"`` does not report the count.
         jsonl_on_error: How to handle a malformed JSON/JSONL record, applied
             identically to file, bytes, and async byte inputs: "skip" (default)
             skips it, counts it in ``report.execution.error_count``, and returns

--- a/python/tests/test_ragged_csv_policy.py
+++ b/python/tests/test_ragged_csv_policy.py
@@ -1,0 +1,155 @@
+"""Ragged CSV policy parity across file, bytes, and async inputs (#418, #462).
+
+A row whose field count differs from the header is a structural violation. The
+shipped policy per transport is deliberately not uniform, and this file is the
+record of which difference is intended:
+
+===================  ==========================================================
+file (auto/columnar) recover, count in ``execution.ragged_row_count``
+async bytes / URL    recover, count — same signal as the file path
+sync bytes           reject with a ValueError naming the row (no flexible
+                     engine behind the pure-Python bytes reader)
+``csv_flexible``     ``False`` rejects on file *and* async paths
+===================  ==========================================================
+
+What no path may do is recover silently: a repaired scan must never report as a
+clean one. Every rejection is a ``ValueError`` — malformed data is bad input,
+the same category as malformed JSON — and carries the field counts rather than
+being buried under "all engines failed". The async cases are skipped when the
+extension is built without async support.
+
+Run after building the extension:
+    maturin develop --features python,python-async,async-streaming
+    pytest python/tests/test_ragged_csv_policy.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import dataprof as dp
+import pytest
+
+# Row 2 is short (2 fields), row 3 is over-long (4 fields); both differ from the
+# 3-column header, so both count.
+RAGGED = b"name,age,city\nAlice,25,NYC\nBob,30\nCarol,35,LA,EXTRA\nDave,40,SF\n"
+CLEAN = b"name,age,city\nAlice,25,NYC\nBob,30,LA\n"
+
+_HAS_ASYNC = dp.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+
+def _write(tmp_path: Path, data: bytes) -> str:
+    target = tmp_path / "data.csv"
+    target.write_bytes(data)
+    return str(target)
+
+
+def _async_bytes(data: bytes, **kwargs):
+    from dataprof.asyncio import profile_bytes
+
+    async def _inner():
+        return await profile_bytes(data, format="csv", **kwargs)
+
+    return asyncio.run(_inner())
+
+
+# --- Recovering paths count what they repaired ------------------------------
+
+
+def test_file_recovers_and_counts(tmp_path):
+    report = dp.profile(_write(tmp_path, RAGGED))
+    assert report.rows == 4
+    assert report.ragged_row_count == 2
+
+
+@requires_async
+def test_async_bytes_recover_and_count():
+    report = _async_bytes(RAGGED)
+    assert report.rows == 4
+    assert report.ragged_row_count == 2
+    assert report.to_dict()["execution"]["ragged_row_count"] == 2
+
+
+@requires_async
+def test_async_bytes_match_the_file_path(tmp_path):
+    from_file = dp.profile(_write(tmp_path, RAGGED))
+    from_async = _async_bytes(RAGGED)
+    assert from_async.rows == from_file.rows
+    assert from_async.ragged_row_count == from_file.ragged_row_count
+
+
+# --- Clean input stays clean ------------------------------------------------
+
+
+def test_file_clean_reports_zero(tmp_path):
+    assert dp.profile(_write(tmp_path, CLEAN)).ragged_row_count == 0
+
+
+def test_bytes_clean_reports_zero():
+    assert dp.profile(CLEAN, format="csv").ragged_row_count == 0
+
+
+@requires_async
+def test_async_bytes_clean_reports_zero():
+    report = _async_bytes(CLEAN)
+    assert report.rows == 2
+    assert report.ragged_row_count == 0
+    assert report.error_count == 0
+
+
+# --- Rejecting paths --------------------------------------------------------
+
+
+def test_sync_bytes_reject_and_point_at_the_flexible_engine():
+    with pytest.raises(ValueError) as excinfo:
+        dp.profile(RAGGED, format="csv")
+    message = str(excinfo.value)
+    assert "row 3" in message, message
+    assert "csv_flexible" in message, message
+
+
+def test_file_csv_flexible_false_rejects(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        dp.profile(_write(tmp_path, RAGGED), csv_flexible=False)
+    message = str(excinfo.value)
+    assert "3 fields" in message, message
+    # Strict parsing opts out of recovery, so the auto engine must not retry
+    # under a second parser and lose the diagnostic.
+    assert "All engines failed" not in message, message
+
+
+@requires_async
+def test_async_bytes_csv_flexible_false_rejects():
+    # Previously accepted and ignored on this path: a caller asking for strict
+    # parsing got a repaired report instead of an error.
+    with pytest.raises(ValueError) as excinfo:
+        _async_bytes(RAGGED, csv_flexible=False)
+    assert "csv_flexible" in str(excinfo.value)
+
+
+# --- Delimiter is a property of the data, not of the transport --------------
+
+
+@requires_async
+def test_async_detects_the_same_delimiter_as_the_file_path(tmp_path):
+    # The async reader used to assume a comma, collapsing a semicolon source
+    # into one column that profiled as perfectly clean.
+    semicolon = b"name;age;city\nAlice;25;NYC\nBob;30;LA\n"
+    from_file = dp.profile(_write(tmp_path, semicolon))
+    from_async = _async_bytes(semicolon)
+
+    assert from_async.columns == from_file.columns == 3
+    assert from_async.rows == from_file.rows == 2
+
+
+@requires_async
+def test_async_honors_explicit_delimiter():
+    report = _async_bytes(b"a|b|c\n1|2|3\n", csv_delimiter="|")
+    assert report.columns == 3
+    assert report.rows == 1

--- a/python/tests/test_ragged_csv_policy.py
+++ b/python/tests/test_ragged_csv_policy.py
@@ -4,19 +4,21 @@ A row whose field count differs from the header is a structural violation. The
 shipped policy per transport is deliberately not uniform, and this file is the
 record of which difference is intended:
 
-===================  ==========================================================
-file (auto/columnar) recover, count in ``execution.ragged_row_count``
-async bytes / URL    recover, count — same signal as the file path
-sync bytes           reject with a ValueError naming the row (no flexible
-                     engine behind the pure-Python bytes reader)
-``csv_flexible``     ``False`` rejects on file *and* async paths
-===================  ==========================================================
+====================  =========================================================
+file (auto/increm.)   recover, count in ``execution.ragged_row_count``
+async bytes / URL     recover, count — same signal as the file path
+sync bytes            reject with a ValueError naming the row (no flexible
+                      engine behind the pure-Python bytes reader)
+``csv_flexible``      ``False`` rejects on file *and* async paths
+``engine="columnar"`` **not covered** — rejects extra fields, but pads missing
+                      ones and still reports 0. Tracked in #470.
+====================  =========================================================
 
-What no path may do is recover silently: a repaired scan must never report as a
-clean one. Every rejection is a ``ValueError`` — malformed data is bad input,
-the same category as malformed JSON — and carries the field counts rather than
-being buried under "all engines failed". The async cases are skipped when the
-extension is built without async support.
+What no covered path may do is recover silently: a repaired scan must never
+report as a clean one. Every rejection is a ``ValueError`` — malformed data is
+bad input, the same category as malformed JSON — and carries the field counts
+rather than being buried under "all engines failed". The async cases are skipped
+when the extension is built without async support.
 
 Run after building the extension:
     maturin develop --features python,python-async,async-streaming
@@ -82,6 +84,29 @@ def test_async_bytes_match_the_file_path(tmp_path):
     from_async = _async_bytes(RAGGED)
     assert from_async.rows == from_file.rows
     assert from_async.ragged_row_count == from_file.ragged_row_count
+
+
+# --- The columnar engine is a documented gap, not a covered path ------------
+
+
+def test_columnar_rejects_extra_fields(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        dp.profile(_write(tmp_path, RAGGED), engine="columnar")
+    assert "incorrect number of fields" in str(excinfo.value)
+
+
+def test_columnar_pads_missing_fields_without_counting(tmp_path):
+    # Pins the #470 gap rather than endorsing it: the Arrow backend pads a short
+    # row to null and reports a clean parse, so `engine="columnar"` is still a
+    # silent-clean path. When #470 lands this assertion must flip to 1 and the
+    # policy table at the top of this module must be updated with it.
+    short_only = b"name,age,city\nAlice,25,NYC\nBob,30\n"
+    report = dp.profile(_write(tmp_path, short_only), engine="columnar")
+
+    assert report.rows == 2
+    assert report.ragged_row_count == 0
+    # The default path sees the same file honestly.
+    assert dp.profile(_write(tmp_path, short_only)).ragged_row_count == 1
 
 
 # --- Clean input stays clean ------------------------------------------------

--- a/tests/async_streaming.rs
+++ b/tests/async_streaming.rs
@@ -330,6 +330,73 @@ async fn test_profiler_profile_url_csv() {
     server.join();
 }
 
+/// The delimiter is a property of the data, not of the transport: a
+/// semicolon-separated source must profile the same read from disk or off a
+/// stream. Previously the async reader always assumed a comma, collapsing such
+/// a source into a single column. #462.
+#[tokio::test]
+async fn test_async_delimiter_matches_the_file_path() {
+    let body = "name;age;city\nAlice;25;NYC\nBob;30;LA\n";
+
+    let mut tmp = tempfile::NamedTempFile::with_suffix(".csv").unwrap();
+    write!(tmp, "{body}").unwrap();
+    tmp.flush().unwrap();
+    let from_file = Profiler::new().analyze_file(tmp.path()).unwrap();
+
+    let source = BytesSource::new(
+        bytes::Bytes::from(body),
+        AsyncSourceInfo::new("semicolon", FileFormat::Csv),
+    );
+    let from_stream = Profiler::new().profile_stream(source).await.unwrap();
+
+    assert_eq!(from_file.column_profiles.len(), 3);
+    assert_eq!(
+        from_stream.column_profiles.len(),
+        from_file.column_profiles.len(),
+        "async must detect the same delimiter as the file path"
+    );
+    assert_eq!(
+        from_stream.execution.rows_processed,
+        from_file.execution.rows_processed
+    );
+}
+
+/// An explicit delimiter was accepted and ignored on the async path.
+#[tokio::test]
+async fn test_async_explicit_delimiter_is_honored() {
+    let source = BytesSource::new(
+        bytes::Bytes::from_static(b"a|b|c\n1|2|3\n"),
+        AsyncSourceInfo::new("piped", FileFormat::Csv),
+    );
+
+    let report = Profiler::new()
+        .csv_delimiter(b'|')
+        .profile_stream(source)
+        .await
+        .unwrap();
+
+    assert_eq!(report.column_profiles.len(), 3);
+    assert_eq!(report.execution.rows_processed, 1);
+}
+
+/// A remote CSV rides the same async reader as byte streams, so a ragged
+/// download must carry the same structural signal rather than looking clean
+/// because it arrived over HTTP. #462.
+#[tokio::test]
+async fn test_profiler_profile_url_counts_ragged_rows() {
+    let server = spawn_csv_server(b"city,pop\nRome,2873\nMilan\nTurin,886,EXTRA\n");
+
+    let report = Profiler::new().profile_url(server.url()).await.unwrap();
+
+    assert_eq!(report.execution.rows_processed, 3);
+    assert_eq!(
+        report.execution.ragged_row_count, 2,
+        "a ragged remote CSV must not profile as clean"
+    );
+
+    server.join();
+}
+
 #[cfg(not(feature = "parquet-async"))]
 #[tokio::test]
 async fn test_profiler_profile_url_rejects_parquet_without_feature() {

--- a/tests/ragged_rows.rs
+++ b/tests/ragged_rows.rs
@@ -4,7 +4,7 @@
 //! (extra fields dropped, missing fields padded to null), but a recovered row
 //! is not a clean row. `execution.ragged_row_count` is the honest answer to
 //! "did parsing silently go wrong?" — it must be nonzero for broken input and
-//! zero for well-formed input. Guards #418.
+//! zero for well-formed input. Guards #418 and #462.
 
 use std::io::Write;
 
@@ -61,4 +61,88 @@ fn truly_broken_example_is_not_reported_clean() {
         "truly_broken.csv must surface a structural-violation signal, got {}",
         report.execution.ragged_row_count
     );
+}
+
+#[test]
+fn strict_file_parsing_keeps_its_own_diagnostic() {
+    // Asking for strict parsing opts out of recovery, so the auto engine must
+    // not retry under a second parser and replace the actionable CSV error
+    // with "all engines failed".
+    let csv = write_csv("name,age,city\nAlice,25,NYC\nBob,30\n");
+
+    let err = Profiler::new()
+        .csv_flexible(false)
+        .analyze_file(csv.path())
+        .expect_err("strict parsing must reject a ragged record");
+
+    let message = err.to_string();
+    assert!(
+        !message.contains("All engines failed"),
+        "a deterministic parse rejection must not be buried: {message}"
+    );
+    assert!(message.contains("3 fields"), "unexpected error: {message}");
+}
+
+/// Async byte streams follow the same policy as the default file path: recover
+/// the row, count it. The two transports must not disagree about the same
+/// bytes, or a caller can launder a broken source through the async API. #462.
+#[cfg(feature = "async-streaming")]
+mod async_parity {
+    use super::write_csv;
+
+    use dataprof::{AsyncSourceInfo, BytesSource, FileFormat, Profiler};
+
+    const RAGGED: &[u8] = b"name,age,city\nAlice,25,NYC\nBob,30\nCarol,35,LA,EXTRA\nDave,40,SF\n";
+    const CLEAN: &[u8] = b"name,age,city\nAlice,25,NYC\nBob,30,LA\n";
+
+    fn source(data: &'static [u8]) -> BytesSource {
+        BytesSource::new(
+            bytes::Bytes::from_static(data),
+            AsyncSourceInfo::new("ragged-parity", FileFormat::Csv)
+                .size_hint(Some(data.len() as u64)),
+        )
+    }
+
+    #[tokio::test]
+    async fn async_bytes_match_the_file_path_ragged_count() {
+        let file = write_csv(std::str::from_utf8(RAGGED).unwrap());
+        let from_file = Profiler::new().analyze_file(file.path()).unwrap();
+        let from_stream = Profiler::new()
+            .profile_stream(source(RAGGED))
+            .await
+            .unwrap();
+
+        assert_eq!(from_file.execution.ragged_row_count, 2);
+        assert_eq!(
+            from_stream.execution.ragged_row_count, from_file.execution.ragged_row_count,
+            "async bytes and the file path must agree on the same input"
+        );
+        assert_eq!(
+            from_stream.execution.rows_processed,
+            from_file.execution.rows_processed
+        );
+    }
+
+    #[tokio::test]
+    async fn async_bytes_report_clean_input_as_clean() {
+        let report = Profiler::new().profile_stream(source(CLEAN)).await.unwrap();
+        assert_eq!(report.execution.ragged_row_count, 0);
+        assert_eq!(report.execution.error_count, 0);
+    }
+
+    #[tokio::test]
+    async fn async_bytes_honor_csv_flexible_false() {
+        // The option was previously accepted and ignored on this path; a caller
+        // asking for strict parsing must get a rejection, not a repaired report.
+        let err = Profiler::new()
+            .csv_flexible(false)
+            .profile_stream(source(RAGGED))
+            .await
+            .expect_err("strict parsing must reject a ragged record");
+
+        assert!(
+            err.to_string().contains("csv_flexible"),
+            "strict failure must name the recovering option: {err}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #462.

## What was wrong

The async CSV reader recovered ragged rows — extra fields dropped, missing ones padded to null — while reporting `ragged_row_count: 0`, `error_count: 0` and a perfect consistency score. It was the last silent-clean path after #418/#457/#458, and `docs/release-notes.md` already documented it as a 0.10 blocker.

Two adjacent silent-ignores on the same path, folded in rather than deferred:

- `csv_flexible=False` was accepted and ignored — strict parsing repaired rows anyway.
- `csv_delimiter` was accepted and ignored, and no detection ran, so the reader always assumed a comma. A semicolon or tab stream collapsed into a single column and profiled as perfectly clean.

## Policy

Async recovers and counts, matching the incremental file path — the transport can no longer launder a broken source.

| Path | Ragged input |
|---|---|
| file (auto/incremental) | recovers, `ragged_row_count=2` |
| async bytes / URL | recovers, `ragged_row_count=2` |
| columnar | rejects |
| sync bytes | rejects (pure-Python reader, no flexible engine) |
| any path, `csv_flexible=False` | rejects |

The file-vs-sync-bytes difference is pre-existing and intentional; it is now pinned by tests and stated in the release notes.

## Changes

- `async_reader.rs` — the reader task returns a `ReaderOutcome` carrying both `malformed_records` (JSON) and `ragged_rows` (CSV). Ragged records are counted before rows are queued, so the signal covers every record read rather than only sampled ones, matching where the incremental engine counts. Alignment is unchanged — `process_record` already pads and truncates against the header.
- `async_reader.rs` — `csv_flexible` and `csv_delimiter` builders. With no delimiter set, the head of the stream is sniffed and chained back in front of the parser, using the same 4 KiB sample and scoring as the file path.
- `profiler.rs` — both options forwarded through `profile_stream`, which covers the Rust facade, `dataprof.asyncio.profile_bytes`, and `profile_url`.
- `errors.rs` — `CsvParsingError` joins `JsonParsingError` in the `ValueError` arm. Malformed data of either format is bad input, and callers could not previously catch it as one category.
- `adaptive.rs` — a `CsvParsingError` under `csv_flexible=False` is returned as-is instead of being retried under the fallback parser and reported as `All engines failed: ...`. Strict parsing means opting out of recovery, so a second parser cannot help; this follows the existing `DuplicateColumnName` short-circuit.

## Tests

- 7 unit tests in `async_reader.rs`: counted, clean, strict-rejects, count stable across chunk boundaries (`channel_capacity(1)`), delimiter detected, explicit delimiter honored, and no rows lost when the source is longer than the sniff sample.
- `tests/ragged_rows.rs` — an `async_parity` module asserting file and async report identical counts for identical bytes, plus a test that a strict rejection is not buried under "all engines failed".
- `tests/async_streaming.rs` — URL ragged counting, and delimiter parity between file and stream.
- `python/tests/test_ragged_csv_policy.py` — 11 tests covering the full table above end to end.

## Verification

```
cargo fmt --all --check
cargo clippy --all --all-targets -- -D warnings
cargo clippy --all --all-targets --features async-streaming -- -D warnings
cargo test --features async-streaming          # 92 passed
cargo test -p dataprof-engines -p dataprof-csv -p dataprof-core --features dataprof-engines/async-streaming   # 173 passed
uv run pytest python/tests -q                  # 420 passed, 5 skipped
uv run ruff format python/ && uv run ruff check python/ && uv run ty check python/
```

## Notes for review

- `docs/release-notes.md` previously advertised the async path as a known blocker; rewritten, with new sections for the delimiter and `ValueError` changes.
- The `ValueError` remap is a behavior change for anyone catching `RuntimeError` around CSV parse failures. It is listed in the release notes.
