### PR TITLE
fix(execution): honor resource controls and correct provenance (#460)

### DIFF
--- a/crates/dataprof-core/src/sampling/chunk_size.rs
+++ b/crates/dataprof-core/src/sampling/chunk_size.rs
@@ -1,20 +1,33 @@
 use sysinfo::System;
 
+/// How much data a streaming engine reads per chunk.
+///
+/// **The unit is bytes, everywhere.** Chunk size bounds how much of the source
+/// is resident at once, so it is expressed in the unit that actually bounds
+/// memory rather than in rows, whose width varies per dataset. Every engine and
+/// binding agrees: `ChunkSize::Fixed(65_536)` and Python's `chunk_size=65536`
+/// both mean 64 KiB per chunk, whether the source is a file, a byte stream, or
+/// a URL.
+///
+/// Chunk size never changes *what* a profile contains — only the granularity at
+/// which the source is read, progress is emitted, and chunk-level stop
+/// conditions are evaluated.
 #[derive(Debug, Clone, Default)]
 pub enum ChunkSize {
-    /// Fixed chunk size in rows
+    /// Fixed chunk size in **bytes**.
     Fixed(usize),
 
-    /// Adaptive based on available memory
+    /// Derive a chunk size from the memory limit and the size of the source.
     #[default]
     Adaptive,
 
-    /// Custom sizing function - cannot derive Debug/Clone with function pointer
+    /// Custom sizing function, given the source size in bytes and returning a
+    /// chunk size in bytes. Cannot derive Debug/Clone with a function pointer.
     Custom(fn(u64) -> usize),
 }
 
 impl ChunkSize {
-    /// Calculate optimal chunk size based on available memory and file size
+    /// Resolve to a concrete chunk size in bytes for a source of the given size.
     pub fn calculate(&self, file_size_bytes: u64) -> usize {
         match self {
             ChunkSize::Fixed(size) => *size,
@@ -30,23 +43,16 @@ impl ChunkSize {
         let available_memory = system.available_memory();
 
         // Use max 10% of available memory for each chunk
-        let memory_per_chunk = (available_memory / 10).max(64 * 1024 * 1024); // Min 64MB
-
-        // Estimate rows per MB (rough heuristic: 1KB per row average)
-        let estimated_row_size = 1024;
-        let rows_per_chunk = (memory_per_chunk / estimated_row_size) as usize;
+        let bytes_per_chunk = (available_memory / 10).max(64 * 1024 * 1024) as usize; // Min 64MB
 
         // Adjust based on file size
         let file_size_mb = file_size_bytes / (1024 * 1024);
 
-        if file_size_mb < 100 {
-            // Small files: process all at once
-            rows_per_chunk * 10
-        } else if file_size_mb > 10_000 {
+        if file_size_mb > 10_000 {
             // Very large files: smaller chunks to avoid memory pressure
-            rows_per_chunk / 2
+            bytes_per_chunk / 2
         } else {
-            rows_per_chunk
+            bytes_per_chunk
         }
     }
 }

--- a/crates/dataprof-core/src/sampling/chunk_size.rs
+++ b/crates/dataprof-core/src/sampling/chunk_size.rs
@@ -17,7 +17,13 @@ pub enum ChunkSize {
     /// Fixed chunk size in **bytes**.
     Fixed(usize),
 
-    /// Derive a chunk size from the memory limit and the size of the source.
+    /// Let the engine choose the chunk size (default).
+    ///
+    /// Each engine resolves this against what it knows: the incremental engine
+    /// derives a size from its memory limit and the file size, while the async
+    /// reader — whose source has no length to adapt to — uses a fixed working-set
+    /// target. Unlike [`Fixed`](Self::Fixed), the resulting size is not a
+    /// guarantee, so it is not something to assert against.
     #[default]
     Adaptive,
 
@@ -28,6 +34,12 @@ pub enum ChunkSize {
 
 impl ChunkSize {
     /// Resolve to a concrete chunk size in bytes for a source of the given size.
+    ///
+    /// This is a standalone helper, not the path any engine takes: `Fixed` and
+    /// `Custom` resolve exactly as an engine would, but `Adaptive` here is
+    /// derived from *system* available memory, whereas an engine derives it
+    /// from its own configured memory limit. Do not use this to predict what an
+    /// engine will do with `Adaptive`.
     pub fn calculate(&self, file_size_bytes: u64) -> usize {
         match self {
             ChunkSize::Fixed(size) => *size,
@@ -36,6 +48,7 @@ impl ChunkSize {
         }
     }
 
+    /// Derive a chunk size from system available memory and the source size.
     fn adaptive_size(&self, file_size_bytes: u64) -> usize {
         let mut system = System::new_all();
         system.refresh_memory();

--- a/crates/dataprof-engines/src/adaptive.rs
+++ b/crates/dataprof-engines/src/adaptive.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use dataprof_core::{DataProfilerError, MetricPack, QualityDimension, SemanticHints};
+use dataprof_core::{ChunkSize, DataProfilerError, MetricPack, QualityDimension, SemanticHints};
 use dataprof_csv::CsvParserConfig;
 use dataprof_runtime::ProfileReport;
 
@@ -26,6 +26,8 @@ pub struct AdaptiveProfiler {
     csv_config: Option<CsvParserConfig>,
     locale: Option<String>,
     semantic_hints: SemanticHints,
+    memory_limit_mb: Option<usize>,
+    chunk_size: Option<ChunkSize>,
 }
 
 impl AdaptiveProfiler {
@@ -36,7 +38,21 @@ impl AdaptiveProfiler {
             csv_config: None,
             locale: None,
             semantic_hints: SemanticHints::default(),
+            memory_limit_mb: None,
+            chunk_size: None,
         }
+    }
+
+    /// Set the memory limit, in MB, passed on to whichever engine is selected.
+    pub fn memory_limit_mb(mut self, limit: usize) -> Self {
+        self.memory_limit_mb = Some(limit);
+        self
+    }
+
+    /// Set the per-chunk read size, in bytes, for the streaming engine.
+    pub fn chunk_size(mut self, chunk_size: ChunkSize) -> Self {
+        self.chunk_size = Some(chunk_size);
+        self
     }
 
     pub fn quality_dimensions(mut self, dims: Vec<QualityDimension>) -> Self {
@@ -232,11 +248,20 @@ impl AdaptiveProfiler {
                 if let Some(ref l) = self.locale {
                     profiler = profiler.locale(l.clone());
                 }
+                if let Some(mb) = self.memory_limit_mb {
+                    profiler = profiler.memory_limit_mb(mb);
+                }
                 profiler = profiler.semantic_hints(self.semantic_hints.clone());
                 profiler.analyze_csv_file(file_path)
             }
             InternalEngineType::Incremental => {
                 let mut profiler = IncrementalProfiler::new();
+                if let Some(mb) = self.memory_limit_mb {
+                    profiler = profiler.memory_limit_mb(mb);
+                }
+                if let Some(ref cs) = self.chunk_size {
+                    profiler = profiler.chunk_size(cs.clone());
+                }
                 if let Some(ref dims) = self.quality_dimensions {
                     profiler = profiler.quality_dimensions(dims.clone());
                 }

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -70,6 +70,10 @@ pub struct AsyncStreamingProfiler {
 /// delimiter whether it is read from disk or off a socket.
 const DELIMITER_SAMPLE_BYTES: u64 = 4096;
 
+/// Bytes per chunk when [`ChunkSize::Adaptive`] is in effect. A stream has no
+/// size to adapt to, so this is a fixed working-set target.
+const DEFAULT_CHUNK_BYTES: usize = 512 * 1024;
+
 impl AsyncStreamingProfiler {
     pub fn new() -> Self {
         Self {
@@ -187,7 +191,7 @@ impl AsyncStreamingProfiler {
         let start = std::time::Instant::now();
         let reader = source.into_async_read().await?;
 
-        let rows_per_chunk = self.rows_per_chunk();
+        let bytes_per_chunk = self.bytes_per_chunk();
         let (tx, rx) = mpsc::channel::<ParsedChunk>(self.channel_capacity);
 
         // Bridge the AsyncRead into a sync Read for parsing.
@@ -200,11 +204,15 @@ impl AsyncStreamingProfiler {
         let csv_flexible = self.csv_flexible;
         let csv_delimiter = self.csv_delimiter;
         let reader_handle = tokio::task::spawn_blocking(move || match format {
-            FileFormat::Csv => {
-                Self::reader_task(sync_reader, tx, rows_per_chunk, csv_flexible, csv_delimiter)
-            }
+            FileFormat::Csv => Self::reader_task(
+                sync_reader,
+                tx,
+                bytes_per_chunk,
+                csv_flexible,
+                csv_delimiter,
+            ),
             FileFormat::Json | FileFormat::Jsonl => {
-                Self::json_reader_task(sync_reader, tx, rows_per_chunk, format, json_error_policy)
+                Self::json_reader_task(sync_reader, tx, bytes_per_chunk, format, json_error_policy)
                     .map(|malformed_records| ReaderOutcome {
                         malformed_records,
                         ragged_rows: 0,
@@ -275,9 +283,19 @@ impl AsyncStreamingProfiler {
             last_record_at: None,
         };
 
+        // A scan that ran to the end of a source of known length consumed
+        // exactly that many bytes. The per-chunk tally is the best available
+        // answer for a bounded scan, but it is derived from parsed records and
+        // would otherwise leave a complete scan reporting fewer bytes than the
+        // source holds.
+        let bytes_consumed = match (truncation_reason.is_none(), source_info.size_hint) {
+            (true, Some(total)) => total,
+            _ => total_bytes,
+        };
+
         let mut execution = ExecutionMetadata::new(sampled_rows, num_columns, scan_time_ms)
             .with_engine("incremental")
-            .with_bytes_consumed(total_bytes)
+            .with_bytes_consumed(bytes_consumed)
             // Tolerant JSONL scans surface skipped malformed records so callers
             // can distinguish a partial profile from a clean one.
             .with_error_count(reader_outcome.malformed_records)
@@ -332,7 +350,7 @@ impl AsyncStreamingProfiler {
             std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
         >,
         tx: mpsc::Sender<ParsedChunk>,
-        rows_per_chunk: usize,
+        bytes_per_chunk: usize,
         flexible: bool,
         delimiter: Option<u8>,
     ) -> Result<ReaderOutcome, DataProfilerError> {
@@ -370,22 +388,31 @@ impl AsyncStreamingProfiler {
 
         let header_fields: Vec<String> = headers.iter().map(|f| f.to_string()).collect();
         let header_len = header_fields.len();
+        // Byte counts come from the parser's own position rather than from the
+        // parsed fields: a record's fields exclude delimiters, quotes and line
+        // endings, so summing them under-reports every row and would leave
+        // `bytes_consumed` short of the source even on a complete scan.
+        let mut byte_offset = csv_reader.position().byte();
         let header_chunk = ParsedChunk {
             records: vec![header_fields],
-            bytes_read: 0,
+            bytes_read: byte_offset,
         };
         let mut outcome = ReaderOutcome::default();
         if tx.blocking_send(header_chunk).is_err() {
             return Ok(outcome);
         }
 
-        // Read data records in chunks
-        let mut current_chunk: Vec<Vec<String>> = Vec::with_capacity(rows_per_chunk);
+        // Read data records, emitting a chunk once it holds the configured
+        // number of bytes. Chunking by bytes rather than by a row count keeps
+        // the working set bounded regardless of how wide the rows are.
+        let mut current_chunk: Vec<Vec<String>> = Vec::new();
         let mut bytes_in_chunk: u64 = 0;
+        let mut record = csv::StringRecord::new();
 
-        for result in csv_reader.records() {
-            let record = result.map_err(|e| Self::csv_error(&e, flexible))?;
-
+        while csv_reader
+            .read_record(&mut record)
+            .map_err(|e| Self::csv_error(&e, flexible))?
+        {
             // A field count differing from the header is a structural violation.
             // Counted here, before the row is queued, so the signal covers every
             // record read rather than only the ones that survive sampling.
@@ -393,16 +420,16 @@ impl AsyncStreamingProfiler {
                 outcome.ragged_rows += 1;
             }
 
-            bytes_in_chunk += record.as_slice().len() as u64 + 1;
+            let position = csv_reader.position().byte();
+            bytes_in_chunk += position.saturating_sub(byte_offset);
+            byte_offset = position;
+
             let fields: Vec<String> = record.iter().map(|f| f.to_string()).collect();
             current_chunk.push(fields);
 
-            if current_chunk.len() >= rows_per_chunk {
+            if bytes_in_chunk as usize >= bytes_per_chunk {
                 let chunk = ParsedChunk {
-                    records: std::mem::replace(
-                        &mut current_chunk,
-                        Vec::with_capacity(rows_per_chunk),
-                    ),
+                    records: std::mem::take(&mut current_chunk),
                     bytes_read: bytes_in_chunk,
                 };
                 bytes_in_chunk = 0;
@@ -437,7 +464,7 @@ impl AsyncStreamingProfiler {
             std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
         >,
         tx: mpsc::Sender<ParsedChunk>,
-        rows_per_chunk: usize,
+        bytes_per_chunk: usize,
         format: FileFormat,
         error_policy: JsonErrorPolicy,
     ) -> Result<usize, DataProfilerError> {
@@ -446,7 +473,7 @@ impl AsyncStreamingProfiler {
 
         let mut buf_reader = std::io::BufReader::new(sync_reader);
         let mut known_columns: Vec<String> = Vec::new();
-        let mut current_chunk: Vec<Vec<String>> = Vec::with_capacity(rows_per_chunk);
+        let mut current_chunk: Vec<Vec<String>> = Vec::new();
         let mut known_columns_set: std::collections::HashSet<String> =
             std::collections::HashSet::new();
         let mut bytes_in_chunk: u64 = 0;
@@ -512,7 +539,7 @@ impl AsyncStreamingProfiler {
 
             if !chunk.is_empty() {
                 let data_chunk = ParsedChunk {
-                    records: std::mem::replace(chunk, Vec::with_capacity(rows_per_chunk)),
+                    records: std::mem::take(chunk),
                     bytes_read: *bytes,
                 };
                 *bytes = 0;
@@ -563,7 +590,7 @@ impl AsyncStreamingProfiler {
                         current_chunk.push(row);
                         emitted_records += 1;
 
-                        if current_chunk.len() >= rows_per_chunk
+                        if bytes_in_chunk as usize >= bytes_per_chunk
                             && !send_chunk(
                                 &mut current_chunk,
                                 &mut bytes_in_chunk,
@@ -651,7 +678,7 @@ impl AsyncStreamingProfiler {
                                     current_chunk.push(row);
                                     emitted_records += 1;
 
-                                    if current_chunk.len() >= rows_per_chunk
+                                    if bytes_in_chunk as usize >= bytes_per_chunk
                                         && !send_chunk(
                                             &mut current_chunk,
                                             &mut bytes_in_chunk,
@@ -781,11 +808,19 @@ impl AsyncStreamingProfiler {
         progress_tracker.emit_started(estimated_total_rows, size_hint);
         progress_tracker.emit_schema(headers.clone());
 
+        // A row cap is a hard ceiling on what the caller authorized us to
+        // analyze, so it is checked per row. Evaluating it only per chunk
+        // returned every row of the chunk that crossed it — up to a whole chunk
+        // more data than requested, while the report named the smaller limit.
+        let row_limit = self.stop_condition.max_rows();
+
         // Process data chunks
         while let Some(chunk) = rx.recv().await {
             total_bytes += chunk.bytes_read;
             let chunk_rows = chunk.records.len();
             let chunk_bytes = chunk.bytes_read;
+            let mut rows_consumed = chunk_rows;
+            let mut hit_row_limit = false;
 
             for (row_idx, values) in chunk.records.into_iter().enumerate() {
                 let global_row_idx = total_rows + row_idx;
@@ -800,9 +835,33 @@ impl AsyncStreamingProfiler {
 
                 column_stats.process_record(&headers, values);
                 sampled_rows += 1;
+
+                if let Some(limit) = row_limit
+                    && sampled_rows as u64 >= limit
+                {
+                    rows_consumed = row_idx + 1;
+                    hit_row_limit = true;
+                    break;
+                }
             }
 
-            total_rows += chunk_rows;
+            total_rows += rows_consumed;
+
+            if hit_row_limit {
+                // Reaching the cap is only a truncation if a row actually
+                // remained. Rows left in this chunk prove it outright;
+                // otherwise ask the reader for one more chunk, which resolves
+                // to `None` when the source is exhausted.
+                let more_rows_remain = rows_consumed < chunk_rows
+                    || rx.recv().await.is_some_and(|next| !next.records.is_empty());
+
+                if more_rows_remain {
+                    stop_eval.update(rows_consumed as u64, chunk_bytes, 0.0);
+                    truncation_reason = stop_eval.truncation_reason();
+                }
+                drop(rx);
+                break;
+            }
 
             // Check memory pressure
             if column_stats.is_memory_pressure() {
@@ -849,18 +908,14 @@ impl AsyncStreamingProfiler {
         ))
     }
 
-    /// Calculate rows per chunk based on ChunkSize config.
-    fn rows_per_chunk(&self) -> usize {
+    /// Bytes to accumulate per chunk, per the configured [`ChunkSize`].
+    ///
+    /// A stream does not know its own length, so `Custom` is called with `0`.
+    fn bytes_per_chunk(&self) -> usize {
         match self.chunk_size {
-            ChunkSize::Adaptive => 8192,
-            ChunkSize::Fixed(bytes) => {
-                // Estimate ~50 bytes per row on average
-                (bytes / 50).max(100)
-            }
-            ChunkSize::Custom(f) => {
-                // Use the custom function with a dummy file size (streams don't know size upfront)
-                f(0).max(100)
-            }
+            ChunkSize::Adaptive => DEFAULT_CHUNK_BYTES,
+            ChunkSize::Fixed(bytes) => bytes.max(1),
+            ChunkSize::Custom(f) => f(0).max(1),
         }
     }
 }

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -135,6 +135,7 @@ impl IncrementalProfiler {
         let mut ragged_rows = 0;
         let mut offset = 0u64;
         let mut source_exhausted = true;
+        let mut schema_stopped = false;
 
         // Extract the max_rows limit (if any) for per-row stop checking
         let row_limit = Self::extract_max_rows(&self.stop_condition);
@@ -262,8 +263,14 @@ impl IncrementalProfiler {
                 0.0
             };
 
+            // A condition that fires on the chunk which also finished the file
+            // has not truncated anything: the whole source was read. Reporting
+            // it as partial would make an exhaustive profile indistinguishable
+            // from a bounded one, which is what this metadata exists to answer.
+            let reached_eof = offset >= file_size_bytes;
+
             if stop_eval.update(records.len() as u64, actual_bytes as u64, memory_fraction) {
-                source_exhausted = false;
+                source_exhausted = reached_eof;
                 break;
             }
 
@@ -271,8 +278,11 @@ impl IncrementalProfiler {
             if let Some(ref mut tracker) = schema_tracker {
                 let fingerprint = column_stats.column_type_fingerprint();
                 if tracker.update(fingerprint, records.len() as u64) {
-                    stop_eval = StopEvaluator::new(StopCondition::Never); // prevent double-reason
-                    source_exhausted = false;
+                    // The tracker reports the reason; `stop_eval` keeps its
+                    // accumulated row and byte counters, which the report still
+                    // needs for `bytes_consumed`.
+                    schema_stopped = true;
+                    source_exhausted = reached_eof;
                     break;
                 }
             }
@@ -319,13 +329,15 @@ impl IncrementalProfiler {
             execution = execution.with_memory_peak_mb(peak_mb);
         }
 
-        // Apply stop condition truncation reason
-        if let Some(reason) = stop_eval.truncation_reason() {
-            execution = execution.with_truncation(reason);
-        } else if let Some(ref tracker) = schema_tracker
-            && !source_exhausted
-        {
-            execution = execution.with_truncation(tracker.truncation_reason());
+        // Apply the truncation reason — but only when something was actually
+        // left unread. A condition satisfied by the last chunk of a fully read
+        // file is not a truncation.
+        if !source_exhausted {
+            if let Some(reason) = stop_eval.truncation_reason() {
+                execution = execution.with_truncation(reason);
+            } else if schema_stopped && let Some(ref tracker) = schema_tracker {
+                execution = execution.with_truncation(tracker.truncation_reason());
+            }
         }
 
         // Determine if actual row-level sampling occurred (rows skipped by strategy)
@@ -373,7 +385,19 @@ impl IncrementalProfiler {
         condition.max_rows()
     }
 
+    /// Resolve the per-chunk read size in bytes.
+    ///
+    /// An explicitly configured size is honored as given: it is a resource
+    /// control, so silently substituting a computed size would make the option
+    /// a no-op. Only `Adaptive` derives a size from the memory limit and the
+    /// file.
     fn calculate_optimal_chunk_size(&self, file_size: u64) -> usize {
+        match self.chunk_size {
+            ChunkSize::Fixed(bytes) => return bytes.max(1),
+            ChunkSize::Custom(f) => return f(file_size).max(1),
+            ChunkSize::Adaptive => {}
+        }
+
         let max_memory_bytes = self.memory.limit_mb * 1024 * 1024;
 
         // Reserve memory for statistics (estimate)

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -613,7 +613,11 @@ impl Profiler {
                 if !matches!(self.config.stop_condition, StopCondition::Never) {
                     self.run_incremental(file_path, format)
                 } else {
-                    let mut profiler = AdaptiveProfiler::new();
+                    let mut profiler =
+                        AdaptiveProfiler::new().chunk_size(self.config.chunk_size.clone());
+                    if let Some(mb) = self.config.memory_limit_mb {
+                        profiler = profiler.memory_limit_mb(mb);
+                    }
                     if let Some(d) = &self.config.quality_dimensions {
                         profiler = profiler.quality_dimensions(d.clone());
                     }
@@ -679,6 +683,9 @@ impl Profiler {
             .sampling(self.config.sampling.clone())
             .stop_condition(self.config.stop_condition.clone())
             .progress(self.progress_sink.clone(), self.config.progress_interval);
+        if let Some(mb) = self.config.memory_limit_mb {
+            profiler = profiler.memory_limit_mb(mb);
+        }
         if let Some(d) = &self.config.quality_dimensions {
             profiler = profiler.quality_dimensions(d.clone());
         }

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -81,7 +81,7 @@ dp.profile(
     source,                          # str, Path, DataFrame, Arrow, dict, rows, or bytes
     *,
     engine="auto",                   # "auto", "incremental", "columnar"
-    chunk_size=None,                 # int -- custom chunk size
+    chunk_size=None,                 # int -- bytes per streaming chunk
     memory_limit_mb=None,            # int -- memory cap
     format=None,                     # str -- file format override
     max_rows=None,                   # int -- stop after N rows
@@ -248,7 +248,7 @@ Reusable configuration object:
 ```python
 config = dp.ProfilerConfig(
     engine="incremental",
-    chunk_size=5000,
+    chunk_size=65536,                # bytes per chunk
     memory_limit_mb=512,
     max_rows=100000,
     csv_delimiter=";",

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,54 @@
 # Unreleased
 
+## Execution controls take effect, and execution metadata tells the truth
+
+`chunk_size` and `memory_limit_mb` were accepted and then dropped on the paths
+that document them, so a resource control could be silently ineffective. Both
+now reach the engine that does the work:
+
+- The incremental engine honors an explicitly configured `chunk_size` instead of
+  always deriving one from the memory limit and file size.
+- `memory_limit_mb` is forwarded on the incremental and default (`auto`) paths,
+  not only on the explicit columnar and async ones.
+
+**`chunk_size` is measured in bytes, on every engine and in every binding.** The
+type documented rows while the async reader treated the value as bytes and the
+incremental engine ignored it; bytes is now the single unit, because it is what
+actually bounds the working set. Chunk size never changes the result of a
+complete scan — only read granularity, progress cadence, and the points at which
+chunk-level stop conditions are evaluated. Async callers who passed
+`ChunkSize::Fixed` see effectively no change, since that path already divided
+the value by an assumed row width.
+
+Stop conditions and the metadata they produce were also inconsistent:
+
+- **Row caps are hard caps.** `dataprof.asyncio` evaluated `max_rows` per chunk,
+  so a request for 123 rows could return 200 while the report named the limit of
+  123. Async CSV, JSON and JSONL now stop exactly at the cap.
+- **A condition met on the final chunk is not a truncation.** A confidence
+  threshold or `quality_sample()` preset satisfied by the last chunk of a fully
+  read file reported `source_exhausted: false` with a truncation reason, making
+  a complete profile indistinguishable from a bounded one. The same holds for a
+  row cap equal to the row count.
+- **Schema stability keeps its counters.** Stopping on `schema_stable` reset the
+  stop evaluator to suppress a duplicate reason, discarding the accumulated byte
+  count with it and reporting `bytes_consumed: 0` on a scan that had read
+  thousands of bytes.
+- **Async byte counts are no longer short.** They were summed from parsed
+  fields, which exclude delimiters, quotes and line endings, so even a complete
+  scan reported fewer bytes than the source held. CSV now counts from the
+  parser's own byte position, and a scan that reaches the end of a source of
+  known length reports that source's full size.
+
+Byte caps remain chunk-boundary caps: `bytes_consumed` may exceed `MaxBytes` by
+at most one chunk, a bound the caller controls through `chunk_size`. Row caps
+have no such allowance.
+
+`rows_processed`, `bytes_consumed`, `source_exhausted` and `truncation_reason`
+are now covered by invariant tests on both the sync and async paths — a
+truncated scan is exactly a non-exhausted one, and an exhausted scan accounts
+for every byte of its source.
+
 ## Ragged CSV rows leave a signal instead of vanishing
 
 A CSV row whose field count differs from the header — extra trailing fields, or

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -906,8 +906,13 @@ def profile_file(
     Args:
         path: File path to profile.
         engine: Engine to use ("auto", "incremental", "columnar").
-        chunk_size: Fixed chunk size for streaming (None = adaptive).
-        memory_limit_mb: Memory limit in MB.
+        chunk_size: Bytes to read per streaming chunk (None = adaptive).
+            Bounds the working set and the granularity at which progress
+            and stop conditions are evaluated; it never changes the
+            result of a complete scan.
+        memory_limit_mb: Memory limit in MB, applied by the incremental,
+            columnar and async engines. Bounds retained per-column state;
+            it does not drop rows.
         format: Override format detection ("csv", "json", "jsonl", "parquet").
         max_rows: Maximum rows to process before stopping.
         csv_delimiter: Single-character CSV delimiter (default: detected
@@ -1011,8 +1016,13 @@ def profile(
     Args:
         source: Data source to profile.
         engine: Engine to use ("auto", "incremental", "columnar").
-        chunk_size: Fixed chunk size for streaming (None = adaptive).
-        memory_limit_mb: Memory limit in MB.
+        chunk_size: Bytes to read per streaming chunk (None = adaptive).
+            Bounds the working set and the granularity at which progress
+            and stop conditions are evaluated; it never changes the
+            result of a complete scan.
+        memory_limit_mb: Memory limit in MB, applied by the incremental,
+            columnar and async engines. Bounds retained per-column state;
+            it does not drop rows.
         format: Override format detection ("csv", "json", "jsonl", "parquet").
         max_rows: Maximum rows to process before stopping.
         name: Name for DataFrame sources in the report.

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -1,0 +1,254 @@
+"""Execution controls take effect, and execution metadata tells the truth (#460).
+
+Two promises, checked across the sync and async entry points:
+
+1. ``chunk_size`` and ``memory_limit_mb`` reach the engine that does the work.
+   Both were previously accepted and dropped on the default and incremental
+   paths, so a resource control could be silently ineffective.
+2. ``rows``, ``bytes_consumed``, ``source_exhausted`` and ``truncation_reason``
+   agree with each other. These four fields are how an agent or quality gate
+   tells a complete profile from a bounded one, so they must never contradict.
+
+Units: ``chunk_size`` is **bytes**, everywhere. Row caps are hard caps. Byte
+caps are evaluated at chunk boundaries, so ``bytes_consumed`` may exceed the cap
+by at most one chunk — a bound the caller sets via ``chunk_size``.
+
+Run after building the extension:
+    maturin develop --features python,python-async,async-streaming
+    pytest python/tests/test_execution_controls.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import dataprof as dp
+import pytest
+
+_HAS_ASYNC = dp.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+
+def _write_csv(tmp_path: Path, rows: int) -> str:
+    target = tmp_path / "data.csv"
+    lines = ["id,name,value,category,ts"]
+    lines += [f"{i},name_{i},{i * 3},cat_{i % 7},2026-01-{(i % 28) + 1:02d}" for i in range(rows)]
+    target.write_text("\n".join(lines) + "\n")
+    return str(target)
+
+
+def _csv_bytes(rows: int) -> bytes:
+    body = "".join(f"{i},name_{i},{i * 3}\n" for i in range(rows))
+    return ("id,name,value\n" + body).encode()
+
+
+def _bytes_consumed(report) -> int:
+    return report.to_dict()["execution"].get("bytes_consumed") or 0
+
+
+def _assert_consistent(report, source_size: int, label: str) -> None:
+    """The invariants every report must satisfy, whatever produced it."""
+    assert report.source_exhausted == (report.truncation_reason is None), (
+        f"{label}: a truncated scan is exactly a non-exhausted one "
+        f"(exhausted={report.source_exhausted}, reason={report.truncation_reason})"
+    )
+    consumed = _bytes_consumed(report)
+    if report.source_exhausted:
+        assert consumed == source_size, f"{label}: an exhausted source consumed all its bytes"
+    else:
+        assert 0 < consumed <= source_size, f"{label}: consumed {consumed} of {source_size}"
+    if report.rows > 0:
+        assert consumed > 0, f"{label}: {report.rows} rows were read from 0 bytes"
+
+
+def _async_bytes(data: bytes, fmt: str = "csv", **kwargs):
+    from dataprof.asyncio import profile_bytes
+
+    async def _inner():
+        return await profile_bytes(data, format=fmt, **kwargs)
+
+    return asyncio.run(_inner())
+
+
+# --- Controls are not decorative --------------------------------------------
+
+
+def test_chunk_size_changes_where_a_byte_cap_lands(tmp_path):
+    path = _write_csv(tmp_path, 5_000)
+    small = dp.profile(
+        path, engine="incremental", chunk_size=4096, stop_condition=dp.StopCondition.max_bytes(2048)
+    )
+    large = dp.profile(
+        path,
+        engine="incremental",
+        chunk_size=65536,
+        stop_condition=dp.StopCondition.max_bytes(2048),
+    )
+    assert small.rows < large.rows, "a smaller chunk must stop sooner"
+
+
+def test_chunk_size_reaches_the_default_engine(tmp_path):
+    path = _write_csv(tmp_path, 5_000)
+    small = dp.profile(path, chunk_size=4096, stop_condition=dp.StopCondition.max_bytes(2048))
+    large = dp.profile(path, chunk_size=65536, stop_condition=dp.StopCondition.max_bytes(2048))
+    assert small.rows < large.rows, "engine='auto' must forward chunk_size"
+
+
+@pytest.mark.parametrize("chunk_size", [1024, 65536, None])
+def test_chunk_size_never_changes_a_complete_profile(tmp_path, chunk_size):
+    path = _write_csv(tmp_path, 2_000)
+    size = Path(path).stat().st_size
+
+    report = dp.profile(path, engine="incremental", chunk_size=chunk_size)
+
+    assert report.rows == 2_000
+    assert report.columns == 5
+    _assert_consistent(report, size, f"chunk_size={chunk_size}")
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental"])
+def test_memory_limit_reaches_the_engine(tmp_path, engine):
+    path = _write_csv(tmp_path, 20_000)
+    size = Path(path).stat().st_size
+
+    tight = dp.profile(path, engine=engine, memory_limit_mb=1)
+    loose = dp.profile(path, engine=engine, memory_limit_mb=64)
+
+    # The limit bounds retained state; it never drops rows.
+    assert tight.rows == loose.rows == 20_000
+    _assert_consistent(tight, size, f"{engine} tight")
+    _assert_consistent(loose, size, f"{engine} loose")
+
+
+# --- Provenance agrees with what happened -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        dp.StopCondition.confidence_threshold(0.9),
+        dp.StopCondition.schema_stable(50),
+        dp.StopCondition.quality_sample(),
+    ],
+)
+def test_condition_met_on_the_last_chunk_is_not_a_truncation(tmp_path, condition):
+    path = _write_csv(tmp_path, 5_000)
+    size = Path(path).stat().st_size
+
+    # One chunk larger than the file: the condition becomes true on the same
+    # chunk that finishes the source, so nothing was left unread.
+    report = dp.profile(path, engine="incremental", chunk_size=size * 2, stop_condition=condition)
+
+    assert report.rows == 5_000
+    assert report.source_exhausted, f"complete scan reported {report.truncation_reason}"
+    assert report.truncation_reason is None
+    _assert_consistent(report, size, "last-chunk condition")
+
+
+def test_genuine_early_stop_still_reports_truncation(tmp_path):
+    path = _write_csv(tmp_path, 5_000)
+    size = Path(path).stat().st_size
+
+    report = dp.profile(
+        path,
+        engine="incremental",
+        chunk_size=4096,
+        stop_condition=dp.StopCondition.confidence_threshold(0.9),
+    )
+
+    assert report.rows < 5_000
+    assert not report.source_exhausted
+    assert report.truncation_reason is not None
+    _assert_consistent(report, size, "early stop")
+
+
+def test_schema_stable_keeps_byte_provenance(tmp_path):
+    path = _write_csv(tmp_path, 5_000)
+    size = Path(path).stat().st_size
+
+    report = dp.profile(
+        path,
+        engine="incremental",
+        chunk_size=4096,
+        stop_condition=dp.StopCondition.schema_stable(50),
+    )
+
+    assert not report.source_exhausted
+    assert _bytes_consumed(report) > 0, "a stopped scan must account for the bytes it read"
+    _assert_consistent(report, size, "schema stable")
+
+
+@pytest.mark.parametrize("limit", [1, 123, 4999])
+def test_row_caps_are_hard_caps(tmp_path, limit):
+    path = _write_csv(tmp_path, 5_000)
+    size = Path(path).stat().st_size
+
+    report = dp.profile(path, engine="incremental", stop_condition=dp.StopCondition.max_rows(limit))
+
+    assert report.rows == limit, "max_rows must be exact, not approximate"
+    _assert_consistent(report, size, f"max_rows({limit})")
+
+
+def test_byte_cap_overshoot_is_bounded_by_one_chunk(tmp_path):
+    path = _write_csv(tmp_path, 5_000)
+    size = Path(path).stat().st_size
+
+    for chunk in (4096, 16384, 65536):
+        report = dp.profile(
+            path,
+            engine="incremental",
+            chunk_size=chunk,
+            stop_condition=dp.StopCondition.max_bytes(2048),
+        )
+        consumed = _bytes_consumed(report)
+        assert consumed <= 2048 + chunk, f"chunk {chunk}: consumed {consumed} for a 2048 cap"
+        _assert_consistent(report, size, f"byte cap, chunk {chunk}")
+
+
+# --- Async paths ------------------------------------------------------------
+
+
+@requires_async
+@pytest.mark.parametrize("fmt", ["csv", "jsonl", "json"])
+def test_async_row_caps_do_not_overshoot(fmt):
+    if fmt == "csv":
+        data = _csv_bytes(500)
+    elif fmt == "jsonl":
+        data = b"".join(b'{"id":%d,"v":"x%d"}\n' % (i, i) for i in range(500))
+    else:
+        data = b"[" + b",".join(b'{"id":%d,"v":"x%d"}' % (i, i) for i in range(500)) + b"]"
+
+    report = _async_bytes(data, fmt, chunk_size=1024, max_rows=123)
+
+    assert report.rows == 123, f"{fmt}: the cap must be exact, got {report.rows}"
+    assert report.truncation_reason == "max_rows(123)"
+    assert not report.source_exhausted
+
+
+@requires_async
+def test_async_row_cap_equal_to_the_row_count_is_complete():
+    data = _csv_bytes(123)
+
+    report = _async_bytes(data, max_rows=123)
+
+    assert report.rows == 123
+    assert report.source_exhausted, "the cap landed on the final row"
+    assert report.truncation_reason is None
+    _assert_consistent(report, len(data), "async exact-fit cap")
+
+
+@requires_async
+@pytest.mark.parametrize("chunk_size", [512, 65536, None])
+def test_async_chunk_size_never_changes_a_complete_profile(chunk_size):
+    data = _csv_bytes(2_000)
+
+    report = _async_bytes(data, chunk_size=chunk_size)
+
+    assert report.rows == 2_000
+    assert report.columns == 3
+    _assert_consistent(report, len(data), f"async chunk_size={chunk_size}")

--- a/tests/execution_controls.rs
+++ b/tests/execution_controls.rs
@@ -1,0 +1,455 @@
+//! Execution controls must take effect, and execution metadata must describe
+//! what actually happened. Guards #460.
+//!
+//! Two separate promises are covered here:
+//!
+//! 1. **Controls are not decorative.** `chunk_size` and `memory_limit_mb` reach
+//!    the engine that does the work, on every path that documents them.
+//! 2. **Provenance is self-consistent.** `rows_processed`, `bytes_consumed`,
+//!    `source_exhausted` and `truncation_reason` cannot contradict each other —
+//!    an agent or quality gate uses exactly these fields to tell a complete
+//!    profile from a bounded one.
+//!
+//! Row caps are hard caps: `rows_processed` never exceeds the limit. Byte caps
+//! are evaluated at chunk boundaries, so `bytes_consumed` may exceed the cap by
+//! at most one chunk — a bound the caller controls through `chunk_size`.
+
+use std::io::Write;
+
+use dataprof::{ChunkSize, EngineType, ProfileReport, Profiler, StopCondition};
+
+/// A CSV of `rows` data rows with a stable 5-column schema.
+fn write_csv(rows: usize) -> tempfile::NamedTempFile {
+    let mut file = tempfile::Builder::new().suffix(".csv").tempfile().unwrap();
+    writeln!(file, "id,name,value,category,ts").unwrap();
+    for i in 0..rows {
+        writeln!(
+            file,
+            "{i},name_{i},{},cat_{},2026-01-{:02}",
+            i * 3,
+            i % 7,
+            (i % 28) + 1
+        )
+        .unwrap();
+    }
+    file.flush().unwrap();
+    file
+}
+
+fn file_size(file: &tempfile::NamedTempFile) -> u64 {
+    std::fs::metadata(file.path()).unwrap().len()
+}
+
+/// The invariants every report must satisfy, whatever produced it.
+fn assert_provenance_consistent(report: &ProfileReport, source_size: u64, label: &str) {
+    let exec = &report.execution;
+
+    assert_eq!(
+        exec.source_exhausted,
+        exec.truncation_reason.is_none(),
+        "{label}: a truncated scan is exactly a non-exhausted one \
+         (exhausted={}, reason={:?})",
+        exec.source_exhausted,
+        exec.truncation_reason
+    );
+
+    let bytes = exec.bytes_consumed.unwrap_or(0);
+    if exec.source_exhausted {
+        assert_eq!(
+            bytes, source_size,
+            "{label}: an exhausted source consumed all of its bytes"
+        );
+    } else {
+        assert!(
+            bytes > 0,
+            "{label}: a truncated scan read something, so it cannot report 0 bytes"
+        );
+        assert!(
+            bytes <= source_size,
+            "{label}: consumed {bytes} of a {source_size}-byte source"
+        );
+    }
+
+    if exec.rows_processed > 0 {
+        assert!(
+            bytes > 0,
+            "{label}: {} rows were read from 0 bytes",
+            exec.rows_processed
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Controls take effect
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chunk_size_changes_where_a_byte_cap_lands() {
+    // With the cap far below any chunk, the stop lands at the first chunk
+    // boundary — so the configured chunk size is directly observable. When it
+    // was ignored, every value produced identical results.
+    let csv = write_csv(5_000);
+    let cap = StopCondition::MaxBytes(2_048);
+
+    let small = Profiler::new()
+        .engine(EngineType::Incremental)
+        .chunk_size(ChunkSize::Fixed(4_096))
+        .stop_when(cap.clone())
+        .analyze_file(csv.path())
+        .unwrap();
+
+    let large = Profiler::new()
+        .engine(EngineType::Incremental)
+        .chunk_size(ChunkSize::Fixed(65_536))
+        .stop_when(cap)
+        .analyze_file(csv.path())
+        .unwrap();
+
+    assert!(
+        small.execution.rows_processed < large.execution.rows_processed,
+        "a smaller chunk must stop sooner: {} vs {}",
+        small.execution.rows_processed,
+        large.execution.rows_processed
+    );
+    assert_provenance_consistent(&small, file_size(&csv), "small chunk");
+    assert_provenance_consistent(&large, file_size(&csv), "large chunk");
+}
+
+#[test]
+fn chunk_size_reaches_the_auto_engine_too() {
+    let csv = write_csv(5_000);
+    let cap = StopCondition::MaxBytes(2_048);
+
+    let small = Profiler::new()
+        .chunk_size(ChunkSize::Fixed(4_096))
+        .stop_when(cap.clone())
+        .analyze_file(csv.path())
+        .unwrap();
+    let large = Profiler::new()
+        .chunk_size(ChunkSize::Fixed(65_536))
+        .stop_when(cap)
+        .analyze_file(csv.path())
+        .unwrap();
+
+    assert!(
+        small.execution.rows_processed < large.execution.rows_processed,
+        "auto must forward chunk_size to the engine it selects"
+    );
+}
+
+#[test]
+fn chunk_size_never_changes_a_complete_profile() {
+    // Chunking is a read-granularity control, not a semantic one: a full scan
+    // must produce the same answer at every chunk size.
+    let csv = write_csv(2_000);
+    let sizes = [
+        ChunkSize::Fixed(1_024),
+        ChunkSize::Fixed(64 * 1024),
+        ChunkSize::Adaptive,
+    ];
+
+    let mut baseline: Option<(usize, usize, u64)> = None;
+    for size in sizes {
+        let report = Profiler::new()
+            .engine(EngineType::Incremental)
+            .chunk_size(size.clone())
+            .analyze_file(csv.path())
+            .unwrap();
+
+        assert_provenance_consistent(&report, file_size(&csv), &format!("{size:?}"));
+        assert!(report.execution.source_exhausted);
+
+        let observed = (
+            report.execution.rows_processed,
+            report.column_profiles.len(),
+            report.execution.bytes_consumed.unwrap_or(0),
+        );
+        match baseline {
+            None => baseline = Some(observed),
+            Some(expected) => assert_eq!(observed, expected, "{size:?} changed the result"),
+        }
+    }
+}
+
+#[test]
+fn memory_limit_reaches_the_incremental_and_auto_paths() {
+    // The limit bounds retained per-column state, so a tighter limit must not
+    // silently behave like no limit at all. It never changes the row count.
+    let csv = write_csv(20_000);
+
+    for engine in [EngineType::Auto, EngineType::Incremental] {
+        let tight = Profiler::new()
+            .engine(engine)
+            .memory_limit_mb(1)
+            .analyze_file(csv.path())
+            .unwrap();
+        let loose = Profiler::new()
+            .engine(engine)
+            .memory_limit_mb(64)
+            .analyze_file(csv.path())
+            .unwrap();
+
+        assert_eq!(
+            tight.execution.rows_processed, loose.execution.rows_processed,
+            "{engine:?}: a memory limit bounds state, it does not drop rows"
+        );
+        assert_provenance_consistent(&tight, file_size(&csv), "tight limit");
+        assert_provenance_consistent(&loose, file_size(&csv), "loose limit");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provenance agrees with what happened
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_condition_met_on_the_last_chunk_is_not_a_truncation() {
+    // The final chunk can satisfy a condition at the same moment it finishes
+    // the file. Nothing was left unread, so the report must not claim it was.
+    let csv = write_csv(5_000);
+    let whole_file = ChunkSize::Fixed(file_size(&csv) as usize * 2);
+
+    for condition in [
+        StopCondition::ConfidenceThreshold(0.9),
+        StopCondition::SchemaStable {
+            consecutive_stable_rows: 50,
+        },
+        StopCondition::quality_sample(),
+    ] {
+        let report = Profiler::new()
+            .engine(EngineType::Incremental)
+            .chunk_size(whole_file.clone())
+            .stop_when(condition.clone())
+            .analyze_file(csv.path())
+            .unwrap();
+
+        assert_eq!(
+            report.execution.rows_processed, 5_000,
+            "{condition:?}: the whole file was read"
+        );
+        assert!(
+            report.execution.source_exhausted,
+            "{condition:?}: a complete scan is not truncated, got {:?}",
+            report.execution.truncation_reason
+        );
+        assert_provenance_consistent(&report, file_size(&csv), &format!("{condition:?}"));
+    }
+}
+
+#[test]
+fn a_genuine_early_stop_still_reports_truncation() {
+    // The converse of the test above: shrinking the chunk so the condition
+    // fires well before EOF must still be reported as a bounded scan.
+    let csv = write_csv(5_000);
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .chunk_size(ChunkSize::Fixed(4_096))
+        .stop_when(StopCondition::ConfidenceThreshold(0.9))
+        .analyze_file(csv.path())
+        .unwrap();
+
+    assert!(report.execution.rows_processed < 5_000);
+    assert!(!report.execution.source_exhausted);
+    assert!(report.execution.truncation_reason.is_some());
+    assert_provenance_consistent(&report, file_size(&csv), "early confidence stop");
+}
+
+#[test]
+fn schema_stability_keeps_its_byte_counters() {
+    // The schema tracker fires from outside the stop evaluator; resetting the
+    // evaluator to suppress a duplicate reason used to discard the byte count
+    // with it, leaving `bytes_consumed: 0` on a scan that read thousands.
+    let csv = write_csv(5_000);
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .chunk_size(ChunkSize::Fixed(4_096))
+        .stop_when(StopCondition::SchemaStable {
+            consecutive_stable_rows: 50,
+        })
+        .analyze_file(csv.path())
+        .unwrap();
+
+    assert!(!report.execution.source_exhausted);
+    assert!(
+        report.execution.bytes_consumed.unwrap_or(0) > 0,
+        "a stopped scan must account for the bytes it read"
+    );
+    assert_provenance_consistent(&report, file_size(&csv), "schema stable");
+}
+
+#[test]
+fn row_caps_are_hard_caps() {
+    let csv = write_csv(5_000);
+
+    for limit in [1u64, 123, 4_999] {
+        let report = Profiler::new()
+            .engine(EngineType::Incremental)
+            .stop_when(StopCondition::MaxRows(limit))
+            .analyze_file(csv.path())
+            .unwrap();
+
+        assert_eq!(
+            report.execution.rows_processed as u64, limit,
+            "max_rows({limit}) must be exact, not approximate"
+        );
+        assert_provenance_consistent(&report, file_size(&csv), &format!("max_rows({limit})"));
+    }
+}
+
+#[test]
+fn a_row_cap_equal_to_the_row_count_is_a_complete_scan() {
+    let csv = write_csv(500);
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .stop_when(StopCondition::MaxRows(500))
+        .analyze_file(csv.path())
+        .unwrap();
+
+    assert_eq!(report.execution.rows_processed, 500);
+    assert!(
+        report.execution.source_exhausted,
+        "reaching the cap on the last row read everything"
+    );
+    assert_provenance_consistent(&report, file_size(&csv), "exact-fit row cap");
+}
+
+#[test]
+fn byte_caps_overshoot_by_at_most_one_chunk() {
+    // Byte caps are evaluated at chunk boundaries. That overshoot is allowed,
+    // but it is bounded by the chunk size the caller chose — not unbounded.
+    let csv = write_csv(5_000);
+
+    for chunk in [4_096usize, 16_384, 65_536] {
+        let cap = 2_048u64;
+        let report = Profiler::new()
+            .engine(EngineType::Incremental)
+            .chunk_size(ChunkSize::Fixed(chunk))
+            .stop_when(StopCondition::MaxBytes(cap))
+            .analyze_file(csv.path())
+            .unwrap();
+
+        let consumed = report.execution.bytes_consumed.unwrap_or(0);
+        assert!(
+            consumed <= cap + chunk as u64,
+            "chunk {chunk}: consumed {consumed} for a {cap}-byte cap, \
+             which exceeds the one-chunk bound"
+        );
+        assert_provenance_consistent(
+            &report,
+            file_size(&csv),
+            &format!("byte cap, chunk {chunk}"),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Async paths
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "async-streaming")]
+mod async_controls {
+    use super::assert_provenance_consistent;
+
+    use dataprof::{AsyncSourceInfo, BytesSource, ChunkSize, FileFormat, Profiler, StopCondition};
+
+    fn csv_bytes(rows: usize) -> Vec<u8> {
+        let mut data = String::from("id,name,value\n");
+        for i in 0..rows {
+            data.push_str(&format!("{i},name_{i},{}\n", i * 3));
+        }
+        data.into_bytes()
+    }
+
+    fn jsonl_bytes(rows: usize) -> Vec<u8> {
+        let mut data = String::new();
+        for i in 0..rows {
+            data.push_str(&format!("{{\"id\":{i},\"v\":\"x{i}\"}}\n"));
+        }
+        data.into_bytes()
+    }
+
+    fn source(data: Vec<u8>, format: FileFormat) -> BytesSource {
+        let len = data.len() as u64;
+        BytesSource::new(
+            bytes::Bytes::from(data),
+            AsyncSourceInfo::new("controls", format).size_hint(Some(len)),
+        )
+    }
+
+    /// A row cap must be exact on every async format. Evaluating it per chunk
+    /// returned a whole chunk more data than the caller authorized, while the
+    /// report named the smaller limit.
+    #[tokio::test]
+    async fn async_row_caps_do_not_overshoot() {
+        for (format, data) in [
+            (FileFormat::Csv, csv_bytes(500)),
+            (FileFormat::Jsonl, jsonl_bytes(500)),
+        ] {
+            let size = data.len() as u64;
+            let report = Profiler::new()
+                .chunk_size(ChunkSize::Fixed(1_024))
+                .stop_when(StopCondition::MaxRows(123))
+                .profile_stream(source(data, format.clone()))
+                .await
+                .unwrap();
+
+            assert_eq!(
+                report.execution.rows_processed, 123,
+                "{format:?}: the cap must be exact"
+            );
+            assert!(!report.execution.source_exhausted);
+            assert_provenance_consistent(&report, size, &format!("{format:?} row cap"));
+        }
+    }
+
+    #[tokio::test]
+    async fn async_row_cap_equal_to_the_row_count_is_complete() {
+        let data = csv_bytes(123);
+        let size = data.len() as u64;
+
+        let report = Profiler::new()
+            .stop_when(StopCondition::MaxRows(123))
+            .profile_stream(source(data, FileFormat::Csv))
+            .await
+            .unwrap();
+
+        assert_eq!(report.execution.rows_processed, 123);
+        assert!(
+            report.execution.source_exhausted,
+            "the cap landed on the final row, so nothing was left unread"
+        );
+        assert!(report.execution.truncation_reason.is_none());
+        assert_provenance_consistent(&report, size, "async exact-fit cap");
+    }
+
+    #[tokio::test]
+    async fn async_chunk_size_never_changes_a_complete_profile() {
+        let mut baseline: Option<(usize, usize)> = None;
+        for chunk in [
+            ChunkSize::Fixed(512),
+            ChunkSize::Fixed(64 * 1024),
+            ChunkSize::Adaptive,
+        ] {
+            let data = csv_bytes(2_000);
+            let size = data.len() as u64;
+            let report = Profiler::new()
+                .chunk_size(chunk.clone())
+                .profile_stream(source(data, FileFormat::Csv))
+                .await
+                .unwrap();
+
+            assert_provenance_consistent(&report, size, &format!("{chunk:?}"));
+            let observed = (
+                report.execution.rows_processed,
+                report.column_profiles.len(),
+            );
+            match baseline {
+                None => baseline = Some(observed),
+                Some(expected) => assert_eq!(observed, expected, "{chunk:?} changed the result"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #460.

Two independent promises were broken. Resource controls were accepted and then dropped, and the execution metadata that exists to distinguish a complete profile from a bounded one could contradict itself.

## Controls that did nothing

- **`chunk_size` was ignored by the incremental engine.** `calculate_optimal_chunk_size` never read `self.chunk_size`; every value produced identical chunk boundaries. It is now honored as configured, with `Adaptive` keeping the memory/file heuristic.
- **`memory_limit_mb` was not forwarded** to the incremental or auto paths, despite the Rust docs saying it applies to Incremental and Columnar. `AdaptiveProfiler` gained `memory_limit_mb` and `chunk_size` and passes both to the engine it selects.

### `chunk_size` is bytes, everywhere

The unit was genuinely ambiguous: `ChunkSize::Fixed`'s doc said rows, the async reader treated the value as bytes (`bytes / 50`), the incremental engine ignored it, and `ChunkSize::calculate()` — which also said rows — turned out to be dead code no engine calls. Bytes is now the single unit, since it is what actually bounds the working set.

Async callers see effectively no change (`Fixed(1024)` meant ~20 rows before via the ÷50 estimate, and means 1024 bytes now). The enum doc, the dead `adaptive_size` heuristic, the Python docstrings, and the Python README were all corrected to match.

Chunk size never changes the result of a complete scan — only read granularity, progress cadence, and where chunk-level conditions are evaluated. There is a test asserting exactly that.

## Metadata that lied

- **Async row caps overshot.** `max_rows` was evaluated per chunk, so a request for 123 rows returned 200 while `truncation_reason` said `max_rows(123)`. CSV, JSON and JSONL now stop exactly at the cap, matching the per-row check the incremental engine already had.
- **A condition met on the final chunk was reported as a truncation.** `confidence_threshold(0.9)` and the `quality_sample()` preset on a fully read file reported `source_exhausted: false` with a reason. If the same chunk that satisfies the condition also finishes the source, nothing was left unread.
- **Schema stability lost its byte counters.** The engine replaced `stop_eval` with a fresh `StopEvaluator::new(Never)` to avoid emitting a duplicate reason, discarding the accumulated counts — `bytes_consumed: 0` on a scan that had read 65 KB. Replaced with a flag, so the evaluator keeps its counters.
- **Async byte counts were systematically short.** They were summed from parsed fields via `StringRecord::as_slice()`, which excludes delimiters, quotes and line endings, and the header chunk was sent as 0 bytes — so a complete 1847-byte scan reported 1587. CSV now counts from the parser's own byte position, and a scan reaching the end of a source of known length reports that source's full size.

The last one was **not in the issue** — the invariant tests below caught it.

## Cap semantics, now stated

| Cap | Guarantee |
|---|---|
| `MaxRows` | hard cap; `rows_processed` never exceeds it |
| `MaxBytes` | chunk-boundary cap; `bytes_consumed` may exceed it by at most one chunk, a bound the caller sets via `chunk_size` |

## Tests

`tests/execution_controls.rs` (13) and `python/tests/test_execution_controls.py` (23) are table-driven over both paths, and share one `assert_provenance_consistent` helper asserting the invariants:

- `source_exhausted` ⟺ `truncation_reason.is_none()`
- exhausted ⇒ `bytes_consumed == source_size`
- truncated ⇒ `0 < bytes_consumed <= source_size`
- `rows_processed > 0` ⇒ `bytes_consumed > 0`

Every case in the issue is covered, plus the converse in each direction: a genuine early stop must still report truncation, and a row cap equal to the row count must not.

## Verification

```
cargo fmt --all --check
cargo clippy --all --all-targets -- -D warnings
cargo clippy --all --all-targets --features async-streaming -- -D warnings
cargo test --features async-streaming            # 100 passed across 9 targets
cargo test -p dataprof-core -p dataprof-engines -p dataprof-csv -p dataprof-runtime   # 224 passed
uv run pytest python/tests -q                    # 445 passed, 5 skipped
uv run ruff format python/ && uv run ruff check python/ && uv run ty check python/
```

Each of the issue's five reproductions was also run by hand against the built extension before and after.

## Note for review

The `chunk_size` unit is a public API semantic. Bytes was chosen deliberately over rows — rows would have been a 50x behavior change for existing async callers and would have required per-record byte accounting through a buffer the mmap reader rebuilds with `join("\n")`, which is the same accounting the `bytes_consumed` fix depends on. The decision is documented on the enum and in the release notes.
