### PR TITLE
fix(json): reject truncated final JSONL records

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -560,13 +560,34 @@ impl AsyncStreamingProfiler {
                 // record can be recovered from (skip to next line) or reported,
                 // matching the sync `scan_json_from_reader` contract.
                 loop {
+                    // Distinguish clean exhaustion from an incomplete trailing
+                    // value. serde reports both as `Category::Eof`, but only an
+                    // empty/whitespace-only remainder is a clean end of stream.
+                    let has_value = loop {
+                        let whitespace_len = {
+                            let buf = buf_reader.fill_buf().map_err(DataProfilerError::from)?;
+                            if buf.is_empty() {
+                                break false;
+                            }
+                            buf.iter()
+                                .take_while(|byte| byte.is_ascii_whitespace())
+                                .count()
+                        };
+                        if whitespace_len == 0 {
+                            break true;
+                        }
+                        buf_reader.consume(whitespace_len);
+                    };
+                    if !has_value {
+                        break;
+                    }
+
                     let parsed = {
                         let mut de = serde_json::Deserializer::from_reader(&mut buf_reader);
                         <Value as serde::Deserialize>::deserialize(&mut de)
                     };
                     let v = match parsed {
                         Ok(v) => v,
-                        Err(e) if e.classify() == serde_json::error::Category::Eof => break,
                         Err(e) => {
                             if error_policy == JsonErrorPolicy::Strict {
                                 return Err(DataProfilerError::JsonParsingError {
@@ -574,6 +595,9 @@ impl AsyncStreamingProfiler {
                                 });
                             }
                             malformed_records += 1;
+                            if e.classify() == serde_json::error::Category::Eof {
+                                break;
+                            }
                             // Recover by discarding the rest of the offending line.
                             let mut discard = Vec::new();
                             buf_reader
@@ -1295,5 +1319,28 @@ mod tests {
             .unwrap();
         assert_eq!(report.execution.rows_processed, 3);
         assert_eq!(report.execution.error_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_async_jsonl_truncated_final_record_obeys_error_policy() {
+        let data = b"{\"id\":1}\n{\"id\":2";
+
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(jsonl_source(data))
+            .await
+            .unwrap();
+        assert_eq!(report.execution.rows_processed, 1);
+        assert_eq!(report.execution.error_count, 1);
+
+        let err = AsyncStreamingProfiler::new()
+            .json_error_policy(JsonErrorPolicy::Strict)
+            .analyze_stream(jsonl_source(data))
+            .await
+            .expect_err("strict mode must reject an incomplete trailing record");
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("malformed json record")
+        );
     }
 }

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -564,19 +564,23 @@ impl AsyncStreamingProfiler {
                     // value. serde reports both as `Category::Eof`, but only an
                     // empty/whitespace-only remainder is a clean end of stream.
                     let has_value = loop {
-                        let whitespace_len = {
+                        let whitespace_only_len = {
                             let buf = buf_reader.fill_buf().map_err(DataProfilerError::from)?;
                             if buf.is_empty() {
                                 break false;
                             }
-                            buf.iter()
-                                .take_while(|byte| byte.is_ascii_whitespace())
-                                .count()
+                            if buf.iter().all(u8::is_ascii_whitespace) {
+                                Some(buf.len())
+                            } else {
+                                None
+                            }
                         };
-                        if whitespace_len == 0 {
+                        let Some(whitespace_only_len) = whitespace_only_len else {
+                            // Leave a mixed whitespace/value buffer untouched so
+                            // serde retains its line and column context.
                             break true;
-                        }
-                        buf_reader.consume(whitespace_len);
+                        };
+                        buf_reader.consume(whitespace_only_len);
                     };
                     if !has_value {
                         break;
@@ -1337,10 +1341,8 @@ mod tests {
             .analyze_stream(jsonl_source(data))
             .await
             .expect_err("strict mode must reject an incomplete trailing record");
-        assert!(
-            err.to_string()
-                .to_lowercase()
-                .contains("malformed json record")
-        );
+        let message = err.to_string().to_lowercase();
+        assert!(message.contains("malformed json record"));
+        assert!(message.contains("line 2"), "got: {message}");
     }
 }

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -115,15 +115,25 @@ where
                 break;
             }
 
+            // `serde_json` classifies both a clean end of input and an
+            // incomplete trailing value as `Category::Eof`. Check whether a
+            // non-whitespace value actually starts here so only the former is
+            // treated as normal exhaustion.
+            if consume_leading_whitespace(&mut reader)?.is_none() {
+                break;
+            }
+
             let mut deserializer = serde_json::Deserializer::from_reader(&mut reader);
             let value: Value = match Value::deserialize(&mut deserializer) {
                 Ok(v) => v,
-                Err(err) if err.classify() == serde_json::error::Category::Eof => break,
                 Err(err) => {
                     if config.error_policy == JsonErrorPolicy::Strict {
                         return Err(malformed_record_error(&err));
                     }
                     malformed_lines += 1;
+                    if err.classify() == serde_json::error::Category::Eof {
+                        break;
+                    }
                     skip_to_next_line(&mut reader)?;
                     continue;
                 }
@@ -751,17 +761,22 @@ mod tests {
     }
 
     #[test]
-    fn test_truncated_final_record_is_treated_as_eof() {
-        // serde classifies an incomplete trailing object as EOF, not a parse
-        // error, so it is silently dropped rather than counted or raised.
+    fn test_truncated_final_record_obeys_error_policy() {
         let data = b"{\"x\":1}\n{\"x\":2";
-        for policy in [JsonErrorPolicy::Skip, JsonErrorPolicy::Strict] {
-            let config = JsonParserConfig::jsonl().with_error_policy(policy);
-            let summary =
-                scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
-            assert_eq!(summary.rows_read, 1, "policy {policy:?}");
-            assert_eq!(summary.malformed_lines, 0, "policy {policy:?}");
-        }
+
+        let skip = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Skip);
+        let summary = scan_json_from_reader(Cursor::new(data.as_ref()), &skip, |_| {}).unwrap();
+        assert_eq!(summary.rows_read, 1);
+        assert_eq!(summary.malformed_lines, 1);
+
+        let strict = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
+        let err = scan_json_from_reader(Cursor::new(data.as_ref()), &strict, |_| {})
+            .expect_err("strict mode must reject an incomplete trailing record");
+        assert!(
+            err.to_string()
+                .to_lowercase()
+                .contains("malformed json record")
+        );
     }
 
     #[test]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -180,6 +180,16 @@ structurally broken; the gap is tracked in
 
 Ragged rows do not yet influence the consistency dimension's score.
 
+## Truncated JSONL records are never a clean EOF
+
+An incomplete final JSONL object was silently discarded on file and async
+inputs because `serde_json` classifies both a clean end of input and a partial
+value as EOF. That made tolerant mode report `error_count: 0`, and even
+`jsonl_on_error="strict"` returned a successful profile. The scanners now
+distinguish an empty or whitespace-only remainder from a value that started but
+did not finish. Tolerant mode skips and counts the partial record; strict mode
+raises `ValueError`, matching synchronous bytes input.
+
 ## Async CSV detects its delimiter instead of assuming a comma
 
 `csv_delimiter` was accepted and ignored on every async path, which always

--- a/python/tests/test_jsonl_error_policy.py
+++ b/python/tests/test_jsonl_error_policy.py
@@ -158,8 +158,9 @@ def test_truncated_final_record_async_parity():
     assert report.rows == 1
     assert report.error_count == 1
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         _async_bytes(TRUNCATED, jsonl_on_error="strict")
+    assert "line 2" in str(excinfo.value)
 
 
 def test_invalid_policy_value_rejected():

--- a/python/tests/test_jsonl_error_policy.py
+++ b/python/tests/test_jsonl_error_policy.py
@@ -24,6 +24,7 @@ import pytest
 # Malformed record in the middle position.
 MIXED = b'{"id":1,"x":10}\nnot-json\n{"id":2,"x":20}\n'
 ALL_BAD = b"not-json\nalso-bad\n"
+TRUNCATED = b'{"id":1}\n{"id":2'
 
 _HAS_ASYNC = dataprof.capabilities().async_streaming
 requires_async = pytest.mark.skipif(
@@ -134,6 +135,31 @@ def test_blank_lines_are_not_counted():
     report = dataprof.profile(data, format="jsonl")
     assert report.rows == 2
     assert report.error_count == 0
+
+
+def test_truncated_final_record_tolerant_parity(tmp_path):
+    path = _write(tmp_path, TRUNCATED)
+    for source in (path, TRUNCATED):
+        report = dataprof.profile(source, format="jsonl")
+        assert report.rows == 1
+        assert report.error_count == 1
+
+
+def test_truncated_final_record_strict_parity(tmp_path):
+    path = _write(tmp_path, TRUNCATED)
+    for source in (path, TRUNCATED):
+        with pytest.raises(ValueError):
+            dataprof.profile(source, format="jsonl", jsonl_on_error="strict")
+
+
+@requires_async
+def test_truncated_final_record_async_parity():
+    report = _async_bytes(TRUNCATED)
+    assert report.rows == 1
+    assert report.error_count == 1
+
+    with pytest.raises(ValueError):
+        _async_bytes(TRUNCATED, jsonl_on_error="strict")
 
 
 def test_invalid_policy_value_rejected():


### PR DESCRIPTION
## Summary

- distinguish clean JSONL exhaustion from an incomplete trailing value
- apply skip/strict malformed-record policy consistently in file and async scanners
- add Rust and Python regression coverage across file, bytes, and async transports
- document the corrected behavior in the 0.10 release notes

## Root cause

`serde_json` classifies both a clean end of input and an incomplete trailing value as `Category::Eof`. The file and async scanners treated every EOF-category parse failure as normal exhaustion, so tolerant mode reported a clean profile and strict mode incorrectly succeeded.

The scanners now first determine whether any non-whitespace input remains. Only an empty or whitespace-only remainder is clean EOF; a value that starts and then reaches EOF follows the configured malformed-record policy.

## Validation

- `cargo test --workspace --all-features` (complete workspace and doctest graph passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p dataprof-json -p dataprof-engines --all-targets --all-features -- -D warnings`
- `uv run pytest python/tests -q` with async enabled (521 passed, 5 environment/feature skips)
- `uv run pytest python/tests/test_jsonl_error_policy.py -q` (17 passed)
- `uv run ruff format --check python/tests/test_jsonl_error_policy.py`
- `uv run ruff check python/tests/test_jsonl_error_policy.py`
- manual public-API parity check for file, synchronous bytes, and async bytes in both skip and strict modes

Tested after rebasing onto the current `master`, including PyArrow 25 and setup-python 7.

Closes #480
