### PR TITLE
fix(json): validate streaming array grammar

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -36,6 +36,51 @@ struct ReaderOutcome {
     ragged_rows: usize,
 }
 
+fn peek_non_whitespace<R: std::io::BufRead>(
+    reader: &mut R,
+) -> Result<(Option<u8>, usize), DataProfilerError> {
+    let mut consumed = 0;
+    loop {
+        let whitespace_len = {
+            let buf = reader.fill_buf().map_err(DataProfilerError::from)?;
+            if buf.is_empty() {
+                return Ok((None, consumed));
+            }
+            buf.iter()
+                .take_while(|byte| byte.is_ascii_whitespace())
+                .count()
+        };
+        if whitespace_len == 0 {
+            let next = reader
+                .fill_buf()
+                .map_err(DataProfilerError::from)?
+                .first()
+                .copied();
+            return Ok((next, consumed));
+        }
+        reader.consume(whitespace_len);
+        consumed += whitespace_len;
+    }
+}
+
+fn malformed_json_array_error(message: &str) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!("malformed JSON array: {message}"),
+    }
+}
+
+fn drain_to_end<R: std::io::BufRead>(reader: &mut R) -> Result<usize, DataProfilerError> {
+    let mut consumed = 0;
+    loop {
+        let available = reader.fill_buf().map_err(DataProfilerError::from)?.len();
+        if available == 0 {
+            return Ok(consumed);
+        }
+        reader.consume(available);
+        consumed += available;
+    }
+}
+
 /// Async streaming profiler that accepts [`AsyncDataSource`] instead of file paths.
 ///
 /// Uses a bounded channel between a blocking CSV reader task and an async
@@ -610,108 +655,151 @@ impl AsyncStreamingProfiler {
             }
             _ => {
                 // JSON array: stream elements efficiently
-                let mut found_array = false;
+                let (opening, whitespace) = peek_non_whitespace(&mut buf_reader)?;
+                bytes_in_chunk += whitespace as u64;
+                if opening != Some(b'[') {
+                    return Err(DataProfilerError::JsonParsingError {
+                        message: "Expected JSON array (starts with '[') but input does not match"
+                            .to_string(),
+                    });
+                }
+                buf_reader.consume(1);
+                bytes_in_chunk += 1;
+
+                let mut expect_value = true;
+                let mut allow_end = true;
+                let mut array_closed = false;
+                let mut drain_remainder = false;
+
                 loop {
-                    let mut consume = 0;
-                    {
-                        let buf = buf_reader.fill_buf().map_err(DataProfilerError::from)?;
-                        if buf.is_empty() {
+                    let (next, whitespace) = peek_non_whitespace(&mut buf_reader)?;
+                    bytes_in_chunk += whitespace as u64;
+                    let Some(next) = next else {
+                        if error_policy == JsonErrorPolicy::Strict {
+                            return Err(malformed_json_array_error(
+                                "unexpected end of input before closing ']'",
+                            ));
+                        }
+                        malformed_records += 1;
+                        drain_remainder = true;
+                        break;
+                    };
+
+                    if expect_value {
+                        if next == b']' {
+                            if !allow_end {
+                                if error_policy == JsonErrorPolicy::Strict {
+                                    return Err(malformed_json_array_error(
+                                        "trailing comma before closing ']'",
+                                    ));
+                                }
+                                malformed_records += 1;
+                                drain_remainder = true;
+                                break;
+                            }
+                            buf_reader.consume(1);
+                            bytes_in_chunk += 1;
+                            array_closed = true;
                             break;
                         }
-                        for &b in buf {
-                            consume += 1;
-                            if b == b'[' {
-                                found_array = true;
-                                break;
-                            } else if !b.is_ascii_whitespace() {
+
+                        if next == b',' {
+                            if error_policy == JsonErrorPolicy::Strict {
+                                return Err(malformed_json_array_error(
+                                    "unexpected comma where an array value was required",
+                                ));
+                            }
+                            malformed_records += 1;
+                            drain_remainder = true;
+                            break;
+                        }
+
+                        let mut de = serde_json::Deserializer::from_reader(&mut buf_reader);
+                        match serde::Deserialize::deserialize(&mut de) {
+                            Ok(Value::Object(obj)) => {
+                                let row = process_object(
+                                    &obj,
+                                    &mut known_columns,
+                                    &mut known_columns_set,
+                                    headers_sent,
+                                );
+                                bytes_in_chunk +=
+                                    row.iter().map(|s| s.len() as u64 + 4).sum::<u64>();
+                                current_chunk.push(row);
+                                emitted_records += 1;
+
+                                if bytes_in_chunk as usize >= bytes_per_chunk
+                                    && !send_chunk(
+                                        &mut current_chunk,
+                                        &mut bytes_in_chunk,
+                                        &known_columns,
+                                        &mut headers_sent,
+                                        &tx,
+                                    )?
+                                {
+                                    return Ok(malformed_records);
+                                }
+                            }
+                            Ok(_) => {
+                                // Skip non-object items, approximate 10 bytes progress
+                                bytes_in_chunk += 10;
+                            }
+                            Err(e) => {
+                                // A corrupt element leaves the array parser unable
+                                // to resync, so we stop here either way; strict mode
+                                // surfaces the failure instead of a partial profile.
+                                if error_policy == JsonErrorPolicy::Strict {
+                                    return Err(DataProfilerError::JsonParsingError {
+                                        message: format!("malformed JSON record: {e}"),
+                                    });
+                                }
+                                malformed_records += 1;
+                                drain_remainder = true;
                                 break;
                             }
                         }
-                    }
-                    buf_reader.consume(consume);
-                    bytes_in_chunk += consume as u64;
-                    if found_array || consume == 0 {
-                        break;
+                        expect_value = false;
+                    } else {
+                        match next {
+                            b',' => {
+                                buf_reader.consume(1);
+                                bytes_in_chunk += 1;
+                                expect_value = true;
+                                allow_end = false;
+                            }
+                            b']' => {
+                                buf_reader.consume(1);
+                                bytes_in_chunk += 1;
+                                array_closed = true;
+                                break;
+                            }
+                            _ => {
+                                if error_policy == JsonErrorPolicy::Strict {
+                                    return Err(malformed_json_array_error(
+                                        "expected ',' or ']' after an array value",
+                                    ));
+                                }
+                                malformed_records += 1;
+                                drain_remainder = true;
+                                break;
+                            }
+                        }
                     }
                 }
 
-                if found_array {
-                    loop {
-                        let mut consume = 0;
-                        let mut found_value = false;
-                        let mut end_of_array = false;
-
-                        {
-                            let buf = buf_reader.fill_buf().map_err(DataProfilerError::from)?;
-                            if buf.is_empty() {
-                                break;
-                            }
-                            for &b in buf {
-                                if b.is_ascii_whitespace() || b == b',' {
-                                    consume += 1;
-                                } else if b == b']' {
-                                    end_of_array = true;
-                                    consume += 1;
-                                    break;
-                                } else {
-                                    found_value = true;
-                                    break;
-                                }
-                            }
+                if drain_remainder {
+                    bytes_in_chunk += drain_to_end(&mut buf_reader)? as u64;
+                } else if array_closed {
+                    let (trailing, whitespace) = peek_non_whitespace(&mut buf_reader)?;
+                    bytes_in_chunk += whitespace as u64;
+                    if trailing.is_some() {
+                        if error_policy == JsonErrorPolicy::Strict {
+                            return Err(malformed_json_array_error(
+                                "non-whitespace content follows the closing ']'",
+                            ));
                         }
-
-                        buf_reader.consume(consume);
-                        bytes_in_chunk += consume as u64;
-
-                        if end_of_array {
-                            break;
-                        }
-
-                        if found_value {
-                            let mut de = serde_json::Deserializer::from_reader(&mut buf_reader);
-                            match serde::Deserialize::deserialize(&mut de) {
-                                Ok(Value::Object(obj)) => {
-                                    let row = process_object(
-                                        &obj,
-                                        &mut known_columns,
-                                        &mut known_columns_set,
-                                        headers_sent,
-                                    );
-                                    bytes_in_chunk +=
-                                        row.iter().map(|s| s.len() as u64 + 4).sum::<u64>();
-                                    current_chunk.push(row);
-                                    emitted_records += 1;
-
-                                    if bytes_in_chunk as usize >= bytes_per_chunk
-                                        && !send_chunk(
-                                            &mut current_chunk,
-                                            &mut bytes_in_chunk,
-                                            &known_columns,
-                                            &mut headers_sent,
-                                            &tx,
-                                        )?
-                                    {
-                                        return Ok(malformed_records);
-                                    }
-                                }
-                                Ok(_) => {
-                                    // Skip non-object items, approximate 10 bytes progress
-                                    bytes_in_chunk += 10;
-                                }
-                                Err(e) => {
-                                    // A corrupt element leaves the array parser unable
-                                    // to resync, so we stop here either way; strict mode
-                                    // surfaces the failure instead of a partial profile.
-                                    if error_policy == JsonErrorPolicy::Strict {
-                                        return Err(DataProfilerError::JsonParsingError {
-                                            message: format!("malformed JSON record: {e}"),
-                                        });
-                                    }
-                                    malformed_records += 1;
-                                    break;
-                                }
-                            }
-                        }
+                        malformed_records += 1;
+                        bytes_in_chunk += drain_to_end(&mut buf_reader)? as u64;
                     }
                 }
             }
@@ -1252,6 +1340,13 @@ mod tests {
         )
     }
 
+    fn json_source(data: &'static [u8]) -> BytesSource {
+        BytesSource::new(
+            bytes::Bytes::from_static(data),
+            AsyncSourceInfo::new("test", FileFormat::Json).size_hint(Some(data.len() as u64)),
+        )
+    }
+
     #[tokio::test]
     async fn test_async_jsonl_tolerant_skips_and_counts() {
         // Malformed record in the middle: default policy skips and counts it.
@@ -1283,6 +1378,51 @@ mod tests {
             let message = err.to_string();
             assert!(message.to_lowercase().contains("malformed json record"));
             assert!(!message.contains("not-json"), "leaked record: {message}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_json_array_container_grammar_obeys_error_policy() {
+        let recoverable_cases = [
+            (b"[{\"x\":1}".as_ref(), "missing closing bracket"),
+            (b"[{\"x\":1},".as_ref(), "comma followed by EOF"),
+            (b"[{\"x\":1} {\"x\":2}]".as_ref(), "missing comma"),
+            (b"[{\"x\":1},,{\"x\":2}]".as_ref(), "doubled comma"),
+            (b"[{\"x\":1},]".as_ref(), "trailing comma"),
+            (b"[{\"x\":1}] trailing".as_ref(), "trailing content"),
+            (b"[{\"x\":1}][{\"x\":2}]".as_ref(), "second top-level value"),
+        ];
+
+        for (data, case) in recoverable_cases {
+            let report = AsyncStreamingProfiler::new()
+                .analyze_stream(json_source(data))
+                .await
+                .expect("tolerant scan should retain the valid prefix");
+            assert_eq!(report.execution.rows_processed, 1, "{case}");
+            assert_eq!(report.execution.error_count, 1, "{case}");
+        }
+
+        let err = AsyncStreamingProfiler::new()
+            .analyze_stream(json_source(b"[,{\"x\":1}]"))
+            .await
+            .expect_err("an array failing before its first value must fail");
+        assert!(err.to_string().to_lowercase().contains("malformed"));
+
+        for (data, case) in recoverable_cases
+            .into_iter()
+            .chain([(b"[,{\"x\":1}]".as_ref(), "leading comma")])
+        {
+            let err = AsyncStreamingProfiler::new()
+                .json_error_policy(JsonErrorPolicy::Strict)
+                .analyze_stream(json_source(data))
+                .await
+                .expect_err("strict mode must reject invalid array grammar");
+            assert!(
+                err.to_string()
+                    .to_lowercase()
+                    .contains("malformed json array"),
+                "{case}: {err}"
+            );
         }
     }
 

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -167,42 +167,57 @@ where
                     });
                 }
             } else {
-                loop {
-                    let mut consume = 0;
-                    let mut found_value = false;
-                    let mut end_of_array = false;
+                let mut expect_value = true;
+                let mut allow_end = true;
+                let mut array_closed = false;
+                let mut drain_remainder = false;
 
-                    {
-                        let buf = reader.fill_buf().map_err(DataProfilerError::from)?;
-                        if buf.is_empty() {
-                            break;
+                loop {
+                    let Some(next) = consume_leading_whitespace(&mut reader)? else {
+                        if config.error_policy == JsonErrorPolicy::Strict {
+                            return Err(malformed_array_error(
+                                "unexpected end of input before closing ']'",
+                            ));
                         }
-                        for &byte in buf {
-                            if byte.is_ascii_whitespace() || byte == b',' {
-                                consume += 1;
-                            } else if byte == b']' {
-                                end_of_array = true;
-                                consume += 1;
-                                break;
-                            } else {
-                                found_value = true;
+                        malformed_lines += 1;
+                        drain_remainder = true;
+                        break;
+                    };
+
+                    if expect_value {
+                        if next == b']' {
+                            if !allow_end {
+                                if config.error_policy == JsonErrorPolicy::Strict {
+                                    return Err(malformed_array_error(
+                                        "trailing comma before closing ']'",
+                                    ));
+                                }
+                                malformed_lines += 1;
+                                drain_remainder = true;
                                 break;
                             }
+                            reader.consume(1);
+                            array_closed = true;
+                            break;
                         }
-                    }
 
-                    reader.consume(consume);
-                    if end_of_array {
-                        break;
-                    }
-
-                    if found_value {
                         if let Some(max) = config.max_rows
                             && rows_read >= max
                         {
-                            // `found_value` means a real element follows, not the
-                            // closing bracket, so the array was genuinely cut short.
+                            // A value remains unread. Do not validate the unread
+                            // suffix of an intentionally bounded scan.
                             truncated = true;
+                            break;
+                        }
+
+                        if next == b',' {
+                            if config.error_policy == JsonErrorPolicy::Strict {
+                                return Err(malformed_array_error(
+                                    "unexpected comma where an array value was required",
+                                ));
+                            }
+                            malformed_lines += 1;
+                            drain_remainder = true;
                             break;
                         }
 
@@ -218,10 +233,47 @@ where
                                     return Err(malformed_record_error(&err));
                                 }
                                 malformed_lines += 1;
+                                drain_remainder = true;
+                                break;
+                            }
+                        }
+                        expect_value = false;
+                    } else {
+                        match next {
+                            b',' => {
+                                reader.consume(1);
+                                expect_value = true;
+                                allow_end = false;
+                            }
+                            b']' => {
+                                reader.consume(1);
+                                array_closed = true;
+                                break;
+                            }
+                            _ => {
+                                if config.error_policy == JsonErrorPolicy::Strict {
+                                    return Err(malformed_array_error(
+                                        "expected ',' or ']' after an array value",
+                                    ));
+                                }
+                                malformed_lines += 1;
+                                drain_remainder = true;
                                 break;
                             }
                         }
                     }
+                }
+
+                if drain_remainder {
+                    drain_to_end(&mut reader)?;
+                } else if array_closed && consume_leading_whitespace(&mut reader)?.is_some() {
+                    if config.error_policy == JsonErrorPolicy::Strict {
+                        return Err(malformed_array_error(
+                            "non-whitespace content follows the closing ']'",
+                        ));
+                    }
+                    malformed_lines += 1;
+                    drain_to_end(&mut reader)?;
                 }
             }
         }
@@ -242,6 +294,22 @@ where
 fn malformed_record_error(err: &serde_json::Error) -> DataProfilerError {
     DataProfilerError::JsonParsingError {
         message: format!("malformed JSON record: {err}"),
+    }
+}
+
+fn malformed_array_error(message: &str) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!("malformed JSON array: {message}"),
+    }
+}
+
+fn drain_to_end<R: BufRead>(reader: &mut R) -> Result<(), DataProfilerError> {
+    loop {
+        let available = reader.fill_buf().map_err(DataProfilerError::from)?.len();
+        if available == 0 {
+            return Ok(());
+        }
+        reader.consume(available);
     }
 }
 
@@ -561,6 +629,53 @@ mod tests {
         assert_eq!(summary.rows_read, 2);
         assert_eq!(keys.len(), 2);
         assert_eq!(keys[0], vec!["name".to_string()]);
+    }
+
+    #[test]
+    fn test_json_array_container_grammar_obeys_error_policy() {
+        let cases = [
+            (br#"[{"x":1}"#.as_ref(), 1, "missing closing bracket"),
+            (br#"[{"x":1},"#.as_ref(), 1, "comma followed by EOF"),
+            (br#"[{"x":1} {"x":2}]"#.as_ref(), 1, "missing comma"),
+            (br#"[{"x":1},,{"x":2}]"#.as_ref(), 1, "doubled comma"),
+            (br#"[,{"x":1}]"#.as_ref(), 0, "leading comma"),
+            (br#"[{"x":1},]"#.as_ref(), 1, "trailing comma"),
+            (br#"[{"x":1}] trailing"#.as_ref(), 1, "trailing content"),
+            (
+                br#"[{"x":1}][{"x":2}]"#.as_ref(),
+                1,
+                "second top-level value",
+            ),
+        ];
+
+        for (data, expected_rows, case) in cases {
+            let skip = JsonParserConfig::json_array();
+            let summary =
+                scan_json_from_reader(Cursor::new(data), &skip, |_| {}).expect("tolerant scan");
+            assert_eq!(summary.rows_read, expected_rows, "{case}");
+            assert_eq!(summary.malformed_lines, 1, "{case}");
+
+            let strict = JsonParserConfig::json_array().with_error_policy(JsonErrorPolicy::Strict);
+            let err = scan_json_from_reader(Cursor::new(data), &strict, |_| {})
+                .expect_err("strict mode must reject invalid array grammar");
+            assert!(
+                err.to_string()
+                    .to_lowercase()
+                    .contains("malformed json array"),
+                "{case}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_json_array_max_rows_does_not_validate_unread_values() {
+        let data = br#"[{"x":1},not-valid-json"#;
+        let config = JsonParserConfig::json_array().with_max_rows(1);
+        let summary = scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
+
+        assert_eq!(summary.rows_read, 1);
+        assert_eq!(summary.malformed_lines, 0);
+        assert!(summary.truncated);
     }
 
     #[test]

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -190,6 +190,17 @@ the stream using the same sample size and scoring as the file path — so the sa
 bytes yield the same columns whether they are read from disk, from memory, or
 off a URL.
 
+## Streaming JSON arrays enforce their container grammar
+
+The file and async JSON readers streamed each array value correctly but treated
+commas as optional whitespace and stopped at either `]` or EOF. Missing,
+leading, doubled, and trailing commas; a missing closing bracket; trailing
+garbage; and a second top-level value could all produce a clean profile.
+Container parsing now follows the JSON array state machine and validates the
+closing bracket and trailing input. Tolerant mode retains a valid prefix but
+increments `error_count`; strict mode raises `ValueError`. A scan intentionally
+bounded by `max_rows` still does not validate values it did not read.
+
 ## Malformed CSV raises `ValueError`, like malformed JSON
 
 A CSV parse failure reached Python as a `RuntimeError` while the equivalent JSON

--- a/python/tests/test_json_array_error_policy.py
+++ b/python/tests/test_json_array_error_policy.py
@@ -1,0 +1,114 @@
+"""Structural JSON-array errors must never produce a clean profile.
+
+File and async inputs stream array elements and can retain a valid prefix under
+the default tolerant policy. Synchronous bytes decode the whole document and
+therefore reject it. Every path must at least surface the malformed container,
+and strict mode must always raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import dataprof
+import pytest
+
+INVALID_WITH_VALID_PREFIX = [
+    (b'[{"id":1}', "missing closing bracket"),
+    (b'[{"id":1},', "comma followed by EOF"),
+    (b'[{"id":1} {"id":2}]', "missing comma"),
+    (b'[{"id":1},,{"id":2}]', "doubled comma"),
+    (b'[{"id":1},]', "trailing comma"),
+    (b'[{"id":1}] trailing', "trailing content"),
+    (b'[{"id":1}][{"id":2}]', "second top-level value"),
+]
+
+_HAS_ASYNC = dataprof.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+
+def _write(tmp_path: Path, data: bytes) -> Path:
+    target = tmp_path / "data.json"
+    target.write_bytes(data)
+    return target
+
+
+def _async_bytes(data: bytes, **kwargs):
+    from dataprof.asyncio import profile_bytes
+
+    async def _inner():
+        return await profile_bytes(data, format="json", **kwargs)
+
+    return asyncio.run(_inner())
+
+
+@pytest.mark.parametrize(("data", "case"), INVALID_WITH_VALID_PREFIX)
+def test_file_tolerant_surfaces_invalid_container(tmp_path, data, case):
+    report = dataprof.profile(_write(tmp_path, data), format="json")
+
+    assert report.rows == 1, case
+    assert report.error_count == 1, case
+
+
+@pytest.mark.parametrize(("data", "case"), INVALID_WITH_VALID_PREFIX)
+def test_file_strict_rejects_invalid_container(tmp_path, data, case):
+    with pytest.raises(ValueError, match="malformed JSON array"):
+        dataprof.profile(
+            _write(tmp_path, data),
+            format="json",
+            jsonl_on_error="strict",
+        )
+
+
+@pytest.mark.parametrize(("data", "case"), INVALID_WITH_VALID_PREFIX)
+def test_bytes_reject_invalid_container(data, case):
+    with pytest.raises(ValueError, match="malformed JSON"):
+        dataprof.profile(data, format="json")
+
+
+@requires_async
+@pytest.mark.parametrize(("data", "case"), INVALID_WITH_VALID_PREFIX)
+def test_async_tolerant_surfaces_invalid_container(data, case):
+    report = _async_bytes(data)
+
+    assert report.rows == 1, case
+    assert report.error_count == 1, case
+
+
+@requires_async
+@pytest.mark.parametrize(("data", "case"), INVALID_WITH_VALID_PREFIX)
+def test_async_strict_rejects_invalid_container(data, case):
+    with pytest.raises(ValueError, match="malformed JSON array"):
+        _async_bytes(data, jsonl_on_error="strict")
+
+
+@pytest.mark.parametrize("source_kind", ["file", "bytes"])
+def test_invalid_before_first_value_fails(tmp_path, source_kind):
+    data = b'[,{"id":1}]'
+    source = _write(tmp_path, data) if source_kind == "file" else data
+
+    with pytest.raises(ValueError):
+        dataprof.profile(source, format="json")
+
+
+@requires_async
+def test_invalid_before_first_value_fails_async():
+    with pytest.raises(ValueError):
+        _async_bytes(b'[,{"id":1}]')
+
+
+def test_file_max_rows_does_not_validate_unread_suffix(tmp_path):
+    report = dataprof.profile(
+        _write(tmp_path, b'[{"id":1},not-valid-json'),
+        format="json",
+        max_rows=1,
+    )
+
+    assert report.rows == 1
+    assert report.error_count == 0
+    assert not report.source_exhausted


### PR DESCRIPTION
## Summary

- replace permissive comma-skipping in the file and async JSON array scanners with an explicit array grammar state machine
- require valid separators, a closing bracket, and a whitespace-only suffix
- keep tolerant mode useful by retaining a valid prefix, counting the structural violation, and exhausting the unread source; strict mode fails immediately
- preserve intentional `max_rows` truncation without validating unread values
- add Rust and public Python regressions for missing/extra commas, missing brackets, trailing content, and multiple top-level values

## Root cause

The streaming readers deserialized each array element correctly, but manually treated every comma as optional whitespace and considered either `]` or EOF a successful end. They therefore validated values while never validating the JSON container around them.

Synchronous bytes use a whole-document JSON decoder and correctly rejected the same inputs, exposing transport-dependent behavior.

## Validation

- `cargo test --workspace --all-features` (complete workspace and doctest graph passed)
- `cargo test -p dataprof-json` (37 passed)
- `cargo test -p dataprof-engines --all-features` (30 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p dataprof-json -p dataprof-engines --all-targets --all-features -- -D warnings`
- `uv run pytest python/tests -q` with async enabled (557 passed, 5 expected environment/feature skips)
- `uv run pytest python/tests/test_json_array_error_policy.py -q` (39 passed)
- `uv run ruff format --check python/tests/test_json_array_error_policy.py`
- `uv run ruff check python/tests/test_json_array_error_policy.py`
- manual public-API adversarial matrix across file, synchronous bytes, and async bytes

Closes #482
