### PR TITLE
fix(python): preserve async byte source sizes

### DIFF
--- a/crates/dataprof-python/src/async_streaming.rs
+++ b/crates/dataprof-python/src/async_streaming.rs
@@ -35,6 +35,14 @@ fn build_profiler(config: Option<&PyProfilerConfig>) -> Profiler {
     }
 }
 
+fn python_bytes_source(data: Vec<u8>, format: FileFormat) -> BytesSource {
+    let size = data.len() as u64;
+    BytesSource::new(
+        bytes::Bytes::from(data),
+        AsyncSourceInfo::new("python-bytes", format).size_hint(Some(size)),
+    )
+}
+
 /// Profile in-memory bytes asynchronously.
 ///
 /// Accepts raw bytes and a format string. Returns a ProfileReport.
@@ -64,10 +72,7 @@ pub fn profile_bytes_async<'py>(
     let profiler = build_profiler(config);
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let source = BytesSource::new(
-            bytes::Bytes::from(data),
-            AsyncSourceInfo::new("python-bytes", fmt),
-        );
+        let source = python_bytes_source(data, fmt);
 
         let report = profiler
             .profile_stream(source)
@@ -113,10 +118,7 @@ pub fn infer_schema_stream_async<'py>(
     let fmt = parse_format(format)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let source = BytesSource::new(
-            bytes::Bytes::from(data),
-            AsyncSourceInfo::new("python-bytes", fmt),
-        );
+        let source = python_bytes_source(data, fmt);
 
         let result = Profiler::new()
             .infer_schema_stream(source)
@@ -140,10 +142,7 @@ pub fn quick_row_count_stream_async<'py>(
     let fmt = parse_format(format)?;
 
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        let source = BytesSource::new(
-            bytes::Bytes::from(data),
-            AsyncSourceInfo::new("python-bytes", fmt),
-        );
+        let source = python_bytes_source(data, fmt);
 
         let result = Profiler::new()
             .quick_row_count_stream(source)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -139,6 +139,12 @@ Byte caps remain chunk-boundary caps: `bytes_consumed` may exceed `MaxBytes` by
 at most one chunk, a bound the caller controls through `chunk_size`. Row caps
 have no such allowance.
 
+Python's `dataprof.asyncio.profile_bytes()` now preserves the buffer's known
+length in the async source metadata. Complete JSON and JSONL byte scans therefore
+report the exact input length in `bytes_consumed`, rather than an estimate
+derived from parsed values; bounded scans still report only the bytes they
+actually read.
+
 `rows_processed`, `bytes_consumed`, `source_exhausted` and `truncation_reason`
 are now covered by invariant tests on both the sync and async paths — a
 truncated scan is exactly a non-exhausted one, and an exhausted scan accounts

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -252,3 +252,34 @@ def test_async_chunk_size_never_changes_a_complete_profile(chunk_size):
     assert report.rows == 2_000
     assert report.columns == 3
     _assert_consistent(report, len(data), f"async chunk_size={chunk_size}")
+
+
+@requires_async
+@pytest.mark.parametrize(
+    ("fmt", "data"),
+    [
+        ("json", b'[{"id":1},{"id":2}]'),
+        ("jsonl", b'{"id":1}\n{"id":2}\n'),
+    ],
+)
+def test_async_json_bytes_account_for_the_complete_buffer(fmt, data):
+    report = _async_bytes(data, fmt)
+
+    assert report.rows == 2
+    _assert_consistent(report, len(data), f"async {fmt} bytes")
+
+
+@requires_async
+@pytest.mark.parametrize(
+    ("fmt", "data"),
+    [
+        ("json", b'[{"id":1},{"id":2},{"id":3}]'),
+        ("jsonl", b'{"id":1}\n{"id":2}\n{"id":3}\n'),
+    ],
+)
+def test_async_json_row_cap_keeps_partial_byte_accounting(fmt, data):
+    report = _async_bytes(data, fmt, max_rows=1)
+
+    assert report.rows == 1
+    assert not report.source_exhausted
+    _assert_consistent(report, len(data), f"async bounded {fmt} bytes")

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -278,8 +278,9 @@ def test_async_json_bytes_account_for_the_complete_buffer(fmt, data):
     ],
 )
 def test_async_json_row_cap_keeps_partial_byte_accounting(fmt, data):
-    report = _async_bytes(data, fmt, max_rows=1)
+    report = _async_bytes(data, fmt, chunk_size=8, max_rows=1)
 
     assert report.rows == 1
     assert not report.source_exhausted
+    assert 0 < _bytes_consumed(report) < len(data)
     _assert_consistent(report, len(data), f"async bounded {fmt} bytes")


### PR DESCRIPTION
## Summary

- attach the exact Python buffer length to every async `BytesSource`
- reuse one constructor across profiling, schema inference, and quick row count bindings
- add public API invariants for exhaustive and row-capped JSON/JSONL byte scans
- document the corrected execution metadata in the 0.10 release notes

## Root cause

The async engine already replaces its parsed-field byte estimate with `AsyncSourceInfo.size_hint` when a scan exhausts a source of known length. Python's byte bindings discarded that known length, so complete JSON and JSONL scans reported estimates smaller than the payload while claiming `source_exhausted=True`.

CSV masked the bug because its parser tracks raw byte positions directly.

## Validation

- `cargo test -p dataprof-python --all-features`
- `cargo clippy -p dataprof-python --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `uv run pytest python/tests -q` with async enabled (522 passed, 5 expected environment/feature skips)
- `uv run pytest python/tests/test_execution_controls.py -q` (27 passed)
- `uv run ruff format --check python/tests/test_execution_controls.py`
- `uv run ruff check python/tests/test_execution_controls.py`
- manual complete/capped public-API matrix for CSV, JSON, and JSONL

Closes #483
