### PR TITLE
docs: document workspace crate boundaries

### DIFF
--- a/crates/dataprof-core/Cargo.toml
+++ b/crates/dataprof-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Shared core types for dataprof"
+readme = "README.md"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/dataprof-core/README.md
+++ b/crates/dataprof-core/README.md
@@ -1,0 +1,36 @@
+# dataprof-core
+
+Shared data model and configuration types for the `dataprof` workspace.
+
+This crate owns format-independent contracts: profile and schema types, execution
+metadata, errors, configuration, sampling and stop conditions, semantic hints,
+source descriptions, validation, progress, and memory tracking. Parsing,
+statistical analysis, report assembly, and engine orchestration belong to their
+specialized crates.
+
+## Public surface
+
+Common entry points include `DataprofConfig`, `DataProfilerError`,
+`ExecutionMetadata`, `ColumnProfile`, `SamplingStrategy`, `StopCondition`,
+`SemanticHints`, and `DataSource`.
+
+## Features
+
+- `arrow`: Arrow-backed core types.
+- `async-streaming`: async coordination primitives.
+- `database`: database-specific configuration.
+- `parquet`: Parquet-specific source metadata.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-core
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-core/README.md
+++ b/crates/dataprof-core/README.md
@@ -30,7 +30,7 @@ cargo test -p dataprof-core
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-csv/Cargo.toml
+++ b/crates/dataprof-csv/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "CSV parsing and profiling support for dataprof"
+readme = "README.md"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/dataprof-csv/README.md
+++ b/crates/dataprof-csv/README.md
@@ -23,7 +23,7 @@ cargo test -p dataprof-csv
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-csv/README.md
+++ b/crates/dataprof-csv/README.md
@@ -1,0 +1,29 @@
+# dataprof-csv
+
+CSV parsing and report assembly for the `dataprof` workspace.
+
+This crate owns delimiter detection, parser configuration, robust CSV recovery
+and diagnostics, reader- and file-based CSV analysis, and memory-mapped CSV
+reading. Format-independent metrics and engine selection belong elsewhere.
+
+## Public surface
+
+The main entry points are `CsvParserConfig`, `detect_delimiter`,
+`analyze_csv_from_reader`, `analyze_csv_file`, and
+`MemoryMappedCsvReader`.
+
+## Features
+
+This crate has no feature flags.
+
+## Development
+
+```bash
+cargo test -p dataprof-csv
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-db/Cargo.toml
+++ b/crates/dataprof-db/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Database connectivity and query profiling support for dataprof"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/dataprof-db/README.md
+++ b/crates/dataprof-db/README.md
@@ -28,7 +28,7 @@ cargo test -p dataprof-db --all-features
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-db/README.md
+++ b/crates/dataprof-db/README.md
@@ -1,0 +1,34 @@
+# dataprof-db
+
+Database connectivity and query profiling support for the `dataprof` workspace.
+
+This crate owns connector configuration and traits, PostgreSQL, MySQL, and
+SQLite implementations, SQL validation and credential safety, database
+sampling, retries, and batched streaming helpers. It does not own generic
+profile metrics or Python bindings.
+
+## Public surface
+
+The primary entry points are `DatabaseConfig`, `DatabaseConnector`,
+`create_connector`, `analyze_database`, and the backend connector types.
+
+## Features
+
+- `postgres`: PostgreSQL support.
+- `mysql`: MySQL/MariaDB support.
+- `sqlite`: SQLite support.
+- `all-db`: all three backends.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-db --all-features
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-engines/Cargo.toml
+++ b/crates/dataprof-engines/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Streaming and adaptive profiling engines for dataprof"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/dataprof-engines/README.md
+++ b/crates/dataprof-engines/README.md
@@ -1,0 +1,35 @@
+# dataprof-engines
+
+Adaptive, incremental, and asynchronous profiling engines for the `dataprof`
+workspace.
+
+This crate owns engine selection and execution strategies, including
+memory-mapped, incremental, async-streaming, and optional columnar paths. File
+format parsing, shared report types, and metric calculations remain in their
+own crates.
+
+## Public surface
+
+The principal engine types are `AdaptiveProfiler`, `IncrementalProfiler`, and,
+when enabled, `AsyncStreamingProfiler`.
+
+## Features
+
+- `arrow`: Arrow-backed columnar profiling.
+- `parquet`: synchronous Parquet engine support; enables `arrow`.
+- `async-streaming`: async sources and streaming analysis.
+- `parquet-async`: async Parquet integration; enables `async-streaming`.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-engines --all-features
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-engines/README.md
+++ b/crates/dataprof-engines/README.md
@@ -29,7 +29,7 @@ cargo test -p dataprof-engines --all-features
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-json/Cargo.toml
+++ b/crates/dataprof-json/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "JSON and JSONL scanning support for dataprof"
+readme = "README.md"
 
 [dependencies]
 dataprof-core = { workspace = true }

--- a/crates/dataprof-json/README.md
+++ b/crates/dataprof-json/README.md
@@ -23,7 +23,7 @@ cargo test -p dataprof-json
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-json/README.md
+++ b/crates/dataprof-json/README.md
@@ -1,0 +1,29 @@
+# dataprof-json
+
+Streaming JSON and JSON Lines scanning for the `dataprof` workspace.
+
+This crate owns JSON format selection, tolerant and strict error handling,
+row-wise scanning, and reader- and file-based report assembly. General metrics,
+source orchestration, and Python-facing APIs belong elsewhere.
+
+## Public surface
+
+The main entry points are `JsonFormat`, `JsonParserConfig`,
+`scan_json_from_reader`, `analyze_json_from_reader`, and
+`analyze_json_file`.
+
+## Features
+
+This crate has no feature flags.
+
+## Development
+
+```bash
+cargo test -p dataprof-json
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-metrics/Cargo.toml
+++ b/crates/dataprof-metrics/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Metrics and statistical analysis engine for dataprof"
+readme = "README.md"
 
 [dependencies]
 chrono = { workspace = true }

--- a/crates/dataprof-metrics/README.md
+++ b/crates/dataprof-metrics/README.md
@@ -23,7 +23,7 @@ cargo test -p dataprof-metrics
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-metrics/README.md
+++ b/crates/dataprof-metrics/README.md
@@ -1,0 +1,29 @@
+# dataprof-metrics
+
+Statistical analysis and data-quality metrics for the `dataprof` workspace.
+
+This crate owns column analysis, type and pattern inference, statistical
+summaries, approximate cardinality, validators, and ISO-oriented quality
+assessments. It does not read input formats or choose profiling engines.
+
+## Public surface
+
+Common entry points include `MetricsCalculator`, `analyze_column`,
+`detect_patterns`, `infer_type`, `QualityAssessment`,
+`CardinalityEstimator`, and the numeric, text, and datetime summary functions.
+
+## Features
+
+This crate has no feature flags.
+
+## Development
+
+```bash
+cargo test -p dataprof-metrics
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-parquet/Cargo.toml
+++ b/crates/dataprof-parquet/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Parquet profiling support for dataprof"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/dataprof-parquet/README.md
+++ b/crates/dataprof-parquet/README.md
@@ -27,7 +27,7 @@ cargo test -p dataprof-parquet --all-features
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-parquet/README.md
+++ b/crates/dataprof-parquet/README.md
@@ -1,0 +1,33 @@
+# dataprof-parquet
+
+Parquet and Arrow-backed profiling support for the `dataprof` workspace.
+
+This crate owns synchronous Parquet analysis, shared Arrow record-batch
+analysis, and optional asynchronous HTTP Range reading. It does not choose the
+overall profiling engine or own format-independent report contracts.
+
+## Public surface
+
+Depending on enabled features, the main entry points are `ArrowProfiler`,
+`RecordBatchAnalyzer`, `ParquetConfig`, `analyze_parquet_with_config`, and
+`HttpParquetReader`.
+
+## Features
+
+- `arrow`: Arrow record-batch analysis.
+- `parquet`: synchronous Parquet profiling; enables `arrow`.
+- `parquet-async`: asynchronous HTTP Parquet profiling; enables `parquet`.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-parquet --all-features
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-partial/Cargo.toml
+++ b/crates/dataprof-partial/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Fast schema inference and row-count APIs for dataprof"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/dataprof-partial/README.md
+++ b/crates/dataprof-partial/README.md
@@ -27,7 +27,7 @@ cargo test -p dataprof-partial --all-features
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.

--- a/crates/dataprof-partial/README.md
+++ b/crates/dataprof-partial/README.md
@@ -1,0 +1,33 @@
+# dataprof-partial
+
+Fast schema inference, structure inspection, and row-count estimation for the
+`dataprof` workspace.
+
+This crate owns partial-analysis operations that avoid building a full profile,
+with explicit file-format and async-stream variants. Full metric calculation,
+report assembly, and engine orchestration belong elsewhere.
+
+## Public surface
+
+The primary entry points are `infer_schema`, `quick_row_count`,
+`analyze_structure`, their explicit-format variants, and, when enabled,
+`infer_schema_stream` and `quick_row_count_stream`.
+
+## Features
+
+- `parquet`: Parquet schema and row-count support.
+- `async-streaming`: async file and byte-stream partial analysis.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-partial --all-features
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-python/Cargo.toml
+++ b/crates/dataprof-python/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Python extension bindings for dataprof"
+readme = "README.md"
 
 [lib]
 name = "dataprof_python"

--- a/crates/dataprof-python/README.md
+++ b/crates/dataprof-python/README.md
@@ -1,0 +1,35 @@
+# dataprof-python
+
+PyO3 extension bindings for the `dataprof` Python package.
+
+This crate owns Python function registration, configuration and report
+wrappers, Arrow export, progress callbacks, and optional async and database
+bindings. Core profiling behavior remains in the Rust facade and its component
+crates. Python users install the `dataprof` package rather than depending on
+this crate directly.
+
+## Public surface
+
+The extension module exposes file and column analysis, partial analysis,
+pattern discovery, report wrappers, and feature-gated async and database APIs.
+
+## Features
+
+- `python`: synchronous extension marker.
+- `python-async` / `async-streaming`: async Python APIs.
+- `parquet-async`: async Parquet APIs.
+- `database`: shared database bindings.
+- `postgres`, `mysql`, `sqlite`: individual database backends.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-python --all-features
+```
+
+See the
+[`dataprof` Python and Rust overview](https://github.com/AndreaBozzo/dataprof/blob/master/README.md)
+and the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md).

--- a/crates/dataprof-python/README.md
+++ b/crates/dataprof-python/README.md
@@ -30,6 +30,6 @@ cargo test -p dataprof-python --all-features
 ```
 
 See the
-[`dataprof` Python and Rust overview](https://github.com/AndreaBozzo/dataprof/blob/master/README.md)
+[`dataprof` Python and Rust overview](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md)
 and the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md).
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md).

--- a/crates/dataprof-runtime/Cargo.toml
+++ b/crates/dataprof-runtime/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Shared runtime helpers and composed report types for dataprof"
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/dataprof-runtime/README.md
+++ b/crates/dataprof-runtime/README.md
@@ -1,0 +1,36 @@
+# dataprof-runtime
+
+Shared report assembly and engine-facing runtime helpers for the `dataprof`
+workspace.
+
+This crate owns `ProfileReport`, column-profile construction, report assembly,
+streaming statistics, reservoir and uniqueness tracking, memory configuration,
+and optional async source abstractions. It does not parse formats or select
+engines.
+
+## Public surface
+
+Common entry points include `ProfileReport`, `ReportAssembler`,
+`StreamingStatistics`, `StreamingColumnCollection`, `build_column_profile`,
+and, when enabled, `AsyncDataSource` and `BytesSource`.
+
+## Features
+
+- `async-streaming`: async data-source abstractions, including byte and HTTP
+  sources.
+- `parquet-async`: async Parquet runtime integration; enables
+  `async-streaming`.
+
+The default feature set is empty.
+
+## Development
+
+```bash
+cargo test -p dataprof-runtime --all-features
+```
+
+Most users should depend on the high-level
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+See the
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+for crate ownership details.

--- a/crates/dataprof-runtime/README.md
+++ b/crates/dataprof-runtime/README.md
@@ -30,7 +30,7 @@ cargo test -p dataprof-runtime --all-features
 ```
 
 Most users should depend on the high-level
-[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/master/README.md).
+[`dataprof` facade](https://github.com/AndreaBozzo/dataprof/blob/HEAD/README.md).
 See the
-[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/master/docs/architecture/crate-redesign.md)
+[workspace architecture](https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/architecture/crate-redesign.md)
 for crate ownership details.


### PR DESCRIPTION
## Summary

- document the ownership boundary and intended audience for every component crate
- list each crate's main public entry points and feature flags
- ship each README in Cargo package metadata

## Verification

- `cargo metadata --no-deps --format-version 1`
- `cargo test --workspace --all-features --doc`
- `cargo package -p <each-component-crate> --allow-dirty --no-verify --list` (confirmed every package includes `README.md`)
- `git diff --check`

Closes #306