### PR TITLE
chore(release): prepare 0.10.0

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,5 +1,5 @@
 name: 'Run Tests'
-description: 'Execute DataProfiler test suite with configurable features'
+description: 'Execute the dataprof test suite with configurable features'
 inputs:
   test-type:
     description: 'Type of tests to run (core, integration, all)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
-      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
     - uses: actions/checkout@v7.0.1
       with:
@@ -36,6 +35,48 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Tag: $TAG, Version: $VERSION"
 
+    - name: Install Rust 1.96 for release metadata validation
+      uses: dtolnay/rust-toolchain@1.96
+
+    - name: Validate tag and release metadata
+      env:
+        VERSION: ${{ steps.tag.outputs.version }}
+      run: |
+        mapfile -t WORKSPACE_VERSIONS < <(
+          cargo metadata --no-deps --format-version 1 |
+            jq -r '.packages[].version' |
+            sort -u
+        )
+
+        if [ "${#WORKSPACE_VERSIONS[@]}" -ne 1 ] ||
+           [ "${WORKSPACE_VERSIONS[0]}" != "$VERSION" ]; then
+          echo "::error::Tag v$VERSION does not match every workspace package version."
+          printf 'Workspace versions: %s\n' "${WORKSPACE_VERSIONS[*]}"
+          exit 1
+        fi
+
+        START_COUNT=$(grep -c '^<!-- release-body:start -->$' docs/release-notes.md || true)
+        END_COUNT=$(grep -c '^<!-- release-body:end -->$' docs/release-notes.md || true)
+        if [ "$START_COUNT" -ne 1 ] || [ "$END_COUNT" -ne 1 ]; then
+          echo "::error::docs/release-notes.md must contain one release-body marker pair."
+          exit 1
+        fi
+
+        if ! grep -Fq "# dataprof $VERSION " docs/release-notes.md; then
+          echo "::error::Release-note title does not match v$VERSION."
+          exit 1
+        fi
+
+        NARRATIVE=$(awk '
+          /^<!-- release-body:start -->$/ { capture = 1; next }
+          /^<!-- release-body:end -->$/ { capture = 0; next }
+          capture { print }
+        ' docs/release-notes.md)
+        if [ -z "${NARRATIVE//[[:space:]]/}" ]; then
+          echo "::error::The marked release narrative is empty."
+          exit 1
+        fi
+
     - name: Generate changelog with git-cliff
       id: git-cliff
       uses: orhun/git-cliff-action@v4
@@ -46,63 +87,56 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build release notes
-      id: changelog
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CLIFF_OUTPUT: ${{ steps.git-cliff.outputs.content }}
       run: |
         TAG="${{ steps.tag.outputs.tag }}"
         VERSION="${{ steps.tag.outputs.version }}"
 
-        echo "git-cliff content:"
-        echo "$CLIFF_OUTPUT"
-
-        # Use git-cliff output or fallback
-        if [ -z "$CLIFF_OUTPUT" ]; then
-          CLIFF_OUTPUT="- Various improvements and bug fixes"
+        if [ -z "${CLIFF_OUTPUT//[[:space:]]/}" ]; then
+          echo "::error::git-cliff produced an empty changelog."
+          exit 1
         fi
 
-        # Build release notes file
+        NARRATIVE=$(awk '
+          /^<!-- release-body:start -->$/ { capture = 1; next }
+          /^<!-- release-body:end -->$/ { capture = 0; next }
+          capture { print }
+        ' docs/release-notes.md)
+
+        # Nest git-cliff's version/category headings under "Full changelog".
+        CLIFF_OUTPUT=$(printf '%s\n' "$CLIFF_OUTPUT" |
+          sed -e 's/^### /#### /' -e 's/^## /### /')
+
         {
-          echo "## What's Changed"
+          printf '%s\n' "$NARRATIVE"
           echo ""
-          echo "$CLIFF_OUTPUT"
+          echo "## Full changelog"
           echo ""
-          echo "## Assets"
+          printf '%s\n' "$CLIFF_OUTPUT"
           echo ""
-          echo "### Python Packages"
+          echo "## Release artifacts"
+          echo ""
+          echo "### Python"
           echo "- **PyPI**: \`pip install dataprof==$VERSION\`"
           echo "- **GitHub Releases**: Baseline and optimized wheels are attached as release assets"
           echo ""
-          echo "### Source Archives"
+          echo "### Source"
           echo "- GitHub automatically attaches source \`.tar.gz\` and \`.zip\` archives for this tag"
           echo ""
-          echo "### Rust Status"
+          echo "### Rust"
           echo "- **Crates.io**: \`cargo add dataprof@$VERSION\`"
           echo "- The published \`dataprof\` crate is the stable Rust facade for profiling files, streams, tables, and database queries."
           echo "- Internal workspace crates are published so the facade can depend on versioned packages."
           echo "- This release ships libraries and Python packages; a CLI binary is not part of the release surface."
           echo ""
-          echo "## Installation"
-          echo ""
-          echo "\`\`\`bash"
-          echo "# Python package"
-          echo "pip install dataprof==$VERSION"
-          echo ""
-          echo "# Rust library"
-          echo "cargo add dataprof@$VERSION"
-          echo "\`\`\`"
-          echo ""
           echo "---"
           echo ""
-          echo "**Full changelog**: [CHANGELOG.md](https://github.com/AndreaBozzo/dataprof/blob/master/docs/CHANGELOG.md)"
-          echo ""
-          echo "**Release notes and migration guide**: [release-notes.md](https://github.com/AndreaBozzo/dataprof/blob/master/docs/release-notes.md)"
+          echo "**Versioned documents**: [full changelog](https://github.com/AndreaBozzo/dataprof/blob/$TAG/docs/CHANGELOG.md) · [release notes and migration guide](https://github.com/AndreaBozzo/dataprof/blob/$TAG/docs/release-notes.md)"
         } > release_notes.md
 
-        echo "changelog<<EOF" >> $GITHUB_OUTPUT
-        cat release_notes.md >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+        echo "Release body preview:"
+        cat release_notes.md
 
     - name: Create GitHub Release
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-csv"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "csv",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-db"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "dataprof-core",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-engines"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-json"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "dataprof-core",
  "dataprof-runtime",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-metrics"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "dataprof-core",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-parquet"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-partial"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arrow",
  "bytes",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "dataprof-runtime"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "3"
 
 # Shared package metadata inherited by every workspace member via `field.workspace = true`.
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.96"
 license = "MIT OR Apache-2.0"
@@ -26,16 +26,16 @@ repository = "https://github.com/AndreaBozzo/dataprof"
 # `dep.workspace = true` and may add `optional`, `features`, or `default-features` locally.
 [workspace.dependencies]
 # Internal crates
-dataprof = { version = "0.9.0", path = "." }
-dataprof-core = { version = "0.9.0", path = "crates/dataprof-core" }
-dataprof-metrics = { version = "0.9.0", path = "crates/dataprof-metrics" }
-dataprof-csv = { version = "0.9.0", path = "crates/dataprof-csv" }
-dataprof-json = { version = "0.9.0", path = "crates/dataprof-json" }
-dataprof-parquet = { version = "0.9.0", path = "crates/dataprof-parquet" }
-dataprof-engines = { version = "0.9.0", path = "crates/dataprof-engines" }
-dataprof-partial = { version = "0.9.0", path = "crates/dataprof-partial" }
-dataprof-db = { version = "0.9.0", path = "crates/dataprof-db" }
-dataprof-runtime = { version = "0.9.0", path = "crates/dataprof-runtime" }
+dataprof = { version = "0.10.0", path = "." }
+dataprof-core = { version = "0.10.0", path = "crates/dataprof-core" }
+dataprof-metrics = { version = "0.10.0", path = "crates/dataprof-metrics" }
+dataprof-csv = { version = "0.10.0", path = "crates/dataprof-csv" }
+dataprof-json = { version = "0.10.0", path = "crates/dataprof-json" }
+dataprof-parquet = { version = "0.10.0", path = "crates/dataprof-parquet" }
+dataprof-engines = { version = "0.10.0", path = "crates/dataprof-engines" }
+dataprof-partial = { version = "0.10.0", path = "crates/dataprof-partial" }
+dataprof-db = { version = "0.10.0", path = "crates/dataprof-db" }
+dataprof-runtime = { version = "0.10.0", path = "crates/dataprof-runtime" }
 
 # External dependencies
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   [![PyPI](https://img.shields.io/pypi/v/dataprof.svg)](https://pypi.org/project/dataprof/)
   [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE)
 
-  [Website](https://andreabozzo.github.io/dataprof/) · [Live benchmarks](https://andreabozzo.github.io/dataprof/benchmarks/) · [Getting started](docs/guides/getting-started.md)
+  [Website](https://andreabozzo.github.io/dataprof/) · [Live benchmarks](https://andreabozzo.github.io/dataprof/benchmarks/) · [Getting started](docs/guides/getting-started.md) · [0.10.0 release notes](docs/release-notes.md)
 
 </div>
 
@@ -129,8 +129,8 @@ two quality metrics that surprise people.
 
 ```toml
 [dependencies]
-dataprof = "0.9"
-# or: dataprof = { version = "0.9", default-features = false }
+dataprof = "0.10"
+# or: dataprof = { version = "0.10", default-features = false }
 ```
 
 Minimum supported Rust version: 1.96.
@@ -224,6 +224,7 @@ certified by ISO. Rust callers can customize the relative weights through
 ### Understand it
 
 - [Crate Redesign Notes](docs/architecture/crate-redesign.md) -- what the facade owns and why the workspace is split this way
+- [0.10.0 Release Notes](docs/release-notes.md) -- upgrade checklist, migration details, and known limitations
 - [Contributing](docs/CONTRIBUTING.md)
 - [Changelog](docs/CHANGELOG.md)
 
@@ -233,7 +234,7 @@ certified by ISO. Rust callers can customize the relative weights through
 
 ## Academic Work
 
-dataprof is the subject of a peer-reviewed paper submitted to **IEEE ScalCom 2026**:
+dataprof is the subject of a research paper submitted to **IEEE ScalCom 2026**:
 
 > A. Bozzo, "A Compiled Paradigm for Scalable and Sustainable Edge AI: Out-of-Core Execution and SIMD Acceleration in Telemetry Profiling," *IEEE ScalCom 2026* (under review).
 > [[Repository & reproducible benchmarks]](https://github.com/AndreaBozzo/scalcom2026-dataprof)

--- a/cliff.toml
+++ b/cliff.toml
@@ -5,7 +5,7 @@
 header = """
 # Changelog
 
-All notable changes to DataProfiler will be documented in this file.
+All notable changes to dataprof are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,36 +1,166 @@
 # Changelog
 
-All notable changes to DataProfiler will be documented in this file.
+All notable changes to dataprof are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+For the user-oriented overview, upgrade checklist, and migration details, read
+the [0.10.0 release notes](release-notes.md).
+
+## [0.10.0] - 2026-07-24
 
 ### Added
 
-- Semantic hints are now validated instead of silently dropped. A hint
-  (`positive_columns`, `identifier_columns`, `temporal_columns`) that names a
-  column absent from the schema raises an error listing the unmatched names and
-  the available columns; in Python this is a `ValueError`. A hint that names a
-  real column but binds to no value over the full data — a `positive` hint on a
-  column with no numeric values, a `temporal` hint on a column with no dates — is
-  also rejected. Identifier hints coerce the column's type, so they bind to any
-  existing column. (#420)
-- Reports now carry `semantic_hint_bindings`: per-column evidence of how each
-  hint bound (`column`, `kind`, `checked_values`, `matched_values`, `exact`).
-  Value-driven hints are measured over the same data the quality metrics
-  assessed; `exact` states whether that covered every row. A hint that matched
-  nothing is only rejected when the evidence is `exact`, so a sampled zero is
-  recorded but never mistaken for proof of absence. Additive report field —
-  older readers ignore it. (#420)
+- **Json**: Unify malformed-record policy across file/bytes/async JSONL (#382) (#457) by @AndreaBozzo
+
+- **Input**: Enforce duplicate column-name policy across engines (#381) (#456) by @AndreaBozzo
+
+- **Python**: Finish #435 report API ergonomics — profiles, save html/md, low_sample_warning, zero-row semantics (#455) by @AndreaBozzo
+
+- **Errors**: Standardize actionable diagnostics and preserve source context (#446) by @AndreaBozzo
+
+- **Hints**: Validate semantic hints and record binding evidence (#420) (#441) by @AndreaBozzo
+
+- Record report execution engine (#438) by @floze-the-genius
+
+- **Metrics**: Per-column invalid_count for values excluded from numeric stats (#437) by @AndreaBozzo
+
+- **Report**: Version the serialized ProfileReport schema (#415) by @AndreaBozzo
+
+- **Python**: Add agent security guard for MCP surfaces (#410) by @AndreaBozzo
+
+- **Capabilities**: Add capabilities function to report installed features and metadata (#409) by @AndreaBozzo
+
+- **Contributor**: Add smoke test script and update CONTRIBUTING.md (#408) by @AndreaBozzo
+
+- **Metrics**: Expose provenance for approximate distinct counts (#406) by @AndreaBozzo
+
+- **Metrics**: Add Validity and Precision dimensions (#399) by @AndreaBozzo
+
+- **Metrics**: Make quality score weights configurable (#398) by @AndreaBozzo
+
+- **Metrics**: Require explicit temporal columns (#397) by @AndreaBozzo
+
+- **Metrics**: Honor identifier column hints (#396) by @AndreaBozzo
+
+- **Metrics**: Track duplicate rows across streams (#395) by @AndreaBozzo
+
+- **Metrics**: Score only assessed dimensions, using every sub-metric (#394) by @AndreaBozzo
+
+- **Site**: Rehaul GitHub Pages into a project homepage by @AndreaBozzo
+
+### Changed
+
+- **Ci**: Parallelize database integration builds (#468) by @AndreaBozzo
+
+- **Metrics**: Add table-driven completeness scenarios (#407) by @AndreaBozzo
+
+- Add issue templates in the directory GitHub actually reads (#390) by @AndreaBozzo
+
+- **Json**: Format decode audit by @AndreaBozzo
+
+- Add cross-engine parity suite (#369) by @AndreaBozzo
+
+- Make the ty type check blocking now that the codebase passes it by @AndreaBozzo
+
+- **Deny**: Document why RUSTSEC-2024-0436 is ignored by @AndreaBozzo
+
+- Make the benchmark page generator pass ruff format and lint by @AndreaBozzo
+
+### Dependencies
+
+- **Deps-dev**: Bump pytest from 9.0.3 to 9.1.1 (#478) by @dependabot[bot]
+
+- **Deps-dev**: Bump maturin from 1.12.6 to 1.14.1 (#477) by @dependabot[bot]
+
+- **Deps**: Bump github/codeql-action from 4.36.1 to 4.37.3 (#476) by @dependabot[bot]
+
+- **Deps**: Bump actions/checkout from 6.0.3 to 7.0.1 (#475) by @dependabot[bot]
+
+- **Deps-dev**: Bump pyarrow from 23.0.1 to 25.0.0 (#479) by @dependabot[bot]
+
+- **Deps**: Bump actions/setup-python from 6 to 7 (#474) by @dependabot[bot]
+
+- **Deps**: Bump serde_json from 1.0.149 to 1.0.151 (#450) by @dependabot[bot]
+
+- **Deps**: Bump uuid from 1.23.4 to 1.24.0 (#451) by @dependabot[bot]
+
+- **Deps**: Bump futures from 0.3.32 to 0.3.33 (#448) by @dependabot[bot]
+
+- **Deps**: Bump toml from 0.9.12+spec-1.1.0 to 1.1.3+spec-1.1.0 (#285) by @dependabot[bot]
+
+- **Deps**: Bump wide from 1.2.0 to 1.5.0 (#391) by @dependabot[bot]
+
+- **Deps**: Bump sysinfo from 0.39.5 to 0.39.6 (#392) by @dependabot[bot]
+
+- **Deps**: Bump regex from 1.12.3 to 1.13.0 (#393) by @dependabot[bot]
+
+### Documentation
+
+- Document workspace crate boundaries (#487) by @AndreaBozzo
+
+- Add "Why dataprof?" comparison guide (#414) by @AndreaBozzo
+
+- **Templates**: Drop CLI references and reinforce profile-only boundary by @AndreaBozzo
+
+- Add AGENTS.md with a CLAUDE.md redirect by @AndreaBozzo
+
+- Align SECURITY.md supported versions with the 0.9.x line by @AndreaBozzo
 
 ### Fixed
 
-- Python DataFrame and Arrow-backed profiles now preserve source schema column
-  order in report exports. `ProfileReport.compare()` column output is no longer
-  alphabetically sorted: it follows the left report's schema order, then appends
-  right-only columns in their source order. (#427)
+- **Python**: Preserve async byte source sizes (#485) by @AndreaBozzo
+
+- **Json**: Validate streaming array grammar (#484) by @AndreaBozzo
+
+- **Json**: Reject truncated final JSONL records (#481) by @AndreaBozzo
+
+- **Security**: Audit every published feature graph (#464) (#473) by @AndreaBozzo
+
+- **Sampling**: Make every strategy sample, on every path (#459) (#472) by @AndreaBozzo
+
+- **Execution**: Honor resource controls and correct provenance (#460) (#471) by @AndreaBozzo
+
+- **Async**: Count ragged CSV rows and honor CSV options (#462) (#469) by @AndreaBozzo
+
+- **Patterns**: Require locale evidence for summary claims (#467) by @AndreaBozzo
+
+- Harden profiling contracts before 0.10 (#466) by @AndreaBozzo
+
+- **Csv**: One clean diagnostic for non-UTF-8 input (#426) (#458) by @AndreaBozzo
+
+- **Partial**: Apply multi-offset row-count sampling to JSONL (#454) by @AndreaBozzo
+
+- **Partial**: Remove prefix bias from CSV quick_row_count sampling (#453) by @AndreaBozzo
+
+- **Csv**: Surface ragged CSV rows instead of silently normalizing them (#452) by @AndreaBozzo
+
+- **Python**: Preserve DataFrame column order (#444) by @floze-the-genius
+
+- Assess inferred dates in timeliness (#445) by @AndreaBozzo
+
+- **Hints**: Make streamed binding evidence exact (#443) by @AndreaBozzo
+
+- **Metrics**: Base numeric stats from exact accumulators; disclose sampled order statistics (#432) by @AndreaBozzo
+
+- **Csv**: Quote-aware delimiter sniffer; absent delimiters can no longer win (#431) by @AndreaBozzo
+
+- **Metrics**: Populate execution.memory_peak_mb in incremental and columnar engines (#422) by @AndreaBozzo
+
+- **Metrics**: Track duplicate rows in columnar and record-batch engines (#421) by @AndreaBozzo
+
+- **Python**: Describe() 50% falls back to median when quartiles are absent (#416) by @AndreaBozzo
+
+- **Metrics**: Treat quality_dimensions=[] as quality not analyzed (#411) by @AndreaBozzo
+
+- Replace columnar 1,000-value unique-count cap with bounded estimator (#389) by @AndreaBozzo
+
+- **Decode**: Enforce audited invariants by @AndreaBozzo
+
+- **Decode**: Audit swallowed errors on decode paths by @AndreaBozzo
+
+- **Python**: Make ty check pass across examples, tests, and stubs by @AndreaBozzo
 
 ## [0.9.0] - 2026-07-09
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -231,8 +231,8 @@ Describe:
 
 ### Questions?
 
-- Check [DEVELOPMENT.md](docs/DEVELOPMENT.md) for architecture details
-- Read [docs/](docs/) for detailed documentation
+- Check the [crate redesign notes](architecture/crate-redesign.md) for architecture details
+- Browse the [documentation directory](./) for detailed guides and references
 - Open a discussion issue if you're unsure
 
 ## Code Guidelines
@@ -270,7 +270,7 @@ fn test_handles_empty_file() {
 - Document public APIs with doc comments
 - Include examples in doc comments
 - Update README.md for user-facing changes
-- Update [docs/](docs/) for architectural changes
+- Update the [documentation directory](./) for architectural changes
 
 ## Development Tips
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,9 +6,9 @@ We actively support the following versions of dataprof:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.9.x   | :white_check_mark: |
-| 0.8.x   | Security fixes     |
-| < 0.8   | :x:                |
+| 0.10.x  | :white_check_mark: |
+| 0.9.x   | Security fixes     |
+| < 0.9   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/architecture/crate-redesign.md
+++ b/docs/architecture/crate-redesign.md
@@ -158,9 +158,9 @@ validation:
 | `postgres`, `mysql`, `sqlite` | Individual SQL backends through `dataprof-db` features |
 | `all-db` | Convenience bundle for all three SQL backends |
 
-The facade crate now optimizes for `dataprof = "0.9"` as a Rust dependency. A
+The facade crate now optimizes for `dataprof = "0.10"` as a Rust dependency. A
 CLI could return later as a separate product if it becomes useful, but it is
-not part of the shipped 0.9 surface.
+not part of the shipped 0.10 surface.
 
 ## Migration Plan
 

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -18,7 +18,7 @@ ship.
 
 ```toml
 [dependencies]
-dataprof = { version = "0.9", features = ["postgres"] }
+dataprof = { version = "0.10", features = ["postgres"] }
 ```
 
 For local Python extension development:

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -336,8 +336,8 @@ import dataprof as dp
 
 report = dp.profile("s3_landing/orders_2024-03-17.csv")
 
-# 0.8.0: bail out early on tiny samples — the score is computed but not
-# statistically meaningful below 10 rows.
+# Bail out early on tiny samples: the score is computed but not statistically
+# meaningful below 10 rows.
 if report.low_sample_warning:
     print(f"WARN: sample too small ({report.rows} rows), skipping quality gate")
     sys.exit(0)
@@ -362,7 +362,7 @@ if score < 90.0:
 print(f"ACCEPTED (score={score:.2f}), {report.rows} rows")
 ```
 
-### Per-column outlier triage (0.8.0)
+### Per-column outlier triage
 
 The global `accuracy.outlier_ratio` tells you *something* is suspicious, but
 per-column `outlier_count` tells you *where* to look.
@@ -387,7 +387,7 @@ for name, n_outliers, lo, hi in suspicious[:5]:
     print(f"{name:30} {n_outliers:>4} outliers  range=[{lo}, {hi}]")
 ```
 
-### Domain hints for IDs and positive values (0.8.0)
+### Domain hints for IDs and positive values
 
 ```python
 report = dp.profile(
@@ -401,7 +401,7 @@ if report.quality and report.quality.accuracy:
     print(report.quality.accuracy["negative_values_in_positive"])
 ```
 
-### Serialize a single column (0.8.0)
+### Serialize a single column
 
 For piping individual column profiles into Airflow XCom, Prometheus, a
 warehouse, etc., without dragging the whole report along:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -24,7 +24,7 @@ uv pip install dataprof
 # or: pip install dataprof
 
 # Rust library -- add to Cargo.toml
-# dataprof = "0.9"
+# dataprof = "0.10"
 ```
 
 The published Python wheels cover the base package API for local files, DataFrames, and Arrow objects. If you need async URL profiling or database helpers, build the extension from source with the corresponding Rust features.
@@ -102,7 +102,10 @@ Measures how much data is present vs. missing.
 The completeness score is on the same 0–100 scale as the other dimensions. It
 combines cell completeness (`100 - missing_values_ratio`) and row completeness
 (`complete_records_ratio`), so inspect both underlying values when setting a
-quality gate.
+quality gate. `complete_records_ratio` is deliberately strict: every column is
+treated as required, so one sparse optional field can drive it to zero. Inspect
+`missing_values_ratio` and `null_columns` beside it; a richer optional-column
+policy is tracked in [#436](https://github.com/AndreaBozzo/dataprof/issues/436).
 
 ### Consistency
 
@@ -301,12 +304,17 @@ report = await dp.analyze_database_async(
 ### Rust
 
 ```rust
-use dataprof::{Profiler, DatabaseConfig};
+use dataprof::Profiler;
 
-let report = Profiler::new()
-    .connection_string("postgres://user:pass@localhost/mydb")
-    .analyze_query("SELECT * FROM users")
-    .await?;
+async fn profile_users() -> Result<(), dataprof::DataProfilerError> {
+    let report = Profiler::new()
+        .connection_string("postgres://user:pass@localhost/mydb")
+        .analyze_query("SELECT * FROM users")
+        .await?;
+
+    println!("Profiled {} rows", report.execution.rows_processed);
+    Ok(())
+}
 ```
 
 See the [Database Connectors Guide](database-connectors.md) for connection strings, SSL, retry configuration, and more.

--- a/docs/guides/why-dataprof.md
+++ b/docs/guides/why-dataprof.md
@@ -14,8 +14,8 @@ follows from that job.
 > **A note on performance claims:** this page makes none. dataprof's
 > differences from the tools below are architectural (bounded memory,
 > streaming, quality semantics), not benchmark numbers. Rigorous, reproducible
-> benchmarks are tracked separately and will be published when they meet that
-> bar.
+> measurements are published separately on the
+> [live benchmark site](https://andreabozzo.github.io/dataprof/benchmarks/).
 
 ## What dataprof adds
 
@@ -33,10 +33,12 @@ follows from that job.
   CI quality gates fall out of this naturally.
 - **One tool across sources.** CSV, JSON/JSONL, Parquet, Arrow batches,
   pandas/polars DataFrames, dicts, byte buffers, and (opt-in) live database
-  queries — same report shape from all of them.
+  queries — same report shape from all of them. CSV, JSON, and JSONL byte
+  buffers are dependency-free; Parquet byte buffers currently require the
+  pandas extra.
 - **A dependency-free Python wheel.** `pip install dataprof` pulls in no
-  Python dependencies. Profiling local files, dicts, and byte buffers needs
-  neither pandas nor numpy.
+  Python dependencies. Profiling local files, dicts, and CSV/JSON/JSONL byte
+  buffers needs neither pandas nor numpy.
 - **Agent-ready output.** `to_llm_context()` produces a token-bounded summary
   with fail-closed redaction of sensitive values — built for handing a
   dataset's shape to an LLM without handing it the data.

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -1,6 +1,10 @@
 # Python API Guide
 
-Complete reference for the `dataprof` Python package (v0.9.0).
+Complete reference for the `dataprof` Python package (v0.10.0).
+
+For upgrade-sensitive changes to sampling, execution controls, quality scores,
+parser behavior, semantic hints, and exception types, read the
+[0.10.0 release notes and migration guide](../release-notes.md).
 
 The Python API is built for quick inspection and follow-up analysis: point it at a file, DataFrame, Arrow batch, ad-hoc notebook data, or database query and get back a report you can slice, export, and wire into notebooks or checks.
 
@@ -176,7 +180,7 @@ report.to_polars()               # polars DataFrame -- all stats (requires polar
 report.to_arrow()                # PyArrow Table -- all stats (requires pyarrow)
 report.describe()                # transposed summary like pandas describe()
 report.quality_summary()         # single-row dict for quality tracking
-report.to_html()                 # standalone HTML (same as the notebook display)
+report.to_html()                 # embeddable HTML (same as the notebook display)
 report.to_markdown()             # GitHub-flavored markdown table
 report.compare(other)            # dict of quality/schema/null deltas vs another report
 report.save("report.json")      # save to JSON
@@ -541,7 +545,7 @@ delta = before.compare(after)
 report.save("report.json")      # full report as JSON
 report.save("profiles.csv")     # column profiles as CSV (no extra deps)
 report.save("profiles.parquet") # column profiles as Parquet (requires pyarrow)
-report.save("report.html")      # standalone HTML render (same as to_html())
+report.save("report.html")      # HTML fragment (same as to_html())
 report.save("report.md")        # markdown table (same as to_markdown())
 ```
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,72 @@
-# Unreleased
+# dataprof 0.10.0 — Profiles that tell the truth
 
-## Security auditing covers every published feature graph
+<!-- release-body:start -->
+
+0.10.0 is a correctness-and-control release. Its theme is simple: a profiling
+option must take effect, damaged input must leave evidence, and a score must
+describe only what dataprof actually assessed. That sounds obvious; the
+pre-release dogfooding pass found several places where different engines,
+transports, or bindings had drifted away from that contract.
+
+This release makes sampling real across every supported path, forwards resource
+controls to the engines that use them, closes major parser gaps across
+file/bytes/async inputs, adds Validity and Precision to the quality model, and
+replaces vacuous-perfect dimension scores with assessed-only aggregation.
+Reports also gain stronger execution provenance, exact semantic-hint binding
+evidence, discoverable build capabilities, and clearer errors.
+
+The result is intentionally more honest, even where honesty changes a number or
+turns a formerly accepted call into an error.
+
+## Install
+
+```bash
+# Python
+pip install --upgrade dataprof==0.10.0
+
+# Rust
+cargo add dataprof@0.10.0
+```
+
+Python 3.10+ and Rust 1.96+ remain the supported minimums. dataprof 0.10.0 ships
+libraries and Python packages; there is no CLI binary.
+
+## Upgrade checklist
+
+| If you rely on… | What changed | What to do |
+| --- | --- | --- |
+| `quality_score` thresholds | The aggregate now scores only assessed dimensions, includes every sub-metric, and has seven default dimension weights. An unassessable report returns `None` in Python/Rust report helpers instead of a fabricated 100. | Re-run representative profiles and re-baseline every quality gate. Inspect `assessed_dimensions()` and the underlying facts beside the aggregate. |
+| `SamplingStrategy.importance(...)` | The signature is now `importance(weight_column, weight_threshold)`. Sampling is actually applied on supported CSV/async paths; unsupported readers reject it instead of profiling everything. | Name the numeric weight column explicitly and handle `ValueError` for unsupported source/engine combinations. |
+| `chunk_size` or `memory_limit_mb` | `chunk_size` consistently means bytes, and both controls now reach the engines that document them. | Remove any row-based interpretation of `chunk_size`; choose it as an I/O/memory granularity. |
+| broad `except RuntimeError` blocks | Missing files, invalid input/configuration, permissions, and I/O now map to idiomatic Python exceptions. Malformed CSV and JSON both raise `ValueError` in strict paths. | Catch `FileNotFoundError`, `ValueError`, `PermissionError`, or `OSError` as appropriate. |
+| semantic hints | Unknown or provably inert `positive_columns` / `temporal_columns` hints now raise instead of disappearing silently. | Correct stale column names and request the Quality metric pack when using value-driven hints. |
+| direct Rust metrics methods | `MetricsCalculator::calculate_{comprehensive,bifurcated}_metrics_with_positive_columns` gained `row_duplicates: Option<RowDuplicateSummary>`. | Pass `None` to keep the previous behavior, or provide the engine's row-duplicate summary. |
+
+## Release highlights
+
+- **Sampling is deterministic and stateful.** Fixed-size strategies hold the
+  final sample; progressive sampling measures the data; multi-stage composition
+  is validated before a scan begins.
+- **Execution metadata is internally consistent.** Hard row caps are exact,
+  fully consumed sources are exhausted, byte counts include syntax, and ragged
+  CSV recovery is visible.
+- **The hardened parser paths agree across transports.** Truncated JSONL
+  records, malformed JSON arrays, async delimiters, and malformed CSV now follow
+  explicit strict/tolerant policies. Remaining JSONL boundary choices are listed
+  under known limitations.
+- **Quality scores explain their denominator.** Validity and Precision bring the
+  model to seven dimensions, configurable weights renormalize over assessed
+  dimensions, and full-stream duplicate tracking feeds uniqueness.
+- **Errors and capabilities are usable API surfaces.** Callers can discover what
+  the installed build supports and handle failures by category without parsing
+  generic runtime strings.
+
+The sections below contain the migration details and the reasoning behind each
+compatibility-sensitive change.
+
+## Security and dependency integrity
+
+### Security auditing covers every published feature graph
 
 `cargo deny` ran against the default build only. Optional features are still
 published features — the database connectors pull in the whole SQLx client
@@ -18,7 +84,7 @@ Dependency updates that came with it:
   (excessive allocation size). No API changes were required.
 - `rand` 0.8.5 → 0.8.7 (transitive, via SQLx), clearing
   [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc).
-- `spin` 0.9.8 → 0.9.9, which was a yanked release.
+- `spin` 0.9.8 → 0.9.9, replacing the yanked 0.9.8 release.
 - `Pygments` 2.19.2 → 2.20.0 in the Python environment, clearing
   [GHSA-5239-wwwm-4pmq](https://github.com/advisories/GHSA-5239-wwwm-4pmq).
   Dependabot was not watching the Python dependencies at all, so nothing would
@@ -34,7 +100,9 @@ and the code path is skipped entirely over TLS, which is how dataprof builds
 SQLx. No fixed release of `rsa` exists. The disposition is recorded in both
 `deny.toml` and `.cargo/audit.toml`, so `cargo deny` and `cargo audit` agree.
 
-## Sampling strategies actually sample
+## Execution controls that hold
+
+### Sampling strategies actually sample
 
 `sampling=` was undependable across engines and inputs. The documented default
 call, `dp.profile(path, sampling=...)`, dropped the strategy and profiled
@@ -95,7 +163,7 @@ Note that sampling bounds the cost of *analysis*, not of reading: a uniform
 sample requires seeing the whole source. Pair it with a `StopCondition` to bound
 I/O.
 
-## Execution controls take effect, and execution metadata tells the truth
+### Execution controls take effect, and execution metadata tells the truth
 
 `chunk_size` and `memory_limit_mb` were accepted and then dropped on the paths
 that document them, so a resource control could be silently ineffective. Both
@@ -150,7 +218,9 @@ are now covered by invariant tests on both the sync and async paths — a
 truncated scan is exactly a non-exhausted one, and an exhausted scan accounts
 for every byte of its source.
 
-## Ragged CSV rows leave a signal instead of vanishing
+## Parser behavior aligned across hardened paths
+
+### Ragged CSV rows leave a signal instead of vanishing
 
 A CSV row whose field count differs from the header — extra trailing fields, or
 missing ones — is still recovered (extra fields dropped, missing fields padded
@@ -186,7 +256,7 @@ structurally broken; the gap is tracked in
 
 Ragged rows do not yet influence the consistency dimension's score.
 
-## Truncated JSONL records are never a clean EOF
+### Truncated JSONL records are never a clean EOF
 
 An incomplete final JSONL object was silently discarded on file and async
 inputs because `serde_json` classifies both a clean end of input and a partial
@@ -196,7 +266,7 @@ distinguish an empty or whitespace-only remainder from a value that started but
 did not finish. Tolerant mode skips and counts the partial record; strict mode
 raises `ValueError`, matching synchronous bytes input.
 
-## Async CSV detects its delimiter instead of assuming a comma
+### Async CSV detects its delimiter instead of assuming a comma
 
 `csv_delimiter` was accepted and ignored on every async path, which always
 parsed on commas. A semicolon- or tab-separated stream therefore collapsed into
@@ -206,7 +276,7 @@ the stream using the same sample size and scoring as the file path — so the sa
 bytes yield the same columns whether they are read from disk, from memory, or
 off a URL.
 
-## Streaming JSON arrays enforce their container grammar
+### Streaming JSON arrays enforce their container grammar
 
 The file and async JSON readers streamed each array value correctly but treated
 commas as optional whitespace and stopped at either `]` or EOF. Missing,
@@ -217,7 +287,7 @@ closing bracket and trailing input. Tolerant mode retains a valid prefix but
 increments `error_count`; strict mode raises `ValueError`. A scan intentionally
 bounded by `max_rows` still does not validate values it did not read.
 
-## Malformed CSV raises `ValueError`, like malformed JSON
+### Malformed CSV raises `ValueError`, like malformed JSON
 
 A CSV parse failure reached Python as a `RuntimeError` while the equivalent JSON
 failure raised `ValueError`, so callers could not catch bad input as one
@@ -229,7 +299,9 @@ auto engine used to retry the file under its fallback parser and report
 means opting out of recovery, so the original error — naming the row and the
 expected field count — is returned directly.
 
-## Locale patterns require locale evidence before becoming report claims
+## Reports that explain what was assessed
+
+### Locale patterns require locale evidence before becoming report claims
 
 Ambiguous locale-specific shapes remain available in each column's detailed
 `patterns` evidence, but no longer appear as a top pattern in text, Markdown,
@@ -247,7 +319,7 @@ returned when its semantic validator rejects every regex match, and such a
 candidate cannot suppress another pattern during overlap resolution. This
 resolves [#429](https://github.com/AndreaBozzo/dataprof/issues/429).
 
-## Errors preserve source context and map to idiomatic Python exceptions
+### Errors preserve source context and map to idiomatic Python exceptions
 
 Failure diagnostics are now consistent about what failed, where, and what to do
 next. This is **compatibility-sensitive**: error messages and, on the Python
@@ -275,7 +347,7 @@ side, exception *types* have changed.
   instead of wrapping every failure in a generic `RuntimeError`. `except
   RuntimeError:` blocks that relied on the old behavior need updating.
 
-## Installed capabilities are discoverable
+### Installed capabilities are discoverable
 
 `dataprof.capabilities()` returns an immutable snapshot of the current build:
 local formats, compiled pandas/polars/Arrow interoperability, installed optional
@@ -284,7 +356,7 @@ availability, compiled connectors, and the package version. Discovery imports
 no heavyweight optional dependency and performs no file, database, or network
 operation.
 
-## Validity and Precision join the quality model
+### Validity and Precision join the quality model
 
 Two new selectively requestable dimensions are available in Rust and Python:
 
@@ -302,7 +374,7 @@ consistency, 0.15 uniqueness, 0.15 accuracy, 0.10 timeliness, 0.10 validity,
 and 0.05 precision. Re-baseline aggregate-score gates; underlying facts remain
 individually inspectable.
 
-## Quality score weights are configurable
+### Quality score weights are configurable
 
 The overall score's relative dimension weights now live in
 `IsoQualityConfig::score_weights`. `MetricsCalculator::with_thresholds(...)`
@@ -314,7 +386,7 @@ The documentation now describes ISO 8000 and ISO/IEC 25012 as sources for the
 quality-dimension concepts. Dataprof's aggregate score and its weights are a
 configurable project formula, not an ISO-mandated or certified score.
 
-## The quality score now only scores what was actually assessed
+### The quality score now only scores what was actually assessed
 
 **`quality_score` changes value for almost every dataset.** The facts
 (per-dimension counts and ratios) are unchanged; how they aggregate is not.
@@ -366,7 +438,7 @@ dimensions drop the most. At that stage the five-dimension weights remained
 subsequently expands and rebalances them. The formula remains dataprof's own,
 not an ISO-mandated one.
 
-## Duplicate rows are now counted over the full stream
+### Duplicate rows are now counted over the full stream
 
 The CSV, JSON, and streaming engines track row identity while they read:
 every record's fields fold into a length-prefixed signature fed to the same
@@ -388,7 +460,7 @@ exact-then-HLL distinct estimator that backs `unique_count`. As a result:
 gained a `row_duplicates: Option<RowDuplicateSummary>` parameter; pass `None`
 to keep the previous behavior.
 
-## Semantic hints are validated, not silently dropped
+### Semantic hints are validated, not silently dropped
 
 A semantic hint (`positive_columns`, `identifier_columns`, `temporal_columns`)
 is the user's chosen alternative to overconfident inference, so a hint that
@@ -414,9 +486,33 @@ outside the retained sample. Supplying `positive_columns` or
 those hints would have no consumer; `identifier_columns` remains usable because
 it affects column typing. The field is additive; older readers ignore it.
 
+## Known limitations carried into 0.11.0
+
+The dogfooding pass also found issues that need an explicit product decision or
+larger implementation change. They are documented and scheduled rather than
+hidden in 0.10:
+
+- The columnar CSV engine can pad a short row without incrementing
+  `ragged_row_count`; the default incremental engine reports it correctly
+  ([#470](https://github.com/AndreaBozzo/dataprof/issues/470)).
+- JSON and JSONL still need one cross-transport contract for zero-field records,
+  source field order, and physical record boundaries
+  ([#463](https://github.com/AndreaBozzo/dataprof/issues/463),
+  [#465](https://github.com/AndreaBozzo/dataprof/issues/465),
+  [#486](https://github.com/AndreaBozzo/dataprof/issues/486)).
+- Python Parquet byte buffers still require the pandas extra even though local
+  Parquet files work in the dependency-free wheel
+  ([#461](https://github.com/AndreaBozzo/dataprof/issues/461)).
+- A sparse optional column can make strict all-column
+  `complete_records_ratio` unhelpful; inspect cell completeness and the named
+  null-heavy columns alongside it
+  ([#436](https://github.com/AndreaBozzo/dataprof/issues/436)).
+
+<!-- release-body:end -->
+
 ---
 
-# DataProf 0.9.0 — Release Notes
+# dataprof 0.9.0 — Release Notes
 
 0.9.0 focuses on the Python surface: a report object that behaves like a report
 object, a first-class path for handing profiles to LLM agents, and a correctness

--- a/examples/README.md
+++ b/examples/README.md
@@ -85,6 +85,9 @@ Two results surprise people, so both examples call them out explicitly:
 
 - **`completeness` scores complete *records***, not populated cells. A file where
   22% of cells are missing can score 0 if almost every row is missing something.
+  Optional-column semantics are tracked in
+  [#436](https://github.com/AndreaBozzo/dataprof/issues/436); inspect
+  `missing_values_ratio` and `null_columns` beside the strict record ratio.
 - **`null_columns` lists columns past the null threshold** (50% by default), not
   only columns that are entirely null.
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -2111,11 +2111,11 @@ class ProfileReport:
         return self
 
     def to_html(self) -> str:
-        """Return the standalone HTML representation of the report.
+        """Return the embeddable HTML representation of the report.
 
         Identical to Jupyter's rich display (``_repr_html_``), exposed as a
-        public method for saving standalone HTML files, embedding in CI
-        summaries, or sharing outside a notebook.
+        public method for saving an HTML fragment, embedding in CI summaries,
+        or sharing outside a notebook.
         """
         return self._repr_html_()
 

--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,8 @@
       color: var(--accent-ink);
     }
     .hero-sub { color: var(--muted); font-size: 1.12rem; max-width: 56ch; margin: 0 0 26px; }
+    .release-pill { display: table; margin-bottom: 10px; text-decoration: none; }
+    .release-pill:hover { filter: brightness(1.08); }
     .hero-actions { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 22px; }
     .hero-meta { display: flex; flex-wrap: wrap; gap: 8px 18px; color: var(--muted); font-size: 0.9rem; font-weight: 600; }
     .hero-meta span { display: inline-flex; align-items: center; gap: 7px; }
@@ -106,7 +108,7 @@
       margin: 0 0 18px;
       max-width: 560px;
     }
-    .install-row code { flex: 1; overflow-x: auto; white-space: nowrap; padding: 8px 0; font-size: 0.9rem; }
+    .install-row code { flex: 1; min-width: 0; overflow-x: auto; white-space: nowrap; padding: 8px 0; font-size: 0.9rem; }
     .copy-btn {
       border: 1px solid rgba(255,255,255,0.18);
       background: rgba(255,255,255,0.06);
@@ -198,7 +200,7 @@
 
     @media (max-width: 900px) {
       .hero { padding-top: 48px; }
-      .hero-grid { grid-template-columns: 1fr; gap: 34px; }
+      .hero-grid { grid-template-columns: minmax(0, 1fr); gap: 34px; }
       .bench-band { grid-template-columns: 1fr; padding: 32px 26px; }
       .site-nav a:not(.nav-cta) { display: none; }
     }
@@ -228,6 +230,7 @@
   <section class="hero wrap">
     <div class="hero-grid">
       <div>
+        <a class="pill release-pill" href="https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/release-notes.md">0.10.0 release notes &rarr;</a>
         <span class="eyebrow">Rust core &middot; Python native &middot; ISO 8000/25012</span>
         <h1>Know your data <em>before</em> it bites.</h1>
         <p class="hero-sub">
@@ -259,7 +262,7 @@ report.rows, report.columns
 <span class="t-out">(1_048_576, 14)</span>
 
 report.quality_score
-<span class="t-out">87.4</span>  <span class="t-cm"># 0&ndash;100 across five ISO dimensions</span>
+<span class="t-out">87.4</span>  <span class="t-cm"># 0&ndash;100 across assessed dimensions</span>
 
 age = report[<span class="t-str">"customer_age"</span>]
 age.data_type, age.null_percentage
@@ -335,8 +338,8 @@ report.<span class="t-fn">save</span>(<span class="t-str">"report.json"</span>) 
 before = dp.ProfileReport.<span class="t-fn">load</span>(<span class="t-str">"report.json"</span>)
 delta = before.<span class="t-fn">compare</span>(dp.<span class="t-fn">profile</span>(<span class="t-str">"data_clean.csv"</span>))</code></pre>
       <p class="note">Python 3.10+. Pre-built wheels have <strong>zero Python dependencies</strong> &mdash;
-        pandas is optional, only for DataFrame-typed exports.
-        See the <a href="https://github.com/AndreaBozzo/dataprof/blob/master/docs/python/README.md">Python API guide</a>.</p>
+        pandas is optional, for DataFrame-typed exports and Parquet byte buffers.
+        See the <a href="https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/python/README.md">Python API guide</a>.</p>
     </div>
 
     <div class="card quickstart-panel" id="panel-rust" role="tabpanel" aria-labelledby="tab-rust" hidden>
@@ -403,8 +406,9 @@ delta = before.<span class="t-fn">compare</span>(dp.<span class="t-fn">profile</
     <div class="section-head">
       <span class="eyebrow">ISO 8000-8 &middot; ISO/IEC 25012</span>
       <h2>A quality model you can point an auditor at</h2>
-      <p>Every profile scores data against the five dimensions defined by the international
-        data-quality standards, weighted into a single 0&ndash;100 score.</p>
+      <p>When quality analysis is requested, dataprof assesses up to seven dimensions
+        informed by international data-quality standards. Its configurable aggregate
+        score uses only the dimensions the data could actually support.</p>
     </div>
     <div class="dims">
       <article class="card dim">
@@ -426,6 +430,14 @@ delta = before.<span class="t-fn">compare</span>(dp.<span class="t-fn">profile</
       <article class="card dim">
         <h3>Timeliness</h3>
         <p>Future dates, stale-data ratio, temporal ordering violations.</p>
+      </article>
+      <article class="card dim">
+        <h3>Validity</h3>
+        <p>Conformance to confidently detected semantic patterns, with weak evidence left unassessed.</p>
+      </article>
+      <article class="card dim">
+        <h3>Precision</h3>
+        <p>Consistency of observed decimal scale within floating-point columns.</p>
       </article>
     </div>
   </section>
@@ -470,7 +482,7 @@ delta = before.<span class="t-fn">compare</span>(dp.<span class="t-fn">profile</
   <section id="research" class="block wrap">
     <div class="section-head">
       <span class="eyebrow">Academic work</span>
-      <h2>Peer-reviewed performance claims</h2>
+      <h2>A reproducible performance study</h2>
     </div>
     <div class="card paper-card">
       <p>dataprof is the subject of a paper submitted to <strong>IEEE ScalCom 2026</strong>,
@@ -505,9 +517,9 @@ delta = before.<span class="t-fn">compare</span>(dp.<span class="t-fn">profile</
     <span>dataprof &mdash; dual-licensed MIT or Apache-2.0</span>
     <span class="spacer"></span>
     <a href="https://github.com/AndreaBozzo/dataprof">GitHub</a>
-    <a href="https://github.com/AndreaBozzo/dataprof/blob/master/docs/guides/getting-started.md">Getting started</a>
-    <a href="https://github.com/AndreaBozzo/dataprof/blob/master/docs/CHANGELOG.md">Changelog</a>
-    <a href="https://github.com/AndreaBozzo/dataprof/blob/master/docs/CONTRIBUTING.md">Contributing</a>
+    <a href="https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/guides/getting-started.md">Getting started</a>
+    <a href="https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/CHANGELOG.md">Changelog</a>
+    <a href="https://github.com/AndreaBozzo/dataprof/blob/HEAD/docs/CONTRIBUTING.md">Contributing</a>
     <a href="benchmarks/">Benchmarks</a>
   </div>
 </footer>


### PR DESCRIPTION
## Summary

- bump all 11 workspace packages and public dependency snippets to 0.10.0
- turn the pre-release notes into a user-first release narrative with an upgrade checklist, migration details, and explicitly scheduled 0.11 limitations
- make the tag workflow validate package versions and release-note markers, then place the curated narrative above the generated full changelog with immutable tag links
- refresh the changelog, security support table, guides, executable-example documentation, Python API wording, and GitHub Pages homepage
- correct stale branding, broken documentation links, Parquet-buffer dependency wording, completeness caveats, and the HTML-fragment contract

## Why

The 0.10 milestone contains several compatibility-sensitive correctness and control changes. Users need one readable migration story, and the release workflow needs to publish that exact story rather than a generic generated list. This also makes a mismatched tag/version or malformed release-note source fail before any release is created.

## User and developer impact

The release notes now lead with the changes most likely to affect quality gates, sampling, resource controls, exception handling, semantic hints, and direct Rust metrics calls. Larger dogfooding findings remain visible and linked to their existing 0.11.0 issues instead of being hidden in the release.

The built 0.10.0 wheel remains dependency-free by default and the published Rust surface remains library-only; there is no CLI.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo +1.96 check --workspace --all-features --locked`
- `cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- `cargo package -p <crate> --list` for all 10 publishable crates from the clean commit
- `uv run pytest python/tests/test_python_api.py -q` (308 passed)
- `uv run ruff format --check python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`
- all three Rust and all three Python executable examples
- release wheel and sdist builds; isolated install/smoke test of `dataprof-0.10.0-cp312-cp312-win_amd64.whl`
- wheel metadata and sdist inventory inspection
- simulated final GitHub release body, including heading order and immutable tag links
- `actionlint` across the workflows
- local Markdown/HTML link scan
- desktop and Pixel 7 site interaction/overflow checks with zero browser-console errors