### PR TITLE
fix: harden profiling edge-case behavior

### DIFF
--- a/crates/dataprof-db/src/connectors/common.rs
+++ b/crates/dataprof-db/src/connectors/common.rs
@@ -94,6 +94,14 @@ macro_rules! streaming_profile_loop {
             }
 
             let columns = rows[0].columns();
+            let column_names: Vec<String> = columns
+                .iter()
+                .map(|column| column.name().to_string())
+                .collect();
+            dataprof_core::validate_unique_column_names(
+                &column_names,
+                concat!($db_name, " query result"),
+            )?;
             let mut batch_result: std::collections::HashMap<String, Vec<String>> =
                 std::collections::HashMap::with_capacity(columns.len());
 
@@ -144,29 +152,41 @@ macro_rules! process_rows_to_columns {
         use sqlx::{Column, Row};
 
         if $rows.is_empty() {
-            std::collections::HashMap::new()
+            Ok(std::collections::HashMap::new())
         } else {
             let columns = $rows[0].columns();
-            let mut result: std::collections::HashMap<String, Vec<String>> =
-                std::collections::HashMap::with_capacity(columns.len());
+            let column_names: Vec<String> = columns
+                .iter()
+                .map(|column| column.name().to_string())
+                .collect();
+            match dataprof_core::validate_unique_column_names(
+                &column_names,
+                "database query result",
+            ) {
+                Err(error) => Err(error),
+                Ok(()) => {
+                    let mut result: std::collections::HashMap<String, Vec<String>> =
+                        std::collections::HashMap::with_capacity(columns.len());
 
-            for col in columns {
-                result.insert(col.name().to_string(), Vec::with_capacity($rows.len()));
-            }
-
-            for row in &$rows {
-                for (i, col) in columns.iter().enumerate() {
-                    let value: Option<String> = $crate::db_column_to_string!(row, i);
-                    if let Some(column_data) = result.get_mut(col.name()) {
-                        // decode-audit: no-data — None is SQL NULL (or a type
-                        // db_column_to_string documents as unsupported); "" is
-                        // the profiler's textual null.
-                        column_data.push(value.unwrap_or_default());
+                    for col in columns {
+                        result.insert(col.name().to_string(), Vec::with_capacity($rows.len()));
                     }
+
+                    for row in &$rows {
+                        for (i, col) in columns.iter().enumerate() {
+                            let value: Option<String> = $crate::db_column_to_string!(row, i);
+                            if let Some(column_data) = result.get_mut(col.name()) {
+                                // decode-audit: no-data — None is SQL NULL (or a type
+                                // db_column_to_string documents as unsupported); "" is
+                                // the profiler's textual null.
+                                column_data.push(value.unwrap_or_default());
+                            }
+                        }
+                    }
+
+                    Ok(result)
                 }
             }
-
-            result
         }
     }};
 }

--- a/crates/dataprof-db/src/connectors/mysql.rs
+++ b/crates/dataprof-db/src/connectors/mysql.rs
@@ -110,7 +110,7 @@ impl DatabaseConnector for MySqlConnector {
                 DataProfilerError::database_query(&format!("Query execution failed: {}", e))
             })?;
 
-            Ok(process_rows_to_columns!(rows))
+            process_rows_to_columns!(rows)
         }
 
         #[cfg(not(feature = "mysql"))]

--- a/crates/dataprof-db/src/connectors/postgres.rs
+++ b/crates/dataprof-db/src/connectors/postgres.rs
@@ -111,7 +111,7 @@ impl DatabaseConnector for PostgresConnector {
                 DataProfilerError::database_query(&format!("Query execution failed: {}", e))
             })?;
 
-            Ok(process_rows_to_columns!(rows))
+            process_rows_to_columns!(rows)
         }
 
         #[cfg(not(feature = "postgres"))]

--- a/crates/dataprof-db/src/connectors/sqlite.rs
+++ b/crates/dataprof-db/src/connectors/sqlite.rs
@@ -129,7 +129,7 @@ impl DatabaseConnector for SqliteConnector {
                 DataProfilerError::database_query(&format!("Query execution failed: {}", e))
             })?;
 
-            Ok(process_rows_to_columns!(rows))
+            process_rows_to_columns!(rows)
         }
 
         #[cfg(not(feature = "sqlite"))]

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -167,6 +167,12 @@ pub async fn analyze_database(
     calculate_quality: bool,
     quality_dimensions: Option<Vec<QualityDimension>>,
 ) -> Result<ProfileReport, DataProfilerError> {
+    if config.batch_size == 0 {
+        return Err(DataProfilerError::InvalidConfiguration {
+            message: "database batch_size must be greater than zero".to_string(),
+            suggestion: "Set batch_size to a positive number of rows.".to_string(),
+        });
+    }
     let mut connector = create_connector(config.clone())?;
 
     connector.connect().await?;

--- a/crates/dataprof-db/tests/column_decoding.rs
+++ b/crates/dataprof-db/tests/column_decoding.rs
@@ -11,6 +11,15 @@ use sqlx::sqlite::SqlitePoolOptions;
 
 /// Read a query's rows into the column-oriented map the profiler consumes.
 async fn columns_of(query: &str, ddl: &[&str]) -> std::collections::HashMap<String, Vec<String>> {
+    columns_result_of(query, ddl)
+        .await
+        .expect("unique query columns")
+}
+
+async fn columns_result_of(
+    query: &str,
+    ddl: &[&str],
+) -> Result<std::collections::HashMap<String, Vec<String>>, dataprof_core::DataProfilerError> {
     let pool = SqlitePoolOptions::new()
         .connect("sqlite::memory:")
         .await
@@ -101,4 +110,20 @@ async fn large_integers_are_not_truncated_through_a_float_arm() {
     .await;
 
     assert_eq!(cols["big"], vec!["9007199254740993"]);
+}
+
+#[tokio::test]
+async fn duplicate_query_aliases_are_rejected_before_columns_merge() {
+    let error = columns_result_of(
+        "SELECT a AS x, b AS x FROM t",
+        &[
+            "CREATE TABLE t (a INTEGER, b INTEGER)",
+            "INSERT INTO t VALUES (1, 10), (2, 20)",
+        ],
+    )
+    .await
+    .expect_err("duplicate aliases must not merge");
+
+    assert!(error.to_string().contains("Duplicate column name"));
+    assert!(error.to_string().contains('x'));
 }

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -48,7 +48,7 @@ pub fn infer_type(data: &[String]) -> DataType {
 
     for s in &non_empty {
         let trimmed = s.trim();
-        if trimmed.parse::<i64>().is_ok() || trimmed.parse::<u64>().is_ok() {
+        if is_integer_token(trimmed) {
             integer_count += 1;
             float_count += 1; // integers are also valid floats
         } else if trimmed.parse::<f64>().is_ok() {
@@ -94,6 +94,15 @@ pub fn infer_type(data: &[String]) -> DataType {
     }
 
     DataType::String
+}
+
+/// Return whether a token is an integer representable by dataprof's signed or
+/// unsigned 64-bit integer contract.
+///
+/// Keep inference and quality validation on this shared predicate: values above
+/// `i64::MAX` are valid integer tokens even though they require `u64` to parse.
+pub fn is_integer_token(value: &str) -> bool {
+    value.parse::<i64>().is_ok() || value.parse::<u64>().is_ok()
 }
 
 pub fn is_null_like_token(value: &str) -> bool {

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -48,12 +48,13 @@ pub fn infer_type(data: &[String]) -> DataType {
 
     for s in &non_empty {
         let trimmed = s.trim();
-        if trimmed.parse::<i64>().is_ok() {
+        if trimmed.parse::<i64>().is_ok() || trimmed.parse::<u64>().is_ok() {
             integer_count += 1;
             float_count += 1; // integers are also valid floats
-        } else if let Ok(f) = trimmed.parse::<f64>()
-            && f.is_finite()
-        {
+        } else if trimmed.parse::<f64>().is_ok() {
+            // Infinity is a numeric lexical form even though it cannot enter
+            // finite statistics. Classify the column as numeric and let the
+            // profile's invalid_count disclose the unusable value.
             float_count += 1;
         }
     }
@@ -133,6 +134,27 @@ mod tests {
     fn test_infer_mixed_numeric_as_float() {
         // Mix of integers and floats should be detected as Float
         let data = vec!["1".to_string(), "2.5".to_string(), "3".to_string()];
+        assert!(matches!(infer_type(&data), DataType::Float));
+    }
+
+    #[test]
+    fn test_infer_unsigned_integer_beyond_i64() {
+        let data = vec![
+            u64::MAX.to_string(),
+            (u64::MAX - 1).to_string(),
+            (i64::MAX as u64 + 1).to_string(),
+        ];
+        assert!(matches!(infer_type(&data), DataType::Integer));
+    }
+
+    #[test]
+    fn test_infer_non_finite_numeric_tokens_as_float() {
+        let data = vec![
+            "1.0".to_string(),
+            "Infinity".to_string(),
+            "-inf".to_string(),
+            "2.0".to_string(),
+        ];
         assert!(matches!(infer_type(&data), DataType::Float));
     }
 

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -4,7 +4,9 @@
 //! Key metrics: data type consistency, format violations, encoding issues.
 
 use super::utils::{DATE_FORMAT_REGEXES, is_likely_date_column, is_valid_date_format};
-use crate::analysis::inference::{is_null_like_token, parse_strict_boolean_token};
+use crate::analysis::inference::{
+    is_integer_token, is_null_like_token, parse_strict_boolean_token,
+};
 use crate::core::errors::DataProfilerError;
 use crate::types::{ColumnProfile, DataType};
 use std::collections::HashMap;
@@ -61,7 +63,7 @@ impl ConsistencyCalculator {
 
                     // Check if value is consistent with inferred type
                     let is_consistent = match profile.data_type {
-                        DataType::Integer => trimmed.parse::<i64>().is_ok(),
+                        DataType::Integer => is_integer_token(trimmed),
                         DataType::Float => trimmed.parse::<f64>().is_ok(),
                         DataType::Date => is_valid_date_format(trimmed),
                         DataType::Boolean => parse_strict_boolean_token(trimmed).is_some(),
@@ -267,5 +269,25 @@ mod tests {
             metrics.data_type_consistency < 100.0,
             "likely date columns inferred as strings should still lose consistency when values are malformed"
         );
+    }
+
+    #[test]
+    fn unsigned_integer_tokens_are_consistent_with_integer_profiles() {
+        let data = HashMap::from([(
+            "value".to_string(),
+            vec![
+                "42".to_string(),
+                (i64::MAX as u64 + 1).to_string(),
+                u64::MAX.to_string(),
+            ],
+        )]);
+        let mut profile = string_profile("value");
+        profile.data_type = DataType::Integer;
+
+        let metrics = ConsistencyCalculator::calculate(&data, &[profile])
+            .expect("consistency metrics should be computed");
+
+        assert_eq!(metrics.values_checked, 3);
+        assert_eq!(metrics.data_type_consistency, 100.0);
     }
 }

--- a/crates/dataprof-python/src/database_async.rs
+++ b/crates/dataprof-python/src/database_async.rs
@@ -5,6 +5,7 @@
 
 use pyo3::prelude::*;
 
+use crate::errors::analysis_error_to_py;
 use crate::types::PyProfileReport;
 #[cfg(feature = "database")]
 use dataprof::{DataProfilerError, DatabaseConfig, analyze_database, create_connector};
@@ -48,13 +49,18 @@ pub fn analyze_database_async<'py>(
     batch_size: usize,
     calculate_quality: bool,
 ) -> PyResult<Bound<'py, PyAny>> {
+    if batch_size == 0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "batch_size must be greater than zero",
+        ));
+    }
     // Import pyo3_async_runtimes only when python-async feature is enabled
     #[cfg(feature = "python-async")]
     {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             analyze_database_internal(connection_string, query, batch_size, calculate_quality)
                 .await
-                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+                .map_err(|e| analysis_error_to_py(&e))
         })
     }
 

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -11,7 +11,7 @@ use dataprof_core::{
     BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, SemanticHints, TextStats,
 };
 use dataprof_metrics::{
-    analysis::inference::{is_null_like_token, parse_strict_boolean_token},
+    analysis::inference::{is_integer_token, is_null_like_token, parse_strict_boolean_token},
     analysis::patterns::looks_like_date,
     calculate_datetime_stats, calculate_text_stats, detect_patterns,
     stats::numeric::{calculate_coefficient_of_variation, compute_numeric_stats_with_parsed_count},
@@ -315,31 +315,6 @@ pub fn profile_from_stats_with_hints(
 
 /// Infer [`DataType`] from [`StreamingStatistics`] sample values.
 pub fn infer_data_type_streaming(stats: &StreamingStatistics) -> DataType {
-    if stats.min.is_finite() && stats.max.is_finite() {
-        let sample_values = stats.sample_values();
-        let non_empty: Vec<&String> = sample_values
-            .iter()
-            .filter(|s| !is_null_like_token(s.trim()))
-            .collect();
-
-        if !non_empty.is_empty() {
-            let all_integers = non_empty
-                .iter()
-                .all(|s| s.parse::<i64>().is_ok() || s.parse::<u64>().is_ok());
-            if all_integers {
-                return DataType::Integer;
-            }
-
-            let numeric_count = non_empty
-                .iter()
-                .filter(|s| s.parse::<f64>().is_ok())
-                .count();
-            if numeric_count as f64 / non_empty.len() as f64 > 0.8 {
-                return DataType::Float;
-            }
-        }
-    }
-
     let sample_values = stats.sample_values();
     let non_empty: Vec<&String> = sample_values
         .iter()
@@ -347,6 +322,22 @@ pub fn infer_data_type_streaming(stats: &StreamingStatistics) -> DataType {
         .collect();
 
     if !non_empty.is_empty() {
+        let all_integers = non_empty.iter().all(|s| is_integer_token(s.trim()));
+        if all_integers {
+            return DataType::Integer;
+        }
+
+        // Numeric lexical forms remain numeric even if none are finite enough
+        // to enter the streaming aggregates. `build_column_profile` reports
+        // those unusable values through `invalid_count`.
+        let numeric_count = non_empty
+            .iter()
+            .filter(|s| s.trim().parse::<f64>().is_ok())
+            .count();
+        if numeric_count as f64 / non_empty.len() as f64 > 0.8 {
+            return DataType::Float;
+        }
+
         let date_like_count = non_empty
             .iter()
             .take(100)
@@ -407,6 +398,25 @@ mod tests {
         let age = profiles.iter().find(|p| p.name == "age").unwrap();
         assert_eq!(age.data_type, DataType::Integer);
         assert_eq!(age.total_count, 3);
+    }
+
+    #[test]
+    fn test_all_non_finite_tokens_keep_streaming_float_type() {
+        let mut collection = StreamingColumnCollection::new();
+        let headers = vec!["value".to_string()];
+
+        collection.process_record(&headers, vec!["Infinity".to_string()]);
+        collection.process_record(&headers, vec!["-inf".to_string()]);
+
+        let profiles = profiles_from_streaming(&collection, false, false, None);
+        let value = profiles
+            .iter()
+            .find(|profile| profile.name == "value")
+            .expect("value profile");
+
+        assert_eq!(value.data_type, DataType::Float);
+        assert_eq!(value.invalid_count, Some(2));
+        assert!(matches!(value.stats, ColumnStats::Numeric(_)));
     }
 
     #[test]

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -323,7 +323,9 @@ pub fn infer_data_type_streaming(stats: &StreamingStatistics) -> DataType {
             .collect();
 
         if !non_empty.is_empty() {
-            let all_integers = non_empty.iter().all(|s| s.parse::<i64>().is_ok());
+            let all_integers = non_empty
+                .iter()
+                .all(|s| s.parse::<i64>().is_ok() || s.parse::<u64>().is_ok());
             if all_integers {
                 return DataType::Integer;
             }

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -994,13 +994,17 @@ impl Profiler {
             FileFormat::Parquet => {
                 #[cfg(feature = "parquet")]
                 {
+                    self.ensure_row_limit_only("the async Parquet parser")?;
+                    self.ensure_no_sampling("the async Parquet parser")?;
                     // Parquet requires seeking — delegate to sync parser on a blocking thread.
                     let path = path.to_path_buf();
                     let dims = self.config.quality_dimensions.clone();
                     let semantic_hints = self.semantic_hints();
+                    let parquet_config = self.parquet_config_for_stop();
                     let report = tokio::task::spawn_blocking(move || {
-                        dataprof_parquet::analyze_parquet_with_quality_dims_and_hints(
+                        dataprof_parquet::analyze_parquet_with_config_dims_and_hints(
                             &path,
+                            &parquet_config,
                             dims.as_deref(),
                             &semantic_hints,
                         )

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -126,7 +126,13 @@ A cell is missing when it is `None`, NaN, or a null-like token (`""`, `"null"`,
 *not* round-tripped through pandas, so an integer column containing a null stays
 `integer` rather than being widened to `float`.
 
-For async byte streams, use `dataprof.asyncio.profile_bytes()`.
+Synchronous byte inputs use the in-memory columnar path. They support
+`max_rows`, metric/quality selection, semantic hints, CSV delimiters, and JSONL
+error policy, but reject streaming-only controls (`chunk_size`,
+`memory_limit_mb`, `stop_condition`, progress callbacks, and flexible CSV
+recovery) instead of silently ignoring them. For those controls, use
+`dataprof.asyncio.profile_bytes()`. JSON and JSONL byte buffers follow RFC 8259:
+the non-standard `NaN` and `Infinity` constants are malformed input.
 
 **Engine options:**
 
@@ -593,6 +599,11 @@ report = await profile_bytes(csv_bytes, format="csv")
 report = await profile_url("https://example.com/data.parquet")
 ```
 
+Async byte streams use the incremental engine; `engine="columnar"` is rejected.
+Local async Parquet profiling honors `max_rows` and row-limit stop conditions,
+and rejects stop conditions or sampling strategies the Parquet reader cannot
+apply.
+
 Additional async utilities:
 
 ```python
@@ -641,6 +652,9 @@ async def main():
 
 asyncio.run(main())
 ```
+
+`batch_size` must be greater than zero. Query result column names must be
+unique; duplicate aliases are rejected before values can be merged.
 
 ## Arrow Interop
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -298,6 +298,23 @@ def _bytes_buffer(source: bytes | bytearray | memoryview | _io.BytesIO) -> _io.B
     return _io.BytesIO(bytes(source))
 
 
+class _NonStandardJsonConstant(ValueError):
+    """A JavaScript numeric constant that RFC 8259 JSON does not permit."""
+
+    def __init__(self, value: str) -> None:
+        super().__init__(value)
+        self.value = value
+
+
+def _reject_nonstandard_json_constant(value: str) -> None:
+    raise _NonStandardJsonConstant(value)
+
+
+def _strict_json_loads(text: str) -> Any:
+    """Decode RFC 8259 JSON, rejecting Python's NaN/Infinity extensions."""
+    return json.loads(text, parse_constant=_reject_nonstandard_json_constant)
+
+
 # --- Dependency-free columnar inputs (see _dataprof.profile_columns) ---
 #
 # dict, list-of-dicts, and decoded byte buffers all reduce to named columns of
@@ -409,7 +426,9 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
     This follows the file-based CSV engine, where an empty field is missing data
     rather than an empty string.
     """
-    text = buffer.getvalue().decode("utf-8")
+    # Match the Rust CSV readers: a UTF-8 BOM marks the encoding and is not part
+    # of the first column's name.
+    text = buffer.getvalue().decode("utf-8-sig")
     if delimiter is None:
         try:
             delimiter = _csv.Sniffer().sniff(text[:8192], delimiters=",;\t|").delimiter
@@ -466,7 +485,7 @@ def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
         if not line.strip():
             continue
         try:
-            value = json.loads(line)
+            value = _strict_json_loads(line)
         except json.JSONDecodeError as exc:
             if on_error == "strict":
                 # ``lineno`` is the record's position in the input; ``exc.colno``
@@ -474,6 +493,15 @@ def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
                 # included.
                 raise ValueError(
                     f"jsonl bytes: malformed JSON record on line {lineno}, column {exc.colno}."
+                ) from None
+            skipped += 1
+            continue
+        except _NonStandardJsonConstant as exc:
+            if on_error == "strict":
+                column = line.find(exc.value) + 1
+                raise ValueError(
+                    f"jsonl bytes: malformed JSON record on line {lineno}, column {column} "
+                    f"(non-standard numeric constant {exc.value!r})."
                 ) from None
             skipped += 1
             continue
@@ -1011,7 +1039,10 @@ def profile(
 
     Accepts file paths (str/Path), pandas DataFrames, polars DataFrames,
     Arrow PyCapsule-compatible objects, dict/list-of-dicts, and bytes-like
-    file contents when ``format=`` is provided.
+    file contents when ``format=`` is provided. Synchronous bytes use the
+    in-memory columnar path and reject streaming-only controls such as
+    ``chunk_size``, ``memory_limit_mb``, ``stop_condition``, and progress
+    callbacks; use ``dataprof.asyncio.profile_bytes()`` for those.
 
     Args:
         source: Data source to profile.
@@ -1173,6 +1204,28 @@ def profile(
                 "bytes and BytesIO sources require format='csv', 'json', 'jsonl', or 'parquet'. "
                 "For async byte streams, use dataprof.asyncio.profile_bytes(data, format='csv')."
             )
+        unsupported: list[str] = []
+        if engine not in ("auto", "columnar"):
+            unsupported.append("engine")
+        if chunk_size is not None:
+            unsupported.append("chunk_size")
+        if memory_limit_mb is not None:
+            unsupported.append("memory_limit_mb")
+        if stop_condition is not None:
+            unsupported.append("stop_condition")
+        if on_progress is not None:
+            unsupported.append("on_progress")
+        if progress_interval_ms is not None:
+            unsupported.append("progress_interval_ms")
+        if csv_flexible is True:
+            unsupported.append("csv_flexible=True")
+        if unsupported:
+            joined = ", ".join(unsupported)
+            raise ValueError(
+                f"Synchronous bytes input cannot apply: {joined}. "
+                "Use max_rows for a row cap, or dataprof.asyncio.profile_bytes() "
+                "for streaming controls."
+            )
         if sampling is not None and not getattr(sampling, "is_noop", False):
             # Synchronous byte input is read by the pure-Python reader, which has
             # no row-by-row sampling stage. Returning a full profile while the
@@ -1196,11 +1249,15 @@ def profile(
         elif fmt == "json":
             text = buffer.getvalue().decode("utf-8")
             try:
-                rows = json.loads(text)
+                rows = _strict_json_loads(text)
             except json.JSONDecodeError as exc:
                 # Surface a dataprof error category, not a bare decoder exception.
                 raise ValueError(
                     f"json bytes: malformed JSON (line {exc.lineno}, column {exc.colno})."
+                ) from None
+            except _NonStandardJsonConstant as exc:
+                raise ValueError(
+                    f"json bytes: malformed JSON (non-standard numeric constant {exc.value!r})."
                 ) from None
             if isinstance(rows, dict):
                 if all(isinstance(values, (list, tuple)) for values in rows.values()):

--- a/python/dataprof/asyncio.py
+++ b/python/dataprof/asyncio.py
@@ -63,11 +63,18 @@ async def profile_bytes(
         data: Raw bytes to profile.
         format: Data format ("csv", "json", "jsonl").
         **kwargs: Additional config options (passed to ProfilerConfig).
+            The async stream always uses the incremental engine, so
+            ``engine="columnar"`` is rejected.
 
     Returns:
         ProfileReport with analysis results.
     """
     _check_async()
+    if kwargs.get("engine") == "columnar":
+        raise ValueError(
+            "engine='columnar' is not available for async bytes input; "
+            "use engine='auto' or 'incremental'."
+        )
     config = ProfilerConfig(**kwargs) if kwargs else None
     rust_report = await _profile_bytes_async(data, format, config)
     return ProfileReport(rust_report)

--- a/python/tests/test_database_api.py
+++ b/python/tests/test_database_api.py
@@ -121,6 +121,23 @@ class TestDatabaseAnalysis:
         )
         assert report.rows_processed == 5
 
+    def test_zero_batch_size_is_rejected(self, sqlite_db):
+        with pytest.raises(ValueError, match="greater than zero"):
+            _run(
+                analyze_database_async,
+                sqlite_db,
+                "SELECT * FROM test_users",
+                batch_size=0,
+            )
+
+    def test_duplicate_query_aliases_are_rejected(self, sqlite_db):
+        with pytest.raises(ValueError, match="[Dd]uplicate column name"):
+            _run(
+                analyze_database_async,
+                sqlite_db,
+                "SELECT id AS duplicate, age AS duplicate FROM test_users",
+            )
+
     def test_analyze_filtered_query(self, sqlite_db):
         report = _run(
             analyze_database_async,

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -411,3 +411,24 @@ def test_rectangular_source_has_one_profile_per_column(tmp_path):
         assert report.columns == len(list(report.column_profiles)) == 3, engine
         for col in report.column_profiles:
             assert report[col].total_count == report.rows, f"{engine} {col}"
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_non_finite_csv_tokens_keep_numeric_type(engine, tmp_path):
+    path = tmp_path / "non_finite.csv"
+    path.write_text("x\n1.0\nInfinity\n-inf\n2.0\n")
+
+    column = dataprof.profile(path, engine=engine)["x"]
+    assert column.data_type == "float"
+    assert column.invalid_count == 2
+    assert column.min == 1.0
+    assert column.max == 2.0
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_unsigned_values_beyond_i64_keep_integer_type(engine, tmp_path):
+    path = tmp_path / "unsigned.csv"
+    path.write_text(f"x\n{2**64 - 1}\n{2**64 - 2}\n")
+
+    column = dataprof.profile(path, engine=engine)["x"]
+    assert column.data_type == "integer"

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -426,9 +426,23 @@ def test_non_finite_csv_tokens_keep_numeric_type(engine, tmp_path):
 
 
 @pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_all_non_finite_csv_tokens_keep_numeric_type(engine, tmp_path):
+    path = tmp_path / "all_non_finite.csv"
+    path.write_text("x\nInfinity\n-inf\n")
+
+    column = dataprof.profile(path, engine=engine)["x"]
+    assert column.data_type == "float"
+    assert column.invalid_count == 2
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
 def test_unsigned_values_beyond_i64_keep_integer_type(engine, tmp_path):
     path = tmp_path / "unsigned.csv"
     path.write_text(f"x\n{2**64 - 1}\n{2**64 - 2}\n")
 
-    column = dataprof.profile(path, engine=engine)["x"]
+    report = dataprof.profile(path, engine=engine)
+    column = report["x"]
     assert column.data_type == "integer"
+    assert report.quality is not None
+    assert report.quality.consistency is not None
+    assert report.quality.consistency["data_type_consistency"] == 100.0

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -284,3 +284,43 @@ def test_async_json_row_cap_keeps_partial_byte_accounting(fmt, data):
     assert not report.source_exhausted
     assert 0 < _bytes_consumed(report) < len(data)
     _assert_consistent(report, len(data), f"async bounded {fmt} bytes")
+
+
+@requires_async
+def test_async_bytes_reject_columnar_engine():
+    with pytest.raises(ValueError, match="columnar"):
+        _async_bytes(_csv_bytes(3), engine="columnar")
+
+
+@requires_async
+def test_async_parquet_honors_row_cap(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    from dataprof.asyncio import profile_file
+
+    path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"id": list(range(10))}), path)
+
+    async def _inner():
+        return await profile_file(path, max_rows=3)
+
+    report = asyncio.run(_inner())
+    assert report.rows == 3
+    assert report.truncation_reason == "max_rows(3)"
+    assert not report.source_exhausted
+
+
+@requires_async
+def test_async_parquet_rejects_unsupported_stop_condition(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    from dataprof.asyncio import profile_file
+
+    path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"id": list(range(10))}), path)
+
+    async def _inner():
+        return await profile_file(path, stop_condition=dp.StopCondition.max_bytes(1))
+
+    with pytest.raises(ValueError, match="only row-limit"):
+        asyncio.run(_inner())

--- a/python/tests/test_json_array_error_policy.py
+++ b/python/tests/test_json_array_error_policy.py
@@ -71,6 +71,13 @@ def test_bytes_reject_invalid_container(data, case):
         dataprof.profile(data, format="json")
 
 
+@pytest.mark.parametrize("constant", [b"NaN", b"Infinity", b"-Infinity"])
+def test_bytes_reject_non_standard_numeric_constants(constant):
+    data = b'[{"id":1},{"id":' + constant + b"}]"
+    with pytest.raises(ValueError, match="non-standard numeric constant"):
+        dataprof.profile(data, format="json")
+
+
 @requires_async
 @pytest.mark.parametrize(("data", "case"), INVALID_WITH_VALID_PREFIX)
 def test_async_tolerant_surfaces_invalid_container(data, case):

--- a/python/tests/test_jsonl_error_policy.py
+++ b/python/tests/test_jsonl_error_policy.py
@@ -69,6 +69,21 @@ def test_bytes_tolerant_reports_partial_and_error_count():
     assert report.error_count == 1
 
 
+@pytest.mark.parametrize("constant", [b"NaN", b"Infinity", b"-Infinity"])
+def test_bytes_tolerant_counts_non_standard_numeric_constants(constant):
+    data = b'{"id":1}\n{"id":' + constant + b"}\n"
+    report = dataprof.profile(data, format="jsonl")
+    assert report.rows == 1
+    assert report.error_count == 1
+
+
+@pytest.mark.parametrize("constant", [b"NaN", b"Infinity", b"-Infinity"])
+def test_bytes_strict_rejects_non_standard_numeric_constants(constant):
+    data = b'{"id":1}\n{"id":' + constant + b"}\n"
+    with pytest.raises(ValueError, match="non-standard numeric constant"):
+        dataprof.profile(data, format="jsonl", jsonl_on_error="strict")
+
+
 @requires_async
 def test_async_bytes_tolerant_reports_partial_and_error_count():
     report = _async_bytes(MIXED)

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -334,6 +334,26 @@ class TestProfileAdHocInputs:
         with pytest.raises(ValueError, match="dataprof.asyncio.profile_bytes"):
             dataprof.profile(b"a,b\n1,2\n")
 
+    def test_sync_bytes_reject_controls_they_cannot_apply(self):
+        data = b"a,b\n1,2\n3,4\n"
+        unsupported = [
+            lambda: dataprof.profile(data, format="csv", engine="incremental"),
+            lambda: dataprof.profile(data, format="csv", engine="not-an-engine"),
+            lambda: dataprof.profile(data, format="csv", chunk_size=1024),
+            lambda: dataprof.profile(data, format="csv", memory_limit_mb=1),
+            lambda: dataprof.profile(
+                data,
+                format="csv",
+                stop_condition=dataprof.StopCondition.max_rows(1),
+            ),
+            lambda: dataprof.profile(data, format="csv", on_progress=lambda _event: None),
+            lambda: dataprof.profile(data, format="csv", progress_interval_ms=1),
+            lambda: dataprof.profile(data, format="csv", csv_flexible=True),
+        ]
+        for call in unsupported:
+            with pytest.raises(ValueError, match="cannot apply"):
+                call()
+
     def test_ad_hoc_inputs_do_not_import_pandas(self, monkeypatch):
         """The base wheel has no dependencies; profiling must not reach for one."""
 
@@ -364,6 +384,17 @@ class TestProfileAdHocInputs:
         r = dataprof.profile({"x": ["a", "", None, "null", float("nan")]})
         assert r["x"].null_count == 4
         assert r["x"].unique_count == 1
+
+    def test_dict_infers_unsigned_values_beyond_i64_as_integer(self):
+        r = dataprof.profile({"x": [2**64 - 1, 2**64 - 2]})
+        assert r["x"].data_type == "integer"
+
+    def test_dict_keeps_non_finite_numeric_values_in_a_float_column(self):
+        r = dataprof.profile({"x": [1.0, float("inf"), float("-inf"), 2.0]})
+        assert r["x"].data_type == "float"
+        assert r["x"].invalid_count == 2
+        assert r["x"].min == 1.0
+        assert r["x"].max == 2.0
 
     def test_dict_rejects_ragged_columns(self):
         with pytest.raises(ValueError, match="differing lengths"):
@@ -429,6 +460,10 @@ class TestProfileAdHocInputs:
 
     def test_csv_bytes_auto_detect_delimiter_like_file_input(self):
         r = dataprof.profile(b"a;b\n1;2\n", format="csv")
+        assert list(r.column_profiles) == ["a", "b"]
+
+    def test_csv_bytes_strip_utf8_bom_from_first_header(self):
+        r = dataprof.profile(b"\xef\xbb\xbfa,b\n1,2\n", format="csv")
         assert list(r.column_profiles) == ["a", "b"]
 
     def test_csv_bytes_reject_ragged_rows(self):


### PR DESCRIPTION
## Summary

- reject execution controls that synchronous byte inputs cannot honor, and reject the columnar engine for async byte streams
- make JSON byte decoding RFC 8259-strict and strip CSV UTF-8 BOMs consistently
- align inference for non-finite numeric tokens and unsigned integers beyond `i64`
- apply row limits to async local Parquet profiling
- reject zero-sized database batches and duplicate query aliases before columns can be lost or merged
- add regression coverage and document the clarified behavior

## Why

Deep 0.11.0 dogfooding found several paths that accepted configuration without applying it, or produced different results for equivalent inputs. The contained, reproducible fixes belong together as hardening of input and execution contracts; larger cross-path gaps remain tracked separately in #494, #495, #496, and #497.

## Root causes

Some convenience paths bypass the streaming configuration layer, Python's standard JSON decoder accepts non-standard constants by default, numeric inference was limited to signed 64-bit integers and finite floats, async Parquet did not receive the configured row cap, and database rows were collected into name-keyed maps without validating names first.

## Impact

Callers now receive an explicit error instead of a silently ignored option or lossy database result. Equivalent CSV and numeric inputs profile more consistently across engines, and async Parquet honors configured row limits.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- all-feature Python suite: 605 passed, 4 skipped
- `uv run ruff format --check python/ .github/scripts/`
- `uv run ruff check python/ .github/scripts/`
- `uv run ty check python/`
- `git diff --check`
