### PR TITLE
fix: accept leading UTF-8 BOM in JSON inputs

### DIFF
--- a/crates/dataprof-core/src/io.rs
+++ b/crates/dataprof-core/src/io.rs
@@ -1,0 +1,118 @@
+use std::io::{self, BufRead, Read};
+
+const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
+
+/// A buffered reader that removes exactly one UTF-8 BOM at byte offset zero.
+///
+/// Bytes inspected during construction are replayed unchanged when they are not
+/// the complete UTF-8 BOM. This also makes detection reliable when the wrapped
+/// reader exposes the prefix one byte at a time.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct Utf8BomReader<R> {
+    inner: R,
+    prefix: [u8; UTF8_BOM.len()],
+    prefix_len: usize,
+    prefix_pos: usize,
+    stripped: bool,
+}
+
+impl<R: Read> Utf8BomReader<R> {
+    pub fn new(mut inner: R) -> io::Result<Self> {
+        let mut prefix = [0; UTF8_BOM.len()];
+        let mut prefix_len = 0;
+
+        while prefix_len < prefix.len() {
+            match inner.read(&mut prefix[prefix_len..]) {
+                Ok(0) => break,
+                Ok(read) => prefix_len += read,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(error),
+            }
+        }
+
+        let stripped = prefix_len == UTF8_BOM.len() && prefix == UTF8_BOM;
+        if stripped {
+            prefix_len = 0;
+        }
+
+        Ok(Self {
+            inner,
+            prefix,
+            prefix_len,
+            prefix_pos: 0,
+            stripped,
+        })
+    }
+
+    /// Number of source bytes removed from the decoded view.
+    pub fn stripped_len(&self) -> usize {
+        usize::from(self.stripped) * UTF8_BOM.len()
+    }
+}
+
+impl<R: Read> Read for Utf8BomReader<R> {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        if self.prefix_pos < self.prefix_len && !output.is_empty() {
+            let available = &self.prefix[self.prefix_pos..self.prefix_len];
+            let copied = available.len().min(output.len());
+            output[..copied].copy_from_slice(&available[..copied]);
+            self.prefix_pos += copied;
+            return Ok(copied);
+        }
+
+        self.inner.read(output)
+    }
+}
+
+impl<R: BufRead> BufRead for Utf8BomReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        if self.prefix_pos < self.prefix_len {
+            Ok(&self.prefix[self.prefix_pos..self.prefix_len])
+        } else {
+            self.inner.fill_buf()
+        }
+    }
+
+    fn consume(&mut self, amount: usize) {
+        let prefix_remaining = self.prefix_len.saturating_sub(self.prefix_pos);
+        let prefix_consumed = amount.min(prefix_remaining);
+        self.prefix_pos += prefix_consumed;
+        self.inner.consume(amount - prefix_consumed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn read_all(data: &[u8]) -> (Vec<u8>, usize) {
+        let chunked = BufReader::with_capacity(1, Cursor::new(data));
+        let mut reader = Utf8BomReader::new(chunked).unwrap();
+        let stripped = reader.stripped_len();
+        let mut output = Vec::new();
+        reader.read_to_end(&mut output).unwrap();
+        (output, stripped)
+    }
+
+    #[test]
+    fn strips_one_leading_utf8_bom_across_small_buffers() {
+        let (output, stripped) = read_all(b"\xEF\xBB\xBF{\"id\":1}");
+        assert_eq!(output, b"{\"id\":1}");
+        assert_eq!(stripped, 3);
+    }
+
+    #[test]
+    fn preserves_incomplete_nonleading_and_second_bom_bytes() {
+        for data in [
+            b"\xEF\xBB".as_slice(),
+            b" \xEF\xBB\xBF{}".as_slice(),
+            b"\xEF\xBB\xBF\xEF\xBB\xBF{}".as_slice(),
+        ] {
+            let (output, _) = read_all(data);
+            let expected = data.strip_prefix(&UTF8_BOM).unwrap_or(data);
+            assert_eq!(output, expected);
+        }
+    }
+}

--- a/crates/dataprof-core/src/io.rs
+++ b/crates/dataprof-core/src/io.rs
@@ -25,7 +25,12 @@ impl<R: Read> Utf8BomReader<R> {
         while prefix_len < prefix.len() {
             match inner.read(&mut prefix[prefix_len..]) {
                 Ok(0) => break,
-                Ok(read) => prefix_len += read,
+                Ok(read) => {
+                    prefix_len += read;
+                    if prefix[..prefix_len] != UTF8_BOM[..prefix_len] {
+                        break;
+                    }
+                }
                 Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
                 Err(error) => return Err(error),
             }
@@ -85,10 +90,37 @@ impl<R: BufRead> BufRead for Utf8BomReader<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufReader, Cursor};
+    use std::cell::Cell;
+    use std::io::Cursor;
+    use std::rc::Rc;
+
+    #[derive(Debug)]
+    struct OneByteReader<'a> {
+        inner: Cursor<&'a [u8]>,
+        read_calls: Rc<Cell<usize>>,
+    }
+
+    impl Read for OneByteReader<'_> {
+        fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+            self.read_calls.set(self.read_calls.get() + 1);
+            let limit = output.len().min(1);
+            self.inner.read(&mut output[..limit])
+        }
+    }
+
+    fn one_byte_reader(data: &[u8]) -> (OneByteReader<'_>, Rc<Cell<usize>>) {
+        let read_calls = Rc::new(Cell::new(0));
+        (
+            OneByteReader {
+                inner: Cursor::new(data),
+                read_calls: Rc::clone(&read_calls),
+            },
+            read_calls,
+        )
+    }
 
     fn read_all(data: &[u8]) -> (Vec<u8>, usize) {
-        let chunked = BufReader::with_capacity(1, Cursor::new(data));
+        let (chunked, _) = one_byte_reader(data);
         let mut reader = Utf8BomReader::new(chunked).unwrap();
         let stripped = reader.stripped_len();
         let mut output = Vec::new();
@@ -113,6 +145,20 @@ mod tests {
             let (output, _) = read_all(data);
             let expected = data.strip_prefix(&UTF8_BOM).unwrap_or(data);
             assert_eq!(output, expected);
+        }
+    }
+
+    #[test]
+    fn stops_reading_as_soon_as_the_prefix_cannot_be_a_bom() {
+        for data in [b"{}".as_slice(), b" \xEF\xBB\xBF{}".as_slice()] {
+            let (inner, read_calls) = one_byte_reader(data);
+            let mut reader = Utf8BomReader::new(inner).unwrap();
+
+            assert_eq!(read_calls.get(), 1);
+            let mut output = Vec::new();
+            reader.read_to_end(&mut output).unwrap();
+            assert_eq!(output, data);
+            assert_eq!(reader.stripped_len(), 0);
         }
     }
 }

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -2,6 +2,8 @@ pub mod classification;
 pub mod config;
 pub mod errors;
 pub mod execution;
+#[doc(hidden)]
+pub mod io;
 pub mod memory_sampler;
 pub mod memory_tracker;
 pub mod output;
@@ -26,6 +28,8 @@ pub use config::{
 };
 pub use errors::{DataProfilerError, RecoveryAttempt, RecoveryStrategy, RetryConfig};
 pub use execution::{ExecutionMetadata, TruncationReason};
+#[doc(hidden)]
+pub use io::Utf8BomReader;
 pub use memory_sampler::PeakMemorySampler;
 pub use memory_tracker::{MemoryLeak, MemoryTracker};
 pub use output::OutputFormat;

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -520,12 +520,16 @@ impl AsyncStreamingProfiler {
         use serde_json::Value;
         use std::io::BufRead;
 
-        let mut buf_reader = std::io::BufReader::new(sync_reader);
+        let buf_reader = std::io::BufReader::new(sync_reader);
+        let mut buf_reader =
+            dataprof_core::Utf8BomReader::new(buf_reader).map_err(DataProfilerError::from)?;
         let mut known_columns: Vec<String> = Vec::new();
         let mut current_chunk: Vec<Vec<String>> = Vec::new();
         let mut known_columns_set: std::collections::HashSet<String> =
             std::collections::HashSet::new();
-        let mut bytes_in_chunk: u64 = 0;
+        // The BOM is part of the source and therefore of progress/byte
+        // accounting, even though it is not passed to the JSON decoder.
+        let mut bytes_in_chunk = buf_reader.stripped_len() as u64;
         let mut headers_sent = false;
         let mut malformed_records: usize = 0;
         let mut emitted_records: usize = 0;
@@ -1373,6 +1377,36 @@ mod tests {
             bytes::Bytes::from_static(data),
             AsyncSourceInfo::new("test", FileFormat::Json).size_hint(Some(data.len() as u64)),
         )
+    }
+
+    #[tokio::test]
+    async fn test_async_json_and_jsonl_accept_leading_utf8_bom_and_count_it() {
+        for source in [
+            json_source(b"\xEF\xBB\xBF[{\"id\":1},{\"id\":2}]"),
+            jsonl_source(b"\xEF\xBB\xBF{\"id\":1}\n{\"id\":2}\n"),
+        ] {
+            let expected_bytes = source.source_info().size_hint.unwrap();
+            let report = AsyncStreamingProfiler::new()
+                .analyze_stream(source)
+                .await
+                .unwrap();
+
+            assert_eq!(report.execution.rows_processed, 2);
+            assert_eq!(report.execution.error_count, 0);
+            assert_eq!(report.execution.bytes_consumed, Some(expected_bytes));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_jsonl_does_not_strip_later_utf8_bom() {
+        let source = jsonl_source(b"{\"id\":1}\n\xEF\xBB\xBF{\"id\":2}\n");
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+
+        assert_eq!(report.execution.rows_processed, 1);
+        assert_eq!(report.execution.error_count, 1);
     }
 
     #[tokio::test]

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 pub use dataprof_core::JsonErrorPolicy;
 use dataprof_core::{
     ColumnProfile, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, QualityDimension,
-    SemanticHints, TruncationReason,
+    SemanticHints, TruncationReason, Utf8BomReader,
 };
 use dataprof_runtime::{
     ProfileReport, ReportAssembler, StreamingColumnCollection, profile_builder,
@@ -83,7 +83,7 @@ pub struct JsonScanSummary {
 /// - **JSONL**: scans one top-level JSON value at a time from the reader.
 /// - **JSON array**: streams array elements without buffering the entire input.
 pub fn scan_json_from_reader<R, F>(
-    mut reader: R,
+    reader: R,
     config: &JsonParserConfig,
     mut on_object: F,
 ) -> Result<JsonScanSummary, DataProfilerError>
@@ -91,6 +91,7 @@ where
     R: BufRead,
     F: FnMut(&JsonObject),
 {
+    let mut reader = Utf8BomReader::new(reader).map_err(DataProfilerError::from)?;
     let format = match config.format {
         Some(JsonFormat::JsonArray) => FileFormat::Json,
         Some(JsonFormat::Jsonl) => FileFormat::Jsonl,
@@ -603,6 +604,13 @@ mod tests {
         file
     }
 
+    fn write_bytes(content: &[u8]) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
     #[test]
     fn test_scan_jsonl_detects_format_and_rows() {
         let data = b"{\"x\":1}\n{\"x\":2}\n{\"x\":3}\n";
@@ -639,6 +647,56 @@ mod tests {
         assert_eq!(summary.rows_read, 2);
         assert_eq!(keys.len(), 2);
         assert_eq!(keys[0], vec!["name".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_accepts_one_leading_utf8_bom_for_json_and_jsonl() {
+        for (data, config, expected_format) in [
+            (
+                b"\xEF\xBB\xBF[{\"x\":1},{\"x\":2}]".as_slice(),
+                JsonParserConfig::default(),
+                FileFormat::Json,
+            ),
+            (
+                b"\xEF\xBB\xBF{\"x\":1}\n{\"x\":2}\n".as_slice(),
+                JsonParserConfig::default(),
+                FileFormat::Jsonl,
+            ),
+        ] {
+            let mut rows = 0;
+            let summary = scan_json_from_reader(Cursor::new(data), &config, |_| rows += 1)
+                .expect("leading UTF-8 BOM should be accepted");
+
+            assert_eq!(rows, 2);
+            assert_eq!(summary.rows_read, 2);
+            assert_eq!(summary.malformed_lines, 0);
+            assert_eq!(summary.format, expected_format);
+        }
+    }
+
+    #[test]
+    fn test_scan_does_not_strip_nonleading_or_second_utf8_bom() {
+        let strict = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
+
+        for data in [
+            b" \xEF\xBB\xBF{\"x\":1}\n".as_slice(),
+            b"\xEF\xBB\xBF\xEF\xBB\xBF{\"x\":1}\n".as_slice(),
+            b"{\"x\":1}\n\xEF\xBB\xBF{\"x\":2}\n".as_slice(),
+        ] {
+            scan_json_from_reader(Cursor::new(data), &strict, |_| {})
+                .expect_err("only the BOM at absolute byte offset zero may be stripped");
+        }
+    }
+
+    #[test]
+    fn test_bom_only_input_matches_empty_input_policy() {
+        for config in [JsonParserConfig::default(), JsonParserConfig::jsonl()] {
+            let empty = scan_json_from_reader(Cursor::new(b""), &config, |_| {}).unwrap();
+            let bom =
+                scan_json_from_reader(Cursor::new(b"\xEF\xBB\xBF".as_slice()), &config, |_| {})
+                    .unwrap();
+            assert_eq!(bom, empty);
+        }
     }
 
     #[test]
@@ -1057,6 +1115,23 @@ mod tests {
                 format: FileFormat::Jsonl,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn test_bom_prefixed_file_preserves_source_size() {
+        let data = b"\xEF\xBB\xBF[{\"x\":1}]";
+        let json = write_bytes(data);
+        let report = analyze_json_file(json.path(), &JsonParserConfig::json_array()).unwrap();
+
+        assert_eq!(report.execution.rows_processed, 1);
+        assert!(matches!(
+            report.data_source,
+            DataSource::File {
+                format: FileFormat::Json,
+                size_bytes,
+                ..
+            } if size_bytes == data.len() as u64
         ));
     }
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1243,11 +1243,11 @@ def profile(
         if fmt == "csv":
             columns = _columns_from_csv_bytes(buffer, csv_delimiter)
         elif fmt == "jsonl":
-            text = buffer.getvalue().decode("utf-8")
+            text = buffer.getvalue().decode("utf-8-sig")
             rows, skipped = _scan_jsonl_records(text, jsonl_on_error)
             columns = _columns_from_records(rows, max_rows, sort_keys=True)
         elif fmt == "json":
-            text = buffer.getvalue().decode("utf-8")
+            text = buffer.getvalue().decode("utf-8-sig")
             try:
                 rows = _strict_json_loads(text)
             except json.JSONDecodeError as exc:

--- a/python/tests/test_async_url_api.py
+++ b/python/tests/test_async_url_api.py
@@ -10,6 +10,7 @@ For remote Parquet coverage:
 from __future__ import annotations
 
 import asyncio
+import codecs
 import contextlib
 import http.server
 import socketserver
@@ -67,6 +68,8 @@ def url_server():
     incidents_csv = INCIDENTS_CSV.read_bytes()
     checkout_jsonl = CHECKOUT_JSONL.read_bytes()
     parquet_bytes = PARQUET_FILE.read_bytes()
+    bom_json = codecs.BOM_UTF8 + b'[{"id":1,"score":2.5},{"id":2,"score":3.5}]'
+    bom_jsonl = codecs.BOM_UTF8 + b'{"id":1,"score":2.5}\n{"id":2,"score":3.5}\n'
 
     class Handler(http.server.BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
@@ -115,6 +118,10 @@ def url_server():
                 return checkout_jsonl
             if self.path == "/data.parquet":
                 return parquet_bytes
+            if self.path == "/bom.json":
+                return bom_json
+            if self.path == "/bom.jsonl":
+                return bom_jsonl
             raise AssertionError(f"unexpected path: {self.path}")
 
     server = _ThreadingTcpServer(("127.0.0.1", 0), Handler)
@@ -127,6 +134,8 @@ def url_server():
             "csv": f"http://127.0.0.1:{port}/incidents.csv",
             "jsonl": f"http://127.0.0.1:{port}/checkout_events.jsonl",
             "parquet": f"http://127.0.0.1:{port}/data.parquet",
+            "bom_json": f"http://127.0.0.1:{port}/bom.json",
+            "bom_jsonl": f"http://127.0.0.1:{port}/bom.jsonl",
         }
     finally:
         with contextlib.suppress(Exception):
@@ -177,6 +186,20 @@ class TestAsyncUrlProfiling:
         assert report.columns == 10
         assert report.source_type == "stream"
         assert report["risk_score"].max == 0.98
+
+    @pytest.mark.parametrize("fmt", ["json", "jsonl"])
+    def test_profile_bom_prefixed_json_url(self, url_server, fmt):
+        report = _run(profile_url, url_server[f"bom_{fmt}"])
+        payload = (
+            b'[{"id":1,"score":2.5},{"id":2,"score":3.5}]'
+            if fmt == "json"
+            else b'{"id":1,"score":2.5}\n{"id":2,"score":3.5}\n'
+        )
+
+        assert report.rows == 2
+        assert report.columns == 2
+        assert report["score"].max == 3.5
+        assert report.to_dict()["execution"]["bytes_consumed"] == len(codecs.BOM_UTF8 + payload)
 
     def test_profile_parquet_url(self, url_server):
         try:

--- a/python/tests/test_json_bom.py
+++ b/python/tests/test_json_bom.py
@@ -1,0 +1,94 @@
+"""UTF-8 BOM parity for JSON and JSONL transports (#497)."""
+
+from __future__ import annotations
+
+import asyncio
+import codecs
+
+import dataprof
+import pytest
+from dataprof.asyncio import profile_bytes, profile_file
+
+PAYLOADS = {
+    "json": b'[{"id":1,"label":"alpha"},{"id":2,"label":"beta"}]',
+    "jsonl": b'{"id":1,"label":"alpha"}\n{"id":2,"label":"beta"}\n',
+}
+
+
+def _signature(report) -> tuple:
+    return (
+        report.rows,
+        report.columns,
+        tuple(
+            (
+                name,
+                report[name].data_type,
+                report[name].total_count,
+                report[name].null_count,
+            )
+            for name in report.column_profiles
+        ),
+    )
+
+
+def _run(awaitable):
+    return asyncio.run(awaitable)
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_sync_bytes_accept_one_leading_utf8_bom(fmt):
+    plain = dataprof.profile(PAYLOADS[fmt], format=fmt)
+    prefixed = dataprof.profile(codecs.BOM_UTF8 + PAYLOADS[fmt], format=fmt)
+
+    assert _signature(prefixed) == _signature(plain)
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_sync_file_accepts_one_leading_utf8_bom(tmp_path, fmt):
+    plain_path = tmp_path / f"plain.{fmt}"
+    bom_path = tmp_path / f"bom.{fmt}"
+    plain_path.write_bytes(PAYLOADS[fmt])
+    bom_path.write_bytes(codecs.BOM_UTF8 + PAYLOADS[fmt])
+
+    plain = dataprof.profile(plain_path, format=fmt)
+    prefixed = dataprof.profile(bom_path, format=fmt)
+
+    assert _signature(prefixed) == _signature(plain)
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_async_bytes_and_file_accept_bom_and_count_source_bytes(tmp_path, fmt):
+    data = codecs.BOM_UTF8 + PAYLOADS[fmt]
+    path = tmp_path / f"bom.{fmt}"
+    path.write_bytes(data)
+
+    bytes_report = _run(profile_bytes(data, format=fmt))
+    file_report = _run(profile_file(path, format=fmt))
+
+    assert _signature(bytes_report) == _signature(file_report)
+    assert bytes_report.to_dict()["execution"]["bytes_consumed"] == len(data)
+    assert file_report.to_dict()["execution"]["bytes_consumed"] == len(data)
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_nonleading_and_second_bom_remain_malformed(fmt):
+    payload = PAYLOADS[fmt]
+    for data in (b" " + codecs.BOM_UTF8 + payload, codecs.BOM_UTF8 * 2 + payload):
+        with pytest.raises(ValueError, match="malformed"):
+            dataprof.profile(data, format=fmt, jsonl_on_error="strict")
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_bom_only_matches_empty_input_policy(fmt):
+    for data in (b"", codecs.BOM_UTF8):
+        try:
+            report = dataprof.profile(data, format=fmt)
+        except ValueError as error:
+            outcome = ("error", str(error))
+        else:
+            outcome = ("report", _signature(report))
+
+        if data == b"":
+            empty_outcome = outcome
+        else:
+            assert outcome == empty_outcome

--- a/python/tests/test_json_bom.py
+++ b/python/tests/test_json_bom.py
@@ -9,6 +9,13 @@ import dataprof
 import pytest
 from dataprof.asyncio import profile_bytes, profile_file
 
+_HAS_ASYNC = dataprof.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
 PAYLOADS = {
     "json": b'[{"id":1,"label":"alpha"},{"id":2,"label":"beta"}]',
     "jsonl": b'{"id":1,"label":"alpha"}\n{"id":2,"label":"beta"}\n',
@@ -57,6 +64,7 @@ def test_sync_file_accepts_one_leading_utf8_bom(tmp_path, fmt):
 
 
 @pytest.mark.parametrize("fmt", ["json", "jsonl"])
+@requires_async
 def test_async_bytes_and_file_accept_bom_and_count_source_bytes(tmp_path, fmt):
     data = codecs.BOM_UTF8 + PAYLOADS[fmt]
     path = tmp_path / f"bom.{fmt}"


### PR DESCRIPTION
## Summary

- accept exactly one leading UTF-8 BOM for JSON and JSONL across synchronous bytes, native files, async bytes/files, and URL streams
- preserve the BOM in source-size and bytes-consumed accounting while keeping later or repeated BOMs malformed
- add a replaying buffered-reader boundary so detection remains correct even when the three-byte prefix arrives in separate chunks

## Root cause

JSON decoding began directly at byte zero in the Python byte wrapper and both Rust scanners. Unlike the CSV paths, they exposed the UTF-8 signature to the JSON parser, which rejected it before container or record detection.

## Impact

BOM-prefixed JSON exports from Windows editors and export tooling now profile identically to the same UTF-8 payload without a BOM. This is signature handling only; non-UTF-8 input remains unsupported.

Closes #497

## Validation

- `cargo test -p dataprof-core`
- `cargo test -p dataprof-json`
- `cargo test -p dataprof-engines --features async-streaming`
- `cargo clippy -p dataprof-core -p dataprof-json -p dataprof-engines --features dataprof-engines/async-streaming --all-targets -- -D warnings`
- `uv run pytest python/tests/test_json_bom.py python/tests/test_async_url_api.py -q` (19 passed)
- JSON/API regression matrix (407 passed, 1 expected skip)
- `uv run ruff check ...`
- `uv run ty check python/`
- `cargo fmt --all -- --check`