### PR TITLE
fix(json): preserve source field order for JSON and JSONL columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,6 +3152,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,9 @@ regex = "1.12"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 schemars = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.149"
+# preserve_order is load-bearing: it backs `Map` with an IndexMap so JSON/JSONL
+# records profile into source field order instead of alphabetical order (#465).
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
 sqlx = { version = "0.8.1", default-features = false, features = ["runtime-tokio-rustls", "chrono", "uuid"] }
 sysinfo = "0.39"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ For the leanest Rust build, use `default-features = false` or `cargo --no-defaul
 | bytes / BytesIO | Columnar | Python API only; requires `format=`. CSV, JSON and JSONL need no dependencies; Parquet bytes need the `pandas` extra |
 | Async byte stream | Incremental | Any `AsyncRead` source (HTTP, WebSocket, etc.) |
 
+Reported columns follow source order in every format and on every transport: the
+CSV header, the Parquet/Arrow schema, and for JSON/JSONL the first record's field
+order, with fields that only appear in later records appended where they were
+first seen. Converting a dataset between formats does not reshuffle the report.
+
 ## Quality Metrics
 
 dataprof reports seven quality dimensions informed by concepts in [ISO 8000-8](https://www.iso.org/standard/76834.html) and [ISO/IEC 25012](https://www.iso.org/standard/35749.html):

--- a/crates/dataprof-core/src/partial.rs
+++ b/crates/dataprof-core/src/partial.rs
@@ -3,8 +3,9 @@ use crate::{classification::DataType, source::FileFormat};
 /// Result of fast schema inference — column names paired with inferred data types.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SchemaResult {
-    /// Columns with their inferred types. For CSV/Parquet the order matches
-    /// the source; for JSON/JSONL columns are sorted alphabetically.
+    /// Columns with their inferred types, in source order: CSV/Parquet follow
+    /// the header/schema, JSON/JSONL follow the first record's field order with
+    /// later-only fields appended in first-seen order.
     pub columns: Vec<ColumnSchema>,
     /// How many rows were sampled to infer the schema (0 for Parquet metadata).
     pub rows_sampled: usize,

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -537,6 +537,8 @@ impl AsyncStreamingProfiler {
         // Helper closure: convert a JSON object into a row aligned to known_columns.
         // New columns are only registered before headers are sent; once headers have
         // been emitted, the schema is frozen to keep rows aligned with the header set.
+        // `serde_json/preserve_order` makes `obj.keys()` yield source field order,
+        // so the header set matches the sync scanner's ordering contract.
         let process_object = |obj: &serde_json::Map<String, Value>,
                               known_cols: &mut Vec<String>,
                               known_cols_set: &mut std::collections::HashSet<String>,

--- a/crates/dataprof-json/README.md
+++ b/crates/dataprof-json/README.md
@@ -12,6 +12,14 @@ The main entry points are `JsonFormat`, `JsonParserConfig`,
 `scan_json_from_reader`, `analyze_json_from_reader`, and
 `analyze_json_file`.
 
+## Column order
+
+Columns are reported in source order: the first record's field order, with
+fields that only appear in later records appended where they were first seen.
+This matches CSV header order and Parquet schema order, so the same logical
+dataset profiles to the same column order in every format. The contract relies
+on the workspace enabling `serde_json/preserve_order`.
+
 ## Features
 
 This crate has no feature flags.

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -64,6 +64,11 @@ impl JsonParserConfig {
 }
 
 /// Borrowed JSON object callback payload.
+///
+/// The workspace enables `serde_json/preserve_order`, so iterating this map
+/// yields fields in the order they appear in the source document rather than
+/// alphabetically. That is what makes the column-ordering contract on
+/// [`analyze_json_from_reader`] possible.
 pub type JsonObject = serde_json::Map<String, Value>;
 
 /// Summary of a JSON/JSONL scan.
@@ -372,6 +377,10 @@ fn json_value_to_string(value: &Value) -> String {
 }
 
 /// Feed a JSON object's fields into a [`StreamingColumnCollection`].
+///
+/// Columns are registered in the order the fields appear in each record, so the
+/// resulting column order is the first record's field order with later-only
+/// fields appended where they were first seen.
 fn feed_json_object(
     obj: &JsonObject,
     prior_rows: usize,
@@ -403,6 +412,13 @@ fn feed_json_object(
 /// Analyze JSON/JSONL data from a buffered reader using streaming statistics.
 ///
 /// Returns `(column_profiles, streaming_stats, rows_read, malformed_lines, detected_format)`.
+///
+/// # Column order
+///
+/// Columns are returned in source order — the first record's field order, with
+/// fields that only appear in later records appended in first-seen order. This
+/// matches CSV (header order) and Parquet (schema order), so the same logical
+/// dataset profiles to the same column order in every format.
 pub fn analyze_json_from_reader<R: BufRead>(
     reader: R,
     config: &JsonParserConfig,
@@ -1055,6 +1071,58 @@ mod tests {
 
         let col_b = profiles.iter().find(|profile| profile.name == "b").unwrap();
         assert_eq!(col_b.total_count, 2);
+    }
+
+    /// Deliberately non-alphabetical field order: sorting would give
+    /// `active, amount, date, id`, so any re-sort is visible.
+    const UNSORTED_FIELDS: &str = r#"{"id":1,"amount":12.5,"active":true,"date":"2026-07-23"}"#;
+    const UNSORTED_ORDER: [&str; 4] = ["id", "amount", "active", "date"];
+
+    fn profile_names(report: &ProfileReport) -> Vec<&str> {
+        report
+            .column_profiles
+            .iter()
+            .map(|profile| profile.name.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn test_json_column_order_follows_source_not_alphabet() {
+        let array = write_file(&format!("[{UNSORTED_FIELDS},{UNSORTED_FIELDS}]"));
+        let jsonl = write_file(&format!("{UNSORTED_FIELDS}\n{UNSORTED_FIELDS}\n"));
+
+        for file in [&array, &jsonl] {
+            let report = analyze_json_file(file.path(), &JsonParserConfig::default()).unwrap();
+            assert_eq!(profile_names(&report), UNSORTED_ORDER);
+        }
+    }
+
+    #[test]
+    fn test_json_column_order_appends_later_keys_in_first_seen_order() {
+        // Each record introduces two keys in reverse-alphabetical order, so
+        // sorting would reshuffle both the leading pair and the appended pair.
+        let data = b"{\"zulu\":1,\"mike\":2}\n{\"zulu\":3,\"mike\":4,\"delta\":5,\"alpha\":6}\n";
+        let file = write_bytes(data);
+        let report = analyze_json_file(file.path(), &JsonParserConfig::jsonl()).unwrap();
+
+        assert_eq!(profile_names(&report), ["zulu", "mike", "delta", "alpha"]);
+    }
+
+    #[test]
+    fn test_json_column_order_survives_report_serialization() {
+        let file = write_file(&format!("[{UNSORTED_FIELDS}]"));
+        let report = analyze_json_file(file.path(), &JsonParserConfig::default()).unwrap();
+
+        let json = serde_json::to_string(&report).unwrap();
+        let restored: Value = serde_json::from_str(&json).unwrap();
+        let names: Vec<&str> = restored["column_profiles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|profile| profile["name"].as_str().unwrap())
+            .collect();
+
+        assert_eq!(names, UNSORTED_ORDER);
     }
 
     #[test]

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -284,10 +284,9 @@ fn infer_schema_from_json_reader<R: BufRead>(
     let (_profiles, column_stats, rows_read, _malformed_lines, _detected_format) =
         dataprof_json::analyze_json_from_reader(reader, &config)?;
 
-    // column_names() returns HashMap keys in arbitrary order. Sort
-    // alphabetically so the output is deterministic across runs.
-    let mut names = column_stats.column_names();
-    names.sort();
+    // column_names() is already in first-seen source order, which is the
+    // public ordering contract for JSON/JSONL. Do not re-sort it.
+    let names = column_stats.column_names();
 
     Ok(schema_from_streaming_stats(
         &column_stats,
@@ -845,9 +844,10 @@ fn analyze_structure_json(
         _ => JsonParserConfig::default().with_max_rows(max_rows),
     };
 
-    let (mut profiles, column_stats, rows_sampled, malformed_lines, detected_format) =
+    // Profiles arrive in first-seen source order, the public ordering contract
+    // for JSON/JSONL. Do not re-sort them.
+    let (profiles, column_stats, rows_sampled, malformed_lines, detected_format) =
         dataprof_json::analyze_json_from_reader(reader, &config)?;
-    profiles.sort_by(|a, b| a.name.cmp(&b.name));
 
     let row_count = if rows_sampled < max_rows && malformed_lines == 0 {
         exact_row_count_from_sample(rows_sampled, start.elapsed().as_millis())
@@ -1275,9 +1275,9 @@ mod tests {
         let result = infer_schema(f.path()).unwrap();
 
         assert_eq!(result.columns.len(), 2);
-        // JSON columns are sorted alphabetically
-        assert_eq!(result.columns[0].name, "age");
-        assert_eq!(result.columns[1].name, "name");
+        // Source field order, not alphabetical.
+        assert_eq!(result.columns[0].name, "name");
+        assert_eq!(result.columns[1].name, "age");
     }
 
     #[test]
@@ -1286,7 +1286,6 @@ mod tests {
         let result = infer_schema(f.path()).unwrap();
 
         assert_eq!(result.columns.len(), 2);
-        // JSON columns are sorted alphabetically
         assert_eq!(result.columns[0].name, "x");
         assert_eq!(result.columns[1].name, "y");
     }
@@ -1894,9 +1893,9 @@ mod async_tests {
         let result = infer_schema_stream(source).await.unwrap();
 
         assert_eq!(result.columns.len(), 2);
-        // JSON columns are sorted alphabetically
-        assert_eq!(result.columns[0].name, "age");
-        assert_eq!(result.columns[1].name, "name");
+        // Source field order, not alphabetical.
+        assert_eq!(result.columns[0].name, "name");
+        assert_eq!(result.columns[1].name, "age");
     }
 
     #[tokio::test]

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -278,7 +278,36 @@ pub fn profile_report_schema_document() -> serde_json::Value {
     );
     make_compatibility_defaults_optional(&mut document);
     allow_additive_properties(&mut document);
+    canonicalize_key_order(&mut document);
     document
+}
+
+/// Sort every object's keys so the committed schema has one canonical byte
+/// layout.
+///
+/// Key order carries no meaning in JSON Schema, but the committed document is a
+/// reviewed artifact: it must not churn because `serde_json` switched its map
+/// backing (`preserve_order`) or because Schemars changed the order in which it
+/// builds a schema. Arrays such as `required` and `oneOf` keep their order,
+/// which *is* meaningful.
+fn canonicalize_key_order(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(object) => {
+            for child in object.values_mut() {
+                canonicalize_key_order(child);
+            }
+            let mut sorted: Vec<(String, serde_json::Value)> =
+                std::mem::take(object).into_iter().collect();
+            sorted.sort_by(|(left, _), (right, _)| left.cmp(right));
+            object.extend(sorted);
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                canonicalize_key_order(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn make_compatibility_defaults_optional(document: &mut serde_json::Value) {

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -126,6 +126,12 @@ A cell is missing when it is `None`, NaN, or a null-like token (`""`, `"null"`,
 *not* round-tripped through pandas, so an integer column containing a null stays
 `integer` rather than being widened to `float`.
 
+**Column order** follows the source on every input and transport: the CSV
+header, the Parquet/Arrow schema, the dict or DataFrame key order, and for
+JSON/JSONL the field order of the first record, with fields that only appear in
+later records appended where they were first seen. Converting a dataset between
+formats therefore does not reshuffle the report.
+
 Synchronous byte inputs use the in-memory columnar path. They support
 `max_rows`, metric/quality selection, semantic hints, CSV delimiters, and JSONL
 error policy, but reject streaming-only controls (`chunk_size`,

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -379,8 +379,6 @@ def _columns_from_dict(source: dict[Any, Any]) -> list[_Column]:
 def _columns_from_records(
     rows: list[dict[Any, Any]],
     max_rows: int | None = None,
-    *,
-    sort_keys: bool = False,
 ) -> list[_Column]:
     """Convert a list of row dicts into columns, keyed in first-seen order.
 
@@ -394,10 +392,7 @@ def _columns_from_records(
     """
     key_rows = rows if max_rows is None else rows[:max_rows]
     cell_rows = rows if max_rows is None else rows[: max_rows + 1]
-    if sort_keys:
-        keys = list(dict.fromkeys(key for row in key_rows for key in sorted(row, key=str)))
-    else:
-        keys = list(dict.fromkeys(key for row in key_rows for key in row))
+    keys = list(dict.fromkeys(key for row in key_rows for key in row))
     if key_rows and not keys:
         raise ValueError(
             "list-of-dicts input contains rows but no columns, so their row count "
@@ -1245,7 +1240,7 @@ def profile(
         elif fmt == "jsonl":
             text = buffer.getvalue().decode("utf-8-sig")
             rows, skipped = _scan_jsonl_records(text, jsonl_on_error)
-            columns = _columns_from_records(rows, max_rows, sort_keys=True)
+            columns = _columns_from_records(rows, max_rows)
         elif fmt == "json":
             text = buffer.getvalue().decode("utf-8-sig")
             try:
@@ -1263,9 +1258,9 @@ def profile(
                 if all(isinstance(values, (list, tuple)) for values in rows.values()):
                     columns = _columns_from_dict(rows)
                 else:
-                    columns = _columns_from_records([rows], max_rows, sort_keys=True)
+                    columns = _columns_from_records([rows], max_rows)
             elif _is_list_of_dicts(rows):
-                columns = _columns_from_records(rows, max_rows, sort_keys=True)
+                columns = _columns_from_records(rows, max_rows)
             else:
                 raise ValueError(
                     f"{fmt} bytes must decode to an object of columns or an array of "

--- a/python/tests/test_column_order.py
+++ b/python/tests/test_column_order.py
@@ -1,0 +1,101 @@
+"""Column-ordering contract across formats and transports (#465).
+
+Columns are reported in source order: CSV header order, Parquet schema order,
+and for JSON/JSONL the first record's field order with fields that only appear
+in later records appended where they were first seen. Reordering is invisible in
+value-based correctness tests but shows up in every report the user reads, so it
+needs its own guard on every transport.
+
+The fixture field names are deliberately non-alphabetical — sorting them yields
+``active, amount, date, id``, which is what JSON profiling used to return.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import dataprof
+import pytest
+from dataprof.asyncio import profile_bytes, profile_file
+
+_HAS_ASYNC = dataprof.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+SOURCE_ORDER = ["id", "amount", "active", "date"]
+
+ROWS = [
+    {"id": 1, "amount": 12.5, "active": True, "date": "2026-07-23"},
+    {"id": 2, "amount": 7.25, "active": False, "date": "2026-07-24"},
+]
+
+PAYLOADS = {
+    "csv": b"id,amount,active,date\n1,12.5,true,2026-07-23\n2,7.25,false,2026-07-24\n",
+    "json": json.dumps(ROWS).encode("utf-8"),
+    "jsonl": ("\n".join(json.dumps(row) for row in ROWS) + "\n").encode("utf-8"),
+}
+
+
+def _write(tmp_path, fmt: str):
+    path = tmp_path / f"fixture.{fmt}"
+    path.write_bytes(PAYLOADS[fmt])
+    return str(path)
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl"])
+def test_file_input_preserves_source_column_order(fmt, tmp_path):
+    report = dataprof.profile(_write(tmp_path, fmt))
+    assert list(report) == SOURCE_ORDER
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl"])
+def test_bytes_input_preserves_source_column_order(fmt):
+    report = dataprof.profile(PAYLOADS[fmt], format=fmt)
+    assert list(report) == SOURCE_ORDER
+
+
+def test_record_input_preserves_source_column_order():
+    assert list(dataprof.profile(ROWS)) == SOURCE_ORDER
+
+
+def test_single_json_object_preserves_source_field_order():
+    # A lone root object profiles as one row; its fields are the columns.
+    payload = json.dumps(ROWS[0]).encode("utf-8")
+    assert list(dataprof.profile(payload, format="json")) == SOURCE_ORDER
+
+
+def test_late_fields_are_appended_in_first_seen_order():
+    # Each record introduces two fields in reverse-alphabetical order, so
+    # sorting would reshuffle both the leading and the appended pair.
+    rows = [{"zulu": 1, "mike": 2}, {"zulu": 3, "mike": 4, "delta": 5, "alpha": 6}]
+    payload = ("\n".join(json.dumps(row) for row in rows) + "\n").encode("utf-8")
+
+    assert list(dataprof.profile(payload, format="jsonl")) == ["zulu", "mike", "delta", "alpha"]
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl"])
+def test_file_and_bytes_transports_agree_on_column_order(fmt, tmp_path):
+    from_file = dataprof.profile(_write(tmp_path, fmt))
+    from_bytes = dataprof.profile(PAYLOADS[fmt], format=fmt)
+    assert list(from_file) == list(from_bytes)
+
+
+@requires_async
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl"])
+def test_async_transports_preserve_source_column_order(fmt, tmp_path):
+    path = _write(tmp_path, fmt)
+    from_file = asyncio.run(profile_file(path))
+    from_bytes = asyncio.run(profile_bytes(PAYLOADS[fmt], format=fmt))
+
+    assert list(from_file) == SOURCE_ORDER, f"{fmt}: async file"
+    assert list(from_bytes) == SOURCE_ORDER, f"{fmt}: async bytes"
+
+
+def test_to_dict_export_keeps_report_column_order(tmp_path):
+    report = dataprof.profile(_write(tmp_path, "json"))
+    exported = [column["name"] for column in report.to_dict()["columns"]]
+    assert exported == SOURCE_ORDER

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -177,6 +177,20 @@ def test_engine_parity(engine, reference, tmp_path):
     assert_profiles_match(engine, report, reference, EXPECTED_EXCEPTIONS)
 
 
+# ── Column order (issue #465) ──
+#
+# Column order is part of the report, not an accident of the parser: a format
+# conversion must not reshuffle it. The fixture keys above are deliberately
+# non-alphabetical (sorting moves all_null to the front and whole to the back),
+# so the JSON paths that used to emit object keys alphabetically fail here.
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_engine_column_order_follows_source(engine, tmp_path):
+    report = build_report(engine, tmp_path)
+    assert list(report) == list(COLUMNS)
+
+
 # ── High-cardinality regression (issue #386) ──
 #
 # The columnar (Arrow) engine used to stop counting distinct values at an

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -516,9 +516,18 @@ class TestProfileAdHocInputs:
         assert list(r.column_profiles) == ["a"]
         assert not r.source_exhausted
 
-    def test_json_bytes_column_order_matches_file_parser(self):
-        r = dataprof.profile(b'[{"z": 1, "a": 2}, {"later": 3}]', format="json")
-        assert list(r.column_profiles) == ["a", "z", "later"]
+    def test_json_bytes_column_order_matches_file_parser(self, tmp_path):
+        # Source field order, with a later-only field appended where it first
+        # appears (#465). Sorting would give ["a", "later", "z"].
+        payload = b'[{"z": 1, "a": 2}, {"later": 3}]'
+        path = tmp_path / "order.json"
+        path.write_bytes(payload)
+
+        from_bytes = dataprof.profile(payload, format="json")
+        from_file = dataprof.profile(str(path))
+
+        assert list(from_bytes.column_profiles) == ["z", "a", "later"]
+        assert list(from_file.column_profiles) == list(from_bytes.column_profiles)
 
     def test_jsonl_bytes_input(self):
         r = dataprof.profile(b'{"a": 1}\n{"a": 2}\n', format="jsonl")

--- a/tests/column_order.rs
+++ b/tests/column_order.rs
@@ -1,0 +1,209 @@
+//! Column-ordering contract (#465).
+//!
+//! Columns are reported in source order: for CSV the header order, for Parquet
+//! the schema order, and for JSON/JSONL the first record's field order with
+//! fields that only appear later appended where they were first seen. Every
+//! format and transport must agree, so a format conversion never reshuffles a
+//! report.
+//!
+//! Every fixture uses deliberately non-alphabetical field names: sorting any of
+//! them yields `active, amount, date, id`, which is what JSON profiling used to
+//! return.
+
+use std::io::Write;
+
+use dataprof::{
+    CsvParserConfig, JsonParserConfig, ProfileReport, analyze_csv_file, analyze_json_file,
+    analyze_structure, infer_schema,
+};
+use tempfile::NamedTempFile;
+
+/// Source field order for every fixture below. Alphabetical order differs in
+/// all four positions.
+const SOURCE_ORDER: [&str; 4] = ["id", "amount", "active", "date"];
+
+const RECORD_ONE: &str = r#"{"id":1,"amount":12.5,"active":true,"date":"2026-07-23"}"#;
+const RECORD_TWO: &str = r#"{"id":2,"amount":7.25,"active":false,"date":"2026-07-24"}"#;
+
+fn write_fixture(suffix: &str, contents: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(suffix).unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+fn csv_fixture() -> NamedTempFile {
+    write_fixture(
+        ".csv",
+        "id,amount,active,date\n1,12.5,true,2026-07-23\n2,7.25,false,2026-07-24\n",
+    )
+}
+
+fn json_fixture() -> NamedTempFile {
+    write_fixture(".json", &format!("[{RECORD_ONE},{RECORD_TWO}]"))
+}
+
+fn jsonl_fixture() -> NamedTempFile {
+    write_fixture(".jsonl", &format!("{RECORD_ONE}\n{RECORD_TWO}\n"))
+}
+
+fn column_names(report: &ProfileReport) -> Vec<&str> {
+    report
+        .column_profiles
+        .iter()
+        .map(|profile| profile.name.as_str())
+        .collect()
+}
+
+#[test]
+fn csv_json_and_jsonl_files_agree_on_column_order() {
+    let csv = csv_fixture();
+    let json = json_fixture();
+    let jsonl = jsonl_fixture();
+
+    let csv_report = analyze_csv_file(csv.path(), &CsvParserConfig::default()).unwrap();
+    let json_report = analyze_json_file(json.path(), &JsonParserConfig::default()).unwrap();
+    let jsonl_report = analyze_json_file(jsonl.path(), &JsonParserConfig::default()).unwrap();
+
+    assert_eq!(column_names(&csv_report), SOURCE_ORDER, "csv");
+    assert_eq!(column_names(&json_report), SOURCE_ORDER, "json");
+    assert_eq!(column_names(&jsonl_report), SOURCE_ORDER, "jsonl");
+}
+
+#[test]
+fn infer_schema_reports_json_columns_in_source_order() {
+    for (label, file) in [
+        ("csv", csv_fixture()),
+        ("json", json_fixture()),
+        ("jsonl", jsonl_fixture()),
+    ] {
+        let schema = infer_schema(file.path()).unwrap();
+        let names: Vec<&str> = schema
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect();
+        assert_eq!(names, SOURCE_ORDER, "{label}");
+    }
+}
+
+#[test]
+fn analyze_structure_reports_json_columns_in_source_order() {
+    for (label, file) in [
+        ("csv", csv_fixture()),
+        ("json", json_fixture()),
+        ("jsonl", jsonl_fixture()),
+    ] {
+        let structure = analyze_structure(file.path(), None).unwrap();
+        let names: Vec<&str> = structure
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect();
+        assert_eq!(names, SOURCE_ORDER, "{label}");
+    }
+}
+
+/// Fields that only appear in a later record are appended where they were first
+/// seen, never folded into alphabetical position.
+#[test]
+fn late_fields_are_appended_in_first_seen_order() {
+    let jsonl = write_fixture(
+        ".jsonl",
+        "{\"zulu\":1,\"mike\":2}\n{\"zulu\":3,\"mike\":4,\"delta\":5,\"alpha\":6}\n",
+    );
+    let report = analyze_json_file(jsonl.path(), &JsonParserConfig::default()).unwrap();
+
+    assert_eq!(column_names(&report), ["zulu", "mike", "delta", "alpha"]);
+}
+
+#[cfg(feature = "parquet")]
+#[test]
+fn parquet_agrees_with_csv_and_json_column_order() {
+    use std::sync::Arc;
+
+    use arrow::array::{BooleanArray, Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("amount", DataType::Float64, false),
+        Field::new("active", DataType::Boolean, false),
+        Field::new("date", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2])),
+            Arc::new(Float64Array::from(vec![12.5, 7.25])),
+            Arc::new(BooleanArray::from(vec![true, false])),
+            Arc::new(StringArray::from(vec!["2026-07-23", "2026-07-24"])),
+        ],
+    )
+    .unwrap();
+
+    let file = NamedTempFile::with_suffix(".parquet").unwrap();
+    let mut writer = ArrowWriter::try_new(file.reopen().unwrap(), schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+
+    let report = dataprof::analyze_parquet_with_quality(file.path()).unwrap();
+    assert_eq!(column_names(&report), SOURCE_ORDER);
+}
+
+#[cfg(feature = "async-streaming")]
+mod async_transport {
+    use super::*;
+
+    use dataprof::{AsyncSourceInfo, BytesSource, FileFormat, Profiler, infer_schema_stream};
+
+    fn source(body: &str, format: FileFormat) -> BytesSource {
+        let bytes = bytes::Bytes::from(body.to_string());
+        let size = bytes.len() as u64;
+        BytesSource::new(
+            bytes,
+            AsyncSourceInfo::new("column-order", format).size_hint(Some(size)),
+        )
+    }
+
+    /// The async pipeline registers columns from the streamed records rather
+    /// than a header row, so it needs its own ordering guard.
+    #[tokio::test]
+    async fn async_streaming_preserves_json_source_order() {
+        for (label, body, format) in [
+            (
+                "json",
+                format!("[{RECORD_ONE},{RECORD_TWO}]"),
+                FileFormat::Json,
+            ),
+            (
+                "jsonl",
+                format!("{RECORD_ONE}\n{RECORD_TWO}\n"),
+                FileFormat::Jsonl,
+            ),
+        ] {
+            let report = Profiler::new()
+                .profile_stream(source(&body, format))
+                .await
+                .unwrap();
+            assert_eq!(column_names(&report), SOURCE_ORDER, "{label}");
+        }
+    }
+
+    #[tokio::test]
+    async fn async_schema_inference_preserves_json_source_order() {
+        let body = format!("{RECORD_ONE}\n{RECORD_TWO}\n");
+        let schema = infer_schema_stream(source(&body, FileFormat::Jsonl))
+            .await
+            .unwrap();
+        let names: Vec<&str> = schema
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect();
+
+        assert_eq!(names, SOURCE_ORDER);
+    }
+}


### PR DESCRIPTION
Closes #465.

## Problem

JSON and JSONL profiling emitted columns alphabetically while CSV, Parquet and Python record inputs followed source order. The numbers were right, so it survived every correctness test — but converting a dataset between formats visibly reshuffled the report, and column order could not be part of cross-input parity.

```text
CSV / Parquet / list[dict]   id, amount, active, date
JSON / JSONL                 active, amount, date, id
```

## Cause

`serde_json::Map` is a `BTreeMap` without the `preserve_order` feature, so `obj.keys()` yielded fields sorted. Everything downstream was already correct — `StreamingColumnCollection` tracks `ordered_names` in insertion order. Two explicit sorts in `dataprof-partial` and one `sort_keys` in the Python bytes path had been added *to match* the alphabetical output.

## Contract

Columns follow source order on every format and transport: the CSV header, the Parquet/Arrow schema, dict/DataFrame key order, and for JSON/JSONL the **first record's field order, with fields that only appear in later records appended where they were first seen**.

## Changes

- `Cargo.toml` — `serde_json` with `preserve_order`. `Cargo.lock` gains only an `indexmap` edge; it was already in the tree.
- `crates/dataprof-partial` — dropped `names.sort()` (schema inference) and `profiles.sort_by` (structure analysis).
- `python/dataprof/__init__.py` — removed the `sort_keys` parameter from `_columns_from_records`.
- `crates/dataprof-runtime/src/profile_report.rs` — new `canonicalize_key_order`. `preserve_order` reorders Schemars output, which rewrote all 1737 lines of the published `profile-report.v1.schema.json` (key order only). Sorting at generation time keeps the artifact **byte-identical** and immune to future Schemars internals.
- Docs: root README, `docs/python/README.md`, `crates/dataprof-json/README.md`, and the `SchemaResult` doc comment that previously promised alphabetical order.

## Verification

Each part of the fix was reverted **separately** and the tests confirmed to fail:

| Reverted part | Caught by |
|---|---|
| `preserve_order` | 6/7 tests in `tests/column_order.rs` (Parquet correctly unaffected); 9 Python tests |
| `names.sort()` | 2 schema-inference tests (sync + async) |
| `profiles.sort_by` | 1 structure test |
| Python `sort_keys` | 6 sync-bytes tests |

One test needed strengthening: the first late-fields case passed with *and* without the fix, because single-key records make alphabetical and first-seen order coincide. It now introduces two reverse-alphabetical fields per record. The CSV/Parquet/record cases in the new files pass in both states by design — they pin a contract that was already correct, not this regression.

New coverage in `tests/column_order.rs` (7) and `python/tests/test_column_order.py` (16), spanning file, sync bytes, async stream, records, `infer_schema`, `analyze_structure` and `to_dict()`, plus a cross-engine ordering assertion in the parity suite. The extension was rebuilt with `python-async,async-streaming` so the async tests actually ran rather than skipping.

`test_json_bytes_column_order_matches_file_parser` pinned the old alphabetical order and never made the file-parser comparison its name promised; updated and made to do one.

## Out of scope

Database query column order is the same defect on a different path, separately tracked as #496. The async reader's "schema frozen after headers sent" path was checked against a 20,001-row payload introducing a field in the last record — it discovers and orders it correctly.

## Commands run

```bash
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace --all-features        # 776 passed
cargo test --test column_order               # default features
uv run maturin develop --features "python,python-async,async-streaming"
uv run pytest python/tests/ -q               # 627 passed, 5 skipped
uv run ruff format python/ .github/scripts/
uv run ruff check python/ .github/scripts/
uv run ty check python/
cargo run --example generate_profile_schema  # no drift
```
