### PR TITLE
ci: label pull requests by changed path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,106 @@
+# Path-based PR labels, applied by .github/workflows/labeler.yml.
+#
+# Two matcher kinds are used deliberately:
+#
+#   any-glob-to-any-file  — "this PR touches that area". Used for `area: *`,
+#                           which are additive and may overlap.
+#   any-glob-to-all-files — "this PR is only that". Used for the type labels
+#                           (`documentation`, `type: example`) so a code PR that
+#                           adjusts a README does not get filed as a docs PR.
+#
+# Labels a human applies by judgement -- priority, difficulty, `good first
+# issue`, `type: epic`, `area: product` -- are deliberately absent: a path
+# cannot imply them. The workflow never removes labels, so anything set by hand
+# survives later pushes.
+
+# Rust code and the manifests that build it -- deliberately not every file
+# under crates/, so a crate README is documentation rather than a code change.
+"area: rust":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.rs"
+          - "**/Cargo.toml"
+          - "Cargo.lock"
+          - "clippy.toml"
+          - "deny.toml"
+          - "Cross.toml"
+
+# The Python surface is both the package and the PyO3 crate behind it; a change
+# to either can alter what users import.
+"area: python":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "python/**"
+          - "crates/dataprof-python/**"
+          - "pyproject.toml"
+          - "uv.lock"
+
+"area: database":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/dataprof-db/**"
+          - ".devcontainer/init-scripts/**"
+          - "docs/guides/database-connectors.md"
+
+"area: metrics":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/dataprof-metrics/**"
+
+"area: streaming":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/dataprof-engines/src/streaming/**"
+          - "python/dataprof/asyncio.py"
+          - "python/dataprof/asyncio.pyi"
+          - "tests/async_streaming.rs"
+
+"area: testing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "python/tests/**"
+          - "crates/*/tests/**"
+
+"area: agents":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "python/dataprof/agent.py"
+          - "python/tests/test_agent_guard.py"
+          - "docs/guides/agent-workflows.md"
+          - ".claude/**"
+          - "AGENTS.md"
+          - "CLAUDE.md"
+
+"area: performance":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "benches/**"
+          - ".github/workflows/benchmarks.yml"
+
+"area: front end":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "site/**"
+          - "assets/**"
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+
+# Type labels: the whole PR must be that kind of change.
+#
+# `site/` is excluded on purpose -- it is the marketing page, covered by
+# `area: front end`, not prose a user reads to learn the library.
+documentation:
+  - changed-files:
+      - any-glob-to-all-files:
+          - "docs/**"
+          - "**/*.md"
+
+"type: example":
+  - changed-files:
+      - any-glob-to-all-files:
+          - "examples/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,35 @@
+name: Labeler
+
+# Applies path-based area/type labels so triage does not depend on the author
+# remembering. Rules live in .github/labeler.yml.
+#
+# `pull_request_target` is required, not incidental: a `pull_request` run from a
+# fork gets a read-only token and cannot label. This event runs in the base
+# repository's context with the base repository's configuration, and the job
+# never checks out or executes PR code -- it only reads the changed-file list --
+# so the usual pull_request_target risk does not apply here.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Apply labels from .github/labeler.yml
+        uses: actions/labeler@v7.0.0
+        with:
+          # Add only. Labels applied by a maintainer -- priority, difficulty,
+          # `on hold` -- must survive the next push to the branch.
+          sync-labels: false


### PR DESCRIPTION
Adds `actions/labeler` so area/type labels are applied from the changed-file list instead of depending on the author remembering.

## Rules

Two matcher kinds, used deliberately:

- **`any-glob-to-any-file`** — "this PR touches that area". Used for all `area: *` labels, which are additive and may overlap.
- **`any-glob-to-all-files`** — "this PR is *only* that". Used for `documentation` and `type: example`, so a code PR that adjusts a README is not filed as a docs PR.

`area: rust` matches `**/*.rs` and the cargo manifests rather than everything under `crates/`, which keeps it aligned with its description ("Pull requests that update rust code") and lets a crate README register as `documentation` instead.

Labels that require human judgement — priority, difficulty, `good first issue`, `type: epic`, `area: product` — are deliberately absent; a path cannot imply them. `sync-labels: false` means the action only ever adds, so anything applied by hand survives the next push.

## Validated against real and synthetic PRs

I evaluated the config offline with `minimatch` under the same options the action uses (`dot: true`), against the actual changed-file lists of recent PRs:

| PR | Labels |
|---|---|
| #507 source field order | `area: python`, `area: rust`, `area: streaming`, `area: testing` |
| #506 UTF-8 BOM | `area: python`, `area: rust`, `area: streaming`, `area: testing` |
| #498 harden edge cases | `area: database`, `area: metrics`, `area: python`, `area: rust`, `area: streaming`, `area: testing` |
| #493 versioned schema | `area: metrics`, `area: python`, `area: rust`, `area: testing`, `github_actions` |
| #490 ty bump | `area: python`, `area: testing` |
| #492 ipython bump | `area: python` |

And synthetic cases for the paths no recent PR exercised:

| Change | Labels |
|---|---|
| guide + changelog | `documentation` |
| crate README only | `documentation` |
| docs + one `.rs` file | `area: rust` (correctly *not* `documentation`) |
| `examples/*.rs` | `area: rust`, `type: example` |
| `Cargo.toml` + `Cargo.lock` | `area: rust` |
| `.github/workflows/` or `.github/actions/` | `github_actions` |
| `.claude/`, `AGENTS.md` | `area: agents`, `documentation` |
| db connector + its tests | `area: database`, `area: rust`, `area: testing` |
| `benches/` | `area: performance`, `area: rust` |
| `site/` | `area: front end` |
| `python/dataprof/asyncio.py` | `area: python`, `area: streaming` |

Three rules were tightened as a result of that run: `area: rust` no longer claims crate READMEs, `documentation` no longer claims the `site/` marketing page, and `area: front end` no longer keys off `deploy-pages.yml` (publishing config, not front-end work).

## `pull_request_target`

Required, not incidental: a `pull_request` run from a fork gets a read-only token and cannot label. The job never checks out or executes PR code — it only reads the changed-file list — so the usual `pull_request_target` risk does not apply.

## Note

Dependabot already applies `dependencies`, `rust`, `python:uv` and `github_actions` on its own PRs. The legacy `rust` label overlaps with `area: rust`; worth retiring one of them, but I left the taxonomy alone here.

The workflow only runs once merged to `master`, so this PR will not label itself.
