### PR TITLE
feat(python): pin the public surface to what __all__ declares

### DIFF
--- a/docs/architecture/public-api-inventory.md
+++ b/docs/architecture/public-api-inventory.md
@@ -68,3 +68,30 @@ CI now enforces the lean facade combinations with `cargo check`,
 `public_api_facade` integration-test runs, and owning-crate unit tests for
 `dataprof-engines`, `dataprof-parquet`, and `dataprof-partial` so the facade
 cannot accidentally grow implementation ownership again.
+
+## Python Package Surface
+
+The Python package is held to the same rule as the Rust facade: what
+`__all__` declares is what is reachable. `python/tests/test_public_surface.py`
+enforces it for every module below, and carries the same names as
+`EXPECTED_SURFACE`, so growing the API is a deliberate edit rather than a side
+effect.
+
+| Module | Exports |
+| --- | --- |
+| `dataprof` | `Capabilities`, `capabilities`, `REPORT_SCHEMA_VERSION`, `profile`, `profile_file`, `Profiler`, `ProfileReport`, `ProfilerConfig`, `ColumnProfile`, `DataQualityMetrics`, `SamplingStrategy`, `StopCondition`, `ProgressEvent`, `list_patterns`, `infer_schema`, `quick_row_count`, `analyze_structure`, `SchemaResult`, `RowCountEstimate`, `StructureColumnSummary`, `StructureReport`, `RecordBatch`, `column_to_dict`, `asyncio`, `__version__`, `analyze_database_async`, `count_table_rows_async`, `get_table_schema_async`, `test_connection_async` |
+| `dataprof.agent` | `AgentGuard`, `AgentSecurityError`, `AgentTimeoutError`, `PathNotAllowedError`, `ResourceLimitExceededError`, `SandboxPolicy` |
+| `dataprof.asyncio` | `profile_bytes`, `profile_file`, `profile_url`, `infer_schema_stream`, `quick_row_count_stream` |
+| `dataprof.interop` | `analyze_file`, `profile_dataframe`, `profile_arrow`, `analyze_csv_to_arrow`, `analyze_parquet_to_arrow`, `column_to_dict`, `ProfilerConfig`, `ProfileReport`, `ColumnProfile`, `DataQualityMetrics`, `RecordBatch` |
+
+### Not Public
+
+Everything the implementation imports for its own use is bound under a private
+alias — `import os as _os`, `from typing import Any as _Any` — so it does not
+land in the package namespace. Before this was enforced, `dataprof.os`,
+`dataprof.json` and `dataprof.pathlib` were all importable, and
+`dataprof.asyncio` declared no `__all__` at all.
+
+The package's own submodules (`dataprof.agent`, `dataprof.interop`) become
+attributes of `dataprof` once imported anywhere in the process. That is normal
+package behaviour rather than a leak, and the guard ignores it.

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1,30 +1,30 @@
 """dataprof - High-performance data profiling library."""
 
-from __future__ import annotations
+from __future__ import annotations as _annotations
 
 import csv as _csv
 import decimal as _decimal
 import errno as _errno
-import functools
+import functools as _functools
 import html as _html
 import importlib as _importlib
 import io as _io
-import json
-import math
-import os
-import pathlib
-import warnings
-from collections.abc import Callable, Iterator
+import json as _json
+import math as _math
+import os as _os
+import pathlib as _pathlib
+import warnings as _warnings
+from collections.abc import Callable as _Callable, Iterator as _Iterator
 from dataclasses import dataclass as _dataclass
 from importlib import util as _importlib_util
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING as _TYPE_CHECKING, Any as _Any, cast as _cast
 
-if TYPE_CHECKING:
+if _TYPE_CHECKING:
     from ._dataprof import Pattern as _NativePattern
 else:
     # Pattern objects are returned by the extension and described by its stub,
     # but the class itself is not exported as a runtime module attribute.
-    _NativePattern = Any
+    _NativePattern = _Any
 
 from ._dataprof import (
     ColumnProfile,
@@ -203,6 +203,7 @@ __all__ = [
     "StructureColumnSummary",
     "StructureReport",
     "RecordBatch",
+    "column_to_dict",
     "asyncio",
     "__version__",
 ]
@@ -249,14 +250,14 @@ def _r2(v: float | None) -> float | None:
     Ratios on a 0..1 scale use :func:`_r4` instead, so that both carry the same
     resolution — 2dp on a ratio is a hundredth of 2dp on a percentage.
     """
-    if v is None or not math.isfinite(v):
+    if v is None or not _math.isfinite(v):
         return None
     return _half_up(v, 2)
 
 
 def _r4(v: float | None) -> float | None:
     """Round to 4 decimal places (statistics, 0..1 ratios). None/NaN → None."""
-    if v is None or not math.isfinite(v):
+    if v is None or not _math.isfinite(v):
         return None
     return _half_up(v, 4)
 
@@ -281,7 +282,7 @@ _QUALITY_DIMENSIONS = (
 )
 
 
-def _round_dimension(values: dict[str, Any]) -> dict[str, Any]:
+def _round_dimension(values: dict[str, _Any]) -> dict[str, _Any]:
     """Round a quality dimension dict the way the Rust serializer does.
 
     Every float across the seven dimension structs is a ``0..100`` percentage
@@ -303,12 +304,12 @@ def _pct_str(value: float | None) -> str:
     return f"{r:.1f}%" if r is not None else "—"
 
 
-def _normalize_pathlike(path: str | os.PathLike[str], *, arg_name: str = "path") -> str:
+def _normalize_pathlike(path: str | _os.PathLike[str], *, arg_name: str = "path") -> str:
     """Normalize Python path-like input to the string form expected by Rust."""
     if isinstance(path, str):
         return path
-    if isinstance(path, os.PathLike):
-        normalized = os.fspath(path)
+    if isinstance(path, _os.PathLike):
+        normalized = _os.fspath(path)
         if isinstance(normalized, str):
             return normalized
     raise TypeError(
@@ -350,9 +351,9 @@ def _reject_nonstandard_json_constant(value: str) -> None:
     raise _NonStandardJsonConstant(value)
 
 
-def _strict_json_loads(text: str) -> Any:
+def _strict_json_loads(text: str) -> _Any:
     """Decode RFC 8259 JSON, rejecting Python's NaN/Infinity extensions."""
-    return json.loads(text, parse_constant=_reject_nonstandard_json_constant)
+    return _json.loads(text, parse_constant=_reject_nonstandard_json_constant)
 
 
 # --- Dependency-free columnar inputs (see _dataprof.profile_columns) ---
@@ -376,13 +377,13 @@ def _cell_to_str(value: object) -> str | None:
         return None
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, float) and math.isnan(value):
+    if isinstance(value, float) and _math.isnan(value):
         return None
     if isinstance(value, str):
         return value
     if isinstance(value, (dict, list)):
         try:
-            return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+            return _json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
         except (TypeError, ValueError):
             # Contents aren't JSON-serialisable (datetime, set, circular ref, ...);
             # fall back to str() so one odd cell doesn't abort profiling.
@@ -390,7 +391,7 @@ def _cell_to_str(value: object) -> str | None:
     return str(value)
 
 
-def _columns_from_dict(source: dict[Any, Any]) -> list[_Column]:
+def _columns_from_dict(source: dict[_Any, _Any]) -> list[_Column]:
     """Convert a dict of equal-length sequences into columns."""
     columns: list[_Column] = []
     normalized_names: set[str] = set()
@@ -417,7 +418,7 @@ def _columns_from_dict(source: dict[Any, Any]) -> list[_Column]:
 
 
 def _columns_from_records(
-    rows: list[dict[Any, Any]],
+    rows: list[dict[_Any, _Any]],
     max_rows: int | None = None,
 ) -> list[_Column]:
     """Convert a list of row dicts into columns, keyed in first-seen order.
@@ -521,7 +522,7 @@ def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
             continue
         try:
             value = _strict_json_loads(line)
-        except json.JSONDecodeError as exc:
+        except _json.JSONDecodeError as exc:
             if on_error == "strict":
                 # ``lineno`` is the record's position in the input; ``exc.colno``
                 # locates the fault within that line. The record text is never
@@ -547,34 +548,34 @@ def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
     return rows, skipped
 
 
-def _normalize_existing_file(path: str | os.PathLike[str], *, arg_name: str = "path") -> str:
+def _normalize_existing_file(path: str | _os.PathLike[str], *, arg_name: str = "path") -> str:
     normalized = _normalize_pathlike(path, arg_name=arg_name)
     try:
-        pathlib.Path(normalized).stat()
+        _pathlib.Path(normalized).stat()
     except FileNotFoundError:
-        raise FileNotFoundError(_errno.ENOENT, os.strerror(_errno.ENOENT), normalized) from None
+        raise FileNotFoundError(_errno.ENOENT, _os.strerror(_errno.ENOENT), normalized) from None
     return normalized
 
 
-def infer_schema(path: str | os.PathLike[str]) -> SchemaResult:
+def infer_schema(path: str | _os.PathLike[str]) -> SchemaResult:
     """Infer a file schema from a string path or path-like object."""
     return _infer_schema(_normalize_existing_file(path))
 
 
-def quick_row_count(path: str | os.PathLike[str]) -> RowCountEstimate:
+def quick_row_count(path: str | _os.PathLike[str]) -> RowCountEstimate:
     """Estimate or count rows from a string path or path-like object."""
     return _quick_row_count(_normalize_existing_file(path))
 
 
 def analyze_structure(
-    path: str | os.PathLike[str],
+    path: str | _os.PathLike[str],
     max_rows: int | None = None,
 ) -> StructureReport:
     """Analyze file structure with a bounded, lightweight pass."""
     return _analyze_structure(_normalize_existing_file(path), max_rows)
 
 
-def list_patterns(locale: str | None = None) -> list[dict[str, Any]]:
+def list_patterns(locale: str | None = None) -> list[dict[str, _Any]]:
     """List supported pattern detectors.
 
     Args:
@@ -594,7 +595,7 @@ def list_patterns(locale: str | None = None) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
+def column_to_dict(col: ColumnProfile) -> dict[str, _Any]:
     """Convert a single ColumnProfile to the nested dict layout used by
     :meth:`ProfileReport.to_dict`.
 
@@ -614,7 +615,7 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
     statistics and for ``0..1`` ratios such as ``uniqueness_ratio``, so that a
     ratio carries the same resolution as the equivalent percentage.
     """
-    col_data: dict[str, Any] = {
+    col_data: dict[str, _Any] = {
         "name": col.name,
         "data_type": col.data_type,
         "total_count": col.total_count,
@@ -670,7 +671,7 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
             }
         )
     if col.true_count is not None:
-        bool_stats: dict[str, Any] = col_data.setdefault("stats", {})
+        bool_stats: dict[str, _Any] = col_data.setdefault("stats", {})
         bool_stats["true_count"] = col.true_count
         bool_stats["false_count"] = col.false_count
         bool_stats["true_ratio"] = _r4(col.true_ratio)
@@ -690,7 +691,7 @@ def column_to_dict(col: ColumnProfile) -> dict[str, Any]:
     return col_data
 
 
-def _column_record(col: ColumnProfile) -> dict[str, Any]:
+def _column_record(col: ColumnProfile) -> dict[str, _Any]:
     """Build a flat dict of all column stats with proper rounding.
 
     Used by to_dataframe(), to_polars(), to_arrow(), describe(), save().
@@ -955,7 +956,7 @@ def _fit_section(header: str, items: list[str], budget: int) -> tuple[list[str],
 
 
 def profile_file(
-    path: str | os.PathLike[str],
+    path: str | _os.PathLike[str],
     *,
     engine: str = "auto",
     chunk_size: int | None = None,
@@ -967,7 +968,7 @@ def profile_file(
     jsonl_on_error: str = "skip",
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
-    on_progress: Callable[[ProgressEvent], None] | None = None,
+    on_progress: _Callable[[ProgressEvent], None] | None = None,
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
@@ -1063,7 +1064,7 @@ def profile_file(
 
 
 def profile(
-    source: Any,
+    source: _Any,
     *,
     engine: str = "auto",
     chunk_size: int | None = None,
@@ -1076,7 +1077,7 @@ def profile(
     jsonl_on_error: str = "skip",
     sampling: SamplingStrategy | None = None,
     stop_condition: StopCondition | None = None,
-    on_progress: Callable[[ProgressEvent], None] | None = None,
+    on_progress: _Callable[[ProgressEvent], None] | None = None,
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
@@ -1156,7 +1157,7 @@ def profile(
         raise ValueError(f"jsonl_on_error must be 'skip' or 'strict', got {jsonl_on_error!r}.")
 
     # File path — build config and delegate to Rust
-    if isinstance(source, (str, pathlib.PurePath)):
+    if isinstance(source, (str, _pathlib.PurePath)):
         return profile_file(
             source,
             engine=engine,
@@ -1222,7 +1223,7 @@ def profile(
     def _warn_if_config_ignored():
         ignored = [k for k, v in _file_only_kwargs.items() if v]
         if ignored:
-            warnings.warn(
+            _warnings.warn(
                 f"Config kwargs {ignored} are ignored for DataFrame/Arrow sources. "
                 "These options only apply to file paths.",
                 stacklevel=3,
@@ -1300,7 +1301,7 @@ def profile(
             text = buffer.getvalue().decode("utf-8-sig")
             try:
                 rows = _strict_json_loads(text)
-            except json.JSONDecodeError as exc:
+            except _json.JSONDecodeError as exc:
                 # Surface a dataprof error category, not a bare decoder exception.
                 raise ValueError(
                     f"json bytes: malformed JSON (line {exc.lineno}, column {exc.colno})."
@@ -1356,7 +1357,7 @@ def profile(
 
 
 # Stop-when shorthand strings for the Profiler builder
-_STOP_SHORTHANDS: dict[str, Callable[[], StopCondition]] = {
+_STOP_SHORTHANDS: dict[str, _Callable[[], StopCondition]] = {
     "schema_stable": lambda: StopCondition.schema_stable(1000),
     "schema_inference": lambda: StopCondition.schema_inference(),
     "quality_sample": lambda: StopCondition.quality_sample(),
@@ -1379,7 +1380,7 @@ class Profiler:
     """
 
     def __init__(self) -> None:
-        self._kwargs: dict[str, Any] = {}
+        self._kwargs: dict[str, _Any] = {}
 
     def engine(self, engine: str) -> Profiler:
         """Set profiling engine ("auto", "incremental", "columnar")."""
@@ -1502,7 +1503,7 @@ class Profiler:
         self._kwargs["metrics"] = normalized_packs
         return self
 
-    def profile(self, source: Any) -> ProfileReport:
+    def profile(self, source: _Any) -> ProfileReport:
         """Profile the given source with accumulated settings.
 
         Accepts file paths (str/Path), pandas DataFrames, polars DataFrames,
@@ -1528,7 +1529,7 @@ class Profiler:
 class _DictPattern:
     """Read-only stand-in for a native Pattern, built from a to_dict() entry."""
 
-    def __init__(self, d: dict[str, Any]):
+    def __init__(self, d: dict[str, _Any]):
         self.name = d.get("name")
         self.regex = d.get("regex")
         self.match_count = d.get("match_count")
@@ -1564,7 +1565,7 @@ class _DictColumn:
         "true_ratio",
     )
 
-    def __init__(self, d: dict[str, Any]):
+    def __init__(self, d: dict[str, _Any]):
         for attr in self._STAT_ATTRS:
             setattr(self, attr, None)
         self.name = d.get("name")
@@ -1605,12 +1606,12 @@ class _DictQuality:
         "precision": 0.05,
     }
 
-    def __init__(self, d: dict[str, Any]):
+    def __init__(self, d: dict[str, _Any]):
         self._d = d
         self.low_sample_warning = bool(d.get("low_sample_warning", False))
 
     def _warn_flat_accessor(self, name: str) -> None:
-        warnings.warn(
+        _warnings.warn(
             f"DataQualityMetrics.{name} is deprecated; use the nested dimension "
             "properties such as completeness, consistency, uniqueness, accuracy, "
             "or timeliness instead.",
@@ -1618,7 +1619,7 @@ class _DictQuality:
             stacklevel=3,
         )
 
-    def _dimension_value(self, dimension: str, key: str, default: Any) -> Any:
+    def _dimension_value(self, dimension: str, key: str, default: _Any) -> _Any:
         value = self._d.get(dimension)
         if isinstance(value, dict):
             return value.get(key, default)
@@ -1705,31 +1706,31 @@ class _DictQuality:
         return self._dimension_value("timeliness", "invalid_date_values", 0)
 
     @property
-    def completeness(self) -> dict[str, Any] | None:
+    def completeness(self) -> dict[str, _Any] | None:
         return self._d.get("completeness")
 
     @property
-    def consistency(self) -> dict[str, Any] | None:
+    def consistency(self) -> dict[str, _Any] | None:
         return self._d.get("consistency")
 
     @property
-    def uniqueness(self) -> dict[str, Any] | None:
+    def uniqueness(self) -> dict[str, _Any] | None:
         return self._d.get("uniqueness")
 
     @property
-    def accuracy(self) -> dict[str, Any] | None:
+    def accuracy(self) -> dict[str, _Any] | None:
         return self._d.get("accuracy")
 
     @property
-    def timeliness(self) -> dict[str, Any] | None:
+    def timeliness(self) -> dict[str, _Any] | None:
         return self._d.get("timeliness")
 
     @property
-    def validity(self) -> dict[str, Any] | None:
+    def validity(self) -> dict[str, _Any] | None:
         return self._d.get("validity")
 
     @property
-    def precision(self) -> dict[str, Any] | None:
+    def precision(self) -> dict[str, _Any] | None:
         return self._d.get("precision")
 
     @property
@@ -1758,7 +1759,7 @@ class _DictQuality:
 class _DictBackedReport:
     """Read-only stand-in for the native ProfileReport, built from to_dict()."""
 
-    def __init__(self, d: dict[str, Any]):
+    def __init__(self, d: dict[str, _Any]):
         execution = d.get("execution") or {}
         self.source = d.get("source")
         self.source_type = d.get("source_type")
@@ -1826,7 +1827,7 @@ class ProfileReport:
     def columns(self) -> int:
         return self._report.columns_detected
 
-    @functools.cached_property
+    @_functools.cached_property
     def column_profiles(self) -> dict[str, ColumnProfile]:
         """Column profiles as a ``name → ColumnProfile`` mapping.
 
@@ -1840,7 +1841,7 @@ class ProfileReport:
         cols = self._report.column_profiles
         d = {col.name: col for col in cols}
         if len(d) != len(cols):
-            warnings.warn(
+            _warnings.warn(
                 f"Dataset has duplicate column names — {len(cols) - len(d)} "
                 "column(s) shadowed in dict access. Use .profiles "
                 "for the full list.",
@@ -1873,7 +1874,7 @@ class ProfileReport:
         return self._report.quality
 
     @property
-    def semantic_hint_bindings(self) -> list[dict[str, Any]]:
+    def semantic_hint_bindings(self) -> list[dict[str, _Any]]:
         """Per-column evidence of how each semantic hint bound to the data.
 
         Empty unless ``positive_columns``/``identifier_columns``/
@@ -1960,7 +1961,7 @@ class ProfileReport:
             return False
         return key in self.column_profiles
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self) -> _Iterator[str]:
         return iter(self.column_profiles)
 
     def __len__(self) -> int:
@@ -2033,9 +2034,9 @@ class ProfileReport:
 
     def to_json(self, indent: int = 2) -> str:
         """Export the report as a JSON string."""
-        return json.dumps(self.to_dict(), indent=indent)
+        return _json.dumps(self.to_dict(), indent=indent)
 
-    def _records(self) -> list[dict[str, Any]]:
+    def _records(self) -> list[dict[str, _Any]]:
         """Build enriched, rounded records for all columns."""
         return [_column_record(col) for col in self._report.column_profiles]
 
@@ -2080,7 +2081,7 @@ class ProfileReport:
             ) from None
         return pa.Table.from_pylist(self._records())
 
-    def describe(self) -> Any:
+    def describe(self) -> _Any:
         """Transposed statistical summary, similar to pandas DataFrame.describe().
 
         Rows are stats (count, null%, unique, mean, std, min, 25%, 50%, 75%,
@@ -2088,10 +2089,10 @@ class ProfileReport:
         Returns a pandas DataFrame if pandas is available, otherwise a
         dict-of-dicts.
         """
-        summary: dict[str, dict[str, Any]] = {}
+        summary: dict[str, dict[str, _Any]] = {}
         for col in self._report.column_profiles:
             q = _round_quartiles(col.quartiles)
-            d: dict[str, Any] = {
+            d: dict[str, _Any] = {
                 "count": col.total_count,
                 "null%": _r2(col.null_percentage),
                 "unique": col.unique_count,
@@ -2120,7 +2121,7 @@ class ProfileReport:
         except ImportError:
             return summary
 
-    def quality_summary(self) -> dict[str, Any]:
+    def quality_summary(self) -> dict[str, _Any]:
         """Single-row quality summary for easy aggregation.
 
         Returns a dict with source, rows, quality_score, per-dimension scores,
@@ -2132,7 +2133,7 @@ class ProfileReport:
         vacuous 100.
         """
         q = self._report.quality
-        row: dict[str, Any] = {
+        row: dict[str, _Any] = {
             "source": self._report.source,
             "rows": self._report.rows_processed,
             "quality_score": _r2(self._report.quality_score),
@@ -2150,7 +2151,7 @@ class ProfileReport:
                 row[name] = _r2(score)
         return row
 
-    def save(self, path: str | os.PathLike[str]) -> ProfileReport:
+    def save(self, path: str | _os.PathLike[str]) -> ProfileReport:
         """Save the report to a file.
 
         Supported formats (by extension):
@@ -2363,7 +2364,7 @@ class ProfileReport:
 
         return "\n".join([*header, *body])
 
-    def compare(self, other: ProfileReport) -> dict[str, Any]:
+    def compare(self, other: ProfileReport) -> dict[str, _Any]:
         """Compare this report with another and return a dict of deltas.
 
         The result captures quality drift and schema differences between two
@@ -2444,7 +2445,7 @@ class ProfileReport:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ProfileReport:
+    def from_dict(cls, data: dict[str, _Any]) -> ProfileReport:
         """Rebuild a read-only ProfileReport from a dict produced by :meth:`to_dict`.
 
         The reconstructed report is backed by a lightweight proxy rather than
@@ -2498,7 +2499,7 @@ class ProfileReport:
             raise ValueError("from_dict(): 'columns' must be a list of mappings.")
         # _DictBackedReport is a read-only proxy that duck-types the raw Rust
         # report; it intentionally isn't a nominal _RustProfileReport.
-        return cls(cast("_RustProfileReport", _DictBackedReport(data)))
+        return cls(_cast("_RustProfileReport", _DictBackedReport(data)))
 
     @classmethod
     def from_json(cls, text: str) -> ProfileReport:
@@ -2510,13 +2511,13 @@ class ProfileReport:
             ValueError: if ``text`` is not valid JSON from ``to_json()``.
         """
         try:
-            data = json.loads(text)
-        except json.JSONDecodeError as exc:
+            data = _json.loads(text)
+        except _json.JSONDecodeError as exc:
             raise ValueError(f"from_json() received invalid JSON: {exc}") from exc
         return cls.from_dict(data)
 
     @classmethod
-    def load(cls, path: str | os.PathLike[str]) -> ProfileReport:
+    def load(cls, path: str | _os.PathLike[str]) -> ProfileReport:
         """Reload a report previously written with :meth:`save`.
 
         This is the path-based counterpart to :meth:`from_json` (which takes a

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -326,6 +326,7 @@ __all__ = [
     "StructureColumnSummary",
     "StructureReport",
     "RecordBatch",
+    "column_to_dict",
     "asyncio",
     "__version__",
 ]

--- a/python/dataprof/agent.py
+++ b/python/dataprof/agent.py
@@ -21,19 +21,19 @@ Every rejection raises a subclass of :class:`AgentSecurityError`, whose message
 is safe to hand back to a model verbatim.
 """
 
-from __future__ import annotations
+from __future__ import annotations as _annotations
 
-import os
-import pathlib
-import threading
-from collections.abc import Callable, Sequence
-from dataclasses import dataclass
-from typing import Any, TypeVar, cast
+import os as _os
+import pathlib as _pathlib
+import threading as _threading
+from collections.abc import Callable as _Callable, Sequence as _Sequence
+from dataclasses import dataclass as _dataclass
+from typing import Any as _Any, TypeVar as _TypeVar, cast as _cast
 
 from . import (
-    ProfileReport,
-    StopCondition,
-    StructureReport,
+    ProfileReport as _ProfileReport,
+    StopCondition as _StopCondition,
+    StructureReport as _StructureReport,
     analyze_structure as _analyze_structure,
     profile as _profile,
 )
@@ -47,7 +47,7 @@ __all__ = [
     "SandboxPolicy",
 ]
 
-_T = TypeVar("_T")
+_T = _TypeVar("_T")
 
 # Schemes an LLM is most likely to hand us when it wants remote data. A source
 # naming any of these is refused unless the policy opts into network access;
@@ -90,19 +90,19 @@ class AgentTimeoutError(AgentSecurityError):
 
 
 def _coerce_roots(
-    roots: Sequence[str | os.PathLike[str]] | str | os.PathLike[str],
-) -> tuple[pathlib.Path, ...]:
-    items: Sequence[str | os.PathLike[str]]
-    if isinstance(roots, (str, os.PathLike)):
+    roots: _Sequence[str | _os.PathLike[str]] | str | _os.PathLike[str],
+) -> tuple[_pathlib.Path, ...]:
+    items: _Sequence[str | _os.PathLike[str]]
+    if isinstance(roots, (str, _os.PathLike)):
         # A lone root is the common case; wrap it rather than making every
         # caller type `[root]`. The cast discards a spurious "sequence that is
         # also path-like" intersection the narrowing leaves behind.
-        items = [cast("str | os.PathLike[str]", roots)]
+        items = [_cast("str | _os.PathLike[str]", roots)]
     else:
         items = roots
-    resolved: list[pathlib.Path] = []
+    resolved: list[_pathlib.Path] = []
     for r in items:
-        p = pathlib.Path(r).expanduser().resolve()
+        p = _pathlib.Path(r).expanduser().resolve()
         if not p.is_dir():
             raise ValueError(f"sandbox root is not an existing directory: {p}")
         resolved.append(p)
@@ -116,7 +116,7 @@ def _coerce_roots(
 # init=False: the validating __init__ below is the point of this class, and
 # leaving it implicit would rely on dataclass declining to overwrite an
 # __init__ already present in the class body.
-@dataclass(frozen=True, init=False)
+@_dataclass(frozen=True, init=False)
 class SandboxPolicy:
     """Limits applied to every call made through an :class:`AgentGuard`.
 
@@ -141,7 +141,7 @@ class SandboxPolicy:
             refuses to include raw sample values.
     """
 
-    roots: tuple[pathlib.Path, ...]
+    roots: tuple[_pathlib.Path, ...]
     max_file_bytes: int = 256 * 1024 * 1024
     max_rows: int = 1_000_000
     max_bytes: int = 256 * 1024 * 1024
@@ -152,7 +152,7 @@ class SandboxPolicy:
 
     def __init__(
         self,
-        roots: Sequence[str | os.PathLike[str]] | str | os.PathLike[str],
+        roots: _Sequence[str | _os.PathLike[str]] | str | _os.PathLike[str],
         *,
         max_file_bytes: int = 256 * 1024 * 1024,
         max_rows: int = 1_000_000,
@@ -199,7 +199,7 @@ class AgentGuard:
 
     # -- path handling ----------------------------------------------------
 
-    def resolve_path(self, source: str | os.PathLike[str]) -> pathlib.Path:
+    def resolve_path(self, source: str | _os.PathLike[str]) -> _pathlib.Path:
         """Resolve a model-supplied source to a real file inside the sandbox.
 
         A relative source is interpreted against the sandbox roots, never
@@ -221,7 +221,7 @@ class AgentGuard:
         raw = self._require_pathlike(source)
         self._reject_network(raw)
 
-        candidate = pathlib.Path(raw).expanduser()
+        candidate = _pathlib.Path(raw).expanduser()
         attempts = (
             [candidate]
             if candidate.is_absolute()
@@ -230,8 +230,8 @@ class AgentGuard:
 
         # Resolve symlinks and `..` fully before comparing against the roots.
         # Comparing an unresolved path would let `root/../../etc` pass.
-        attempted: pathlib.Path | None = None
-        resolved: pathlib.Path | None = None
+        attempted: _pathlib.Path | None = None
+        resolved: _pathlib.Path | None = None
         for attempt in attempts:
             try:
                 candidate_resolved = attempt.resolve(strict=True)
@@ -270,7 +270,7 @@ class AgentGuard:
             )
         return resolved
 
-    def _containing_root(self, resolved: pathlib.Path) -> pathlib.Path | None:
+    def _containing_root(self, resolved: _pathlib.Path) -> _pathlib.Path | None:
         for root in self._policy.roots:
             try:
                 resolved.relative_to(root)
@@ -279,7 +279,7 @@ class AgentGuard:
             return root
         return None
 
-    def _traverses_symlink(self, attempted: pathlib.Path, resolved: pathlib.Path) -> bool:
+    def _traverses_symlink(self, attempted: _pathlib.Path, resolved: _pathlib.Path) -> bool:
         """True if reaching ``resolved`` went through a link.
 
         ``attempted`` is always absolute — either an absolute source or a root
@@ -294,8 +294,8 @@ class AgentGuard:
         if attempted.is_symlink():
             return True
         try:
-            folded = os.path.normcase(os.path.normpath(attempted))
-            return folded != os.path.normcase(str(resolved))
+            folded = _os.path.normcase(_os.path.normpath(attempted))
+            return folded != _os.path.normcase(str(resolved))
         except OSError:
             return True
 
@@ -311,11 +311,11 @@ class AgentGuard:
                 )
 
     @staticmethod
-    def _require_pathlike(source: Any) -> str:
+    def _require_pathlike(source: _Any) -> str:
         if isinstance(source, str):
             return source
-        if isinstance(source, os.PathLike):
-            fs = os.fspath(source)
+        if isinstance(source, _os.PathLike):
+            fs = _os.fspath(source)
             if isinstance(fs, str):
                 return fs
         raise PathNotAllowedError(
@@ -323,7 +323,7 @@ class AgentGuard:
             "in-memory sources bypass the sandbox and are not accepted here"
         )
 
-    def _describe(self, candidate: pathlib.Path) -> str:
+    def _describe(self, candidate: _pathlib.Path) -> str:
         """Render a rejected path without disclosing the host filesystem.
 
         A rejected path resolved outside the sandbox, so there is no in-root
@@ -333,18 +333,18 @@ class AgentGuard:
         return candidate.name or "<empty path>"
 
     @staticmethod
-    def _relative(resolved: pathlib.Path, root: pathlib.Path) -> str:
+    def _relative(resolved: _pathlib.Path, root: _pathlib.Path) -> str:
         return resolved.relative_to(root).as_posix()
 
     # -- bounded execution ------------------------------------------------
 
-    def stop_condition(self) -> StopCondition:
+    def stop_condition(self) -> _StopCondition:
         """The engine-level row and byte ceilings implied by the policy."""
-        return StopCondition.max_rows(self._policy.max_rows) | StopCondition.max_bytes(
+        return _StopCondition.max_rows(self._policy.max_rows) | _StopCondition.max_bytes(
             self._policy.max_bytes
         )
 
-    def run(self, fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    def run(self, fn: _Callable[..., _T], *args: _Any, **kwargs: _Any) -> _T:
         """Run ``fn`` under the policy's per-call deadline.
 
         The deadline bounds what the caller waits for and what the agent sees.
@@ -374,7 +374,7 @@ class AgentGuard:
             except BaseException as exc:  # noqa: BLE001 - re-raised on the calling thread
                 failure.append(exc)
 
-        worker = threading.Thread(target=target, name="dataprof-agent", daemon=True)
+        worker = _threading.Thread(target=target, name="dataprof-agent", daemon=True)
         worker.start()
         worker.join(self._policy.timeout_seconds)
 
@@ -388,7 +388,7 @@ class AgentGuard:
 
     # -- guarded entry points ---------------------------------------------
 
-    def profile(self, source: str | os.PathLike[str], **kwargs: Any) -> ProfileReport:
+    def profile(self, source: str | _os.PathLike[str], **kwargs: _Any) -> _ProfileReport:
         """Profile a sandboxed file under the policy's bounds.
 
         The row and byte ceilings are set from the policy and cannot be widened
@@ -408,8 +408,8 @@ class AgentGuard:
         return self.run(_profile, str(path), stop_condition=self.stop_condition(), **kwargs)
 
     def analyze_structure(
-        self, source: str | os.PathLike[str], max_rows: int | None = None
-    ) -> StructureReport:
+        self, source: str | _os.PathLike[str], max_rows: int | None = None
+    ) -> _StructureReport:
         """Cheap structural first look at a sandboxed file.
 
         ``max_rows`` is clamped to the policy ceiling rather than rejected, so
@@ -422,7 +422,7 @@ class AgentGuard:
         return self.run(_analyze_structure, str(path), bounded)
 
     def llm_context(
-        self, report: ProfileReport, max_tokens: int = 1000, include_samples: bool = False
+        self, report: _ProfileReport, max_tokens: int = 1000, include_samples: bool = False
     ) -> str:
         """Render ``report`` as bounded, redacted model context.
 

--- a/python/dataprof/asyncio.py
+++ b/python/dataprof/asyncio.py
@@ -15,10 +15,10 @@ Example::
     asyncio.run(main())
 """
 
-from __future__ import annotations
+from __future__ import annotations as _annotations
 
-from pathlib import Path
-from typing import Any
+from pathlib import Path as _Path
+from typing import Any as _Any
 
 try:
     from ._dataprof import (  # type: ignore[import-not-found]
@@ -39,8 +39,20 @@ try:
 except ImportError:
     _HAS_URL = False
 
-from . import ProfileReport, RowCountEstimate, SchemaResult
-from ._dataprof import ProfilerConfig  # type: ignore[import-not-found]
+from . import (
+    ProfileReport as _ProfileReport,
+    RowCountEstimate as _RowCountEstimate,
+    SchemaResult as _SchemaResult,
+)
+from ._dataprof import ProfilerConfig as _ProfilerConfig  # type: ignore[import-not-found]
+
+__all__ = [
+    "profile_bytes",
+    "profile_file",
+    "profile_url",
+    "infer_schema_stream",
+    "quick_row_count_stream",
+]
 
 
 def _check_async() -> None:
@@ -55,8 +67,8 @@ async def profile_bytes(
     data: bytes,
     *,
     format: str,
-    **kwargs: Any,
-) -> ProfileReport:
+    **kwargs: _Any,
+) -> _ProfileReport:
     """Profile in-memory bytes asynchronously.
 
     Args:
@@ -75,15 +87,15 @@ async def profile_bytes(
             "engine='columnar' is not available for async bytes input; "
             "use engine='auto' or 'incremental'."
         )
-    config = ProfilerConfig(**kwargs) if kwargs else None
+    config = _ProfilerConfig(**kwargs) if kwargs else None
     rust_report = await _profile_bytes_async(data, format, config)
-    return ProfileReport(rust_report)
+    return _ProfileReport(rust_report)
 
 
 async def profile_file(
-    path: str | Path,
-    **kwargs: Any,
-) -> ProfileReport:
+    path: str | _Path,
+    **kwargs: _Any,
+) -> _ProfileReport:
     """Profile a local file asynchronously.
 
     All formats supported including Parquet.
@@ -96,17 +108,17 @@ async def profile_file(
         ProfileReport with analysis results.
     """
     _check_async()
-    config = ProfilerConfig(**kwargs) if kwargs else None
+    config = _ProfilerConfig(**kwargs) if kwargs else None
     rust_report = await _profile_file_async(str(path), config)
-    return ProfileReport(rust_report)
+    return _ProfileReport(rust_report)
 
 
 async def profile_url(
     url: str,
     *,
     format: str | None = None,
-    **kwargs: Any,
-) -> ProfileReport:
+    **kwargs: _Any,
+) -> _ProfileReport:
     """Profile data from a remote URL asynchronously.
 
     Supports CSV, JSON, and JSONL when async streaming is compiled in.
@@ -127,16 +139,16 @@ async def profile_url(
             "--features 'python-async,async-streaming'. Remote Parquet "
             "also requires 'parquet-async'."
         )
-    config = ProfilerConfig(**kwargs) if kwargs else None
+    config = _ProfilerConfig(**kwargs) if kwargs else None
     rust_report = await _profile_url_async(url, format, config)
-    return ProfileReport(rust_report)
+    return _ProfileReport(rust_report)
 
 
 async def infer_schema_stream(
     data: bytes,
     *,
     format: str,
-) -> SchemaResult:
+) -> _SchemaResult:
     """Infer schema from in-memory bytes asynchronously.
 
     Reads only a small sample. Parquet is not supported.
@@ -156,7 +168,7 @@ async def quick_row_count_stream(
     data: bytes,
     *,
     format: str,
-) -> RowCountEstimate:
+) -> _RowCountEstimate:
     """Quick row count from in-memory bytes asynchronously.
 
     Always a full scan. Parquet not supported.

--- a/python/dataprof/asyncio.pyi
+++ b/python/dataprof/asyncio.pyi
@@ -7,6 +7,14 @@ from typing import Any
 
 from . import ProfileReport, RowCountEstimate, SchemaResult
 
+__all__ = [
+    "profile_bytes",
+    "profile_file",
+    "profile_url",
+    "infer_schema_stream",
+    "quick_row_count_stream",
+]
+
 # True when the extension was built with the corresponding feature flags.
 _HAS_ASYNC: bool
 _HAS_URL: bool

--- a/python/dataprof/interop.py
+++ b/python/dataprof/interop.py
@@ -4,9 +4,9 @@ These are direct bindings to the Rust profiling engine, without the
 high-level dispatch and wrapping provided by ``dataprof.profile()``.
 """
 
-from __future__ import annotations
+from __future__ import annotations as _annotations
 
-import os
+import os as _os
 
 from dataprof._dataprof import (  # type: ignore[import-not-found]
     ColumnProfile,
@@ -24,28 +24,28 @@ from dataprof._dataprof import (  # type: ignore[import-not-found]
 from . import column_to_dict
 
 
-def _normalize_pathlike(path: str | os.PathLike[str], *, arg_name: str = "path") -> str:
+def _normalize_pathlike(path: str | _os.PathLike[str], *, arg_name: str = "path") -> str:
     if isinstance(path, str):
         return path
-    if isinstance(path, os.PathLike):
-        normalized = os.fspath(path)
+    if isinstance(path, _os.PathLike):
+        normalized = _os.fspath(path)
         if isinstance(normalized, str):
             return normalized
     raise TypeError(f"Expected str or path-like object for {arg_name}, got {type(path).__name__}")
 
 
 def analyze_file(
-    path: str | os.PathLike[str],
+    path: str | _os.PathLike[str],
     config: ProfilerConfig | None = None,
 ) -> ProfileReport:
     return _analyze_file(_normalize_pathlike(path), config)
 
 
-def analyze_csv_to_arrow(path: str | os.PathLike[str]) -> RecordBatch:
+def analyze_csv_to_arrow(path: str | _os.PathLike[str]) -> RecordBatch:
     return _analyze_csv_to_arrow(_normalize_pathlike(path))
 
 
-def analyze_parquet_to_arrow(path: str | os.PathLike[str]) -> RecordBatch:
+def analyze_parquet_to_arrow(path: str | _os.PathLike[str]) -> RecordBatch:
     return _analyze_parquet_to_arrow(_normalize_pathlike(path))
 
 

--- a/python/tests/test_public_surface.py
+++ b/python/tests/test_public_surface.py
@@ -22,6 +22,7 @@ declares on purpose, so it is checked for existence rather than for reachability
 """
 
 from __future__ import annotations
+import __future__
 
 import importlib
 from types import ModuleType
@@ -206,6 +207,35 @@ def test_typing_helpers_are_not_package_attributes():
         assert not hasattr(dataprof, leaked), (
             f"dataprof.{leaked} is importable; bind it as _{leaked} instead"
         )
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_SURFACE))
+def test_future_annotations_stay_enabled_under_the_private_alias(name):
+    """``from __future__ import annotations as _annotations`` is a real future statement.
+
+    Future statements accept an alias -- the grammar is ``feature ["as"
+    identifier]`` -- and the compiler enables the feature from the statement's
+    presence, not from the name it binds. The alias is load-bearing because the
+    *unaliased* form binds a public ``annotations`` attribute (a
+    ``__future__._Feature`` object) on every module that uses it, which is one of
+    the leaks this file exists to stop.
+
+    This is pinned because "you cannot alias a future import" is a
+    plausible-sounding objection that has already been raised once. Acting on it
+    brings the leak back; dropping the future statement instead makes every
+    annotation in these modules evaluate at runtime.
+    """
+    module = _module(name)
+    # The loader is typed as an optional protocol without get_code; every loader
+    # that imported these modules from source has it.
+    code = module.__loader__.get_code(module.__name__)  # ty: ignore[unresolved-attribute]
+    assert code is not None, f"{name}: cannot recover compiled code to check flags"
+    assert code.co_flags & __future__.annotations.compiler_flag, (
+        f"{name}: PEP 563 is not active -- annotations will be evaluated at runtime"
+    )
+    assert not hasattr(module, "annotations"), (
+        f"{name}: `annotations` is reachable, so the future import is unaliased again"
+    )
 
 
 def test_column_to_dict_is_public_and_consistent():

--- a/python/tests/test_public_surface.py
+++ b/python/tests/test_public_surface.py
@@ -1,0 +1,233 @@
+"""The Python public surface is what ``__all__`` says it is (#514).
+
+The Rust facade has had this guard for a while — ``tests/public_api_facade.rs``
+pins its surface and ``docs/architecture/public-api-inventory.md`` records it,
+with zero drift across 81 names. Python had no equivalent, and it showed:
+``dataprof.__all__`` declared 28 names while 40 were reachable, because the
+whole package lives in one module namespace and every ``import os`` landed in
+it. ``dataprof.os``, ``dataprof.json`` and ``dataprof.pathlib`` were importable;
+``dataprof.asyncio`` had no ``__all__`` at all.
+
+Two checks, deliberately overlapping:
+
+* the **structural** one — reachable public names equal ``__all__`` — fails the
+  moment a new incidental import is added, without anyone editing this file;
+* the **inventory** — the literal expected names below — makes adding to or
+  removing from the public API a deliberate edit here, so it cannot happen as a
+  side effect of an unrelated change.
+
+Names beginning with an underscore are internal by convention and are not part
+of the surface. ``__version__`` is the exception: it is a dunder that ``__all__``
+declares on purpose, so it is checked for existence rather than for reachability.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+
+EXPECTED_SURFACE: dict[str, frozenset[str]] = {
+    "dataprof": frozenset(
+        {
+            "Capabilities",
+            "ColumnProfile",
+            "DataQualityMetrics",
+            "ProgressEvent",
+            "ProfileReport",
+            "Profiler",
+            "ProfilerConfig",
+            "REPORT_SCHEMA_VERSION",
+            "RecordBatch",
+            "RowCountEstimate",
+            "SamplingStrategy",
+            "SchemaResult",
+            "StopCondition",
+            "StructureColumnSummary",
+            "StructureReport",
+            "__version__",
+            "analyze_database_async",
+            "analyze_structure",
+            "asyncio",
+            "capabilities",
+            "column_to_dict",
+            "count_table_rows_async",
+            "get_table_schema_async",
+            "infer_schema",
+            "list_patterns",
+            "profile",
+            "profile_file",
+            "quick_row_count",
+            "test_connection_async",
+        }
+    ),
+    "dataprof.agent": frozenset(
+        {
+            "AgentGuard",
+            "AgentSecurityError",
+            "AgentTimeoutError",
+            "PathNotAllowedError",
+            "ResourceLimitExceededError",
+            "SandboxPolicy",
+        }
+    ),
+    "dataprof.asyncio": frozenset(
+        {
+            "infer_schema_stream",
+            "profile_bytes",
+            "profile_file",
+            "profile_url",
+            "quick_row_count_stream",
+        }
+    ),
+    "dataprof.interop": frozenset(
+        {
+            "ColumnProfile",
+            "DataQualityMetrics",
+            "ProfileReport",
+            "ProfilerConfig",
+            "RecordBatch",
+            "analyze_csv_to_arrow",
+            "analyze_file",
+            "analyze_parquet_to_arrow",
+            "column_to_dict",
+            "profile_arrow",
+            "profile_dataframe",
+        }
+    ),
+}
+
+
+def _module(name: str) -> ModuleType:
+    return importlib.import_module(name)
+
+
+def _reachable(module: ModuleType) -> set[str]:
+    """Public attribute names, ignoring the package's own submodules.
+
+    Importing ``dataprof.interop`` anywhere in the process binds ``interop`` as
+    an attribute of ``dataprof`` — that is how Python packages work, not an
+    incidental import, and counting it would make this check depend on which
+    tests ran first.
+    """
+    names = set()
+    for name in dir(module):
+        if name.startswith("_"):
+            continue
+        value = getattr(module, name, None)
+        if isinstance(value, ModuleType) and value.__name__.startswith(f"{module.__name__}."):
+            continue
+        names.add(name)
+    return names
+
+
+def _declared(module: ModuleType) -> set[str]:
+    declared = getattr(module, "__all__", None)
+    assert declared is not None, f"{module.__name__} declares no __all__"
+    return set(declared)
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_SURFACE))
+def test_reachable_names_equal_all(name):
+    """Nothing is reachable that ``__all__`` does not declare.
+
+    This is the check that catches a new ``import os`` at the top of the module
+    without anyone remembering to update a list.
+    """
+    module = _module(name)
+    declared = _declared(module)
+    # __all__ may declare dunders (``__version__``); those are never reachable
+    # under the non-underscore rule, so compare only the public-name half.
+    public_declared = {n for n in declared if not n.startswith("_")}
+    reachable = _reachable(module)
+
+    leaked = sorted(reachable - public_declared)
+    assert not leaked, (
+        f"{name}: reachable but not declared in __all__: {leaked}. "
+        "Import it under a private alias (import os as _os) or add it to __all__ "
+        "if it is genuinely public."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_SURFACE))
+def test_every_declared_name_exists(name):
+    """``__all__`` cannot promise a name the module does not have.
+
+    A stale entry makes ``from dataprof import *`` raise, and silently breaks
+    anything reading ``__all__`` to build documentation.
+    """
+    module = _module(name)
+    missing = sorted(n for n in _declared(module) if not hasattr(module, n))
+    assert not missing, f"{name}: declared in __all__ but not defined: {missing}"
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_SURFACE))
+def test_surface_matches_the_recorded_inventory(name):
+    """Adding to or removing from the public API is a deliberate edit.
+
+    The structural check above would happily accept a new public name; this one
+    will not, so growth of the API surface shows up in review as a change to
+    this file.
+    """
+    declared = _declared(_module(name))
+    expected = EXPECTED_SURFACE[name]
+    added = sorted(declared - expected)
+    removed = sorted(expected - declared)
+    assert not added and not removed, (
+        f"{name}: public surface changed.\n"
+        f"  added:   {added}\n"
+        f"  removed: {removed}\n"
+        "If this is intended, update EXPECTED_SURFACE in this file. Removing a "
+        "documented name also needs a release note."
+    )
+
+
+def test_stdlib_modules_are_not_package_attributes():
+    """The specific leak this issue was filed for.
+
+    ``dataprof.os`` and friends worked purely because the implementation lives
+    in one module namespace. Stated directly so the regression is named, not
+    just implied by a set difference.
+    """
+    import dataprof
+
+    for leaked in ("os", "json", "math", "pathlib", "warnings", "functools", "csv", "io"):
+        assert not hasattr(dataprof, leaked), (
+            f"dataprof.{leaked} is importable; bind it as _{leaked} instead"
+        )
+
+
+def test_typing_helpers_are_not_package_attributes():
+    """Typing names leak the same way and are equally not API."""
+    import dataprof
+
+    for leaked in ("Any", "Callable", "Iterator", "TYPE_CHECKING", "cast", "annotations"):
+        assert not hasattr(dataprof, leaked), (
+            f"dataprof.{leaked} is importable; bind it as _{leaked} instead"
+        )
+
+
+def test_column_to_dict_is_public_and_consistent():
+    """``column_to_dict`` was documented but undeclared; it is now exported.
+
+    The stub declared it, ``docs/guides/examples.md`` uses it, and the changelog
+    announced it — so the consistent resolution was to export it rather than
+    make a documented name private.
+    """
+    import dataprof
+
+    assert "column_to_dict" in dataprof.__all__
+    assert callable(dataprof.column_to_dict)
+
+
+def test_star_import_yields_exactly_the_declared_surface():
+    """``from dataprof import *`` is the user-facing form of this contract."""
+    namespace: dict[str, object] = {}
+    exec("from dataprof import *", namespace)  # noqa: S102
+    imported = {n for n in namespace if not n.startswith("__")}
+    expected = {n for n in EXPECTED_SURFACE["dataprof"] if not n.startswith("_")}
+    assert imported == expected, (
+        f"star-import surface differs: unexpected {sorted(imported - expected)}, "
+        f"missing {sorted(expected - imported)}"
+    )

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1785,6 +1785,7 @@ class TestNamespace:
             "StructureColumnSummary",
             "StructureReport",
             "RecordBatch",
+            "column_to_dict",
             "asyncio",
             "__version__",
             # Database helpers: exported unconditionally. Without a `database`
@@ -2592,7 +2593,13 @@ class TestColumnToDict:
         from_report = r.to_dict()["columns"][0]
         assert d == from_report
 
-    def test_column_to_dict_discoverable_from_interop_not_all(self, tmp_path):
+    def test_column_to_dict_is_exported_from_both_namespaces(self, tmp_path):
+        """#514 settled this: the name is public, so __all__ declares it.
+
+        It was reachable, documented in the stub and used in
+        docs/guides/examples.md while __all__ omitted it — public in every way
+        except the one that counts.
+        """
         import dataprof.interop as interop
 
         path = tmp_path / "data.csv"
@@ -2600,7 +2607,8 @@ class TestColumnToDict:
         r = dataprof.profile(str(path))
 
         assert hasattr(dataprof, "column_to_dict")
-        assert "column_to_dict" not in dataprof.__all__
+        assert "column_to_dict" in dataprof.__all__
+        assert "column_to_dict" in interop.__all__
         assert interop.column_to_dict(r["x"]) == dataprof.column_to_dict(r["x"])
 
 


### PR DESCRIPTION
Closes #514. Last of the three guards in #511 and a decent showcase of stacked PR new Gh feature.

> **Stacked on #528** — base is `fix/rounding-parity-513`, so the diff here is
> only the surface work. Merge #528 first and this retargets to `master`
> automatically.

## What was leaking

`dataprof.__all__` declared 28 names; 40 were reachable. Because the whole
package lives in one module namespace, every plain `import` landed in it:

```python
>>> import dataprof
>>> dataprof.os, dataprof.json, dataprof.pathlib   # all worked
>>> dataprof.Any, dataprof.cast, dataprof.TYPE_CHECKING
```

It was not just the top-level package:

| module | `__all__` | reachable | leaked |
| --- | --- | --- | --- |
| `dataprof` | 28 | 40 | 13 |
| `dataprof.agent` | 6 | 19 | 13 |
| `dataprof.asyncio` | **none at all** | 12 | 12 |
| `dataprof.interop` | 11 | 13 | 2 |

`dataprof.agent` leaked `ProfileReport`, `StopCondition` and `StructureReport`
on top of the stdlib and typing names — re-exports of public types that were
never meant to be part of *that* module's API. `dataprof.asyncio` had no
`__all__`, so `from dataprof.asyncio import *` pulled in `Path`, `Any` and four
report types alongside the five real functions.

All four now report zero drift.

## How

Everything imported for internal use is bound under a private alias — the
convention the module **already** used for `csv`, `io`, `decimal`, `html`,
`errno` and `importlib`. `os`, `json`, `math`, `functools`, `warnings` and
`pathlib` were simply the ones that got missed.

Renames were done with `tokenize`, not text substitution, so strings and
comments were never touched. That left exactly one thing a tokenizer cannot
see, which the type checker caught:

```python
_cast("str | os.PathLike[str]", roots)   # a type expression inside a string
```

**On the typing names:** I first tried `del Any, Callable, Iterator` at the end
of the module — the approach #514 suggests. It does not work: ruff and ty read
a module-scope `del` as an unconditional unbind and flagged every annotation in
the file as `Undefined name` (41 errors). Private aliases it is.

## `column_to_dict` is public

It was in the `.pyi` stub, announced in the changelog, and used in
`docs/guides/examples.md:414` — public in every way except `__all__`. Making it
private would have removed a documented name, so it is exported. Two existing
tests encoded the old undecided state, including one literally named
`test_column_to_dict_discoverable_from_interop_not_all`; both are updated.

## The guard

Two overlapping checks, modelled on `tests/public_api_facade.rs`:

- **structural** — reachable names equal `__all__`. Catches a new incidental
  import with nobody editing a list.
- **inventory** — the literal expected names. The structural check would happily
  accept a *new public name*; this one makes growing the API a deliberate edit
  that shows up in review.

Package submodules are ignored: importing `dataprof.interop` anywhere binds
`interop` on the parent by design, and counting it made the check depend on test
ordering — which is how it passed alone and failed in the full suite.

`docs/architecture/public-api-inventory.md` gains a Python section, so the two
languages are recorded the same way.

## Verification

Both halves sabotaged, with targeted reverts:

| Sabotage | Caught by |
| --- | --- |
| `import textwrap` added to `__init__.py` | structural: `reachable but not declared: ['textwrap']` |
| new export `profile_everything` | inventory + star-import: `added: ['profile_everything']` |

```
uv run pytest python/tests/ -q     # 711 passed, 5 skipped, 1 xfailed
uv run ruff format/check, uv run ty check python/
cargo test --test public_api_facade # 15 passed (Rust facade unaffected)
```

No public name is removed, so no release note is needed on that count;
`column_to_dict` is *added* to the declared surface.
