### PR TITLE
fix(json): never discard a non-object JSON record

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -69,6 +69,112 @@ fn malformed_json_array_error(message: &str) -> DataProfilerError {
     }
 }
 
+/// One record read from a JSON or JSONL stream.
+///
+/// This mirrors `dataprof_json::JsonRecord`; the two scanners are kept
+/// byte-for-byte equivalent so a payload profiles identically whether it
+/// arrives as a file or as an async stream.
+enum JsonRecord {
+    /// A JSON object — the only value with named fields to profile as a row.
+    Object(serde_json::Map<String, serde_json::Value>),
+    /// Valid JSON that is not an object, carrying the value's kind for the
+    /// error message.
+    NonObject(&'static str),
+    /// The bytes are not valid JSON.
+    Malformed(serde_json::Error),
+}
+
+/// Read one JSON value and leave the reader positioned immediately after it.
+///
+/// `first` is the value's first byte, already located by
+/// [`peek_non_whitespace`] but not yet consumed.
+fn read_json_record<R: std::io::BufRead>(
+    reader: &mut R,
+    first: u8,
+) -> Result<JsonRecord, DataProfilerError> {
+    // A number is the only JSON value that is not self-delimiting: serde finds
+    // its end by peeking one byte past it and then drops that byte along with
+    // the deserializer. Inside an array that byte is the `,` or `]` the scanner
+    // needs next, so numbers are read byte-wise instead.
+    if first == b'-' || first.is_ascii_digit() {
+        let token = read_number_token(reader)?;
+        return Ok(match serde_json::from_str::<serde_json::Value>(&token) {
+            Ok(_) => JsonRecord::NonObject("number"),
+            Err(err) => JsonRecord::Malformed(err),
+        });
+    }
+
+    let mut de = serde_json::Deserializer::from_reader(reader);
+    Ok(
+        match <serde_json::Value as serde::Deserialize>::deserialize(&mut de) {
+            Ok(serde_json::Value::Object(obj)) => JsonRecord::Object(obj),
+            Ok(value) => JsonRecord::NonObject(json_value_kind(&value)),
+            Err(err) => JsonRecord::Malformed(err),
+        },
+    )
+}
+
+/// Read the bytes that can spell a JSON number, stopping at the first byte that
+/// cannot. The token is returned unvalidated — the caller decides whether it
+/// actually parses, so `1.2.3` stays a malformed record rather than a number.
+///
+/// Leading whitespace is consumed first: the JSONL loop locates the next
+/// value's first byte without consuming what precedes it, because serde needs
+/// that whitespace to keep its line and column context.
+fn read_number_token<R: std::io::BufRead>(reader: &mut R) -> Result<String, DataProfilerError> {
+    peek_non_whitespace(reader)?;
+    let mut token = String::new();
+    loop {
+        let (consume, token_ended) = {
+            let buf = reader.fill_buf().map_err(DataProfilerError::from)?;
+            if buf.is_empty() {
+                break;
+            }
+            let consume = buf
+                .iter()
+                .take_while(|byte| is_json_number_byte(**byte))
+                .count();
+            // decode-audit: impossible — every byte accepted above is ASCII.
+            token.push_str(
+                std::str::from_utf8(&buf[..consume]).expect("JSON number bytes are ASCII"),
+            );
+            (consume, consume < buf.len())
+        };
+        reader.consume(consume);
+        if token_ended {
+            break;
+        }
+    }
+    Ok(token)
+}
+
+fn is_json_number_byte(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b'-' | b'+' | b'.' | b'e' | b'E')
+}
+
+fn json_value_kind(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Build a strict-mode error for valid JSON that is not a row object. This is a
+/// distinct category from a syntax failure: the document parsed, it just does
+/// not hold records. `position` is 1-based over the records scanned so far.
+fn non_object_record_error(kind: &str, position: usize) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!(
+            "non-object JSON record at position {position}: \
+             expected an object with fields to profile, found {kind}"
+        ),
+    }
+}
+
 fn drain_to_end<R: std::io::BufRead>(reader: &mut R) -> Result<usize, DataProfilerError> {
     let mut consumed = 0;
     loop {
@@ -614,36 +720,61 @@ impl AsyncStreamingProfiler {
                     // Distinguish clean exhaustion from an incomplete trailing
                     // value. serde reports both as `Category::Eof`, but only an
                     // empty/whitespace-only remainder is a clean end of stream.
-                    let has_value = loop {
+                    let first = loop {
                         let whitespace_only_len = {
                             let buf = buf_reader.fill_buf().map_err(DataProfilerError::from)?;
                             if buf.is_empty() {
-                                break false;
+                                break None;
                             }
-                            if buf.iter().all(u8::is_ascii_whitespace) {
-                                Some(buf.len())
-                            } else {
-                                None
+                            match buf.iter().find(|byte| !byte.is_ascii_whitespace()) {
+                                // Leave a mixed whitespace/value buffer untouched
+                                // so serde retains its line and column context.
+                                Some(&byte) => break Some(byte),
+                                None => buf.len(),
                             }
-                        };
-                        let Some(whitespace_only_len) = whitespace_only_len else {
-                            // Leave a mixed whitespace/value buffer untouched so
-                            // serde retains its line and column context.
-                            break true;
                         };
                         buf_reader.consume(whitespace_only_len);
                     };
-                    if !has_value {
+                    let Some(first) = first else {
                         break;
-                    }
-
-                    let parsed = {
-                        let mut de = serde_json::Deserializer::from_reader(&mut buf_reader);
-                        <Value as serde::Deserialize>::deserialize(&mut de)
                     };
-                    let v = match parsed {
-                        Ok(v) => v,
-                        Err(e) => {
+
+                    match read_json_record(&mut buf_reader, first)? {
+                        JsonRecord::Object(obj) => {
+                            let row = process_object(
+                                &obj,
+                                &mut known_columns,
+                                &mut known_columns_set,
+                                headers_sent,
+                            );
+                            bytes_in_chunk += row.iter().map(|s| s.len() as u64 + 4).sum::<u64>();
+                            current_chunk.push(row);
+                            emitted_records += 1;
+
+                            if bytes_in_chunk as usize >= bytes_per_chunk
+                                && !send_chunk(
+                                    &mut current_chunk,
+                                    &mut bytes_in_chunk,
+                                    &known_columns,
+                                    &mut headers_sent,
+                                    &tx,
+                                )?
+                            {
+                                return Ok(malformed_records);
+                            }
+                        }
+                        JsonRecord::NonObject(kind) => {
+                            if error_policy == JsonErrorPolicy::Strict {
+                                return Err(non_object_record_error(
+                                    kind,
+                                    emitted_records + malformed_records + 1,
+                                ));
+                            }
+                            malformed_records += 1;
+                            // Approximate progress for a record that yields no row.
+                            bytes_in_chunk += 10;
+                        }
+                        JsonRecord::Malformed(e) => {
                             if error_policy == JsonErrorPolicy::Strict {
                                 return Err(DataProfilerError::JsonParsingError {
                                     message: format!("malformed JSON record: {e}"),
@@ -658,31 +789,6 @@ impl AsyncStreamingProfiler {
                             buf_reader
                                 .read_until(b'\n', &mut discard)
                                 .map_err(DataProfilerError::from)?;
-                            continue;
-                        }
-                    };
-
-                    if let Value::Object(obj) = v {
-                        let row = process_object(
-                            &obj,
-                            &mut known_columns,
-                            &mut known_columns_set,
-                            headers_sent,
-                        );
-                        bytes_in_chunk += row.iter().map(|s| s.len() as u64 + 4).sum::<u64>();
-                        current_chunk.push(row);
-                        emitted_records += 1;
-
-                        if bytes_in_chunk as usize >= bytes_per_chunk
-                            && !send_chunk(
-                                &mut current_chunk,
-                                &mut bytes_in_chunk,
-                                &known_columns,
-                                &mut headers_sent,
-                                &tx,
-                            )?
-                        {
-                            return Ok(malformed_records);
                         }
                     }
                 }
@@ -748,9 +854,8 @@ impl AsyncStreamingProfiler {
                             break;
                         }
 
-                        let mut de = serde_json::Deserializer::from_reader(&mut buf_reader);
-                        match serde::Deserialize::deserialize(&mut de) {
-                            Ok(Value::Object(obj)) => {
+                        match read_json_record(&mut buf_reader, next)? {
+                            JsonRecord::Object(obj) => {
                                 let row = process_object(
                                     &obj,
                                     &mut known_columns,
@@ -774,11 +879,21 @@ impl AsyncStreamingProfiler {
                                     return Ok(malformed_records);
                                 }
                             }
-                            Ok(_) => {
-                                // Skip non-object items, approximate 10 bytes progress
+                            JsonRecord::NonObject(kind) => {
+                                if error_policy == JsonErrorPolicy::Strict {
+                                    return Err(non_object_record_error(
+                                        kind,
+                                        emitted_records + malformed_records + 1,
+                                    ));
+                                }
+                                // The element was consumed in full, so the array
+                                // grammar is still intact and the objects after
+                                // it are still profileable.
+                                malformed_records += 1;
+                                // Approximate progress for a record that yields no row.
                                 bytes_in_chunk += 10;
                             }
-                            Err(e) => {
+                            JsonRecord::Malformed(e) => {
                                 // A corrupt element leaves the array parser unable
                                 // to resync, so we stop here either way; strict mode
                                 // surfaces the failure instead of a partial profile.
@@ -843,7 +958,9 @@ impl AsyncStreamingProfiler {
         // file/bytes paths, rather than surfacing a generic "empty stream" error.
         if emitted_records == 0 && malformed_records > 0 {
             return Err(DataProfilerError::JsonParsingError {
-                message: "No valid JSON records found (all records were malformed)".to_string(),
+                message: "No valid JSON records found \
+                          (every record was malformed or not a JSON object)"
+                    .to_string(),
             });
         }
 
@@ -1443,6 +1560,113 @@ mod tests {
             assert!(message.to_lowercase().contains("malformed json record"));
             assert!(!message.contains("not-json"), "leaked record: {message}");
         }
+    }
+
+    /// Every JSON value that is not an object, so none of them can be a row.
+    /// Numbers appear twice on purpose: they are the one value serde reads from
+    /// a reader by peeking one byte past the end.
+    const NON_OBJECT_VALUES: &[(&str, &str)] = &[
+        ("null", "null"),
+        ("boolean", "true"),
+        ("number", "42"),
+        ("number", "-1.5e3"),
+        ("string", r#""text""#),
+        ("array", "[1, 2]"),
+    ];
+
+    #[tokio::test]
+    async fn test_async_tolerant_counts_non_object_records_and_keeps_scanning() {
+        for (kind, value) in NON_OBJECT_VALUES {
+            for (fmt, data) in [
+                (
+                    FileFormat::Jsonl,
+                    format!("{{\"id\":1}}\n{value}\n{{\"id\":2}}\n"),
+                ),
+                (
+                    FileFormat::Json,
+                    format!("[{{\"id\":1}}, {value}, {{\"id\":2}}]"),
+                ),
+            ] {
+                let label = format!("{fmt:?}/{kind}");
+                let source =
+                    BytesSource::new(bytes::Bytes::from(data), AsyncSourceInfo::new("test", fmt));
+                let report = AsyncStreamingProfiler::new()
+                    .analyze_stream(source)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    report.execution.rows_processed, 2,
+                    "{label}: record after it was lost"
+                );
+                assert_eq!(
+                    report.execution.error_count, 1,
+                    "{label}: was silently dropped"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_strict_rejects_the_first_non_object_record() {
+        for (kind, value) in NON_OBJECT_VALUES {
+            for (fmt, data) in [
+                (
+                    FileFormat::Jsonl,
+                    format!("{{\"id\":1}}\n{value}\n{{\"id\":2}}\n"),
+                ),
+                (
+                    FileFormat::Json,
+                    format!("[{{\"id\":1}}, {value}, {{\"id\":2}}]"),
+                ),
+            ] {
+                let label = format!("{fmt:?}/{kind}");
+                let source =
+                    BytesSource::new(bytes::Bytes::from(data), AsyncSourceInfo::new("test", fmt));
+                let err = AsyncStreamingProfiler::new()
+                    .json_error_policy(JsonErrorPolicy::Strict)
+                    .analyze_stream(source)
+                    .await
+                    .expect_err("strict mode must reject a non-object record");
+
+                let message = err.to_string();
+                assert!(
+                    message.contains("non-object JSON record"),
+                    "{label}: {message}"
+                );
+                assert!(message.contains("at position 2"), "{label}: {message}");
+                assert!(
+                    message.contains(&format!("found {kind}")),
+                    "{label}: {message}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_number_element_does_not_swallow_the_array_delimiter() {
+        // serde ends a number by peeking one byte past it and drops that byte
+        // with the deserializer; here it is the `,` the array scanner needs.
+        let source = json_source(br#"[{"id":1}, 1, 2, 3, {"id":2}, 4, {"id":3}]"#);
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .unwrap();
+        assert_eq!(report.execution.rows_processed, 3);
+        assert_eq!(report.execution.error_count, 4);
+    }
+
+    #[tokio::test]
+    async fn test_async_input_of_only_non_object_records_fails() {
+        let source = jsonl_source(b"\"just a string\"\n1\n[2]\n");
+        let err = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .expect_err("nothing profileable should not return a clean empty profile");
+
+        assert!(
+            err.to_string().contains("No valid JSON records found"),
+            "{err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -76,6 +76,9 @@ pub type JsonObject = serde_json::Map<String, Value>;
 #[non_exhaustive]
 pub struct JsonScanSummary {
     pub rows_read: usize,
+    /// Records that were read but not profiled: malformed JSON, and valid JSON
+    /// values that are not objects and therefore carry no fields. Both are
+    /// counted so a tolerant scan never looks like a clean one.
     pub malformed_lines: usize,
     pub format: FileFormat,
     /// The scan stopped at `max_rows` while records still remained. A source
@@ -87,6 +90,15 @@ pub struct JsonScanSummary {
 ///
 /// - **JSONL**: scans one top-level JSON value at a time from the reader.
 /// - **JSON array**: streams array elements without buffering the entire input.
+///
+/// # Record policy
+///
+/// Only JSON objects are profileable records — they are the only JSON value
+/// with named fields to turn into columns. A record that is valid JSON but not
+/// an object (a scalar, an array, `null`) is never silently discarded: under
+/// [`JsonErrorPolicy::Skip`] it is counted in
+/// [`JsonScanSummary::malformed_lines`] and scanning continues with the next
+/// record, and under [`JsonErrorPolicy::Strict`] the first one fails the scan.
 pub fn scan_json_from_reader<R, F>(
     reader: R,
     config: &JsonParserConfig,
@@ -125,14 +137,25 @@ where
             // incomplete trailing value as `Category::Eof`. Check whether a
             // non-whitespace value actually starts here so only the former is
             // treated as normal exhaustion.
-            if consume_leading_whitespace(&mut reader)?.is_none() {
+            let Some(first) = consume_leading_whitespace(&mut reader)? else {
                 break;
-            }
+            };
 
-            let mut deserializer = serde_json::Deserializer::from_reader(&mut reader);
-            let value: Value = match Value::deserialize(&mut deserializer) {
-                Ok(v) => v,
-                Err(err) => {
+            match read_json_record(&mut reader, first)? {
+                JsonRecord::Object(obj) => {
+                    on_object(&obj);
+                    rows_read += 1;
+                }
+                JsonRecord::NonObject(kind) => {
+                    if config.error_policy == JsonErrorPolicy::Strict {
+                        return Err(non_object_record_error(
+                            kind,
+                            rows_read + malformed_lines + 1,
+                        ));
+                    }
+                    malformed_lines += 1;
+                }
+                JsonRecord::Malformed(err) => {
                     if config.error_policy == JsonErrorPolicy::Strict {
                         return Err(malformed_record_error(&err));
                     }
@@ -141,13 +164,7 @@ where
                         break;
                     }
                     skip_to_next_line(&mut reader)?;
-                    continue;
                 }
-            };
-
-            if let Value::Object(ref obj) = value {
-                on_object(obj);
-                rows_read += 1;
             }
         },
         FileFormat::Json => {
@@ -237,14 +254,24 @@ where
                             break;
                         }
 
-                        let mut deserializer = serde_json::Deserializer::from_reader(&mut reader);
-                        match Value::deserialize(&mut deserializer) {
-                            Ok(Value::Object(obj)) => {
+                        match read_json_record(&mut reader, next)? {
+                            JsonRecord::Object(obj) => {
                                 on_object(&obj);
                                 rows_read += 1;
                             }
-                            Ok(_) => {}
-                            Err(err) => {
+                            JsonRecord::NonObject(kind) => {
+                                if config.error_policy == JsonErrorPolicy::Strict {
+                                    return Err(non_object_record_error(
+                                        kind,
+                                        rows_read + malformed_lines + 1,
+                                    ));
+                                }
+                                // The element was consumed in full, so the array
+                                // grammar is still intact and the objects after
+                                // it are still profileable.
+                                malformed_lines += 1;
+                            }
+                            JsonRecord::Malformed(err) => {
                                 if config.error_policy == JsonErrorPolicy::Strict {
                                     return Err(malformed_record_error(&err));
                                 }
@@ -302,6 +329,127 @@ where
         format,
         truncated,
     })
+}
+
+/// One record read from a JSON or JSONL source.
+enum JsonRecord {
+    /// A JSON object — the only value with named fields to profile as a row.
+    Object(JsonObject),
+    /// Valid JSON that is not an object, carrying the value's kind for the
+    /// error message.
+    NonObject(&'static str),
+    /// The bytes are not valid JSON.
+    Malformed(serde_json::Error),
+}
+
+/// Read one JSON value and leave the reader positioned immediately after it.
+///
+/// `first` is the value's first byte, already located by
+/// [`consume_leading_whitespace`] but not yet consumed.
+fn read_json_record<R: BufRead>(
+    reader: &mut R,
+    first: u8,
+) -> Result<JsonRecord, DataProfilerError> {
+    // A number is the only JSON value that is not self-delimiting: serde finds
+    // its end by peeking one byte past it and then drops that byte along with
+    // the deserializer. Inside an array that byte is the `,` or `]` the scanner
+    // needs next, so numbers are read byte-wise instead.
+    if first == b'-' || first.is_ascii_digit() {
+        let token = read_number_token(reader)?;
+        return Ok(match serde_json::from_str::<Value>(&token) {
+            Ok(_) => JsonRecord::NonObject("number"),
+            Err(err) => JsonRecord::Malformed(err),
+        });
+    }
+
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    Ok(match Value::deserialize(&mut deserializer) {
+        Ok(Value::Object(obj)) => JsonRecord::Object(obj),
+        Ok(value) => JsonRecord::NonObject(json_value_kind(&value)),
+        Err(err) => JsonRecord::Malformed(err),
+    })
+}
+
+/// Read the bytes that can spell a JSON number, stopping at the first byte that
+/// cannot. The token is returned unvalidated — the caller decides whether it
+/// actually parses, so `1.2.3` stays a malformed record rather than a number.
+///
+/// Leading whitespace is consumed first: [`consume_leading_whitespace`] reports
+/// the next value's first byte without consuming what precedes it, because
+/// serde needs that whitespace to keep its line and column context.
+fn read_number_token<R: BufRead>(reader: &mut R) -> Result<String, DataProfilerError> {
+    skip_ascii_whitespace(reader)?;
+    let mut token = String::new();
+    loop {
+        let (consume, token_ended) = {
+            let buf = reader.fill_buf().map_err(DataProfilerError::from)?;
+            if buf.is_empty() {
+                break;
+            }
+            let consume = buf
+                .iter()
+                .take_while(|byte| is_json_number_byte(**byte))
+                .count();
+            // decode-audit: impossible — every byte accepted above is ASCII.
+            token.push_str(
+                std::str::from_utf8(&buf[..consume]).expect("JSON number bytes are ASCII"),
+            );
+            (consume, consume < buf.len())
+        };
+        reader.consume(consume);
+        if token_ended {
+            break;
+        }
+    }
+    Ok(token)
+}
+
+fn is_json_number_byte(byte: u8) -> bool {
+    byte.is_ascii_digit() || matches!(byte, b'-' | b'+' | b'.' | b'e' | b'E')
+}
+
+/// Advance the reader past any ASCII whitespace at its current position.
+fn skip_ascii_whitespace<R: BufRead>(reader: &mut R) -> Result<(), DataProfilerError> {
+    loop {
+        let (consume, done) = {
+            let buf = reader.fill_buf().map_err(DataProfilerError::from)?;
+            if buf.is_empty() {
+                return Ok(());
+            }
+            let consume = buf
+                .iter()
+                .take_while(|byte| byte.is_ascii_whitespace())
+                .count();
+            (consume, consume < buf.len())
+        };
+        reader.consume(consume);
+        if done {
+            return Ok(());
+        }
+    }
+}
+
+fn json_value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Build a strict-mode error for valid JSON that is not a row object. This is a
+/// distinct category from a syntax failure: the document parsed, it just does
+/// not hold records. `position` is 1-based over the records scanned so far.
+fn non_object_record_error(kind: &str, position: usize) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!(
+            "non-object JSON record at position {position}: \
+             expected an object with fields to profile, found {kind}"
+        ),
+    }
 }
 
 /// Build a strict-mode parse error from a serde failure. The serde message
@@ -554,7 +702,8 @@ pub fn analyze_json_file_with_dimensions_and_hints(
     if rows_read == 0 {
         if malformed_lines > 0 {
             return Err(DataProfilerError::JsonParsingError {
-                message: "No valid JSON records found in file (malformed JSON encountered)"
+                message: "No valid JSON records found in file \
+                          (every record was malformed or not a JSON object)"
                     .to_string(),
             });
         }
@@ -817,6 +966,127 @@ mod tests {
         assert_eq!(summary.rows_read, 1);
         assert_eq!(summary.malformed_lines, 0);
         assert_eq!(object_field_counts, vec![2]);
+    }
+
+    /// Every JSON value that is not an object, so none of them can be a row.
+    /// Numbers are listed twice on purpose: they are the one value serde reads
+    /// from a reader by peeking one byte past the end.
+    const NON_OBJECT_VALUES: &[(&str, &str)] = &[
+        ("null", "null"),
+        ("boolean", "true"),
+        ("number", "42"),
+        ("number", "-1.5e3"),
+        ("string", r#""text""#),
+        ("array", "[1, 2]"),
+    ];
+
+    #[test]
+    fn test_jsonl_counts_non_object_records_and_keeps_scanning() {
+        for (kind, value) in NON_OBJECT_VALUES {
+            let data = format!("{{\"id\":1}}\n{value}\n{{\"id\":2}}\n");
+            let mut rows = 0;
+
+            let summary = scan_json_from_reader(
+                Cursor::new(data.as_bytes()),
+                &JsonParserConfig::jsonl(),
+                |_| rows += 1,
+            )
+            .unwrap();
+
+            assert_eq!(summary.rows_read, 2, "{kind}: record after it was lost");
+            assert_eq!(summary.malformed_lines, 1, "{kind}: was silently dropped");
+            assert_eq!(rows, 2, "{kind}");
+        }
+    }
+
+    #[test]
+    fn test_json_array_counts_non_object_elements_and_keeps_scanning() {
+        for (kind, value) in NON_OBJECT_VALUES {
+            let data = format!("[{{\"id\":1}}, {value}, {{\"id\":2}}]");
+            let mut rows = 0;
+
+            let summary = scan_json_from_reader(
+                Cursor::new(data.as_bytes()),
+                &JsonParserConfig::json_array(),
+                |_| rows += 1,
+            )
+            .unwrap();
+
+            assert_eq!(summary.rows_read, 2, "{kind}: element after it was lost");
+            assert_eq!(summary.malformed_lines, 1, "{kind}: was silently dropped");
+            assert_eq!(rows, 2, "{kind}");
+        }
+    }
+
+    #[test]
+    fn test_strict_policy_rejects_the_first_non_object_record() {
+        for (kind, value) in NON_OBJECT_VALUES {
+            for (config, data) in [
+                (
+                    JsonParserConfig::jsonl(),
+                    format!("{{\"id\":1}}\n{value}\n{{\"id\":2}}\n"),
+                ),
+                (
+                    JsonParserConfig::json_array(),
+                    format!("[{{\"id\":1}}, {value}, {{\"id\":2}}]"),
+                ),
+            ] {
+                let config = config.with_error_policy(JsonErrorPolicy::Strict);
+                let err = scan_json_from_reader(Cursor::new(data.as_bytes()), &config, |_| {})
+                    .expect_err("{kind}: strict mode must reject a non-object record");
+
+                let message = err.to_string();
+                assert!(message.contains("non-object JSON record"), "{message}");
+                assert!(message.contains("at position 2"), "{message}");
+                assert!(message.contains(&format!("found {kind}")), "{message}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_number_element_does_not_swallow_the_array_delimiter() {
+        // serde ends a number by peeking one byte past it and drops that byte
+        // with the deserializer; here it is the `,` the array scanner needs.
+        let data = br#"[{"id":1}, 1, 2, 3, {"id":2}, 4, {"id":3}]"#;
+        let mut rows = 0;
+
+        let summary = scan_json_from_reader(
+            Cursor::new(data.as_ref()),
+            &JsonParserConfig::json_array(),
+            |_| rows += 1,
+        )
+        .unwrap();
+
+        assert_eq!(summary.rows_read, 3);
+        assert_eq!(summary.malformed_lines, 4);
+        assert_eq!(rows, 3);
+    }
+
+    #[test]
+    fn test_number_shaped_garbage_stays_a_malformed_record() {
+        // `1.2.3` is read by the byte-wise number scanner but is not a number,
+        // so it must not be reported as a valid non-object record.
+        let data = b"{\"id\":1}\n1.2.3\n";
+        let config = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
+        let err = scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {})
+            .expect_err("number-shaped garbage should be malformed");
+
+        assert!(
+            err.to_string().contains("malformed JSON record"),
+            "{err}, expected the malformed category"
+        );
+    }
+
+    #[test]
+    fn test_input_of_only_non_object_records_fails() {
+        let file = write_file("\"just a string\"\n1\n[2]\n");
+        let err = analyze_json_file(file.path(), &JsonParserConfig::jsonl())
+            .expect_err("nothing profileable should not return a clean empty profile");
+
+        assert!(
+            err.to_string().contains("No valid JSON records found"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -140,6 +140,15 @@ recovery) instead of silently ignoring them. For those controls, use
 `dataprof.asyncio.profile_bytes()`. JSON and JSONL byte buffers follow RFC 8259:
 the non-standard `NaN` and `Infinity` constants are malformed input.
 
+**JSON record policy.** Only JSON objects are profileable records — they are the
+only JSON value with named fields to become columns. A record that is valid JSON
+but not an object (a scalar, an array, `null`) is never silently dropped: with
+`jsonl_on_error="skip"` (the default) it is counted in `error_count` and the
+records after it still profile, and with `jsonl_on_error="strict"` the first one
+raises `ValueError` naming its position and JSON kind. Input whose every record
+is non-object fails, exactly as all-malformed input does. File, byte, and async
+byte transports apply this identically.
+
 **Engine options:**
 
 | Engine | When to use |

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -506,14 +506,31 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
     return [(str(name), cells[i]) for i, name in enumerate(header)]
 
 
+def _json_kind(value: object) -> str:
+    """Name a decoded JSON value's type the way the Rust scanners do."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    return "object"
+
+
 def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
     """Scan JSONL text into row objects, honoring the malformed-record policy.
 
-    Mirrors the file/async JSONL scanners: blank lines are ignored, only object
-    records become rows (other JSON values are skipped without counting), and a
-    malformed record is either skipped-and-counted ("skip") or raised on
-    ("strict"). Error messages carry the 1-based line number, never the record
-    contents. Input that yields no valid record but had malformed lines fails.
+    Mirrors the file/async JSONL scanners: blank lines are ignored, and only
+    object records become rows. A record that is either malformed or valid JSON
+    that is not an object is skipped-and-counted ("skip") or raised on
+    ("strict") — a non-object record is never silently discarded, because that
+    would turn the source into a smaller clean-looking dataset. Error messages
+    carry the 1-based line number, never the record contents. Input that yields
+    no valid record but had skipped ones fails.
     """
     rows: list[dict] = []
     skipped = 0
@@ -543,8 +560,44 @@ def _scan_jsonl_records(text: str, on_error: str) -> tuple[list[dict], int]:
             continue
         if isinstance(value, dict):
             rows.append(value)
+            continue
+        if on_error == "strict":
+            raise ValueError(
+                f"jsonl bytes: non-object JSON record on line {lineno}: expected an "
+                f"object with fields to profile, found {_json_kind(value)}."
+            )
+        skipped += 1
     if not rows and skipped:
-        raise ValueError("jsonl bytes: no valid JSON records found (all records were malformed).")
+        raise ValueError(
+            "jsonl bytes: no valid JSON records found "
+            "(every record was malformed or not a JSON object)."
+        )
+    return rows, skipped
+
+
+def _scan_json_array_records(values: list, on_error: str) -> tuple[list[dict], int]:
+    """Apply the same record policy to the elements of a JSON array document.
+
+    Only objects are rows; any other element is counted ("skip") or raised on
+    ("strict") rather than dropped. Positions are 1-based over the elements.
+    """
+    rows: list[dict] = []
+    skipped = 0
+    for position, value in enumerate(values, start=1):
+        if isinstance(value, dict):
+            rows.append(value)
+            continue
+        if on_error == "strict":
+            raise ValueError(
+                f"json bytes: non-object JSON record at position {position}: expected an "
+                f"object with fields to profile, found {_json_kind(value)}."
+            )
+        skipped += 1
+    if not rows and skipped:
+        raise ValueError(
+            "json bytes: no valid JSON records found "
+            "(every record was malformed or not a JSON object)."
+        )
     return rows, skipped
 
 
@@ -1002,10 +1055,12 @@ def profile_file(
             ``report.ragged_row_count``, and False raises ValueError on the
             first such row. CSV bytes are always parsed strictly, and
             ``engine="columnar"`` does not report the count.
-        jsonl_on_error: How to handle a malformed JSON/JSONL record: "skip"
-            (default) skips it, counts it in ``report.execution.error_count``,
-            and returns a partial profile; "strict" raises ValueError on the
-            first malformed record. A file with no valid records always fails.
+        jsonl_on_error: How to handle a JSON/JSONL record that cannot become a
+            row — malformed JSON, or valid JSON that is not an object and so
+            has no fields to profile: "skip" (default) skips it, counts it in
+            ``report.execution.error_count``, and returns a partial profile;
+            "strict" raises ValueError on the first such record. A file with no
+            valid records always fails.
         sampling: Sampling strategy (e.g. SamplingStrategy.random(1000)).
         stop_condition: Early stop condition (e.g. StopCondition.max_rows(5000)).
             Cannot be used together with max_rows.
@@ -1116,11 +1171,13 @@ def profile(
             ``report.ragged_row_count``, and False raises ValueError on the
             first such row. CSV bytes are always parsed strictly, and
             ``engine="columnar"`` does not report the count.
-        jsonl_on_error: How to handle a malformed JSON/JSONL record, applied
-            identically to file, bytes, and async byte inputs: "skip" (default)
-            skips it, counts it in ``report.execution.error_count``, and returns
-            a partial profile; "strict" raises ValueError on the first malformed
-            record. Input with no valid records always raises.
+        jsonl_on_error: How to handle a JSON/JSONL record that cannot become a
+            row — malformed JSON, or valid JSON that is not an object and so has
+            no fields to profile — applied identically to file, bytes, and async
+            byte inputs: "skip" (default) skips it, counts it in
+            ``report.execution.error_count``, and returns a partial profile;
+            "strict" raises ValueError on the first such record. Input with no
+            valid records always raises.
         sampling: Sampling strategy (e.g. SamplingStrategy.random(1000)).
         stop_condition: Early stop condition (e.g. StopCondition.max_rows(5000)).
             Cannot be used together with max_rows.
@@ -1315,8 +1372,12 @@ def profile(
                     columns = _columns_from_dict(rows)
                 else:
                     columns = _columns_from_records([rows], max_rows)
-            elif _is_list_of_dicts(rows):
-                columns = _columns_from_records(rows, max_rows)
+            elif isinstance(rows, list):
+                # An array is a document of records: elements that are not
+                # objects follow the same policy the file and async scanners
+                # apply, instead of rejecting the whole array.
+                records, skipped = _scan_json_array_records(rows, jsonl_on_error)
+                columns = _columns_from_records(records, max_rows)
             else:
                 raise ValueError(
                     f"{fmt} bytes must decode to an object of columns or an array of "
@@ -1918,12 +1979,12 @@ class ProfileReport:
 
     @property
     def error_count(self) -> int:
-        """Number of records skipped because they could not be parsed.
+        """Number of records skipped because they could not become rows.
 
         Nonzero means the profile is partial: for tolerant JSON/JSONL parsing
-        (``jsonl_on_error="skip"``, the default) each malformed record is
-        skipped and counted here rather than aborting the run. Zero means every
-        record parsed cleanly.
+        (``jsonl_on_error="skip"``, the default) each record that is malformed,
+        or that is valid JSON but not an object, is skipped and counted here
+        rather than aborting the run. Zero means every record became a row.
         """
         return self._report.error_count
 

--- a/python/tests/test_json_record_policy.py
+++ b/python/tests/test_json_record_policy.py
@@ -1,0 +1,227 @@
+"""Non-object JSON record policy across file, bytes, and async inputs (#495).
+
+Only JSON objects are profileable records — they are the only JSON value with
+named fields to turn into columns. A record that is valid JSON but not an
+object is never silently discarded, because dropping it would turn the source
+into a smaller, clean-looking dataset:
+
+- tolerant (``jsonl_on_error="skip"``, the default): the record is skipped and
+  counted in ``report.error_count``, and the records after it still profile;
+- strict: the first such record raises a ValueError naming the position and the
+  value's JSON kind, never the record contents.
+
+Input whose every record is non-object always fails, matching the all-malformed
+policy. Distinct from #463 (zero-field *objects*) and #486 (physical record
+boundaries).
+
+The async cases are skipped when the extension is built without async support.
+
+Run after building the extension:
+    maturin develop --features python,python-async,async-streaming
+    pytest python/tests/test_json_record_policy.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import dataprof
+import pytest
+
+_HAS_ASYNC = dataprof.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+# Every JSON value that is not an object, in the middle of two valid records so
+# a scanner that mishandles one loses the record after it too.
+NON_OBJECT_VALUES = [
+    ("null", b"null"),
+    ("boolean", b"true"),
+    ("number", b"42"),
+    ("negative number", b"-1.5e3"),
+    ("string", b'"text"'),
+    ("array", b"[1, 2]"),
+]
+
+
+def _jsonl(value: bytes) -> bytes:
+    return b'{"id":1}\n' + value + b'\n{"id":2}\n'
+
+
+def _json_array(value: bytes) -> bytes:
+    return b'[{"id":1}, ' + value + b', {"id":2}]'
+
+
+def _write(tmp_path: Path, data: bytes, suffix: str) -> str:
+    target = tmp_path / f"data.{suffix}"
+    target.write_bytes(data)
+    return str(target)
+
+
+def _async_bytes(data: bytes, fmt: str, **kwargs):
+    from dataprof.asyncio import profile_bytes
+
+    async def _inner():
+        return await profile_bytes(data, format=fmt, **kwargs)
+
+    return asyncio.run(_inner())
+
+
+# --- Tolerant: counted, never silently dropped -----------------------------
+
+
+@pytest.mark.parametrize(
+    ("kind", "value"), NON_OBJECT_VALUES, ids=[k for k, _ in NON_OBJECT_VALUES]
+)
+@pytest.mark.parametrize("fmt", ["jsonl", "json"])
+def test_file_tolerant_counts_non_object_record(tmp_path, kind, value, fmt):
+    payload = _jsonl(value) if fmt == "jsonl" else _json_array(value)
+    report = dataprof.profile(_write(tmp_path, payload, fmt), format=fmt)
+    assert report.rows == 2, f"{kind}: the record after it must still profile"
+    assert report.error_count == 1
+
+
+@pytest.mark.parametrize(
+    ("kind", "value"), NON_OBJECT_VALUES, ids=[k for k, _ in NON_OBJECT_VALUES]
+)
+@pytest.mark.parametrize("fmt", ["jsonl", "json"])
+def test_bytes_tolerant_counts_non_object_record(kind, value, fmt):
+    payload = _jsonl(value) if fmt == "jsonl" else _json_array(value)
+    report = dataprof.profile(payload, format=fmt)
+    assert report.rows == 2, f"{kind}: the record after it must still profile"
+    assert report.error_count == 1
+
+
+@requires_async
+@pytest.mark.parametrize(
+    ("kind", "value"), NON_OBJECT_VALUES, ids=[k for k, _ in NON_OBJECT_VALUES]
+)
+@pytest.mark.parametrize("fmt", ["jsonl", "json"])
+def test_async_bytes_tolerant_counts_non_object_record(kind, value, fmt):
+    payload = _jsonl(value) if fmt == "jsonl" else _json_array(value)
+    report = _async_bytes(payload, fmt)
+    assert report.rows == 2, f"{kind}: the record after it must still profile"
+    assert report.error_count == 1
+
+
+@pytest.mark.parametrize(
+    "payload", [b'2\n{"id":1}\n', b'{"id":1}\n2\n', b'{"id":1}\n{"id":2}\n2\n']
+)
+def test_first_middle_and_last_positions_are_all_counted(tmp_path, payload):
+    """A non-object record counts wherever it sits, not only mid-stream."""
+    expected_rows = payload.count(b'{"id":')
+    for report in (
+        dataprof.profile(_write(tmp_path, payload, "jsonl"), format="jsonl"),
+        dataprof.profile(payload, format="jsonl"),
+    ):
+        assert report.rows == expected_rows
+        assert report.error_count == 1
+
+
+# --- Strict: rejected at the first non-object record -----------------------
+
+
+@pytest.mark.parametrize(
+    ("kind", "value"), NON_OBJECT_VALUES, ids=[k for k, _ in NON_OBJECT_VALUES]
+)
+@pytest.mark.parametrize("fmt", ["jsonl", "json"])
+def test_file_strict_rejects_non_object_record(tmp_path, kind, value, fmt):
+    payload = _jsonl(value) if fmt == "jsonl" else _json_array(value)
+    path = _write(tmp_path, payload, fmt)
+    with pytest.raises(ValueError, match="non-object JSON record"):
+        dataprof.profile(path, format=fmt, jsonl_on_error="strict")
+
+
+@pytest.mark.parametrize(
+    ("kind", "value"), NON_OBJECT_VALUES, ids=[k for k, _ in NON_OBJECT_VALUES]
+)
+@pytest.mark.parametrize("fmt", ["jsonl", "json"])
+def test_bytes_strict_rejects_non_object_record(kind, value, fmt):
+    payload = _jsonl(value) if fmt == "jsonl" else _json_array(value)
+    with pytest.raises(ValueError, match="non-object JSON record"):
+        dataprof.profile(payload, format=fmt, jsonl_on_error="strict")
+
+
+@requires_async
+@pytest.mark.parametrize(
+    ("kind", "value"), NON_OBJECT_VALUES, ids=[k for k, _ in NON_OBJECT_VALUES]
+)
+@pytest.mark.parametrize("fmt", ["jsonl", "json"])
+def test_async_bytes_strict_rejects_non_object_record(kind, value, fmt):
+    payload = _jsonl(value) if fmt == "jsonl" else _json_array(value)
+    with pytest.raises(ValueError, match="non-object JSON record"):
+        _async_bytes(payload, fmt, jsonl_on_error="strict")
+
+
+def test_strict_error_names_the_kind_and_never_the_contents(tmp_path):
+    secret = b'"topsecret@example.com"'
+    path = _write(tmp_path, _jsonl(secret), "jsonl")
+    with pytest.raises(ValueError) as excinfo:
+        dataprof.profile(path, format="jsonl", jsonl_on_error="strict")
+    message = str(excinfo.value)
+    assert "found string" in message
+    assert "topsecret" not in message
+
+
+# --- Records with nothing profileable in them ------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "fmt"),
+    [
+        (b'"just a string"', "jsonl"),
+        (b"1\n2\n3\n", "jsonl"),
+        (b"[1, 2, 3]", "json"),
+        (b"[null]", "json"),
+    ],
+)
+def test_input_without_any_object_record_fails(tmp_path, payload, fmt):
+    """Returning an empty-but-clean profile would fabricate a clean dataset."""
+    path = _write(tmp_path, payload, fmt)
+    with pytest.raises(ValueError, match="No valid JSON records|no valid JSON records"):
+        dataprof.profile(path, format=fmt)
+    with pytest.raises(ValueError, match="No valid JSON records|no valid JSON records"):
+        dataprof.profile(payload, format=fmt)
+
+
+# --- Parity with the malformed-record category ------------------------------
+
+
+def test_non_object_and_malformed_records_both_count_once(tmp_path):
+    """The two categories share ``error_count`` but stay separately reported."""
+    payload = b'{"id":1}\n2\nnot-json\n{"id":2}\n'
+    for report in (
+        dataprof.profile(_write(tmp_path, payload, "jsonl"), format="jsonl"),
+        dataprof.profile(payload, format="jsonl"),
+    ):
+        assert report.rows == 2
+        assert report.error_count == 2
+
+    with pytest.raises(ValueError, match="non-object JSON record"):
+        dataprof.profile(payload, format="jsonl", jsonl_on_error="strict")
+
+
+def test_a_number_element_does_not_swallow_the_array_delimiter(tmp_path):
+    """serde ends a number by peeking one byte past it.
+
+    That byte is the array's ``,``; losing it with the deserializer used to
+    strand every element after the first number.
+    """
+    payload = b'[{"id":1}, 1, 2, 3, {"id":2}, 4, {"id":3}]'
+    for report in (
+        dataprof.profile(_write(tmp_path, payload, "json"), format="json"),
+        dataprof.profile(payload, format="json"),
+    ):
+        assert report.rows == 3
+        assert report.error_count == 4
+
+
+def test_malformed_number_stays_a_malformed_record(tmp_path):
+    """``1.2.3`` reads like a number but is not one, so it is not miscategorised."""
+    path = _write(tmp_path, b'{"id":1}\n1.2.3\n', "jsonl")
+    with pytest.raises(ValueError, match="malformed JSON record"):
+        dataprof.profile(path, format="jsonl", jsonl_on_error="strict")


### PR DESCRIPTION
Closes #495.

## Problem

JSON profiling is object-record oriented, but valid non-object JSON values were silently discarded on several paths — no `error_count`, and `jsonl_on_error="strict"` accepted them anyway.

On `master`, `b'{"a":1}\n2\n{"a":3}\n'` profiled as `rows=2, error_count=0` on every transport, in both policies. The scalar line just disappeared.

## Policy

Only JSON objects are profileable records — they are the only JSON value with named fields to become columns. A record that is valid JSON but not an object is now:

- **tolerant** (`jsonl_on_error="skip"`, default): counted in `error_count`, with the records *after* it still profiling;
- **strict**: rejected with a structured `ValueError` naming the record's position and JSON kind, never its contents.

Input whose every record is non-object fails, exactly as all-malformed input already does. Malformed JSON and non-object JSON stay separate categories with distinct messages, sharing one counter.

File, synchronous bytes, and async bytes now agree on rows, `error_count`, and strict rejection for every case.

## The number lookahead

Fixing the array path required reading numbers byte-wise. `serde_json` ends a number by peeking one byte past it and drops that byte with the deserializer — inside an array that byte is the `,` the scanner needs next. That is why `[{"a":1}, 2, {"a":3}]` used to strand every element after the first number (it surfaced as a bogus `expected ',' or ']'` error). Number-shaped garbage like `1.2.3` is still validated, so it stays malformed rather than being miscategorised as a non-object record.

`[{"id":1}, 1, 2, 3, {"id":2}, 4, {"id":3}]` now profiles as `rows=3, error_count=4` on all three transports.

## Scope

| Layer | Change |
| --- | --- |
| `dataprof-json` | `read_json_record` classifies object / non-object / malformed for both the JSONL and array branches |
| `dataprof-engines` async reader | the same, mirrored — the two scanners are kept equivalent by construction |
| `python/dataprof/__init__.py` | `_scan_jsonl_records` counts non-objects; `_scan_json_array_records` replaces the blanket "must decode to an array of row objects" rejection |

Deliberately **not** in scope, per the issue: #463 (zero-field *objects* and whether `rows>0, columns=0` is a supported shape) and #486 (physical JSONL record boundaries).

## Tests

`python/tests/test_json_record_policy.py` (83 cases) covers null, boolean, number, negative/exponent number, string, and nested array; first/middle/last positions; valid objects after an invalid record; and all-non-object input — across file, bytes, and async bytes, in both policies. Rust unit tests in both crates cover the same matrix at scanner level.

Each of the three layers was reverted separately against the new tests: 33 failures with the Python layer reverted, 34 with `dataprof-json` reverted, 24 with the async reader reverted. No layer masks another.

## Verification

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings     # clean
cargo test --workspace                              # pass
cargo test -p dataprof-engines --features async-streaming  # 37 pass
uv run ruff format / ruff check / ty check python/  # clean
uv run pytest python/tests/ -q                      # 816 passed, 4 skipped, 1 xfailed
```

Extension built with `--features "python,python-async,async-streaming,sqlite"`.
