### PR TITLE
ci: stop the wheel smoke build compiling the tree twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,12 @@ jobs:
     # This one installs the built wheel into a bare venv, the way a user would.
     name: Wheel Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # A dependency bump changes Cargo.lock, which changes the rust-cache key, so
+    # every such PR builds ~400 crates cold. Warm, Windows takes 6 minutes; cold,
+    # it needs more than the 20 this used to allow, and a timeout is worse than a
+    # slow run because the cache is only written on success — so the next run is
+    # cold too, and it never recovers on its own.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -273,7 +278,16 @@ jobs:
             uv.lock
 
       - name: Build wheel
-        run: uv run maturin build --out dist
+        # Deliberately not `uv run maturin build`: that syncs the project first,
+        # which builds the extension through the PEP 517 backend into its own
+        # temporary target dir, and then maturin compiles the whole tree again
+        # into ./target. With a warm cache the duplication is invisible; on a
+        # cold one it cost nine minutes here and blew the Windows timeout.
+        # Nothing needs the project inside .venv — the wheel goes into a bare
+        # venv in the next step, which is the whole point of this job.
+        run: |
+          uv sync --no-install-project
+          uv run --no-sync maturin build --out dist
 
       - name: Install the wheel into a bare venv
         # --no-index proves the wheel needs nothing from PyPI: the base package


### PR DESCRIPTION
`Wheel Smoke (windows-latest)` hit its 20-minute timeout on
[run 30817723128](https://github.com/AndreaBozzo/dataprof/actions/runs/30817723128).

## What actually happened

Every other job in that run passed, including the macOS and Ubuntu legs of the
same matrix. The same Windows job took **6 minutes** on the commit before
(`ca419ad`). So this was not a gradual slide.

**The trigger was a cache miss.** #532 (`94eab6e`) touched `Cargo.lock`, which
is part of the `Swatinem/rust-cache` key, so the job began with:

```
... Restoring cache ...
No cache found.
```

and compiled ~400 crates from scratch. macOS and Ubuntu were cold too — both
took ~10 minutes against ~3 warm — and simply fit inside 20. Windows did not.

**What made cold fatal instead of just slow is that the step builds the tree
twice.** From the log:

```
13:51:30  Run uv run maturin build --out dist
13:51:31  Downloading maturin / numpy / pyarrow / pandas / polars     <- uv syncing
14:00:38  Built dataprof @ file:///D:/a/dataprof/dataprof             <- 9 min, build #1
14:00:39  🍹 Building a mixed python/rust project                     <- maturin starts
14:00:40  Compiling proc-macro2 v1.0.107                              <- build #2, from scratch
14:11:30  ##[error]The operation was canceled.                        <- killed in dataprof-python
```

`uv run` syncs the project before running the command, and that sync builds the
extension through the PEP 517 backend into its own temporary target dir. `./target`
is therefore still empty when maturin starts, so it compiles everything again.
Nine minutes of the twenty went to a build whose output this job never uses —
the wheel is installed into a *bare* venv in the next step, which is the entire
point of the job.

## The change

```diff
-        run: uv run maturin build --out dist
+        run: |
+          uv sync --no-install-project
+          uv run --no-sync maturin build --out dist
```

`--no-install-project` syncs the dev dependencies (so the locked `maturin` is
still what runs) without building the project itself; `--no-sync` stops
`uv run` from undoing that.

Timeout also goes **20 → 35**. This is not padding for its own sake: the cache
is only written on success, so a job that times out leaves the *next* run cold
as well. One unlucky dependency bump would strand this job indefinitely, which
is what it was on the way to doing.

## Verification

Locally, the replacement produces the wheel:

```
$ uv sync --no-install-project
Uninstalled 1 package: dataprof==0.10.0 (from file:///C:/dev/dataprof)
$ uv run --no-sync maturin build --out dist_verify
📦 Built wheel for CPython 3.12 to dist_verify\dataprof-0.10.0-cp312-cp312-win_amd64.whl
```

The real proof is this PR's own Windows leg. Note it will run **warm** (this
branch does not touch `Cargo.lock`), so a green run here confirms the command
works but not the cold-path saving. The cold path gets exercised on the next
dependency bump.

No production code is touched — workflow only.
