### PR TITLE
fix(json): report a record with no fields as a row on every transport

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -355,6 +355,9 @@ impl AsyncStreamingProfiler {
         let json_error_policy = self.json_error_policy;
         let csv_flexible = self.csv_flexible;
         let csv_delimiter = self.csv_delimiter;
+        // JSON records with no fields are rows against an empty schema; a CSV
+        // stream with no header line has nothing to profile.
+        let allow_empty_schema = matches!(format, FileFormat::Json | FileFormat::Jsonl);
         let reader_handle = tokio::task::spawn_blocking(move || match format {
             FileFormat::Csv => Self::reader_task(
                 sync_reader,
@@ -374,7 +377,9 @@ impl AsyncStreamingProfiler {
         });
 
         // Process chunks on the current task
-        let process_result = self.process_chunks(rx, source_info.size_hint).await;
+        let process_result = self
+            .process_chunks(rx, source_info.size_hint, allow_empty_schema)
+            .await;
 
         // If processing failed, prefer the reader's error when it also failed:
         // a strict-mode malformed record aborts the reader before any data
@@ -681,13 +686,22 @@ impl AsyncStreamingProfiler {
         };
 
         // Helper closure: send headers (first chunk) and flush accumulated rows.
+        //
+        // Records with no fields are still rows — the file scanner counts them
+        // against zero columns — so a header chunk carrying no column names is
+        // legal. It is only sent once the source is exhausted (`final_flush`):
+        // sending headers freezes the schema, and while input remains a later
+        // record may still introduce the columns these rows are missing. Until
+        // then the fieldless rows stay buffered rather than being emitted ahead
+        // of the headers, where the receiver would read them *as* the headers.
         let send_chunk = |chunk: &mut Vec<Vec<String>>,
                           bytes: &mut u64,
                           cols: &[String],
                           headers_sent: &mut bool,
-                          tx: &mpsc::Sender<ParsedChunk>|
+                          tx: &mpsc::Sender<ParsedChunk>,
+                          final_flush: bool|
          -> Result<bool, DataProfilerError> {
-            if !*headers_sent && !cols.is_empty() {
+            if !*headers_sent && (!cols.is_empty() || final_flush) {
                 let header_chunk = ParsedChunk {
                     records: vec![cols.to_vec()],
                     bytes_read: 0,
@@ -698,7 +712,7 @@ impl AsyncStreamingProfiler {
                 *headers_sent = true;
             }
 
-            if !chunk.is_empty() {
+            if *headers_sent && !chunk.is_empty() {
                 let data_chunk = ParsedChunk {
                     records: std::mem::take(chunk),
                     bytes_read: *bytes,
@@ -758,6 +772,7 @@ impl AsyncStreamingProfiler {
                                     &known_columns,
                                     &mut headers_sent,
                                     &tx,
+                                    false,
                                 )?
                             {
                                 return Ok(malformed_records);
@@ -874,6 +889,7 @@ impl AsyncStreamingProfiler {
                                         &known_columns,
                                         &mut headers_sent,
                                         &tx,
+                                        false,
                                     )?
                                 {
                                     return Ok(malformed_records);
@@ -972,6 +988,7 @@ impl AsyncStreamingProfiler {
                 &known_columns,
                 &mut headers_sent,
                 &tx,
+                true,
             );
         }
 
@@ -985,6 +1002,7 @@ impl AsyncStreamingProfiler {
         &self,
         mut rx: mpsc::Receiver<ParsedChunk>,
         size_hint: Option<u64>,
+        allow_empty_schema: bool,
     ) -> Result<
         (
             Vec<String>,
@@ -1040,7 +1058,10 @@ impl AsyncStreamingProfiler {
             .next()
             .expect("non-empty header chunk has a first record");
 
-        if headers.is_empty() {
+        // A JSON source may legitimately have no columns: records with no fields
+        // are rows against an empty schema. A CSV stream cannot — its first line
+        // is the schema, so an empty one means there is nothing to profile.
+        if headers.is_empty() && !allow_empty_schema {
             return Err(DataProfilerError::StreamingError {
                 message: "No column headers found in stream".to_string(),
             });
@@ -1513,6 +1534,53 @@ mod tests {
             assert_eq!(report.execution.rows_processed, 2);
             assert_eq!(report.execution.error_count, 0);
             assert_eq!(report.execution.bytes_consumed, Some(expected_bytes));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_records_with_no_fields_are_rows_against_no_columns() {
+        // A record with no fields was read and analysed; nothing was found in
+        // it. The file scanner counts it as a row, so the stream must too --
+        // and it must not be mistaken for an input holding no records at all.
+        for (data, rows) in [
+            (jsonl_source(b"{}\n"), 1),
+            (jsonl_source(b"{}\n{}\n"), 2),
+            (json_source(b"[{}]"), 1),
+            (json_source(b"[{},{}]"), 2),
+            // No records at all: zero rows against the same zero columns.
+            (json_source(b"[]"), 0),
+        ] {
+            let report = AsyncStreamingProfiler::new()
+                .analyze_stream(data)
+                .await
+                .expect("a fieldless record is well-formed JSON");
+
+            assert_eq!(report.execution.rows_processed, rows);
+            assert_eq!(report.execution.columns_detected, 0);
+            assert_eq!(report.execution.error_count, 0);
+            assert!(report.column_profiles.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_async_fieldless_records_do_not_hide_the_columns_around_them() {
+        // The schema is discovered from the records, so an empty first record
+        // must not freeze it: the fields that follow still become columns, and
+        // the fieldless row reads as null across them.
+        for data in [
+            jsonl_source(b"{}\n{\"a\":1}\n"),
+            jsonl_source(b"{\"a\":1}\n{}\n"),
+            json_source(b"[{},{\"a\":1}]"),
+        ] {
+            let report = AsyncStreamingProfiler::new()
+                .analyze_stream(data)
+                .await
+                .unwrap();
+
+            assert_eq!(report.execution.rows_processed, 2);
+            assert_eq!(report.column_profiles.len(), 1);
+            assert_eq!(report.column_profiles[0].name, "a");
+            assert_eq!(report.column_profiles[0].null_count, 1);
         }
     }
 

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -33,9 +33,15 @@ pub type PyColumn = (String, Vec<Option<String>>);
 /// Column order is preserved as given, so reports over the same input are
 /// byte-identical across processes.
 ///
+/// `row_count` states how many rows the source held. It is only needed when
+/// `columns` is empty and the source still had rows -- JSON records with no
+/// fields, which the file scanner counts as rows against no columns. When
+/// columns are present their cell count already carries the row count, and a
+/// `row_count` that disagrees with it is rejected rather than silently ignored.
+///
 /// Raises `ValueError` when the columns do not all have the same length.
 #[pyfunction]
-#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0))]
+#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0, row_count = None))]
 pub fn profile_columns(
     py: Python<'_>,
     columns: Vec<PyColumn>,
@@ -43,6 +49,7 @@ pub fn profile_columns(
     max_rows: Option<usize>,
     config: Option<&PyProfilerConfig>,
     error_count: usize,
+    row_count: Option<usize>,
 ) -> PyResult<PyProfileReport> {
     let start = std::time::Instant::now();
 
@@ -60,12 +67,24 @@ pub fn profile_columns(
     // This function is reachable from Python without going through `dp.profile`,
     // so ragged input must raise rather than panic across the FFI boundary --
     // and a short first column must not silently truncate the rest.
-    let source_rows = columns.first().map(|(_, cells)| cells.len()).unwrap_or(0);
+    let source_rows = match columns.first() {
+        Some((_, cells)) => cells.len(),
+        // No columns: the cells cannot carry a row count, so the caller states it.
+        None => row_count.unwrap_or(0),
+    };
     if let Some((name, cells)) = columns.iter().find(|(_, c)| c.len() != source_rows) {
         return Err(PyValueError::new_err(format!(
             "profile_columns: every column must have the same number of cells; \
              column {name:?} has {}, expected {source_rows}",
             cells.len()
+        )));
+    }
+    if let Some(stated) = row_count
+        && !columns.is_empty()
+        && stated != source_rows
+    {
+        return Err(PyValueError::new_err(format!(
+            "profile_columns: row_count is {stated} but the columns hold {source_rows} cells each"
         )));
     }
 

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -151,6 +151,23 @@ raises `ValueError` naming its position and JSON kind. Input whose every record
 is non-object fails, exactly as all-malformed input does. File, byte, and async
 byte transports apply this identically.
 
+**Records with no fields.** A JSON object with no fields (`{}`) is a record: it
+was read and analysed, and nothing was found in it. It profiles as a row against
+zero columns, so `[{}, {}]` reports `rows == 2, columns == 0` on every transport
+— file, bytes, async bytes, URL, and a Python list of dicts. That keeps three
+shapes distinct:
+
+| Shape | Meaning | Example |
+|---|---|---|
+| `rows > 0`, `columns == 0` | rows were read; none of them had fields | `[{}, {}]` |
+| `rows == 0`, `columns == 0` | the input held no records | `[]` |
+| `rows == 0`, `columns > 0` | a known schema with no rows under it | a CSV header line |
+
+A zero-column report is a normal report: it serialises, round-trips, and
+renders. `len(report)` counts columns, so it is `0` while `report.rows` is not.
+A record with no fields is well-formed, so it is clean under both error
+policies and never counted in `error_count`.
+
 **Engine options:**
 
 | Engine | When to use |

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -423,8 +423,13 @@ def _columns_from_dict(source: dict[_Any, _Any]) -> list[_Column]:
 def _columns_from_records(
     rows: list[dict[_Any, _Any]],
     max_rows: int | None = None,
-) -> list[_Column]:
+) -> tuple[list[_Column], int]:
     """Convert a list of row dicts into columns, keyed in first-seen order.
+
+    Returns the columns and the source row count. The row count is carried
+    separately because records with no fields at all produce no columns to hold
+    it: ``[{}, {}]`` is two rows against zero columns, the same shape the file
+    scanner reports, not an empty input.
 
     Rows need not share keys; a row missing a key contributes a null there.
 
@@ -437,11 +442,6 @@ def _columns_from_records(
     key_rows = rows if max_rows is None else rows[:max_rows]
     cell_rows = rows if max_rows is None else rows[: max_rows + 1]
     keys = list(dict.fromkeys(key for row in key_rows for key in row))
-    if key_rows and not keys:
-        raise ValueError(
-            "list-of-dicts input contains rows but no columns, so their row count "
-            "cannot be represented. Provide at least one key or pass an empty list."
-        )
 
     normalized_names = [str(key) for key in keys]
     if len(set(normalized_names)) != len(normalized_names):
@@ -453,10 +453,11 @@ def _columns_from_records(
             f"{collisions!r}. Use distinct string column names."
         )
 
-    return [
+    columns = [
         (name, [_cell_to_str(row.get(key)) for row in cell_rows])
         for key, name in zip(keys, normalized_names, strict=True)
     ]
+    return columns, len(cell_rows)
 
 
 def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[_Column]:
@@ -1294,20 +1295,27 @@ def profile(
         return ProfileReport(rust_report)
 
     def _profile_python_columns(
-        columns: list[_Column], default_name: str, error_count: int = 0
+        columns: list[_Column],
+        default_name: str,
+        error_count: int = 0,
+        row_count: int | None = None,
     ) -> ProfileReport:
         rust_report = _profile_columns(
-            columns, name or default_name, max_rows, _df_config(), error_count
+            columns, name or default_name, max_rows, _df_config(), error_count, row_count
         )
         return ProfileReport(rust_report)
 
     if isinstance(source, dict):
+        # A dict is a mapping of column name to cells, so an empty one is a
+        # source with no columns and therefore no rows. That is a different
+        # input from a record with no fields (`[{}]`), which is one row.
         _warn_if_config_ignored()
         return _profile_python_columns(_columns_from_dict(source), "dataframe")
 
     if _is_list_of_dicts(source):
         _warn_if_config_ignored()
-        return _profile_python_columns(_columns_from_records(source, max_rows), "dataframe")
+        record_columns, record_rows = _columns_from_records(source, max_rows)
+        return _profile_python_columns(record_columns, "dataframe", row_count=record_rows)
 
     if isinstance(source, (bytes, bytearray, memoryview, _io.BytesIO)):
         if format is None:
@@ -1351,12 +1359,13 @@ def profile(
         buffer = _bytes_buffer(source)
 
         skipped = 0
+        row_count: int | None = None
         if fmt == "csv":
             columns = _columns_from_csv_bytes(buffer, csv_delimiter)
         elif fmt == "jsonl":
             text = buffer.getvalue().decode("utf-8-sig")
             rows, skipped = _scan_jsonl_records(text, jsonl_on_error)
-            columns = _columns_from_records(rows, max_rows)
+            columns, row_count = _columns_from_records(rows, max_rows)
         elif fmt == "json":
             text = buffer.getvalue().decode("utf-8-sig")
             try:
@@ -1371,16 +1380,20 @@ def profile(
                     f"json bytes: malformed JSON (non-standard numeric constant {exc.value!r})."
                 ) from None
             if isinstance(rows, dict):
-                if all(isinstance(values, (list, tuple)) for values in rows.values()):
+                # `all(...)` is vacuously true for `{}`, which would read an
+                # empty object as a column-oriented document holding no rows.
+                # The file scanner reads a root `{}` as one record instead, so
+                # require at least one column before taking that branch.
+                if rows and all(isinstance(values, (list, tuple)) for values in rows.values()):
                     columns = _columns_from_dict(rows)
                 else:
-                    columns = _columns_from_records([rows], max_rows)
+                    columns, row_count = _columns_from_records([rows], max_rows)
             elif isinstance(rows, list):
                 # An array is a document of records: elements that are not
                 # objects follow the same policy the file and async scanners
                 # apply, instead of rejecting the whole array.
                 records, skipped = _scan_json_array_records(rows, jsonl_on_error)
-                columns = _columns_from_records(records, max_rows)
+                columns, row_count = _columns_from_records(records, max_rows)
             else:
                 raise ValueError(
                     f"{fmt} bytes must decode to an object of columns or an array of "
@@ -1402,7 +1415,7 @@ def profile(
         else:
             raise ValueError("Unsupported bytes format. Use 'csv', 'json', 'jsonl', or 'parquet'.")
 
-        return _profile_python_columns(columns, f"{fmt}_bytes", skipped)
+        return _profile_python_columns(columns, f"{fmt}_bytes", skipped, row_count)
 
     # DataFrame detection via module name
     source_module = type(source).__module__ or ""

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -384,6 +384,7 @@ def profile_columns(
     max_rows: int | None,
     config: ProfilerConfig | None,
     error_count: int = 0,
+    row_count: int | None = None,
 ) -> ProfileReport: ...
 def profile_parquet_bytes(
     data: bytes,

--- a/python/tests/test_async_url_api.py
+++ b/python/tests/test_async_url_api.py
@@ -70,6 +70,7 @@ def url_server():
     parquet_bytes = PARQUET_FILE.read_bytes()
     bom_json = codecs.BOM_UTF8 + b'[{"id":1,"score":2.5},{"id":2,"score":3.5}]'
     bom_jsonl = codecs.BOM_UTF8 + b'{"id":1,"score":2.5}\n{"id":2,"score":3.5}\n'
+    fieldless_json = b"[{},{}]"
 
     class Handler(http.server.BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
@@ -122,6 +123,8 @@ def url_server():
                 return bom_json
             if self.path == "/bom.jsonl":
                 return bom_jsonl
+            if self.path == "/fieldless.json":
+                return fieldless_json
             raise AssertionError(f"unexpected path: {self.path}")
 
     server = _ThreadingTcpServer(("127.0.0.1", 0), Handler)
@@ -136,6 +139,7 @@ def url_server():
             "parquet": f"http://127.0.0.1:{port}/data.parquet",
             "bom_json": f"http://127.0.0.1:{port}/bom.json",
             "bom_jsonl": f"http://127.0.0.1:{port}/bom.jsonl",
+            "fieldless_json": f"http://127.0.0.1:{port}/fieldless.json",
         }
     finally:
         with contextlib.suppress(Exception):
@@ -200,6 +204,18 @@ class TestAsyncUrlProfiling:
         assert report.columns == 2
         assert report["score"].max == 3.5
         assert report.to_dict()["execution"]["bytes_consumed"] == len(codecs.BOM_UTF8 + payload)
+
+    def test_profile_fieldless_records_url(self, url_server):
+        """Records with no fields are rows against no columns (#463).
+
+        The URL transport shares the async streaming reader, so it must report
+        the same shape the file and bytes paths do rather than failing on an
+        empty schema.
+        """
+        report = _run(profile_url, url_server["fieldless_json"])
+
+        assert (report.rows, report.columns) == (2, 0)
+        assert report.error_count == 0
 
     def test_profile_parquet_url(self, url_server):
         try:

--- a/python/tests/test_json_fieldless_records.py
+++ b/python/tests/test_json_fieldless_records.py
@@ -1,0 +1,252 @@
+"""Shape policy for JSON records with no fields, across transports (#463).
+
+A JSON object with no fields is a record: it was read and analysed, and nothing
+was found in it. It therefore profiles as a row against zero columns, which is
+what the file scanner has always reported. Three shapes stay distinct:
+
+- ``rows > 0, columns == 0`` -- rows with no fields;
+- ``rows == 0, columns == 0`` -- an input with no records at all (``[]``);
+- ``rows == 0, columns > 0`` -- a known schema with no rows.
+
+Every input path applies that policy: file, synchronous bytes, async bytes,
+Python list-of-dicts, and (in ``test_async_url_api.py``) URL. Collapsing a
+fieldless row into "no rows" would erase records from the count, and rejecting
+it would make the same data profileable from a file but not from bytes.
+
+Distinct from #495 (records that are valid JSON but not objects) and #486
+(physical record boundaries).
+
+The async cases are skipped when the extension is built without async support.
+
+Run after building the extension:
+    maturin develop --features python,python-async,async-streaming
+    pytest python/tests/test_json_fieldless_records.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import dataprof
+import pytest
+
+_HAS_ASYNC = dataprof.capabilities().async_streaming
+requires_async = pytest.mark.skipif(
+    not _HAS_ASYNC,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+
+def _write(tmp_path: Path, data: bytes, suffix: str) -> str:
+    target = tmp_path / f"data.{suffix}"
+    target.write_bytes(data)
+    return str(target)
+
+
+def _async_bytes(data: bytes, fmt: str, **kwargs):
+    from dataprof.asyncio import profile_bytes
+
+    async def _inner():
+        return await profile_bytes(data, format=fmt, **kwargs)
+
+    return asyncio.run(_inner())
+
+
+# (id, payload, format, expected rows, expected columns)
+#
+# `format="json"` is the array grammar on the async reader and the object-or-
+# array grammar elsewhere, so a bare `{}` document is listed under "jsonl",
+# where every transport agrees on how records are delimited. Reconciling the
+# format hints themselves is #486.
+SHAPE_CASES = [
+    ("one fieldless object", b"{}", "jsonl", 1, 0),
+    ("two fieldless objects", b"{}\n{}\n", "jsonl", 2, 0),
+    ("array of one fieldless", b"[{}]", "json", 1, 0),
+    ("array of two fieldless", b"[{},{}]", "json", 2, 0),
+    ("empty array", b"[]", "json", 0, 0),
+    ("fieldless then fielded", b'[{},{"a":1}]', "json", 2, 1),
+    ("fielded then fieldless", b'[{"a":1},{}]', "json", 2, 1),
+    ("fieldless among fielded", b'{"a":1}\n{}\n{"a":2}\n', "jsonl", 3, 1),
+]
+
+SHAPE_IDS = [case[0] for case in SHAPE_CASES]
+
+
+@pytest.mark.parametrize(
+    ("payload", "fmt", "rows", "columns"),
+    [case[1:] for case in SHAPE_CASES],
+    ids=SHAPE_IDS,
+)
+def test_file_reports_fieldless_rows(tmp_path, payload, fmt, rows, columns):
+    report = dataprof.profile(_write(tmp_path, payload, fmt), format=fmt)
+    assert (report.rows, report.columns) == (rows, columns)
+    assert report.error_count == 0
+
+
+@pytest.mark.parametrize(
+    ("payload", "fmt", "rows", "columns"),
+    [case[1:] for case in SHAPE_CASES],
+    ids=SHAPE_IDS,
+)
+def test_bytes_match_the_file_shape(payload, fmt, rows, columns):
+    report = dataprof.profile(payload, format=fmt)
+    assert (report.rows, report.columns) == (rows, columns)
+    assert report.error_count == 0
+
+
+@requires_async
+@pytest.mark.parametrize(
+    ("payload", "fmt", "rows", "columns"),
+    [case[1:] for case in SHAPE_CASES],
+    ids=SHAPE_IDS,
+)
+def test_async_bytes_match_the_file_shape(payload, fmt, rows, columns):
+    report = _async_bytes(payload, fmt)
+    assert (report.rows, report.columns) == (rows, columns)
+    assert report.error_count == 0
+
+
+@pytest.mark.parametrize(
+    ("records", "rows", "columns"),
+    [
+        ([{}], 1, 0),
+        ([{}, {}], 2, 0),
+        ([], 0, 0),
+        ([{}, {"a": 1}], 2, 1),
+        ([{"a": 1}, {}], 2, 1),
+    ],
+    ids=["one", "two", "empty list", "fieldless first", "fieldless last"],
+)
+def test_python_records_match_the_file_shape(records, rows, columns):
+    report = dataprof.profile(records)
+    assert (report.rows, report.columns) == (rows, columns)
+
+
+# --- A root `{}` is a record, not an empty map of columns -------------------
+
+
+def test_root_object_bytes_is_a_record_not_an_empty_column_map(tmp_path):
+    """`{}` decodes to an empty mapping, and "every value is a list of cells"
+    is vacuously true of it, so it reads as a column-oriented document holding
+    no rows unless the record interpretation wins. The file scanner reads a root
+    object as one record, so the bytes path must too.
+    """
+    from_bytes = dataprof.profile(b"{}", format="json")
+    from_file = dataprof.profile(_write(tmp_path, b"{}", "json"))
+
+    assert (from_bytes.rows, from_bytes.columns) == (1, 0)
+    assert (from_file.rows, from_file.columns) == (1, 0)
+
+
+@pytest.mark.parametrize(
+    ("payload", "rows", "columns"),
+    [
+        (b'{"a":[1,2]}', 2, 1),
+        (b'{"a":[1,2],"b":[3,4]}', 2, 2),
+        (b'{"a":1}', 1, 1),
+    ],
+    ids=["one column", "two columns", "single record"],
+)
+def test_populated_root_objects_keep_their_reading(payload, rows, columns):
+    """The empty-object carve-out must not change how populated roots are read."""
+    report = dataprof.profile(payload, format="json")
+    assert (report.rows, report.columns) == (rows, columns)
+
+
+# --- The three empty-ish shapes stay distinguishable ------------------------
+
+
+def test_rows_with_no_fields_differ_from_an_input_with_no_records(tmp_path):
+    fieldless = dataprof.profile(_write(tmp_path, b"[{},{}]", "json"), format="json")
+    no_records = dataprof.profile(_write(tmp_path, b"[]", "json"), format="json")
+
+    assert (fieldless.rows, fieldless.columns) == (2, 0)
+    assert (no_records.rows, no_records.columns) == (0, 0)
+
+
+def test_rows_with_no_fields_differ_from_a_schema_with_no_rows(tmp_path):
+    """A CSV header with no data rows is the mirror image: schema, no rows."""
+    schema_only = dataprof.profile(b"a,b\n", format="csv")
+    fieldless = dataprof.profile(b"{}\n", format="jsonl")
+
+    assert (schema_only.rows, schema_only.columns) == (0, 2)
+    assert (fieldless.rows, fieldless.columns) == (1, 0)
+
+
+# --- A zero-column report is a real report ----------------------------------
+
+
+def test_zero_column_report_serialises_and_round_trips(tmp_path):
+    report = dataprof.profile(_write(tmp_path, b"[{},{}]", "json"), format="json")
+    payload = report.to_dict()
+
+    assert payload["columns"] == []
+    assert payload["execution"]["rows_processed"] == 2
+
+    restored = dataprof.ProfileReport.from_dict(payload)
+    assert (restored.rows, restored.columns) == (2, 0)
+
+
+def test_zero_column_report_renders_without_a_schema(tmp_path):
+    report = dataprof.profile(_write(tmp_path, b"[{},{}]", "json"), format="json")
+
+    # `len()` counts columns, so it is 0 while the report still holds 2 rows.
+    assert len(report) == 0
+    assert list(report.column_profiles) == []
+    assert "rows=2" in repr(report)
+    assert report.to_markdown()
+    assert report.to_html()
+
+
+def test_max_rows_caps_fieldless_rows_and_reports_truncation():
+    report = dataprof.profile(b"{}\n{}\n{}\n", format="jsonl", max_rows=2)
+
+    assert (report.rows, report.columns) == (2, 0)
+    assert not report.source_exhausted
+
+
+# --- Fieldless is not malformed ---------------------------------------------
+
+
+@pytest.mark.parametrize("policy", ["skip", "strict"])
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_fieldless_records_are_clean_under_both_error_policies(tmp_path, fmt, policy):
+    """`{}` is a well-formed object, so strict mode has nothing to reject."""
+    payload = b"[{},{}]" if fmt == "json" else b"{}\n{}\n"
+    report = dataprof.profile(_write(tmp_path, payload, fmt), format=fmt, jsonl_on_error=policy)
+
+    assert (report.rows, report.columns) == (2, 0)
+    assert report.error_count == 0
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_malformed_input_still_fails_on_every_path(tmp_path, fmt):
+    """Widening the shape policy must not turn broken input into an empty profile."""
+    payload = b"[{},nope]" if fmt == "json" else b"{}\nnope\n"
+
+    with pytest.raises(ValueError):
+        dataprof.profile(_write(tmp_path, payload, fmt), format=fmt, jsonl_on_error="strict")
+    with pytest.raises(ValueError):
+        dataprof.profile(payload, format=fmt, jsonl_on_error="strict")
+
+
+def test_a_fieldless_record_does_not_mask_a_malformed_one(tmp_path):
+    """Tolerant mode counts the malformed record while the fieldless rows profile."""
+    payload = b"{}\nnope\n{}\n"
+    for report in (
+        dataprof.profile(_write(tmp_path, payload, "jsonl"), format="jsonl"),
+        dataprof.profile(payload, format="jsonl"),
+    ):
+        assert (report.rows, report.columns) == (2, 0)
+        assert report.error_count == 1
+
+
+def test_input_of_only_non_object_records_still_fails(tmp_path):
+    """`[1,2]` has no records to profile; `[{},{}]` has two. They must not merge."""
+    with pytest.raises(ValueError, match="No valid JSON records|no valid JSON records"):
+        dataprof.profile(_write(tmp_path, b"[1,2]", "json"), format="json")
+
+    report = dataprof.profile(_write(tmp_path, b"[{},{}]", "json"), format="json")
+    assert (report.rows, report.columns) == (2, 0)

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -424,6 +424,25 @@ class TestProfileAdHocInputs:
         with pytest.raises(ValueError, match="same number of cells"):
             _dataprof.profile_columns([("a", ["1"]), ("b", ["1", "2"])], "x", None, None)
 
+    def test_raw_extension_carries_a_row_count_without_columns(self):
+        """`row_count` is how a fieldless-record source states its row count.
+
+        With no columns there are no cells to derive it from, so the count would
+        otherwise collapse to zero and erase the rows.
+        """
+        from dataprof import _dataprof
+
+        report = dataprof.ProfileReport(_dataprof.profile_columns([], "x", None, None, 0, 3))
+        assert (report.rows, report.columns) == (3, 0)
+
+    def test_raw_extension_rejects_a_row_count_the_columns_contradict(self):
+        """Where the cells already carry the row count, a disagreeing
+        `row_count` is a caller bug and must not be quietly ignored."""
+        from dataprof import _dataprof
+
+        with pytest.raises(ValueError, match="row_count is 5"):
+            _dataprof.profile_columns([("a", ["1", "2"])], "x", None, None, 0, 5)
+
     def test_list_of_dicts_fills_missing_keys_with_nulls(self):
         r = dataprof.profile([{"a": 1}, {"b": 2}])
         assert list(r.column_profiles) == ["a", "b"]
@@ -447,8 +466,10 @@ class TestProfileAdHocInputs:
             dataprof.profile([{1: "a", "1": "b"}])
 
     def test_non_empty_list_of_empty_records_is_not_reported_as_zero_rows(self):
-        with pytest.raises(ValueError, match="rows but no columns"):
-            dataprof.profile([{}])
+        # Records with no fields are rows against no columns, the same shape the
+        # file scanner reports for `[{}]`. Reporting zero rows would erase them.
+        r = dataprof.profile([{}])
+        assert (r.rows, r.columns) == (1, 0)
 
     def test_csv_bytes_treat_empty_field_as_null(self):
         r = dataprof.profile(b"a,b\n1,\n2,x\n", format="csv")


### PR DESCRIPTION
Closes #463

A JSON object with no fields had no cross-transport contract. The same data was
variously one row against no columns (file), zero rows and zero columns (sync
bytes `{}`), a `ValueError` saying the shape "cannot be represented" (bytes
`[{}]`, Python list-of-dicts), or a generic streaming `RuntimeError` about
missing headers (async bytes, URL).

## Policy

A record with no fields was read and analysed; nothing was found in it. It is a
row against zero columns everywhere — the shape the file scanner has always
reported, and the one that preserves the row count.

| Logical input | file | sync bytes | async bytes | URL | Python records |
|---|---|---|---|---|---|
| `{}` | 1×0 | 1×0 | 1×0 | — | — |
| `[{}]` | 1×0 | 1×0 | 1×0 | — | 1×0 |
| `[{}, {}]` | 2×0 | 2×0 | 2×0 | 2×0 | 2×0 |
| `[]` | 0×0 | 0×0 | 0×0 | — | 0×0 |
| `[{}, {"a":1}]` | 2×1 | 2×1 | 2×1 | — | 2×1 |

Three shapes stay distinct, and are documented in `docs/python/README.md`:

| Shape | Meaning |
|---|---|
| `rows > 0`, `columns == 0` | rows were read; none of them had fields |
| `rows == 0`, `columns == 0` | the input held no records |
| `rows == 0`, `columns > 0` | a known schema with no rows under it |

A zero-column report is a normal report: it serialises, round-trips through
`from_dict`, and renders. A fieldless record is well-formed, so it stays clean
under both error policies and is never counted in `error_count`.

## Changes

- **`profile_columns` takes `row_count`** (`crates/dataprof-python/src/columns.rs`).
  With no columns there are no cells to derive the row count from. A `row_count`
  that contradicts columns that *are* present is rejected rather than silently
  ignored.
- **`_columns_from_records` returns the row count** instead of raising "rows but
  no columns cannot be represented" (`python/dataprof/__init__.py`).
- **A root `{}` is a record, not a map of columns.** "Every value is a list of
  cells" is vacuously true of an empty mapping, which is why sync bytes reported
  `0×0`. Populated roots keep their existing reading.
- **The async reader may emit a header chunk with no column names**, but only at
  the final flush (`crates/dataprof-engines/src/streaming/async_reader.rs`).
  Sending it earlier would freeze the schema while records that *do* have fields
  are still to come, so fieldless rows stay buffered instead of being emitted
  ahead of the headers, where the receiver would read them *as* the headers. CSV
  still rejects an empty header line — its first line is the schema.

## Verification

Each of the four parts was reverted on its own and rebuilt, to confirm the tests
discriminate it rather than passing on a neighbour's fix:

| Reverted part | Tests that fail |
|---|---|
| `columns.rs` `row_count` | 10 |
| `_columns_from_records` | 9 |
| root-`{}` branch guard | 1 (`test_root_object_bytes_is_a_record_not_an_empty_column_map`) |
| `async_reader.rs` | 6 (5 async bytes + URL) |

New coverage: `python/tests/test_json_fieldless_records.py` (table-driven across
file / sync bytes / async bytes / Python records, covering `{}`, `[{}]`,
`[{}, {}]`, `[]`, mixed fieldless-and-fielded, malformed input, `max_rows`, and
report serialisation/rendering), one URL case in `test_async_url_api.py`, two
`profile_columns` cases in `test_python_api.py`, and two async-reader tests in
`async_reader.rs`.

Scale check: 500k fieldless records profile in 0.1s async with matching row
counts on all three transports; a 200k fieldless prefix followed by `{"a":1}`
still yields one column with 200,000 nulls.

Note that `test_async_fieldless_records_do_not_hide_the_columns_around_them`
passes on master too — it guards the design against a naive "always send headers
eagerly" implementation rather than covering the bug.

## Out of scope

`format="json"` on the async reader rejects *any* root object, populated or not
(`{"a":1}` fails the same way `{}` did), while sync bytes accepts one. That is
the format-hint grammar, which is #486's "give standard JSON arrays, standard
JSON objects, and JSONL distinct unambiguous parser modes" — not the fieldless-row
policy. It is called out in the new test file's case table.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace --all-features
uv run maturin develop --features python,python-async,async-streaming
uv run pytest python/tests -q          # 863 passed, 5 skipped, 1 xfailed
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```
