### PR TITLE
fix(core): apply metric packs and locale on JSON, Parquet, and async paths

### DIFF
--- a/crates/dataprof-core/src/analysis_options.rs
+++ b/crates/dataprof-core/src/analysis_options.rs
@@ -1,0 +1,155 @@
+//! The analysis selection every parser and engine must honour.
+//!
+//! Metric packs, quality dimensions, locale, and semantic hints are all
+//! *requests about what to compute*, and the report they produce has to be the
+//! same on every input path. Passing them as loose parameters made that easy to
+//! get wrong: a parser that took dimensions and hints but not packs or locale
+//! compiled fine and silently computed work the caller had deselected.
+//! [`AnalysisOptions`] bundles them so a path either carries the whole selection
+//! or does not compile.
+
+use crate::quality::{MetricPack, QualityDimension};
+use crate::semantic::SemanticHints;
+
+/// What to analyze, and how, for a single profiling run.
+///
+/// Construct with [`AnalysisOptions::default`] (analyze everything) and narrow
+/// with the builder methods.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AnalysisOptions {
+    metric_packs: Option<Vec<MetricPack>>,
+    quality_dimensions: Option<Vec<QualityDimension>>,
+    locale: Option<String>,
+    semantic_hints: SemanticHints,
+}
+
+impl AnalysisOptions {
+    /// Select the metric packs to compute. `None` (the default) means all.
+    pub fn with_metric_packs(mut self, packs: Option<Vec<MetricPack>>) -> Self {
+        self.metric_packs = packs;
+        self
+    }
+
+    /// Select the quality dimensions to assess. `None` (the default) means all.
+    pub fn with_quality_dimensions(mut self, dimensions: Option<Vec<QualityDimension>>) -> Self {
+        self.quality_dimensions = dimensions;
+        self
+    }
+
+    /// Set the ISO 3166-1 alpha-2 locale used to rank detected patterns.
+    pub fn with_locale(mut self, locale: Option<String>) -> Self {
+        self.locale = locale;
+        self
+    }
+
+    /// Set the user's semantic hints.
+    pub fn with_semantic_hints(mut self, hints: SemanticHints) -> Self {
+        self.semantic_hints = hints;
+        self
+    }
+
+    /// The packs to compute, with an empty quality-dimension selection folded in.
+    ///
+    /// Resolved on read rather than in the setters so the outcome does not
+    /// depend on the order the selections were made in.
+    pub fn effective_metric_packs(&self) -> Option<Vec<MetricPack>> {
+        MetricPack::resolve_with_dimensions(
+            self.metric_packs.as_deref(),
+            self.quality_dimensions.as_deref(),
+        )
+    }
+
+    /// Whether per-column statistics should be computed.
+    pub fn include_statistics(&self) -> bool {
+        MetricPack::include_statistics(self.effective_metric_packs().as_deref())
+    }
+
+    /// Whether pattern detection should run.
+    pub fn include_patterns(&self) -> bool {
+        MetricPack::include_patterns(self.effective_metric_packs().as_deref())
+    }
+
+    /// Whether quality metrics should be computed.
+    ///
+    /// `false` means the report carries no quality at all — absent, not an
+    /// empty assessment — because nothing was analyzed.
+    pub fn include_quality(&self) -> bool {
+        MetricPack::include_quality(self.effective_metric_packs().as_deref())
+    }
+
+    /// The locale used to rank detected patterns.
+    ///
+    /// A locale only ranks patterns, so it has no effect of its own when
+    /// [`include_patterns`](Self::include_patterns) is false and detection never
+    /// runs.
+    pub fn locale(&self) -> Option<&str> {
+        self.locale.as_deref()
+    }
+
+    /// The requested quality dimensions, if the caller narrowed them.
+    pub fn quality_dimensions(&self) -> Option<&[QualityDimension]> {
+        self.quality_dimensions.as_deref()
+    }
+
+    /// The user's semantic hints.
+    pub fn semantic_hints(&self) -> &SemanticHints {
+        &self.semantic_hints
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_analyzes_everything() {
+        let options = AnalysisOptions::default();
+        assert!(options.include_statistics());
+        assert!(options.include_patterns());
+        assert!(options.include_quality());
+        assert_eq!(options.locale(), None);
+        assert_eq!(options.quality_dimensions(), None);
+    }
+
+    #[test]
+    fn schema_only_deselects_every_other_pack() {
+        let options = AnalysisOptions::default().with_metric_packs(Some(vec![MetricPack::Schema]));
+        assert!(!options.include_statistics());
+        assert!(!options.include_patterns());
+        assert!(!options.include_quality());
+    }
+
+    #[test]
+    fn empty_dimension_selection_removes_the_quality_pack() {
+        let options = AnalysisOptions::default().with_quality_dimensions(Some(vec![]));
+        assert!(!options.include_quality());
+        // Deselecting quality says nothing about the other packs.
+        assert!(options.include_statistics());
+        assert!(options.include_patterns());
+    }
+
+    #[test]
+    fn resolution_does_not_depend_on_setter_order() {
+        let packs = vec![MetricPack::Schema, MetricPack::Quality];
+        let dims_first = AnalysisOptions::default()
+            .with_quality_dimensions(Some(vec![]))
+            .with_metric_packs(Some(packs.clone()));
+        let packs_first = AnalysisOptions::default()
+            .with_metric_packs(Some(packs))
+            .with_quality_dimensions(Some(vec![]));
+        assert_eq!(
+            dims_first.effective_metric_packs(),
+            packs_first.effective_metric_packs()
+        );
+        assert!(!dims_first.include_quality());
+    }
+
+    #[test]
+    fn a_locale_alone_does_not_re_enable_pattern_detection() {
+        let options = AnalysisOptions::default()
+            .with_locale(Some("IT".to_string()))
+            .with_metric_packs(Some(vec![MetricPack::Schema]));
+        assert_eq!(options.locale(), Some("IT"));
+        assert!(!options.include_patterns());
+    }
+}

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analysis_options;
 pub mod classification;
 pub mod config;
 pub mod errors;
@@ -19,6 +20,7 @@ pub mod source;
 pub mod stop_condition;
 pub mod validation;
 
+pub use analysis_options::AnalysisOptions;
 pub use classification::{DataType, PatternCategory};
 #[cfg(feature = "database")]
 pub use config::{DatabaseSamplingConfig, DatabaseSettings};

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -2,10 +2,10 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use dataprof_core::{
-    ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, JsonErrorPolicy,
-    MetricPack, ProgressSink, QualityDimension, RowSampler, RowView, SamplingStrategy,
-    SchemaStabilityTracker, SemanticHints, StopCondition, StopEvaluator, StreamSourceSystem,
-    TruncationReason,
+    AnalysisOptions, ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat,
+    JsonErrorPolicy, MetricPack, ProgressSink, QualityDimension, RowSampler, RowView,
+    SamplingStrategy, SchemaStabilityTracker, SemanticHints, StopCondition, StopEvaluator,
+    StreamSourceSystem, TruncationReason,
 };
 use dataprof_runtime::{
     ProfileReport, ReportAssembler, StreamingColumnCollection, profile_builder,
@@ -208,9 +208,7 @@ pub struct AsyncStreamingProfiler {
     progress_sink: ProgressSink,
     progress_interval: Duration,
     stop_condition: StopCondition,
-    quality_dimensions: Option<Vec<QualityDimension>>,
-    metric_packs: Option<Vec<MetricPack>>,
-    semantic_hints: SemanticHints,
+    options: AnalysisOptions,
     json_error_policy: JsonErrorPolicy,
     csv_flexible: bool,
     csv_delimiter: Option<u8>,
@@ -236,9 +234,7 @@ impl AsyncStreamingProfiler {
             progress_sink: ProgressSink::None,
             progress_interval: Duration::from_millis(500),
             stop_condition: StopCondition::Never,
-            quality_dimensions: None,
-            metric_packs: None,
-            semantic_hints: SemanticHints::default(),
+            options: AnalysisOptions::default(),
             json_error_policy: JsonErrorPolicy::default(),
             csv_flexible: true,
             csv_delimiter: None,
@@ -276,18 +272,34 @@ impl AsyncStreamingProfiler {
         self
     }
 
+    /// Set the whole analysis selection at once.
+    ///
+    /// Preferred over the individual setters: the async pipeline must apply the
+    /// same selection the synchronous engines do, and passing it as one value is
+    /// what keeps a new option from reaching only some of them.
+    pub fn analysis_options(mut self, options: AnalysisOptions) -> Self {
+        self.options = options;
+        self
+    }
+
     pub fn quality_dimensions(mut self, dims: Vec<QualityDimension>) -> Self {
-        self.quality_dimensions = Some(dims);
+        self.options = std::mem::take(&mut self.options).with_quality_dimensions(Some(dims));
         self
     }
 
     pub fn metric_packs(mut self, packs: Vec<MetricPack>) -> Self {
-        self.metric_packs = Some(packs);
+        self.options = std::mem::take(&mut self.options).with_metric_packs(Some(packs));
+        self
+    }
+
+    /// Set the locale used to rank detected patterns.
+    pub fn locale(mut self, locale: String) -> Self {
+        self.options = std::mem::take(&mut self.options).with_locale(Some(locale));
         self
     }
 
     pub fn semantic_hints(mut self, hints: SemanticHints) -> Self {
-        self.semantic_hints = hints;
+        self.options = std::mem::take(&mut self.options).with_semantic_hints(hints);
         self
     }
 
@@ -412,16 +424,12 @@ impl AsyncStreamingProfiler {
         };
 
         // Build the report
-        let packs = self.metric_packs.as_deref();
-        let skip_stats = !MetricPack::include_statistics(packs);
-        let skip_patterns = !MetricPack::include_patterns(packs);
-
         let column_profiles = profile_builder::profiles_from_streaming_with_hints(
             &column_stats,
-            skip_stats,
-            skip_patterns,
-            None,
-            &self.semantic_hints,
+            !self.options.include_statistics(),
+            !self.options.include_patterns(),
+            self.options.locale(),
+            self.options.semantic_hints(),
         );
         let sample_columns = profile_builder::quality_check_samples(&column_stats);
         let scan_time_ms = start.elapsed().as_millis();
@@ -470,16 +478,13 @@ impl AsyncStreamingProfiler {
             execution = execution.with_sampling(sampled_rows as f64 / total_rows as f64);
         }
 
-        let mut assembler = ReportAssembler::new(data_source, execution)
+        Ok(ReportAssembler::new(data_source, execution)
             .columns(column_profiles)
             .with_quality_data(sample_columns)
             .with_row_duplicates(column_stats.row_duplicate_summary())
             .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
-            .with_semantic_hints(self.semantic_hints.clone());
-        if let Some(ref dims) = self.quality_dimensions {
-            assembler = assembler.with_requested_dimensions(dims.clone());
-        }
-        Ok(assembler.build())
+            .with_analysis_options(&self.options)
+            .build())
     }
 
     /// Map a `csv` crate error, pointing a strict-mode field-count failure at
@@ -1015,7 +1020,7 @@ impl AsyncStreamingProfiler {
         DataProfilerError,
     > {
         let mut column_stats = StreamingColumnCollection::memory_limit(self.memory_limit_mb)
-            .with_semantic_hints(&self.semantic_hints);
+            .with_semantic_hints(self.options.semantic_hints());
         let mut progress_tracker =
             ProgressTracker::new(self.progress_sink.clone(), self.progress_interval);
         let mut total_rows: usize = 0;

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 pub use dataprof_core::JsonErrorPolicy;
 use dataprof_core::{
-    ColumnProfile, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, QualityDimension,
-    SemanticHints, TruncationReason, Utf8BomReader,
+    AnalysisOptions, ColumnProfile, DataProfilerError, DataSource, ExecutionMetadata, FileFormat,
+    QualityDimension, SemanticHints, TruncationReason, Utf8BomReader,
 };
 use dataprof_runtime::{
     ProfileReport, ReportAssembler, StreamingColumnCollection, profile_builder,
@@ -597,8 +597,9 @@ pub fn analyze_json_from_reader_with_hints<R: BufRead>(
     ),
     DataProfilerError,
 > {
+    let options = AnalysisOptions::default().with_semantic_hints(semantic_hints.clone());
     let (profiles, stats, rows_read, malformed_lines, format, _truncated) =
-        analyze_json_from_reader_full(reader, config, semantic_hints)?;
+        analyze_json_from_reader_full(reader, config, &options)?;
     Ok((profiles, stats, rows_read, malformed_lines, format))
 }
 
@@ -608,7 +609,7 @@ pub fn analyze_json_from_reader_with_hints<R: BufRead>(
 fn analyze_json_from_reader_full<R: BufRead>(
     reader: R,
     config: &JsonParserConfig,
-    semantic_hints: &SemanticHints,
+    options: &AnalysisOptions,
 ) -> Result<
     (
         Vec<ColumnProfile>,
@@ -620,6 +621,7 @@ fn analyze_json_from_reader_full<R: BufRead>(
     ),
     DataProfilerError,
 > {
+    let semantic_hints = options.semantic_hints();
     let mut column_stats = StreamingColumnCollection::new().with_semantic_hints(semantic_hints);
     let mut known_columns = Vec::new();
     let mut known_columns_set = HashSet::new();
@@ -638,9 +640,9 @@ fn analyze_json_from_reader_full<R: BufRead>(
 
     let profiles = profile_builder::profiles_from_streaming_with_hints(
         &column_stats,
-        false,
-        false,
-        None,
+        !options.include_statistics(),
+        !options.include_patterns(),
+        options.locale(),
         semantic_hints,
     );
 
@@ -682,6 +684,22 @@ pub fn analyze_json_file_with_dimensions_and_hints(
     quality_dimensions: Option<&[QualityDimension]>,
     semantic_hints: &SemanticHints,
 ) -> Result<ProfileReport, DataProfilerError> {
+    let options = AnalysisOptions::default()
+        .with_quality_dimensions(quality_dimensions.map(<[_]>::to_vec))
+        .with_semantic_hints(semantic_hints.clone());
+    analyze_json_file_with_options(file_path, config, &options)
+}
+
+/// Analyze a JSON or JSONL file, honouring the caller's full analysis selection.
+///
+/// This is the entry point that carries metric packs and locale as well as
+/// dimensions and hints, so a JSON profile reports exactly the analysis the
+/// caller asked for — the same selection the CSV engines apply.
+pub fn analyze_json_file_with_options(
+    file_path: &Path,
+    config: &JsonParserConfig,
+    options: &AnalysisOptions,
+) -> Result<ProfileReport, DataProfilerError> {
     let metadata = std::fs::metadata(file_path).map_err(|error| map_io_error(file_path, error))?;
     let start = std::time::Instant::now();
 
@@ -689,7 +707,7 @@ pub fn analyze_json_file_with_dimensions_and_hints(
     let buf_reader = std::io::BufReader::new(file);
 
     let (column_profiles, column_stats, rows_read, malformed_lines, format, truncated) =
-        analyze_json_from_reader_full(buf_reader, config, semantic_hints)?;
+        analyze_json_from_reader_full(buf_reader, config, options)?;
 
     let file_source = DataSource::File {
         path: file_path.display().to_string(),
@@ -707,16 +725,14 @@ pub fn analyze_json_file_with_dimensions_and_hints(
                     .to_string(),
             });
         }
-        let mut assembler = ReportAssembler::new(
+        return Ok(ReportAssembler::new(
             file_source,
             ExecutionMetadata::new(0, 0, start.elapsed().as_millis()).with_engine("json"),
         )
         .columns(column_profiles)
-        .with_quality_data(HashMap::new());
-        if let Some(dimensions) = quality_dimensions {
-            assembler = assembler.with_requested_dimensions(dimensions.to_vec());
-        }
-        return Ok(assembler.build());
+        .with_quality_data(HashMap::new())
+        .with_analysis_options(options)
+        .build());
     }
 
     let sample_columns = profile_builder::quality_check_samples(&column_stats);
@@ -734,16 +750,13 @@ pub fn analyze_json_file_with_dimensions_and_hints(
         execution = execution.with_truncation(TruncationReason::MaxRows(max as u64));
     }
 
-    let mut assembler = ReportAssembler::new(file_source, execution)
+    Ok(ReportAssembler::new(file_source, execution)
         .columns(column_profiles)
         .with_quality_data(sample_columns)
         .with_row_duplicates(column_stats.row_duplicate_summary())
         .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
-        .with_semantic_hints(semantic_hints.clone());
-    if let Some(dimensions) = quality_dimensions {
-        assembler = assembler.with_requested_dimensions(dimensions.to_vec());
-    }
-    Ok(assembler.build())
+        .with_analysis_options(options)
+        .build())
 }
 
 fn map_io_error(file_path: &Path, error: std::io::Error) -> DataProfilerError {

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -1,7 +1,7 @@
 //! Asynchronous Parquet HTTP reading module
 use bytes::Bytes;
 use dataprof_core::{
-    DataProfilerError, DataSource, ExecutionMetadata, FileFormat, ParquetMetadata,
+    AnalysisOptions, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, ParquetMetadata,
     QualityDimension, SemanticHints,
 };
 use dataprof_runtime::{ProfileReport, ReportAssembler};
@@ -233,6 +233,20 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
     quality_dimensions: Option<Vec<QualityDimension>>,
     semantic_hints: &SemanticHints,
 ) -> Result<ProfileReport, DataProfilerError> {
+    let options = AnalysisOptions::default()
+        .with_quality_dimensions(quality_dimensions)
+        .with_semantic_hints(semantic_hints.clone());
+    analyze_parquet_async_http_with_options(url, config, &options).await
+}
+
+/// Like [`analyze_parquet_async_http`], honouring the caller's full analysis
+/// selection so a remote Parquet profile matches the local one option for option.
+pub async fn analyze_parquet_async_http_with_options(
+    url: &str,
+    config: &ParquetConfig,
+    options: &AnalysisOptions,
+) -> Result<ProfileReport, DataProfilerError> {
+    let semantic_hints = options.semantic_hints();
     let start = std::time::Instant::now();
 
     let reader = HttpParquetReader::try_new(url).await?;
@@ -280,7 +294,12 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
         analyzer.process_batch(&batch)?;
     }
 
-    let column_profiles = analyzer.to_profiles_with_hints(false, false, None, semantic_hints);
+    let column_profiles = analyzer.to_profiles_with_hints(
+        !options.include_statistics(),
+        !options.include_patterns(),
+        options.locale(),
+        semantic_hints,
+    );
     let total_rows = analyzer.total_rows();
 
     let sample_columns = analyzer.create_sample_columns();
@@ -298,7 +317,7 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
 
     let num_columns = column_profiles.len();
 
-    let mut assembler = ReportAssembler::new(
+    Ok(ReportAssembler::new(
         DataSource::File {
             path: url.to_string(),
             format: FileFormat::Parquet,
@@ -312,11 +331,8 @@ pub async fn analyze_parquet_async_http_dims_with_hints(
     .with_row_duplicates(analyzer.row_duplicate_summary())
     .with_quality_data(sample_columns)
     .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
-    .with_semantic_hints(semantic_hints.clone());
-    if let Some(dims) = quality_dimensions {
-        assembler = assembler.with_requested_dimensions(dims);
-    }
-    Ok(assembler.build())
+    .with_analysis_options(options)
+    .build())
 }
 
 #[cfg(test)]

--- a/crates/dataprof-parquet/src/lib.rs
+++ b/crates/dataprof-parquet/src/lib.rs
@@ -16,7 +16,7 @@ pub use arrow_profiler::ArrowProfiler;
 #[cfg(feature = "parquet-async")]
 pub use async_http::{
     HttpParquetReader, analyze_parquet_async_http, analyze_parquet_async_http_dims,
-    analyze_parquet_async_http_dims_with_hints,
+    analyze_parquet_async_http_dims_with_hints, analyze_parquet_async_http_with_options,
 };
 
 #[cfg(feature = "arrow")]
@@ -24,8 +24,9 @@ pub use record_batch_analyzer::RecordBatchAnalyzer;
 
 #[cfg(feature = "parquet")]
 pub use parser::{
-    ParquetConfig, analyze_parquet_bytes, analyze_parquet_with_config,
-    analyze_parquet_with_config_dims, analyze_parquet_with_config_dims_and_hints,
+    ParquetConfig, analyze_parquet_bytes, analyze_parquet_bytes_with_options,
+    analyze_parquet_with_config, analyze_parquet_with_config_dims,
+    analyze_parquet_with_config_dims_and_hints, analyze_parquet_with_options,
     analyze_parquet_with_quality, analyze_parquet_with_quality_dims,
     analyze_parquet_with_quality_dims_and_hints, is_parquet_file,
 };

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 use crate::record_batch_analyzer::RecordBatchAnalyzer;
 use dataprof_core::{
-    DataFrameLibrary, DataProfilerError, DataSource, ExecutionMetadata, FileFormat,
-    ParquetMetadata, QualityDimension, SemanticHints, TruncationReason,
+    AnalysisOptions, DataFrameLibrary, DataProfilerError, DataSource, ExecutionMetadata,
+    FileFormat, ParquetMetadata, QualityDimension, SemanticHints, TruncationReason,
 };
 use dataprof_runtime::{ProfileReport, ReportAssembler};
 
@@ -147,6 +147,17 @@ pub fn analyze_parquet_bytes(
     quality_dimensions: Option<&[QualityDimension]>,
     semantic_hints: &SemanticHints,
 ) -> Result<ProfileReport, DataProfilerError> {
+    let options = options_from_dims_and_hints(quality_dimensions, semantic_hints);
+    analyze_parquet_bytes_with_options(data, name, config, &options)
+}
+
+/// Like [`analyze_parquet_bytes`], honouring the caller's full analysis selection.
+pub fn analyze_parquet_bytes_with_options(
+    data: Bytes,
+    name: &str,
+    config: &ParquetConfig,
+    options: &AnalysisOptions,
+) -> Result<ProfileReport, DataProfilerError> {
     let byte_len = data.len() as u64;
     analyze_parquet_chunks(
         data,
@@ -155,9 +166,18 @@ pub fn analyze_parquet_bytes(
             byte_len,
         },
         config,
-        quality_dimensions,
-        semantic_hints,
+        options,
     )
+}
+
+/// Widen the legacy dimensions-and-hints parameter pair into the full selection.
+fn options_from_dims_and_hints(
+    quality_dimensions: Option<&[QualityDimension]>,
+    semantic_hints: &SemanticHints,
+) -> AnalysisOptions {
+    AnalysisOptions::default()
+        .with_quality_dimensions(quality_dimensions.map(<[_]>::to_vec))
+        .with_semantic_hints(semantic_hints.clone())
 }
 
 /// Where the Parquet bytes came from. The reader and every statistic are shared;
@@ -172,6 +192,20 @@ pub fn analyze_parquet_with_config_dims_and_hints(
     config: &ParquetConfig,
     quality_dimensions: Option<&[QualityDimension]>,
     semantic_hints: &SemanticHints,
+) -> Result<ProfileReport, DataProfilerError> {
+    let options = options_from_dims_and_hints(quality_dimensions, semantic_hints);
+    analyze_parquet_with_options(file_path, config, &options)
+}
+
+/// Analyze a Parquet file, honouring the caller's full analysis selection.
+///
+/// This is the entry point that carries metric packs and locale as well as
+/// dimensions and hints, so a Parquet profile reports exactly the analysis the
+/// caller asked for — the same selection the CSV engines apply.
+pub fn analyze_parquet_with_options(
+    file_path: &Path,
+    config: &ParquetConfig,
+    options: &AnalysisOptions,
 ) -> Result<ProfileReport, DataProfilerError> {
     let file = File::open(file_path).map_err(|error| {
         if error.kind() == std::io::ErrorKind::NotFound {
@@ -191,8 +225,7 @@ pub fn analyze_parquet_with_config_dims_and_hints(
             size_bytes: file_size_bytes,
         },
         config,
-        quality_dimensions,
-        semantic_hints,
+        options,
     )
 }
 
@@ -200,9 +233,9 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
     chunks: R,
     origin: ParquetOrigin,
     config: &ParquetConfig,
-    quality_dimensions: Option<&[QualityDimension]>,
-    semantic_hints: &SemanticHints,
+    options: &AnalysisOptions,
 ) -> Result<ProfileReport, DataProfilerError> {
+    let semantic_hints = options.semantic_hints();
     let start = std::time::Instant::now();
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(chunks).map_err(|error| {
@@ -252,7 +285,12 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
         analyzer.process_batch(&batch)?;
     }
 
-    let column_profiles = analyzer.to_profiles_with_hints(false, false, None, semantic_hints);
+    let column_profiles = analyzer.to_profiles_with_hints(
+        !options.include_statistics(),
+        !options.include_patterns(),
+        options.locale(),
+        semantic_hints,
+    );
     let total_rows = analyzer.total_rows();
     let sample_columns = analyzer.create_sample_columns();
     let scan_time_ms = start.elapsed().as_millis();
@@ -298,16 +336,13 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
         },
     };
 
-    let mut assembler = ReportAssembler::new(data_source, execution)
+    Ok(ReportAssembler::new(data_source, execution)
         .columns(column_profiles)
         .with_row_duplicates(analyzer.row_duplicate_summary())
         .with_quality_data(sample_columns)
         .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
-        .with_semantic_hints(semantic_hints.clone());
-    if let Some(dimensions) = quality_dimensions {
-        assembler = assembler.with_requested_dimensions(dimensions.to_vec());
-    }
-    Ok(assembler.build())
+        .with_analysis_options(options)
+        .build())
 }
 
 #[cfg(test)]

--- a/crates/dataprof-python/src/analysis.rs
+++ b/crates/dataprof-python/src/analysis.rs
@@ -55,10 +55,9 @@ pub fn profile_parquet_bytes(
     max_rows: Option<usize>,
     config: Option<&PyProfilerConfig>,
 ) -> PyResult<PyProfileReport> {
-    use dataprof::{ParquetConfig, analyze_parquet_bytes};
+    use dataprof::{ParquetConfig, analyze_parquet_bytes_with_options};
 
-    let quality_dimensions = config.and_then(|cfg| cfg.quality_dimensions.clone());
-    let semantic_hints = config.map(|cfg| cfg.semantic_hints()).unwrap_or_default();
+    let options = config.map(|cfg| cfg.analysis_options()).unwrap_or_default();
     let effective_max_rows =
         max_rows.or_else(|| config.and_then(|cfg| cfg.max_rows.map(|rows| rows as usize)));
 
@@ -69,13 +68,7 @@ pub fn profile_parquet_bytes(
 
     let report = py
         .detach(|| {
-            analyze_parquet_bytes(
-                data.into(),
-                &name,
-                &parquet_config,
-                quality_dimensions.as_deref(),
-                &semantic_hints,
-            )
+            analyze_parquet_bytes_with_options(data.into(), &name, &parquet_config, &options)
         })
         .map_err(|e| analysis_error_to_py(&e))?;
 

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dataprof::{
-    ChunkSize, EngineType, FileFormat, JsonErrorPolicy, MetricPack, Profiler, QualityDimension,
-    SemanticHints, StopCondition,
+    AnalysisOptions, ChunkSize, EngineType, FileFormat, JsonErrorPolicy, MetricPack, Profiler,
+    QualityDimension, SemanticHints, StopCondition,
 };
 
 use super::progress::py_callback_to_sink;
@@ -324,6 +324,20 @@ impl PyProfilerConfig {
         .with_temporal_columns(self.temporal_columns.clone())
     }
 
+    /// The analysis selection this config asks for.
+    ///
+    /// The entry points that bypass `Profiler` — the in-memory ones and the
+    /// Parquet byte buffer — pass this instead of picking out the two or three
+    /// options they happen to know about, so every Python surface honours the
+    /// same `metrics=`, `quality_dimensions=`, and `locale=`.
+    pub(crate) fn analysis_options(&self) -> AnalysisOptions {
+        AnalysisOptions::default()
+            .with_metric_packs(self.metric_packs.clone())
+            .with_quality_dimensions(self.quality_dimensions.clone())
+            .with_locale(self.locale.clone())
+            .with_semantic_hints(self.semantic_hints())
+    }
+
     /// Metric packs with an empty quality-dimension selection folded in.
     ///
     /// The in-memory entry points (`profile_columns`, the Arrow exporters) gate
@@ -331,10 +345,7 @@ impl PyProfilerConfig {
     /// the same rule here — otherwise `quality_dimensions=[]` would mean one
     /// thing for a file and another for a DataFrame.
     pub(crate) fn effective_metric_packs(&self) -> Option<Vec<MetricPack>> {
-        MetricPack::resolve_with_dimensions(
-            self.metric_packs.as_deref(),
-            self.quality_dimensions.as_deref(),
-        )
+        self.analysis_options().effective_metric_packs()
     }
 }
 

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -8,8 +8,8 @@
 use std::collections::HashMap;
 
 use dataprof_core::{
-    ColumnProfile, DataSource, DataType, ExecutionMetadata, QualityDimension, SemanticHintBinding,
-    SemanticHintKind, SemanticHints,
+    AnalysisOptions, ColumnProfile, DataSource, DataType, ExecutionMetadata, QualityDimension,
+    SemanticHintBinding, SemanticHintKind, SemanticHints,
 };
 use dataprof_metrics::{
     MetricConfidence, MetricsCalculator, QualityAssessment, RowDuplicateSummary,
@@ -82,6 +82,21 @@ impl ReportAssembler {
     /// Set semantic hints used by quality metrics.
     pub fn with_semantic_hints(mut self, hints: SemanticHints) -> Self {
         self.semantic_hints = hints;
+        self
+    }
+
+    /// Apply the caller's analysis selection: requested dimensions, semantic
+    /// hints, and whether quality is computed at all.
+    ///
+    /// Callers still pass their quality sample with
+    /// [`with_quality_data`](Self::with_quality_data); this decides whether it is
+    /// used. Deselecting the quality pack leaves the report with no quality
+    /// object rather than an assessment with every dimension absent — "not
+    /// analyzed" and "analyzed, nothing found" are different answers.
+    pub fn with_analysis_options(mut self, options: &AnalysisOptions) -> Self {
+        self.skip_quality = !options.include_quality();
+        self.semantic_hints = options.semantic_hints().clone();
+        self.requested_dimensions = options.quality_dimensions().map(<[_]>::to_vec);
         self
     }
 

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -23,8 +23,8 @@ pub use profiler::{
 };
 
 pub use dataprof_core::{
-    BooleanStats, ChunkSize, ColumnProfile, ColumnSchema, ColumnStats, CountMethod,
-    DataFrameLibrary, DataProfilerError, DataSource, DataType, DataprofConfig,
+    AnalysisOptions, BooleanStats, ChunkSize, ColumnProfile, ColumnSchema, ColumnStats,
+    CountMethod, DataFrameLibrary, DataProfilerError, DataSource, DataType, DataprofConfig,
     DataprofConfigBuilder, DateTimeStats, ExecutionMetadata, FileFormat, FrequencyItem,
     InputValidator, IsoQualityConfig, MetricPack, NumericStats, OutputFormat, ParquetMetadata,
     Pattern, PatternCategory, ProgressEvent, ProgressSink, QualityDimension, QualityScoreWeights,
@@ -36,7 +36,8 @@ pub use dataprof_csv::{
     CsvDiagnostics, CsvParserConfig, analyze_csv_file, analyze_csv_from_reader,
 };
 pub use dataprof_json::{
-    JsonErrorPolicy, JsonFormat, JsonParserConfig, analyze_json_file, analyze_json_from_reader,
+    JsonErrorPolicy, JsonFormat, JsonParserConfig, analyze_json_file,
+    analyze_json_file_with_options, analyze_json_from_reader,
 };
 pub use dataprof_metrics::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, MetricsCalculator,
@@ -49,8 +50,9 @@ pub use dataprof_metrics::{
 pub use dataprof_parquet::{HttpParquetReader, analyze_parquet_async_http};
 #[cfg(feature = "parquet")]
 pub use dataprof_parquet::{
-    ParquetConfig, analyze_parquet_bytes, analyze_parquet_with_config,
-    analyze_parquet_with_quality, analyze_parquet_with_quality_dims, is_parquet_file,
+    ParquetConfig, analyze_parquet_bytes, analyze_parquet_bytes_with_options,
+    analyze_parquet_with_config, analyze_parquet_with_options, analyze_parquet_with_quality,
+    analyze_parquet_with_quality_dims, is_parquet_file,
 };
 pub use dataprof_partial::{analyze_structure, infer_schema, quick_row_count};
 pub use dataprof_runtime::{ProfileReport, REPORT_SCHEMA_VERSION};

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dataprof_core::{
-    ChunkSize, DataProfilerError, DataSource, FileFormat, MetricPack, ProgressEvent, ProgressSink,
-    QualityDimension, RowCountEstimate, SamplingStrategy, SchemaResult, SemanticHints,
-    StopCondition, StructureReport,
+    AnalysisOptions, ChunkSize, DataProfilerError, DataSource, FileFormat, MetricPack,
+    ProgressEvent, ProgressSink, QualityDimension, RowCountEstimate, SamplingStrategy,
+    SchemaResult, SemanticHints, StopCondition, StructureReport,
 };
 #[cfg(feature = "database")]
 use dataprof_db::DatabaseConfig;
@@ -52,9 +52,11 @@ pub struct ProfilerConfig {
     /// locale patterns are suppressed (unless they have a very high match rate).
     /// `None` = no locale preference (default).
     ///
-    /// Applies to file-based (CSV/Parquet) and DataFrame/Arrow profiling engines.
-    /// Database-backed (`analyze_query`) and async streaming entry points do not
-    /// currently forward this setting.
+    /// Applies to every file format (CSV, JSON/JSONL, Parquet), to DataFrame and
+    /// Arrow sources, and to the async streaming entry points — a locale ranks
+    /// the same patterns whichever path read the data. Database-backed
+    /// profiling (`analyze_query`) does not detect patterns, so it has nothing
+    /// to rank.
     pub locale: Option<String>,
     /// Columns whose numeric values are expected to be non-negative.
     pub positive_columns: Vec<String>,
@@ -492,6 +494,20 @@ impl Profiler {
         Ok(())
     }
 
+    /// The caller's full analysis selection, as every parser and engine needs it.
+    ///
+    /// Built in one place and passed whole, so a path cannot pick up the
+    /// dimensions and hints while quietly dropping the metric packs or the
+    /// locale — which is exactly how JSON, Parquet, and the async pipeline came
+    /// to compute work the caller had deselected.
+    fn analysis_options(&self) -> AnalysisOptions {
+        AnalysisOptions::default()
+            .with_metric_packs(self.config.metric_packs.clone())
+            .with_quality_dimensions(self.config.quality_dimensions.clone())
+            .with_locale(self.config.locale.clone())
+            .with_semantic_hints(self.semantic_hints())
+    }
+
     /// The metric packs to compute, with an empty quality-dimension selection
     /// folded in.
     ///
@@ -499,10 +515,7 @@ impl Profiler {
     /// depend on whether `quality_dimensions` or `metric_packs` was called
     /// first.
     fn effective_metric_packs(&self) -> Option<Vec<MetricPack>> {
-        MetricPack::resolve_with_dimensions(
-            self.config.metric_packs.as_deref(),
-            self.config.quality_dimensions.as_deref(),
-        )
+        self.analysis_options().effective_metric_packs()
     }
 
     /// Reject a stop condition richer than a plain row limit.
@@ -597,17 +610,15 @@ impl Profiler {
         file_path: &Path,
         format: FileFormat,
     ) -> Result<ProfileReport, DataProfilerError> {
-        let dims = self.config.quality_dimensions.as_deref();
-        let semantic_hints = self.semantic_hints();
+        let options = self.analysis_options();
         match format {
             FileFormat::Json | FileFormat::Jsonl => {
                 self.ensure_row_limit_only("the JSON parser")?;
                 self.ensure_no_sampling("the JSON parser")?;
-                dataprof_json::analyze_json_file_with_dimensions_and_hints(
+                dataprof_json::analyze_json_file_with_options(
                     file_path,
                     &self.json_config_for_stop(),
-                    dims,
-                    &semantic_hints,
+                    &options,
                 )
             }
             FileFormat::Parquet => {
@@ -615,11 +626,10 @@ impl Profiler {
                 {
                     self.ensure_row_limit_only("the Parquet parser")?;
                     self.ensure_no_sampling("the Parquet parser")?;
-                    dataprof_parquet::analyze_parquet_with_config_dims_and_hints(
+                    dataprof_parquet::analyze_parquet_with_options(
                         file_path,
                         &self.parquet_config_for_stop(),
-                        dims,
-                        &semantic_hints,
+                        &options,
                     )
                 }
                 #[cfg(not(feature = "parquet"))]
@@ -657,7 +667,7 @@ impl Profiler {
                     if let Some(l) = &self.config.locale {
                         profiler = profiler.locale(l.clone());
                     }
-                    profiler = profiler.semantic_hints(semantic_hints);
+                    profiler = profiler.semantic_hints(options.semantic_hints().clone());
                     let csv_config = self.csv_config_for_file(file_path);
                     profiler = profiler.csv_config(csv_config);
                     // Format already resolved here; skip the engine's extension-based
@@ -674,18 +684,16 @@ impl Profiler {
         file_path: &Path,
         format: FileFormat,
     ) -> Result<ProfileReport, DataProfilerError> {
-        let dims = self.config.quality_dimensions.as_deref();
-        let semantic_hints = self.semantic_hints();
+        let options = self.analysis_options();
         // IncrementalProfiler only supports CSV
         match format {
             FileFormat::Json | FileFormat::Jsonl => {
                 self.ensure_row_limit_only("the JSON parser")?;
                 self.ensure_no_sampling("the JSON parser")?;
-                return dataprof_json::analyze_json_file_with_dimensions_and_hints(
+                return dataprof_json::analyze_json_file_with_options(
                     file_path,
                     &self.json_config_for_stop(),
-                    dims,
-                    &semantic_hints,
+                    &options,
                 );
             }
             FileFormat::Parquet => {
@@ -693,11 +701,10 @@ impl Profiler {
                 {
                     self.ensure_row_limit_only("the Parquet parser")?;
                     self.ensure_no_sampling("the Parquet parser")?;
-                    return dataprof_parquet::analyze_parquet_with_config_dims_and_hints(
+                    return dataprof_parquet::analyze_parquet_with_options(
                         file_path,
                         &self.parquet_config_for_stop(),
-                        dims,
-                        &semantic_hints,
+                        &options,
                     );
                 }
                 #[cfg(not(feature = "parquet"))]
@@ -727,7 +734,7 @@ impl Profiler {
         if let Some(l) = &self.config.locale {
             profiler = profiler.locale(l.clone());
         }
-        profiler = profiler.semantic_hints(semantic_hints);
+        profiler = profiler.semantic_hints(options.semantic_hints().clone());
         let csv_config = self.csv_config_for_file(file_path);
         profiler = profiler.csv_config(csv_config);
 
@@ -740,8 +747,7 @@ impl Profiler {
         file_path: &Path,
         format: FileFormat,
     ) -> Result<ProfileReport, DataProfilerError> {
-        let dims = self.config.quality_dimensions.as_deref();
-        let semantic_hints = self.semantic_hints();
+        let options = self.analysis_options();
         // Every columnar path enforces a row cap, but none can evaluate a richer
         // stop condition per chunk, and none samples row by row.
         self.ensure_row_limit_only("the columnar engine")?;
@@ -749,11 +755,10 @@ impl Profiler {
         match format {
             FileFormat::Parquet => {
                 #[cfg(feature = "parquet")]
-                return dataprof_parquet::analyze_parquet_with_config_dims_and_hints(
+                return dataprof_parquet::analyze_parquet_with_options(
                     file_path,
                     &self.parquet_config_for_stop(),
-                    dims,
-                    &semantic_hints,
+                    &options,
                 );
                 #[cfg(not(feature = "parquet"))]
                 return Err(DataProfilerError::UnsupportedFormat {
@@ -761,11 +766,10 @@ impl Profiler {
                 });
             }
             FileFormat::Json | FileFormat::Jsonl => {
-                return dataprof_json::analyze_json_file_with_dimensions_and_hints(
+                return dataprof_json::analyze_json_file_with_options(
                     file_path,
                     &self.json_config_for_stop(),
-                    dims,
-                    &semantic_hints,
+                    &options,
                 );
             }
             _ => {}
@@ -788,7 +792,7 @@ impl Profiler {
             if let Some(l) = &self.config.locale {
                 profiler = profiler.locale(l.clone());
             }
-            profiler = profiler.semantic_hints(semantic_hints);
+            profiler = profiler.semantic_hints(options.semantic_hints().clone());
             // ArrowProfiler reads the row cap off the CSV config; the incremental
             // engine evaluates the stop condition itself, so only set it here.
             let csv_config = self
@@ -948,13 +952,7 @@ impl Profiler {
         if let Some(delimiter) = self.config.csv_delimiter {
             profiler = profiler.csv_delimiter(delimiter);
         }
-        if let Some(ref d) = self.config.quality_dimensions {
-            profiler = profiler.quality_dimensions(d.clone());
-        }
-        if let Some(p) = self.effective_metric_packs() {
-            profiler = profiler.metric_packs(p);
-        }
-        profiler = profiler.semantic_hints(self.semantic_hints());
+        profiler = profiler.analysis_options(self.analysis_options());
 
         let report = profiler.analyze_stream(source).await?;
         self.validate_semantic_hints(&report)?;
@@ -998,15 +996,13 @@ impl Profiler {
                     self.ensure_no_sampling("the async Parquet parser")?;
                     // Parquet requires seeking — delegate to sync parser on a blocking thread.
                     let path = path.to_path_buf();
-                    let dims = self.config.quality_dimensions.clone();
-                    let semantic_hints = self.semantic_hints();
+                    let options = self.analysis_options();
                     let parquet_config = self.parquet_config_for_stop();
                     let report = tokio::task::spawn_blocking(move || {
-                        dataprof_parquet::analyze_parquet_with_config_dims_and_hints(
+                        dataprof_parquet::analyze_parquet_with_options(
                             &path,
                             &parquet_config,
-                            dims.as_deref(),
-                            &semantic_hints,
+                            &options,
                         )
                     })
                     .await
@@ -1125,11 +1121,10 @@ impl Profiler {
             FileFormat::Parquet => {
                 #[cfg(feature = "parquet-async")]
                 {
-                    let report = dataprof_parquet::analyze_parquet_async_http_dims_with_hints(
+                    let report = dataprof_parquet::analyze_parquet_async_http_with_options(
                         url,
                         &dataprof_parquet::ParquetConfig::default(),
-                        self.config.quality_dimensions.clone(),
-                        &self.semantic_hints(),
+                        &self.analysis_options(),
                     )
                     .await?;
                     self.validate_semantic_hints(&report)?;

--- a/python/tests/test_analysis_option_parity.py
+++ b/python/tests/test_analysis_option_parity.py
@@ -1,0 +1,184 @@
+"""``metrics``, ``quality_dimensions`` and ``locale`` apply on every path (#494).
+
+These options say *what to compute*. They were honoured on the synchronous CSV
+path and quietly dropped by the native JSON/JSONL and Parquet parsers and by the
+async streaming pipeline, so the same five records profiled differently
+depending on which format they were stored in and which entry point read them.
+
+Each test is table-driven over the same records in four formats, across the
+synchronous file API, the async file API, and — for Parquet — the byte-buffer
+API, which bypasses the profiler dispatch entirely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import dataprof as dp
+import pytest
+from dataprof.asyncio import profile_file as profile_file_async
+
+# ``cap`` is what makes locale observable: a five-digit string matches both
+# ``CAP (IT)`` and ``ZIP Code (US)``, and ``locale="IT"`` must suppress the US
+# pattern. ``amount`` gives every format a numeric column to carry statistics.
+RECORDS = [
+    {"id": 1, "cap": "20121", "amount": 10.5},
+    {"id": 2, "cap": "00184", "amount": 21.0},
+    {"id": 3, "cap": "10121", "amount": 33.5},
+    {"id": 4, "cap": "80132", "amount": 42.0},
+    {"id": 5, "cap": "50122", "amount": 55.5},
+]
+
+pa = pytest.importorskip("pyarrow", reason="pyarrow writes the Parquet fixture")
+pq = pytest.importorskip("pyarrow.parquet", reason="pyarrow writes the Parquet fixture")
+
+requires_async = pytest.mark.skipif(
+    not dp.capabilities().async_streaming,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+
+@pytest.fixture(scope="module")
+def fixtures(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Path]:
+    """The same five records written out in every supported format."""
+    import json
+
+    directory = tmp_path_factory.mktemp("analysis_option_parity")
+
+    csv_path = directory / "data.csv"
+    lines = ["id,cap,amount"]
+    lines += [f"{r['id']},{r['cap']},{r['amount']}" for r in RECORDS]
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    json_path = directory / "data.json"
+    json_path.write_text(json.dumps(RECORDS), encoding="utf-8")
+
+    jsonl_path = directory / "data.jsonl"
+    jsonl_path.write_text(
+        "\n".join(json.dumps(record) for record in RECORDS) + "\n", encoding="utf-8"
+    )
+
+    parquet_path = directory / "data.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "id": pa.array([r["id"] for r in RECORDS], type=pa.int64()),
+                "cap": pa.array([r["cap"] for r in RECORDS], type=pa.string()),
+                "amount": pa.array([r["amount"] for r in RECORDS], type=pa.float64()),
+            }
+        ),
+        parquet_path,
+    )
+
+    return {
+        "csv": csv_path,
+        "json": json_path,
+        "jsonl": jsonl_path,
+        "parquet": parquet_path,
+    }
+
+
+def _column(report: dp.ProfileReport, name: str):
+    for column in report.profiles:
+        if column.name == name:
+            return column
+    raise AssertionError(f"column {name} missing from report")
+
+
+def _pattern_names(report: dp.ProfileReport, name: str) -> list[str] | None:
+    patterns = _column(report, name).patterns
+    if patterns is None:
+        return None
+    return sorted(pattern.name for pattern in patterns)
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
+def test_schema_pack_omits_statistics_patterns_and_quality(fixtures, fmt: str) -> None:
+    report = dp.profile(fixtures[fmt], metrics=["schema"])
+
+    assert report.quality is None, f"{fmt}: quality must be absent under metrics=['schema']"
+    assert report.quality_score is None, f"{fmt}: absent quality has no score"
+    for column in report.profiles:
+        assert column.patterns is None, f"{fmt}: {column.name} kept patterns"
+    # Schema itself survives: this is a narrowed profile, not an empty one.
+    assert [c.name for c in report.profiles] == ["id", "cap", "amount"]
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
+def test_empty_quality_dimensions_means_not_analyzed(fixtures, fmt: str) -> None:
+    report = dp.profile(fixtures[fmt], quality_dimensions=[])
+
+    assert report.quality is None, (
+        f"{fmt}: quality_dimensions=[] must mean 'not analyzed', "
+        "not an assessment with nothing in it"
+    )
+    assert report.quality_score is None, f"{fmt}: absent quality has no score"
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
+def test_narrowed_quality_dimensions_still_analyze(fixtures, fmt: str) -> None:
+    # The counterpart: asking for *some* dimension is still a request to
+    # analyze, so quality is present.
+    report = dp.profile(fixtures[fmt], quality_dimensions=["completeness"])
+    assert report.quality is not None, f"{fmt}: a narrowed selection is still an analysis"
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
+def test_locale_reaches_pattern_detection(fixtures, fmt: str) -> None:
+    plain = _pattern_names(dp.profile(fixtures[fmt]), "cap")
+    localized = _pattern_names(dp.profile(fixtures[fmt], locale="IT"), "cap")
+
+    assert plain is not None and localized is not None
+    assert "ZIP Code (US)" in plain, f"{fmt}: without a locale the US pattern should match"
+    assert "ZIP Code (US)" not in localized, f"{fmt}: locale='IT' must suppress the US pattern"
+    assert "CAP (IT)" in localized, f"{fmt}: locale='IT' must keep the Italian pattern"
+
+
+def test_every_format_agrees_on_locale_ranked_patterns(fixtures) -> None:
+    localized: dict[str, list[str]] = {}
+    for fmt, path in fixtures.items():
+        names = _pattern_names(dp.profile(path, locale="IT"), "cap")
+        assert names is not None, f"{fmt}: pattern detection must run by default"
+        localized[fmt] = names
+
+    distinct = {tuple(names) for names in localized.values()}
+    assert len(distinct) == 1, f"formats disagree on locale-ranked patterns: {localized}"
+
+
+@requires_async
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
+def test_async_paths_apply_the_same_selection(fixtures, fmt: str) -> None:
+    path = fixtures[fmt]
+
+    schema_only = asyncio.run(profile_file_async(path, metrics=["schema"]))
+    assert schema_only.quality is None, f"{fmt}, async: metrics=['schema'] must omit quality"
+    for column in schema_only.profiles:
+        assert column.patterns is None, f"{fmt}, async: {column.name} kept patterns"
+
+    no_dimensions = asyncio.run(profile_file_async(path, quality_dimensions=[]))
+    assert no_dimensions.quality is None, (
+        f"{fmt}, async: quality_dimensions=[] must yield no quality"
+    )
+
+    assert _pattern_names(asyncio.run(profile_file_async(path, locale="IT")), "cap") == (
+        _pattern_names(dp.profile(path, locale="IT"), "cap")
+    ), f"{fmt}: sync and async disagree on locale-ranked patterns"
+
+
+def test_parquet_byte_buffers_apply_the_same_selection(fixtures) -> None:
+    # ``profile(bytes, format="parquet")`` reaches the native reader without
+    # going through the profiler dispatch, so it needs its own coverage.
+    data = fixtures["parquet"].read_bytes()
+
+    schema_only = dp.profile(data, format="parquet", metrics=["schema"])
+    assert schema_only.quality is None, "parquet bytes: metrics=['schema'] must omit quality"
+    for column in schema_only.profiles:
+        assert column.patterns is None, f"parquet bytes: {column.name} kept patterns"
+
+    assert dp.profile(data, format="parquet", quality_dimensions=[]).quality is None
+
+    assert _pattern_names(dp.profile(data, format="parquet", locale="IT"), "cap") == (
+        _pattern_names(dp.profile(fixtures["parquet"], locale="IT"), "cap")
+    ), "parquet bytes and file disagree on locale-ranked patterns"

--- a/tests/analysis_option_parity.rs
+++ b/tests/analysis_option_parity.rs
@@ -1,0 +1,331 @@
+//! Analysis-option parity across formats and transports (#494).
+//!
+//! `metrics`, `quality_dimensions`, and `locale` are requests about *what to
+//! compute*. A caller who deselects quality must get no quality whichever format
+//! and transport carried the data, and a locale must reach pattern detection
+//! everywhere or nowhere. The JSON, Parquet, and async paths used to accept
+//! these options and drop them, so the same logical rows profiled differently
+//! depending on how they were stored.
+//!
+//! Every test here is table-driven over the same five records in four formats.
+
+use std::io::Write;
+
+use dataprof::{ColumnStats, MetricPack, ProfileReport, Profiler, QualityDimension};
+use tempfile::NamedTempFile;
+
+/// Five records with an Italian postal code column. `cap` is what makes locale
+/// observable: without a locale both `CAP (IT)` and `ZIP Code (US)` match a
+/// five-digit string, and `locale="IT"` must suppress the US pattern.
+const RECORDS: [(u32, &str, f64); 5] = [
+    (1, "20121", 10.5),
+    (2, "00184", 21.0),
+    (3, "10121", 33.5),
+    (4, "80132", 42.0),
+    (5, "50122", 55.5),
+];
+
+fn csv_fixture() -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".csv").unwrap();
+    writeln!(file, "id,cap,amount").unwrap();
+    for (id, cap, amount) in RECORDS {
+        writeln!(file, "{id},{cap},{amount}").unwrap();
+    }
+    file.flush().unwrap();
+    file
+}
+
+fn json_records() -> Vec<String> {
+    RECORDS
+        .iter()
+        .map(|(id, cap, amount)| format!(r#"{{"id":{id},"cap":"{cap}","amount":{amount}}}"#))
+        .collect()
+}
+
+fn json_fixture() -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".json").unwrap();
+    write!(file, "[{}]", json_records().join(",")).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+fn jsonl_fixture() -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".jsonl").unwrap();
+    writeln!(file, "{}", json_records().join("\n")).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+#[cfg(feature = "parquet")]
+fn parquet_fixture() -> NamedTempFile {
+    use std::sync::Arc;
+
+    use arrow::array::{Float64Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use parquet::arrow::ArrowWriter;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("cap", DataType::Utf8, false),
+        Field::new("amount", DataType::Float64, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(
+                RECORDS.iter().map(|r| r.0 as i64).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                RECORDS.iter().map(|r| r.1).collect::<Vec<_>>(),
+            )),
+            Arc::new(Float64Array::from(
+                RECORDS.iter().map(|r| r.2).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .unwrap();
+
+    let file = NamedTempFile::with_suffix(".parquet").unwrap();
+    let mut writer = ArrowWriter::try_new(file.reopen().unwrap(), schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    file
+}
+
+/// Every format holding the same five records. Parquet joins the table only when
+/// the feature is compiled in.
+fn fixtures() -> Vec<(&'static str, NamedTempFile)> {
+    let mut all = vec![
+        ("csv", csv_fixture()),
+        ("json", json_fixture()),
+        ("jsonl", jsonl_fixture()),
+    ];
+    #[cfg(feature = "parquet")]
+    all.push(("parquet", parquet_fixture()));
+    all
+}
+
+fn pattern_names(report: &ProfileReport, column: &str) -> Option<Vec<String>> {
+    let profile = report
+        .column_profiles
+        .iter()
+        .find(|c| c.name == column)
+        .unwrap_or_else(|| panic!("column {column} missing from report"));
+    profile
+        .patterns
+        .as_ref()
+        .map(|patterns| patterns.iter().map(|p| p.name.clone()).collect())
+}
+
+#[test]
+fn schema_pack_omits_statistics_patterns_and_quality_on_every_format() {
+    for (label, file) in fixtures() {
+        let report = Profiler::new()
+            .metric_packs(vec![MetricPack::Schema])
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] profiling failed: {e}"));
+
+        assert!(
+            report.quality.is_none(),
+            "[{label}] quality must be absent when the quality pack is deselected"
+        );
+        for profile in &report.column_profiles {
+            assert!(
+                matches!(profile.stats, ColumnStats::None),
+                "[{label}] column {} kept statistics under metrics=[schema]",
+                profile.name
+            );
+            assert!(
+                profile.patterns.is_none(),
+                "[{label}] column {} kept patterns under metrics=[schema]",
+                profile.name
+            );
+        }
+        // Schema itself is still reported — this is a narrowed profile, not an
+        // empty one.
+        assert_eq!(
+            report.column_profiles.len(),
+            3,
+            "[{label}] schema pack must still report every column"
+        );
+    }
+}
+
+#[test]
+fn empty_dimension_selection_yields_absent_quality_on_every_format() {
+    for (label, file) in fixtures() {
+        let report = Profiler::new()
+            .quality_dimensions(vec![])
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] profiling failed: {e}"));
+
+        assert!(
+            report.quality.is_none(),
+            "[{label}] quality_dimensions=[] must mean 'not analyzed', not an empty assessment"
+        );
+        assert!(
+            report.quality_score().is_none(),
+            "[{label}] a report with no quality assessment has no score"
+        );
+        // Deselecting quality says nothing about the other packs.
+        assert!(
+            !matches!(
+                report
+                    .column_profiles
+                    .iter()
+                    .find(|c| c.name == "amount")
+                    .unwrap()
+                    .stats,
+                ColumnStats::None
+            ),
+            "[{label}] statistics must survive an empty dimension selection"
+        );
+    }
+}
+
+#[test]
+fn a_narrowed_dimension_selection_still_reports_quality() {
+    // The counterpart to the test above: asking for *some* dimension is a
+    // request to analyze, so quality is present. Only an empty request means
+    // "assess nothing".
+    for (label, file) in fixtures() {
+        let report = Profiler::new()
+            .quality_dimensions(vec![QualityDimension::Completeness])
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] profiling failed: {e}"));
+
+        assert!(
+            report.quality.is_some(),
+            "[{label}] a narrowed dimension selection is still an analysis"
+        );
+    }
+}
+
+#[test]
+fn locale_reaches_pattern_detection_on_every_format() {
+    let mut without_locale = Vec::new();
+    let mut with_locale = Vec::new();
+
+    for (label, file) in fixtures() {
+        let plain = Profiler::new()
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] profiling failed: {e}"));
+        let localized = Profiler::new()
+            .locale("IT")
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] localized profiling failed: {e}"));
+
+        let plain_patterns = pattern_names(&plain, "cap").expect("patterns detected by default");
+        let localized_patterns =
+            pattern_names(&localized, "cap").expect("patterns detected by default");
+
+        assert!(
+            plain_patterns.iter().any(|p| p.contains("ZIP Code (US)")),
+            "[{label}] without a locale the US pattern should still match, got {plain_patterns:?}"
+        );
+        assert!(
+            !localized_patterns
+                .iter()
+                .any(|p| p.contains("ZIP Code (US)")),
+            "[{label}] locale=IT must suppress the US pattern, got {localized_patterns:?}"
+        );
+        assert!(
+            localized_patterns.iter().any(|p| p.contains("CAP (IT)")),
+            "[{label}] locale=IT must keep the Italian pattern, got {localized_patterns:?}"
+        );
+
+        without_locale.push((label, plain_patterns));
+        with_locale.push((label, localized_patterns));
+    }
+
+    // Parity, not just presence: every format must reach the same conclusion.
+    for table in [&without_locale, &with_locale] {
+        let (first_label, first) = &table[0];
+        for (label, patterns) in &table[1..] {
+            assert_eq!(
+                first, patterns,
+                "{first_label} and {label} disagree on detected patterns"
+            );
+        }
+    }
+}
+
+#[cfg(feature = "async-streaming")]
+mod async_transport {
+    use super::*;
+
+    /// The async pipeline must apply the same selection the sync one does.
+    /// CSV/JSON/JSONL stream through the async reader; Parquet is delegated to
+    /// the blocking parser, and that delegation used to drop the options.
+    fn profile_async(profiler: Profiler, path: &std::path::Path) -> ProfileReport {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async { profiler.profile_file(path).await })
+            .expect("async profiling should succeed")
+    }
+
+    #[test]
+    fn async_paths_honour_the_schema_pack() {
+        for (label, file) in fixtures() {
+            let report = profile_async(
+                Profiler::new().metric_packs(vec![MetricPack::Schema]),
+                file.path(),
+            );
+
+            assert!(
+                report.quality.is_none(),
+                "[{label}, async] quality must be absent under metrics=[schema]"
+            );
+            for profile in &report.column_profiles {
+                assert!(
+                    matches!(profile.stats, ColumnStats::None),
+                    "[{label}, async] column {} kept statistics",
+                    profile.name
+                );
+                assert!(
+                    profile.patterns.is_none(),
+                    "[{label}, async] column {} kept patterns",
+                    profile.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn async_paths_honour_an_empty_dimension_selection() {
+        for (label, file) in fixtures() {
+            let report = profile_async(Profiler::new().quality_dimensions(vec![]), file.path());
+            assert!(
+                report.quality.is_none(),
+                "[{label}, async] quality_dimensions=[] must yield no quality"
+            );
+        }
+    }
+
+    #[test]
+    fn async_paths_honour_the_locale_and_match_the_sync_result() {
+        for (label, file) in fixtures() {
+            let sync = Profiler::new()
+                .locale("IT")
+                .analyze_file(file.path())
+                .unwrap_or_else(|e| panic!("[{label}] sync profiling failed: {e}"));
+            let async_ = profile_async(Profiler::new().locale("IT"), file.path());
+
+            assert_eq!(
+                pattern_names(&sync, "cap"),
+                pattern_names(&async_, "cap"),
+                "[{label}] sync and async disagree on locale-ranked patterns"
+            );
+            assert!(
+                !pattern_names(&async_, "cap")
+                    .unwrap()
+                    .iter()
+                    .any(|p| p.contains("ZIP Code (US)")),
+                "[{label}, async] locale=IT must suppress the US pattern"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #494.

## The problem

`metrics`, `quality_dimensions`, and `locale` are requests about *what to
compute*. Only the synchronous CSV engines honoured all three. The JSON/JSONL
and Parquet parsers and the async streaming pipeline accepted the options and
dropped most of them, so the same logical rows profiled differently depending
on which format stored them and which entry point read them.

The parsers took the selection as loose parameters and simply had no parameter
for metric packs or locale. That is what made partial plumbing compile
silently: `dataprof-json` and `dataprof-parquet` called
`profiles_from_streaming_with_hints(…, false, false, None, …)` — statistics and
patterns hardcoded on, locale hardcoded off — and attached quality
unconditionally. The async reader honoured packs for statistics and patterns
but still called `with_quality_data(…)` regardless.

## The fix

`AnalysisOptions` (`dataprof-core`) carries packs, dimensions, locale, and
semantic hints as one value, and `ReportAssembler::with_analysis_options`
applies it. A path now either carries the whole selection or does not compile.

Each parser gained a `*_with_options` entry point; the existing
`_with_dimensions_and_hints` functions widen into it, so their callers are
unchanged. `Profiler::analysis_options()` builds the value once and every
dispatch path passes it — including the async local-Parquet `spawn_blocking`
delegation and `profile_url`. On the Python side
`PyProfilerConfig::analysis_options()` does the same for
`profile_parquet_bytes`, which bypasses `Profiler` entirely.

A stale doc comment on `ProfilerConfig::locale` claiming async entry points do
not forward the setting is corrected.

## Verification

New `tests/analysis_option_parity.rs` and
`python/tests/test_analysis_option_parity.py` are table-driven over the same
five records in CSV, JSON, JSONL, and Parquet, across the sync file API, the
async file API, and the Parquet byte-buffer API.

Each part of the fix was reverted separately to confirm the tests discriminate
rather than merely catching *something*:

| Reverted | What failed |
| --- | --- |
| Everything | 6/7 Rust tests — CSV sync passed, JSON/Parquet/async failed, reproducing the issue's table |
| Parquet parser only | all 6, labelled `[parquet]` / `[parquet, async]`; CSV and JSON passed |
| Async reader only | exactly the 3 async tests; every sync test passed |
| JSON parser only | all 4 JSON-touching tests, labelled `[json]` |
| Python `analysis.rs` only | only `test_parquet_byte_buffers_apply_the_same_selection` |

`a_narrowed_dimension_selection_still_reports_quality` is the preservation
counterpart and passes both with and without the fix by design: asking for
*some* dimension is still a request to analyze, so quality stays present. Only
an empty request means "assess nothing".

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets --all-features -- -D warnings
cargo test --workspace --all-features
uv run maturin develop --features "python,python-async,async-streaming"
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
uv run pytest python/tests/          # 885 passed, 5 skipped, 1 xfailed
```

## Out of scope

`analyze_query()` has the same defect — it hardcodes `calculate_quality: true`
and forwards only dimensions, so `metrics=["schema"]` is ignored there too.
#494's acceptance criteria named CSV/JSON/JSONL/Parquet/async only, the
database connectors do no pattern detection (so locale has nothing to rank),
and fixing it is a second behaviour change needing its own sqlite-gated tests.
Filed as #536.
