### PR TITLE
fix(database): preserve query column order in profile reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "regex",
  "serde",
  "sqlx",
+ "tempfile",
  "tokio",
  "url",
 ]

--- a/crates/dataprof-db/Cargo.toml
+++ b/crates/dataprof-db/Cargo.toml
@@ -28,3 +28,6 @@ serde = { workspace = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
 url = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/dataprof-db/src/connectors/common.rs
+++ b/crates/dataprof-db/src/connectors/common.rs
@@ -77,7 +77,7 @@ macro_rules! streaming_profile_loop {
         use $crate::streaming::{StreamingProgress, merge_column_batches};
 
         let mut progress = StreamingProgress::new(Some($total_rows as u64));
-        let mut all_batches: Vec<std::collections::HashMap<String, Vec<String>>> = Vec::new();
+        let mut all_batches: Vec<$crate::QueryColumns> = Vec::new();
         let mut offset = 0usize;
 
         loop {
@@ -102,22 +102,18 @@ macro_rules! streaming_profile_loop {
                 &column_names,
                 concat!($db_name, " query result"),
             )?;
-            let mut batch_result: std::collections::HashMap<String, Vec<String>> =
-                std::collections::HashMap::with_capacity(columns.len());
-
-            for col in columns {
-                batch_result.insert(col.name().to_string(), Vec::with_capacity(rows.len()));
-            }
+            // Built from the driver's column list, so the batch carries the
+            // query's column order and values are filed by position.
+            let mut batch_result =
+                $crate::QueryColumns::with_names(column_names.clone(), rows.len());
 
             for row in &rows {
-                for (i, col) in columns.iter().enumerate() {
+                for i in 0..columns.len() {
                     let value: Option<String> = $crate::db_column_to_string!(row, i);
-                    if let Some(column_data) = batch_result.get_mut(col.name()) {
-                        // decode-audit: no-data — None is SQL NULL (or a type
-                        // db_column_to_string documents as unsupported); "" is
-                        // the profiler's textual null.
-                        column_data.push(value.unwrap_or_default());
-                    }
+                    // decode-audit: no-data — None is SQL NULL (or a type
+                    // db_column_to_string documents as unsupported); "" is
+                    // the profiler's textual null.
+                    batch_result.push_value(i, value.unwrap_or_default());
                 }
             }
 
@@ -141,18 +137,18 @@ macro_rules! streaming_profile_loop {
             }
         }
 
-        merge_column_batches(all_batches)
+        Ok(merge_column_batches(all_batches))
     }};
 }
 
-/// Macro to process rows into column-oriented HashMap.
+/// Macro to process rows into column-oriented results, in query column order.
 #[macro_export]
 macro_rules! process_rows_to_columns {
     ($rows:expr) => {{
         use sqlx::{Column, Row};
 
         if $rows.is_empty() {
-            Ok(std::collections::HashMap::new())
+            Ok($crate::QueryColumns::new())
         } else {
             let columns = $rows[0].columns();
             let column_names: Vec<String> = columns
@@ -165,22 +161,17 @@ macro_rules! process_rows_to_columns {
             ) {
                 Err(error) => Err(error),
                 Ok(()) => {
-                    let mut result: std::collections::HashMap<String, Vec<String>> =
-                        std::collections::HashMap::with_capacity(columns.len());
-
-                    for col in columns {
-                        result.insert(col.name().to_string(), Vec::with_capacity($rows.len()));
-                    }
+                    // Built from the driver's column list, so the result carries
+                    // the query's column order and values are filed by position.
+                    let mut result = $crate::QueryColumns::with_names(column_names, $rows.len());
 
                     for row in &$rows {
-                        for (i, col) in columns.iter().enumerate() {
+                        for i in 0..columns.len() {
                             let value: Option<String> = $crate::db_column_to_string!(row, i);
-                            if let Some(column_data) = result.get_mut(col.name()) {
-                                // decode-audit: no-data — None is SQL NULL (or a type
-                                // db_column_to_string documents as unsupported); "" is
-                                // the profiler's textual null.
-                                column_data.push(value.unwrap_or_default());
-                            }
+                            // decode-audit: no-data — None is SQL NULL (or a type
+                            // db_column_to_string documents as unsupported); "" is
+                            // the profiler's textual null.
+                            result.push_value(i, value.unwrap_or_default());
                         }
                     }
 

--- a/crates/dataprof-db/src/connectors/mysql.rs
+++ b/crates/dataprof-db/src/connectors/mysql.rs
@@ -7,11 +7,10 @@ use super::common::{build_count_query, not_connected_error};
 use crate::connection::ConnectionInfo;
 #[cfg(feature = "mysql")]
 use crate::security::validate_sql_identifier;
-use crate::{DataProfilerError, DatabaseConfig, DatabaseConnector};
+use crate::{DataProfilerError, DatabaseConfig, DatabaseConnector, QueryColumns};
 #[cfg(feature = "mysql")]
 use crate::{process_rows_to_columns, streaming_profile_loop};
 use async_trait::async_trait;
-use std::collections::HashMap;
 
 #[cfg(feature = "mysql")]
 use {sqlx::mysql::MySqlPool, sqlx::mysql::MySqlPoolOptions};
@@ -98,10 +97,7 @@ impl DatabaseConnector for MySqlConnector {
     }
 
     #[allow(unused_variables)]
-    async fn profile_query(
-        &mut self,
-        query: &str,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
+    async fn profile_query(&mut self, query: &str) -> Result<QueryColumns, DataProfilerError> {
         #[cfg(feature = "mysql")]
         {
             let pool = self.pool.as_ref().ok_or_else(not_connected_error)?;
@@ -122,7 +118,7 @@ impl DatabaseConnector for MySqlConnector {
         &mut self,
         query: &str,
         batch_size: usize,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
+    ) -> Result<QueryColumns, DataProfilerError> {
         #[cfg(feature = "mysql")]
         {
             let pool = self.pool.as_ref().ok_or_else(not_connected_error)?;

--- a/crates/dataprof-db/src/connectors/postgres.rs
+++ b/crates/dataprof-db/src/connectors/postgres.rs
@@ -7,11 +7,10 @@ use super::common::{build_count_query, not_connected_error};
 use crate::connection::ConnectionInfo;
 #[cfg(feature = "postgres")]
 use crate::security::validate_sql_identifier;
-use crate::{DataProfilerError, DatabaseConfig, DatabaseConnector};
+use crate::{DataProfilerError, DatabaseConfig, DatabaseConnector, QueryColumns};
 #[cfg(feature = "postgres")]
 use crate::{process_rows_to_columns, streaming_profile_loop};
 use async_trait::async_trait;
-use std::collections::HashMap;
 
 #[cfg(feature = "postgres")]
 use {sqlx::postgres::PgPool, sqlx::postgres::PgPoolOptions};
@@ -99,10 +98,7 @@ impl DatabaseConnector for PostgresConnector {
     }
 
     #[allow(unused_variables)]
-    async fn profile_query(
-        &mut self,
-        query: &str,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
+    async fn profile_query(&mut self, query: &str) -> Result<QueryColumns, DataProfilerError> {
         #[cfg(feature = "postgres")]
         {
             let pool = self.pool.as_ref().ok_or_else(not_connected_error)?;
@@ -123,7 +119,7 @@ impl DatabaseConnector for PostgresConnector {
         &mut self,
         query: &str,
         batch_size: usize,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
+    ) -> Result<QueryColumns, DataProfilerError> {
         #[cfg(feature = "postgres")]
         {
             let pool = self.pool.as_ref().ok_or_else(not_connected_error)?;

--- a/crates/dataprof-db/src/connectors/sqlite.rs
+++ b/crates/dataprof-db/src/connectors/sqlite.rs
@@ -7,11 +7,10 @@ use super::common::{build_count_query, not_connected_error};
 use crate::connection::ConnectionInfo;
 #[cfg(feature = "sqlite")]
 use crate::security::validate_sql_identifier;
-use crate::{DataProfilerError, DatabaseConfig, DatabaseConnector};
+use crate::{DataProfilerError, DatabaseConfig, DatabaseConnector, QueryColumns};
 #[cfg(feature = "sqlite")]
 use crate::{process_rows_to_columns, streaming_profile_loop};
 use async_trait::async_trait;
-use std::collections::HashMap;
 
 #[cfg(feature = "sqlite")]
 use {sqlx::sqlite::SqlitePool, sqlx::sqlite::SqlitePoolOptions};
@@ -117,10 +116,7 @@ impl DatabaseConnector for SqliteConnector {
     }
 
     #[allow(unused_variables)]
-    async fn profile_query(
-        &mut self,
-        query: &str,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
+    async fn profile_query(&mut self, query: &str) -> Result<QueryColumns, DataProfilerError> {
         #[cfg(feature = "sqlite")]
         {
             let pool = self.pool.as_ref().ok_or_else(not_connected_error)?;
@@ -141,7 +137,7 @@ impl DatabaseConnector for SqliteConnector {
         &mut self,
         query: &str,
         batch_size: usize,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
+    ) -> Result<QueryColumns, DataProfilerError> {
         #[cfg(feature = "sqlite")]
         {
             let pool = self.pool.as_ref().ok_or_else(not_connected_error)?;

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -10,10 +10,10 @@ use dataprof_core::{
 };
 use dataprof_metrics::analyze_column_with_analysis_options;
 use dataprof_runtime::{ProfileReport, ReportAssembler};
-use std::collections::HashMap;
 
 pub mod connection;
 pub mod connectors;
+pub mod query_columns;
 pub mod retry;
 pub mod sampling;
 pub mod security;
@@ -21,6 +21,7 @@ pub mod streaming;
 
 pub use connection::*;
 pub use connectors::*;
+pub use query_columns::QueryColumns;
 pub use retry::*;
 pub use sampling::*;
 pub use security::*;
@@ -63,17 +64,14 @@ pub trait DatabaseConnector: Send + Sync {
     async fn disconnect(&mut self) -> Result<(), DataProfilerError>;
 
     /// Execute a query and get column data for profiling
-    async fn profile_query(
-        &mut self,
-        query: &str,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError>;
+    async fn profile_query(&mut self, query: &str) -> Result<QueryColumns, DataProfilerError>;
 
     /// Execute a query with streaming for large result sets
     async fn profile_query_streaming(
         &mut self,
         query: &str,
         batch_size: usize,
-    ) -> Result<HashMap<String, Vec<String>>, DataProfilerError>;
+    ) -> Result<QueryColumns, DataProfilerError>;
 
     /// Get table schema information
     async fn get_table_schema(
@@ -290,15 +288,17 @@ pub async fn analyze_database_with_options(
         .build());
     }
 
-    let mut column_profiles = Vec::new();
     // decode-audit: no-data — the empty-columns case returned early above, so
     // this default is only a guard; every column vec has the same length.
-    let actual_rows_processed = columns.values().next().map(|v| v.len()).unwrap_or(0);
+    let actual_rows_processed = columns.row_count();
 
-    for (name, data) in &columns {
-        let profile = analyze_column_with_analysis_options(name, data, options);
-        column_profiles.push(profile);
-    }
+    // `columns` keeps the query's column order, so the report reports columns in
+    // the order they were selected — the same source-order contract CSV, Parquet
+    // and JSON honour.
+    let column_profiles: Vec<_> = columns
+        .iter()
+        .map(|(name, data)| analyze_column_with_analysis_options(name, data, options))
+        .collect();
 
     let scan_time_ms = start.elapsed().as_millis();
     let sampling_ratio = sample_info.map(|s| s.sampling_ratio).unwrap_or(1.0);
@@ -322,7 +322,9 @@ pub async fn analyze_database_with_options(
         execution,
     )
     .columns(column_profiles)
-    .with_quality_data(columns)
+    // Quality metrics look every column up by name and never iterate for
+    // presentation, so dropping the order here costs nothing.
+    .with_quality_data(columns.into_map())
     .with_analysis_options(options)
     .build())
 }

--- a/crates/dataprof-db/src/query_columns.rs
+++ b/crates/dataprof-db/src/query_columns.rs
@@ -1,0 +1,236 @@
+//! Column-oriented query results that keep the query's column order.
+//!
+//! The connectors used to hand back `HashMap<String, Vec<String>>`, which has no
+//! order at all: `SELECT a, b FROM t` could profile as `["b", "a"]`, and hash
+//! iteration is not even stable between processes, so two runs of the same query
+//! could disagree. Every other input path reports columns in source order — CSV
+//! header order, Parquet schema order, JSON first-seen field order — so the
+//! database path was the one place where a format conversion reshuffled a
+//! report.
+//!
+//! [`QueryColumns`] is that map with the order kept: a vector of named columns,
+//! built in the order the driver reports them.
+
+use std::collections::HashMap;
+use std::ops::Index;
+
+/// A query result as columns, in the order the query selected them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QueryColumns {
+    columns: Vec<(String, Vec<String>)>,
+}
+
+impl QueryColumns {
+    /// An empty result with no columns.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build empty columns for `names`, in order, each sized for `row_capacity`
+    /// values.
+    ///
+    /// Callers then fill them positionally with [`push_value`](Self::push_value),
+    /// which is what ties a value to the column the driver read it from.
+    pub fn with_names<I, S>(names: I, row_capacity: usize) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            columns: names
+                .into_iter()
+                .map(|name| (name.into(), Vec::with_capacity(row_capacity)))
+                .collect(),
+        }
+    }
+
+    /// Append a value to the column at `index`.
+    ///
+    /// Out-of-range indices are ignored; callers iterate the same column list
+    /// they built the result from, so there is no in-range/out-of-range decision
+    /// for them to get wrong.
+    pub fn push_value(&mut self, index: usize, value: String) {
+        if let Some((_, data)) = self.columns.get_mut(index) {
+            data.push(value);
+        }
+    }
+
+    /// Number of columns.
+    pub fn len(&self) -> usize {
+        self.columns.len()
+    }
+
+    /// Whether the result has no columns.
+    pub fn is_empty(&self) -> bool {
+        self.columns.is_empty()
+    }
+
+    /// Rows in the result, read off the first column.
+    pub fn row_count(&self) -> usize {
+        self.columns.first().map_or(0, |(_, data)| data.len())
+    }
+
+    /// Column names, in query order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.columns.iter().map(|(name, _)| name.as_str())
+    }
+
+    /// Column data, in query order.
+    pub fn values(&self) -> impl Iterator<Item = &Vec<String>> {
+        self.columns.iter().map(|(_, data)| data)
+    }
+
+    /// Name/data pairs, in query order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &Vec<String>)> {
+        self.columns
+            .iter()
+            .map(|(name, data)| (name.as_str(), data))
+    }
+
+    /// Mutable column data, in query order.
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut Vec<String>> {
+        self.columns.iter_mut().map(|(_, data)| data)
+    }
+
+    /// The data for `name`, if the result has such a column.
+    pub fn get(&self, name: &str) -> Option<&Vec<String>> {
+        self.columns
+            .iter()
+            .find(|(column, _)| column == name)
+            .map(|(_, data)| data)
+    }
+
+    /// Drop the order and hand back a plain map.
+    ///
+    /// For consumers keyed purely by name — quality metrics look every column up
+    /// by name and never iterate for presentation.
+    pub fn into_map(self) -> HashMap<String, Vec<String>> {
+        self.columns.into_iter().collect()
+    }
+
+    /// Append a batch's values to the matching columns.
+    ///
+    /// Columns are matched by name so a driver that reorders between batches
+    /// cannot interleave data; a column seen for the first time in a later batch
+    /// is appended at the end, the same first-seen rule the JSON path uses for
+    /// fields that only appear in later records.
+    fn extend_from(&mut self, batch: QueryColumns) {
+        for (name, data) in batch.columns {
+            match self.columns.iter_mut().find(|(column, _)| *column == name) {
+                Some((_, existing)) => existing.extend(data),
+                None => self.columns.push((name, data)),
+            }
+        }
+    }
+}
+
+impl Index<&str> for QueryColumns {
+    type Output = Vec<String>;
+
+    fn index(&self, name: &str) -> &Self::Output {
+        self.get(name)
+            .unwrap_or_else(|| panic!("no column named {name} in query result"))
+    }
+}
+
+impl FromIterator<(String, Vec<String>)> for QueryColumns {
+    fn from_iter<I: IntoIterator<Item = (String, Vec<String>)>>(iter: I) -> Self {
+        Self {
+            columns: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl IntoIterator for QueryColumns {
+    type Item = (String, Vec<String>);
+    type IntoIter = std::vec::IntoIter<(String, Vec<String>)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.columns.into_iter()
+    }
+}
+
+/// Merge batches of a streamed query into one result.
+///
+/// The first batch fixes the column order; later batches append to it.
+pub fn merge_column_batches(batches: Vec<QueryColumns>) -> QueryColumns {
+    let mut merged = QueryColumns::new();
+    for batch in batches {
+        merged.extend_from(batch);
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn columns(pairs: &[(&str, &[&str])]) -> QueryColumns {
+        pairs
+            .iter()
+            .map(|(name, data)| {
+                (
+                    (*name).to_string(),
+                    data.iter().map(|v| (*v).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn names_come_back_in_the_order_they_went_in() {
+        // Deliberately non-alphabetical: sorting or hashing this yields a
+        // different order, so a regression is visible rather than accidental.
+        let result = QueryColumns::with_names(["id", "amount", "active"], 0);
+        assert_eq!(
+            result.names().collect::<Vec<_>>(),
+            ["id", "amount", "active"]
+        );
+    }
+
+    #[test]
+    fn values_land_in_the_column_they_were_pushed_to() {
+        let mut result = QueryColumns::with_names(["b", "a"], 2);
+        result.push_value(0, "b1".to_string());
+        result.push_value(1, "a1".to_string());
+        result.push_value(0, "b2".to_string());
+        result.push_value(1, "a2".to_string());
+
+        assert_eq!(result["b"], vec!["b1", "b2"]);
+        assert_eq!(result["a"], vec!["a1", "a2"]);
+        assert_eq!(result.row_count(), 2);
+    }
+
+    #[test]
+    fn merging_keeps_the_first_batch_order() {
+        let merged = merge_column_batches(vec![
+            columns(&[("id", &["1"]), ("cap", &["20121"])]),
+            columns(&[("id", &["2"]), ("cap", &["00184"])]),
+        ]);
+
+        assert_eq!(merged.names().collect::<Vec<_>>(), ["id", "cap"]);
+        assert_eq!(merged["id"], vec!["1", "2"]);
+        assert_eq!(merged["cap"], vec!["20121", "00184"]);
+    }
+
+    #[test]
+    fn merging_matches_columns_by_name_not_position() {
+        // A driver that hands back a later batch in another order must not have
+        // its values interleaved into the wrong column.
+        let merged = merge_column_batches(vec![
+            columns(&[("id", &["1"]), ("cap", &["20121"])]),
+            columns(&[("cap", &["00184"]), ("id", &["2"])]),
+        ]);
+
+        assert_eq!(merged.names().collect::<Vec<_>>(), ["id", "cap"]);
+        assert_eq!(merged["id"], vec!["1", "2"]);
+        assert_eq!(merged["cap"], vec!["20121", "00184"]);
+    }
+
+    #[test]
+    fn merging_nothing_yields_nothing() {
+        let merged = merge_column_batches(Vec::new());
+        assert!(merged.is_empty());
+        assert_eq!(merged.row_count(), 0);
+    }
+}

--- a/crates/dataprof-db/src/streaming.rs
+++ b/crates/dataprof-db/src/streaming.rs
@@ -1,7 +1,12 @@
 //! Streaming utilities for processing large database result sets
 
 use crate::DataProfilerError;
-use std::collections::HashMap;
+use crate::query_columns::QueryColumns;
+
+/// Merging lives with [`QueryColumns`], which owns the ordering rule; re-exported
+/// here because the streaming macros have always reached for it through this
+/// module.
+pub use crate::query_columns::merge_column_batches;
 
 /// Configuration for streaming database results
 #[derive(Debug, Clone)]
@@ -21,27 +26,8 @@ impl Default for StreamingConfig {
     }
 }
 
-/// Utility to merge multiple batches of column data
-pub fn merge_column_batches(
-    batches: Vec<HashMap<String, Vec<String>>>,
-) -> Result<HashMap<String, Vec<String>>, DataProfilerError> {
-    if batches.is_empty() {
-        return Ok(HashMap::new());
-    }
-
-    let mut merged: HashMap<String, Vec<String>> = HashMap::new();
-
-    for batch in batches {
-        for (column_name, column_data) in batch {
-            merged.entry(column_name).or_default().extend(column_data);
-        }
-    }
-
-    Ok(merged)
-}
-
 /// Calculate memory usage of column data (rough estimate)
-pub fn estimate_memory_usage(columns: &HashMap<String, Vec<String>>) -> usize {
+pub fn estimate_memory_usage(columns: &QueryColumns) -> usize {
     columns
         .iter()
         .map(|(name, data)| name.len() + data.iter().map(|s| s.len()).sum::<usize>())
@@ -50,10 +36,10 @@ pub fn estimate_memory_usage(columns: &HashMap<String, Vec<String>>) -> usize {
 
 /// Sample large datasets to fit within memory constraints
 pub fn apply_sampling_if_needed(
-    mut columns: HashMap<String, Vec<String>>,
+    mut columns: QueryColumns,
     max_memory_mb: usize,
     sampling_ratio: f64,
-) -> Result<(HashMap<String, Vec<String>>, bool), DataProfilerError> {
+) -> Result<(QueryColumns, bool), DataProfilerError> {
     let memory_usage_bytes = estimate_memory_usage(&columns);
     let memory_usage_mb = memory_usage_bytes / 1_048_576;
 
@@ -61,13 +47,13 @@ pub fn apply_sampling_if_needed(
         return Ok((columns, false));
     }
 
-    // decode-audit: no-data — an empty column map has zero rows; the sampling
+    // decode-audit: no-data — an empty column set has zero rows; the sampling
     // below then returns an empty result rather than fabricating data.
-    let total_rows = columns.values().next().map(|v| v.len()).unwrap_or(0);
+    let total_rows = columns.row_count();
     let target_rows = (total_rows as f64 * sampling_ratio) as usize;
 
     if target_rows == 0 {
-        return Ok((HashMap::new(), true));
+        return Ok((QueryColumns::new(), true));
     }
 
     let step = total_rows / target_rows;
@@ -152,22 +138,27 @@ mod tests {
 
     #[test]
     fn test_merge_column_batches() {
-        let batch1 = {
-            let mut map = HashMap::new();
-            map.insert("col1".to_string(), vec!["a".to_string(), "b".to_string()]);
-            map.insert("col2".to_string(), vec!["1".to_string(), "2".to_string()]);
-            map
+        let batch = |a: [&str; 2], b: [&str; 2]| -> QueryColumns {
+            [
+                (
+                    "col1".to_string(),
+                    a.iter().map(|v| v.to_string()).collect(),
+                ),
+                (
+                    "col2".to_string(),
+                    b.iter().map(|v| v.to_string()).collect(),
+                ),
+            ]
+            .into_iter()
+            .collect()
         };
 
-        let batch2 = {
-            let mut map = HashMap::new();
-            map.insert("col1".to_string(), vec!["c".to_string(), "d".to_string()]);
-            map.insert("col2".to_string(), vec!["3".to_string(), "4".to_string()]);
-            map
-        };
+        let merged = merge_column_batches(vec![
+            batch(["a", "b"], ["1", "2"]),
+            batch(["c", "d"], ["3", "4"]),
+        ]);
 
-        let merged = merge_column_batches(vec![batch1, batch2]).expect("Failed to merge batches");
-
+        assert_eq!(merged.names().collect::<Vec<_>>(), ["col1", "col2"]);
         assert_eq!(
             merged.get("col1").expect("col1 not found"),
             &vec!["a", "b", "c", "d"]
@@ -180,11 +171,12 @@ mod tests {
 
     #[test]
     fn test_memory_estimation() {
-        let mut columns = HashMap::new();
-        columns.insert(
+        let columns: QueryColumns = [(
             "test".to_string(),
             vec!["hello".to_string(), "world".to_string()],
-        );
+        )]
+        .into_iter()
+        .collect();
 
         let memory = estimate_memory_usage(&columns);
         assert_eq!(memory, 14);

--- a/crates/dataprof-db/tests/column_decoding.rs
+++ b/crates/dataprof-db/tests/column_decoding.rs
@@ -9,8 +9,8 @@
 
 use sqlx::sqlite::SqlitePoolOptions;
 
-/// Read a query's rows into the column-oriented map the profiler consumes.
-async fn columns_of(query: &str, ddl: &[&str]) -> std::collections::HashMap<String, Vec<String>> {
+/// Read a query's rows into the column-oriented result the profiler consumes.
+async fn columns_of(query: &str, ddl: &[&str]) -> dataprof_db::QueryColumns {
     columns_result_of(query, ddl)
         .await
         .expect("unique query columns")
@@ -19,7 +19,7 @@ async fn columns_of(query: &str, ddl: &[&str]) -> std::collections::HashMap<Stri
 async fn columns_result_of(
     query: &str,
     ddl: &[&str],
-) -> Result<std::collections::HashMap<String, Vec<String>>, dataprof_core::DataProfilerError> {
+) -> Result<dataprof_db::QueryColumns, dataprof_core::DataProfilerError> {
     let pool = SqlitePoolOptions::new()
         .connect("sqlite::memory:")
         .await

--- a/crates/dataprof-db/tests/column_order.rs
+++ b/crates/dataprof-db/tests/column_order.rs
@@ -1,0 +1,153 @@
+//! Query results keep the query's column order (#496).
+//!
+//! The connectors used to return `HashMap<String, Vec<String>>`, so
+//! `SELECT a, b FROM t` could come back as `["b", "a"]` — and because hash
+//! iteration is not stable between processes, two runs of the same query could
+//! disagree. These tests pin the order at the connector boundary, where it is
+//! established, rather than only at the report.
+
+#![cfg(feature = "sqlite")]
+
+use dataprof_db::{DatabaseConfig, DatabaseConnector, QueryColumns, create_connector};
+use sqlx::sqlite::SqlitePoolOptions;
+
+/// Four columns whose declaration order differs from alphabetical order in
+/// every position, so a sorted or hashed result is visibly wrong rather than
+/// accidentally right.
+const DECLARED_ORDER: [&str; 4] = ["id", "amount", "active", "date"];
+
+/// Create a SQLite file with a table in [`DECLARED_ORDER`] and `rows` rows.
+async fn fixture(rows: usize) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("order.db");
+    std::fs::File::create(&db_path).unwrap();
+    let db_path = db_path.display().to_string();
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&format!("sqlite://{db_path}"))
+        .await
+        .unwrap();
+    sqlx::query("CREATE TABLE t (id INTEGER, amount REAL, active INTEGER, date TEXT)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    for i in 0..rows {
+        sqlx::query("INSERT INTO t VALUES (?, ?, ?, ?)")
+            .bind(i as i64)
+            .bind(i as f64 + 0.5)
+            .bind(i64::from(i % 2 == 0))
+            .bind("2026-08-06")
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    pool.close().await;
+
+    (dir, db_path)
+}
+
+async fn connect(db_path: &str) -> Box<dyn DatabaseConnector> {
+    let mut connector = create_connector(DatabaseConfig {
+        connection_string: db_path.to_string(),
+        load_credentials_from_env: false,
+        ..Default::default()
+    })
+    .unwrap();
+    connector.connect().await.unwrap();
+    connector
+}
+
+fn names(columns: &QueryColumns) -> Vec<&str> {
+    columns.names().collect()
+}
+
+#[tokio::test]
+async fn profile_query_reports_select_list_order() {
+    let (_dir, db_path) = fixture(4).await;
+    let mut connector = connect(&db_path).await;
+
+    let columns = connector.profile_query("SELECT * FROM t").await.unwrap();
+    assert_eq!(names(&columns), DECLARED_ORDER);
+
+    connector.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn an_explicit_select_list_wins_over_the_table_declaration() {
+    // The query asked for this order; the table's declaration order is not the
+    // answer here.
+    let (_dir, db_path) = fixture(4).await;
+    let mut connector = connect(&db_path).await;
+
+    let columns = connector
+        .profile_query("SELECT date, id, active, amount FROM t")
+        .await
+        .unwrap();
+    assert_eq!(names(&columns), ["date", "id", "active", "amount"]);
+
+    connector.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn streaming_batches_preserve_the_schema_order() {
+    // Three batches over four rows, so the merge path is exercised rather than
+    // a single batch that would pass trivially.
+    let (_dir, db_path) = fixture(4).await;
+    let mut connector = connect(&db_path).await;
+
+    let columns = connector
+        .profile_query_streaming("SELECT date, id, active, amount FROM t", 2)
+        .await
+        .unwrap();
+
+    assert_eq!(names(&columns), ["date", "id", "active", "amount"]);
+    assert_eq!(columns.row_count(), 4, "every row survives the merge");
+    assert_eq!(columns["id"], ["0", "1", "2", "3"]);
+
+    connector.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn column_values_stay_with_their_column() {
+    // Order is only worth having if the data under each name is still right:
+    // a positional fill that drifted would keep the names and corrupt the values.
+    let (_dir, db_path) = fixture(3).await;
+    let mut connector = connect(&db_path).await;
+
+    let columns = connector
+        .profile_query("SELECT amount, id FROM t ORDER BY id")
+        .await
+        .unwrap();
+
+    assert_eq!(names(&columns), ["amount", "id"]);
+    assert_eq!(columns["id"], ["0", "1", "2"]);
+    assert_eq!(columns["amount"], ["0.5", "1.5", "2.5"]);
+
+    connector.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn the_order_is_the_same_on_every_run() {
+    // Hash iteration order varies per process and could also vary per map
+    // instance; profiling the same query repeatedly must not.
+    let (_dir, db_path) = fixture(2).await;
+    let mut connector = connect(&db_path).await;
+
+    let mut seen = Vec::new();
+    for _ in 0..8 {
+        let columns = connector
+            .profile_query("SELECT date, id, active, amount FROM t")
+            .await
+            .unwrap();
+        seen.push(names(&columns).join(","));
+    }
+    seen.dedup();
+    assert_eq!(
+        seen,
+        ["date,id,active,amount"],
+        "repeated runs disagreed on column order"
+    );
+
+    connector.disconnect().await.unwrap();
+}

--- a/python/tests/test_column_order.py
+++ b/python/tests/test_column_order.py
@@ -99,3 +99,69 @@ def test_to_dict_export_keeps_report_column_order(tmp_path):
     report = dataprof.profile(_write(tmp_path, "json"))
     exported = [column["name"] for column in report.to_dict()["columns"]]
     assert exported == SOURCE_ORDER
+
+
+# ---------------------------------------------------------------------------
+# Database (#496)
+# ---------------------------------------------------------------------------
+#
+# Query results used to come back through a Rust `HashMap`, so a query reported
+# its columns in hash order — the one input path where a format conversion
+# reshuffled the report. Hash iteration is not stable between processes either,
+# so the order was not even consistently wrong.
+
+_HAS_DATABASE = dataprof.capabilities().database
+requires_database = pytest.mark.skipif(
+    not _HAS_DATABASE,
+    reason="Database support not compiled. Build with --features "
+    "'python,python-async,database,sqlite'.",
+)
+
+
+@pytest.fixture()
+def sqlite_db(tmp_path):
+    import sqlite3
+
+    db_path = tmp_path / "column_order.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE t (id INTEGER, amount REAL, active INTEGER, date TEXT)")
+    conn.executemany(
+        "INSERT INTO t VALUES (?, ?, ?, ?)",
+        [(row["id"], row["amount"], int(row["active"]), row["date"]) for row in ROWS],
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@requires_database
+def test_database_agrees_with_the_file_formats_on_column_order(sqlite_db, tmp_path):
+    report = asyncio.run(dataprof.analyze_database_async(str(sqlite_db), "SELECT * FROM t"))
+
+    assert list(report) == SOURCE_ORDER
+    assert list(report) == list(dataprof.profile(_write(tmp_path, "csv")))
+
+
+@requires_database
+def test_a_query_reports_its_own_select_list_order(sqlite_db):
+    report = asyncio.run(
+        dataprof.analyze_database_async(str(sqlite_db), "SELECT date, id, active, amount FROM t")
+    )
+    assert list(report) == ["date", "id", "active", "amount"]
+
+
+@requires_database
+def test_database_column_order_is_stable_across_runs(sqlite_db):
+    # The report is what a user reads; two profiles of the same query must not
+    # disagree.
+    orders = {
+        tuple(
+            asyncio.run(
+                dataprof.analyze_database_async(
+                    str(sqlite_db), "SELECT date, id, active, amount FROM t"
+                )
+            )
+        )
+        for _ in range(5)
+    }
+    assert len(orders) == 1, f"repeated runs disagreed on column order: {orders}"

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -108,10 +108,9 @@ def test_schema_pack_omits_patterns_and_quality(sqlite_db) -> None:
     assert report.quality_score is None, "absent quality has no score"
     for column in report.profiles:
         assert column.patterns is None, f"{column.name} kept patterns"
-    # Schema itself survives: a narrowed profile, not an empty one. Compared as
-    # a set because the database path does not preserve query column order —
-    # that is #496, and asserting on it here would couple the two.
-    assert sorted(c.name for c in report.profiles) == ["amount", "cap", "id"]
+    # Schema itself survives: a narrowed profile, not an empty one. Order is
+    # query order since #496; `test_column_order.py` is what pins that.
+    assert [c.name for c in report.profiles] == ["id", "cap", "amount"]
 
 
 def test_empty_quality_dimensions_means_not_analyzed(sqlite_db) -> None:

--- a/tests/column_order.rs
+++ b/tests/column_order.rs
@@ -207,3 +207,78 @@ mod async_transport {
         assert_eq!(names, SOURCE_ORDER);
     }
 }
+
+#[cfg(feature = "sqlite")]
+mod database {
+    use super::*;
+
+    use dataprof::{DatabaseConfig, Profiler};
+
+    /// A SQLite table whose columns are declared in [`SOURCE_ORDER`].
+    async fn fixture() -> (tempfile::TempDir, String) {
+        use sqlx::sqlite::SqlitePoolOptions;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("column_order.db");
+        std::fs::File::create(&db_path).unwrap();
+        let db_path = db_path.display().to_string();
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&format!("sqlite://{db_path}"))
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER, amount REAL, active INTEGER, date TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        for (id, amount, active) in [(1, 12.5, 1), (2, 7.25, 0)] {
+            sqlx::query("INSERT INTO t VALUES (?, ?, ?, ?)")
+                .bind(id as i64)
+                .bind(amount)
+                .bind(active as i64)
+                .bind("2026-07-23")
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+        pool.close().await;
+
+        (dir, db_path)
+    }
+
+    fn profiler(db_path: &str) -> Profiler {
+        Profiler::new().database(DatabaseConfig {
+            connection_string: db_path.to_string(),
+            load_credentials_from_env: false,
+            ..Default::default()
+        })
+    }
+
+    /// Database results used to come back through a `HashMap`, so a query
+    /// reported its columns in hash order — the one input path where a format
+    /// conversion reshuffled the report (#496).
+    #[tokio::test]
+    async fn database_agrees_with_the_file_formats_on_column_order() {
+        let (_dir, db_path) = fixture().await;
+
+        let report = profiler(&db_path)
+            .analyze_query("SELECT * FROM t")
+            .await
+            .unwrap();
+
+        assert_eq!(column_names(&report), SOURCE_ORDER);
+    }
+
+    #[tokio::test]
+    async fn a_query_reports_its_own_select_list_order() {
+        let (_dir, db_path) = fixture().await;
+
+        let report = profiler(&db_path)
+            .analyze_query("SELECT date, id, active, amount FROM t")
+            .await
+            .unwrap();
+
+        assert_eq!(column_names(&report), ["date", "id", "active", "amount"]);
+    }
+}


### PR DESCRIPTION
Closes #496. This is the last of the three 0.11.0 database/parity items
(#537, #538, this one).

## The problem

Database results travelled as `HashMap<String, Vec<String>>` from the connector
trait all the way to report assembly. A `HashMap` has no order, so
`SELECT a, b FROM t` could profile as `["b", "a"]` — and because hash iteration
is not stable between processes, two runs of the same query could disagree.

Every other input path reports columns in source order: CSV header order,
Parquet schema order, JSON first-seen field order (#465). The database path was
the one place where a format conversion reshuffled a report.

The scramble is real and varies per run. Against the unfixed code the two
report-level tests produced *different* wrong orders:

```
database_agrees_with_the_file_formats_on_column_order
  left: ["amount", "date", "active", "id"]   right: ["id", "amount", "active", "date"]

a_query_reports_its_own_select_list_order
  left: ["amount", "active", "id", "date"]   right: ["date", "id", "active", "amount"]
```

## The fix

`QueryColumns` (new, `dataprof-db`) replaces the map with a vector of named
columns built from the driver's column list, so the order is the query's.

- Values are filed **by position** (`push_value(index, value)`) rather than
  looked up by name per cell, which also drops a `get_mut` per value.
- `DatabaseConnector::{profile_query, profile_query_streaming}`, both row
  macros, and batch merging all carry it.
- Merging keeps the first batch's order and matches later batches **by name**,
  so a driver that reorders between batches cannot interleave values into the
  wrong column. A column first seen in a later batch is appended — the same
  first-seen rule the JSON path uses.
- Quality metrics still take a plain map via `into_map()`: they look columns up
  by name and never iterate for presentation, so dropping the order there costs
  nothing.
- Duplicate-name rejection stays exactly where it was, before any name-keyed
  state is built.

## Verification

Three layers, because order can be established correctly and lost later:

- **`crates/dataprof-db/tests/column_order.rs`** (new, 5 tests) — the connector
  boundary: select-list order, an explicit list overriding the table
  declaration, streaming across three batches, values staying with their column,
  and stability across repeated runs.
- **`tests/column_order.rs`** — a `database` module beside the existing
  CSV/JSON/JSONL/Parquet/async cases, asserting the query result matches
  `SOURCE_ORDER` and its own select-list order. Both **fail against the unfixed
  code** with the scrambles quoted above.
- **`python/tests/test_column_order.py`** — the same at the report level, plus a
  stability check over five runs.

`crates/dataprof-db/src/query_columns.rs` carries unit tests for the ordering
and merge rules, including that merging matches by name rather than position.

Being precise about what discriminates: the connector-level and unit tests
cannot fail against the unfixed tree, because `QueryColumns` does not exist
there. The **report-level** tests are the ones that reproduce the bug on
unmodified code; the others pin the mechanism underneath.

`python/tests/test_database_option_parity.py` gets its assertion tightened back
to exact order — I had loosened it to a sorted set in #538 precisely because of
this bug.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets --all-features -- -D warnings
cargo test --workspace --all-features           # 39 suites, 827 tests
cargo test -p dataprof-db --features sqlite
uv run maturin develop --features "python,python-async,async-streaming,database,sqlite"
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
uv run pytest python/tests/                     # 912 passed, 4 skipped, 1 xfailed
```

## API note

`DatabaseConnector::profile_query` and `profile_query_streaming` now return
`QueryColumns` instead of `HashMap<String, Vec<String>>` — a breaking change for
anyone implementing the trait or calling those methods directly. `QueryColumns`
supports `Index<&str>`, `get`, `len`, `values`, and `iter`, so most call sites
need no change beyond the type name; `crates/dataprof-db/tests/column_decoding.rs`
needed only its signature updated. `tempfile` is added as a `dataprof-db`
dev-dependency for the new connector tests.
