### PR TITLE
fix(json): define JSONL as one record per physical line on every transport

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -63,6 +63,16 @@ fn peek_non_whitespace<R: std::io::BufRead>(
     }
 }
 
+/// Build a strict-mode error for a standard JSON document that is not exactly
+/// one value. Mirrors `dataprof_json::json_document_error`.
+fn json_document_error(err: &serde_json::Error) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!(
+            "malformed JSON document: {err}. A JSON source must hold exactly one              array or object; for one record per line use format=\"jsonl\""
+        ),
+    }
+}
+
 fn malformed_json_array_error(message: &str) -> DataProfilerError {
     DataProfilerError::JsonParsingError {
         message: format!("malformed JSON array: {message}"),
@@ -82,6 +92,19 @@ enum JsonRecord {
     NonObject(&'static str),
     /// The bytes are not valid JSON.
     Malformed(serde_json::Error),
+}
+
+/// Parse one JSONL line as exactly one JSON value.
+///
+/// `serde_json::from_str` requires the value to fill the whole input, so a line
+/// carrying two adjacent or space-separated values is a malformed record rather
+/// than two clean ones. Mirrors `dataprof_json::read_jsonl_line`.
+fn read_jsonl_line(line: &str) -> JsonRecord {
+    match serde_json::from_str::<serde_json::Value>(line.trim()) {
+        Ok(serde_json::Value::Object(obj)) => JsonRecord::Object(obj),
+        Ok(value) => JsonRecord::NonObject(json_value_kind(&value)),
+        Err(err) => JsonRecord::Malformed(err),
+    }
 }
 
 /// Read one JSON value and leave the reader positioned immediately after it.
@@ -732,33 +755,36 @@ impl AsyncStreamingProfiler {
 
         match format {
             FileFormat::Jsonl => {
-                // True streaming: deserialize one record at a time so a malformed
-                // record can be recovered from (skip to next line) or reported,
-                // matching the sync `scan_json_from_reader` contract.
+                // True streaming, one physical line at a time: JSONL is
+                // line-delimited, so a line is exactly one record and a record
+                // never spans lines. This is the same grammar
+                // `dataprof_json::scan_json_from_reader` applies, which is what
+                // keeps a payload profiling identically over either transport.
+                let mut line = String::new();
+                // Counts every physical line, blank ones included, so a
+                // diagnostic points at the line the user would open.
+                let mut line_number = 0usize;
                 loop {
-                    // Distinguish clean exhaustion from an incomplete trailing
-                    // value. serde reports both as `Category::Eof`, but only an
-                    // empty/whitespace-only remainder is a clean end of stream.
-                    let first = loop {
-                        let whitespace_only_len = {
-                            let buf = buf_reader.fill_buf().map_err(DataProfilerError::from)?;
-                            if buf.is_empty() {
-                                break None;
-                            }
-                            match buf.iter().find(|byte| !byte.is_ascii_whitespace()) {
-                                // Leave a mixed whitespace/value buffer untouched
-                                // so serde retains its line and column context.
-                                Some(&byte) => break Some(byte),
-                                None => buf.len(),
-                            }
-                        };
-                        buf_reader.consume(whitespace_only_len);
+                    // Blank lines are separators, not records.
+                    let found = loop {
+                        line.clear();
+                        let read = buf_reader
+                            .read_line(&mut line)
+                            .map_err(DataProfilerError::from)?;
+                        if read == 0 {
+                            break false;
+                        }
+                        line_number += 1;
+                        if !line.trim().is_empty() {
+                            break true;
+                        }
                     };
-                    let Some(first) = first else {
+                    if !found {
                         break;
-                    };
+                    }
+                    bytes_in_chunk += line.len() as u64;
 
-                    match read_json_record(&mut buf_reader, first)? {
+                    match read_jsonl_line(&line) {
                         JsonRecord::Object(obj) => {
                             let row = process_object(
                                 &obj,
@@ -796,32 +822,72 @@ impl AsyncStreamingProfiler {
                         }
                         JsonRecord::Malformed(e) => {
                             if error_policy == JsonErrorPolicy::Strict {
+                                // Each line is parsed on its own, so the
+                                // decoder's own line number is always 1 and
+                                // would mislead; its column is within the line
+                                // and so is also the column in the source.
                                 return Err(DataProfilerError::JsonParsingError {
-                                    message: format!("malformed JSON record: {e}"),
+                                    message: format!(
+                                        "malformed JSON record on line {line_number}, column {}:                                          a JSONL record must be one complete JSON value on one line",
+                                        e.column()
+                                    ),
                                 });
                             }
+                            // The offending line has already been consumed in
+                            // full, so the next read starts at the next record.
                             malformed_records += 1;
-                            if e.classify() == serde_json::error::Category::Eof {
-                                break;
-                            }
-                            // Recover by discarding the rest of the offending line.
-                            let mut discard = Vec::new();
-                            buf_reader
-                                .read_until(b'\n', &mut discard)
-                                .map_err(DataProfilerError::from)?;
                         }
                     }
                 }
             }
-            _ => {
-                // JSON array: stream elements efficiently
+            _ => 'document: {
+                // A standard JSON document takes either of the two shapes that
+                // carry records. An array streams element by element; a single
+                // object is one record and is read whole, which is why it may be
+                // pretty-printed across lines.
                 let (opening, whitespace) = peek_non_whitespace(&mut buf_reader)?;
                 bytes_in_chunk += whitespace as u64;
                 if opening != Some(b'[') {
-                    return Err(DataProfilerError::JsonParsingError {
-                        message: "Expected JSON array (starts with '[') but input does not match"
-                            .to_string(),
-                    });
+                    use std::io::Read as _;
+                    let mut text = String::new();
+                    buf_reader
+                        .read_to_string(&mut text)
+                        .map_err(DataProfilerError::from)?;
+                    bytes_in_chunk += text.len() as u64;
+
+                    if !text.trim().is_empty() {
+                        match serde_json::from_str::<serde_json::Value>(text.trim()) {
+                            Ok(serde_json::Value::Object(obj)) => {
+                                let row = process_object(
+                                    &obj,
+                                    &mut known_columns,
+                                    &mut known_columns_set,
+                                    headers_sent,
+                                );
+                                current_chunk.push(row);
+                                emitted_records += 1;
+                            }
+                            Ok(value) => {
+                                if error_policy == JsonErrorPolicy::Strict {
+                                    return Err(non_object_record_error(
+                                        json_value_kind(&value),
+                                        1,
+                                    ));
+                                }
+                                malformed_records += 1;
+                            }
+                            Err(e) => {
+                                if error_policy == JsonErrorPolicy::Strict {
+                                    return Err(json_document_error(&e));
+                                }
+                                malformed_records += 1;
+                            }
+                        }
+                    }
+
+                    // Fall out to the shared tail so the "nothing profileable"
+                    // guard and the final flush still run.
+                    break 'document;
                 }
                 buf_reader.consume(1);
                 bytes_in_chunk += 1;
@@ -1348,15 +1414,23 @@ mod tests {
         assert!(progress_count.load(std::sync::atomic::Ordering::Relaxed) >= 2);
     }
 
+    /// A bare object is the second shape a standard JSON document takes, so it
+    /// is one record rather than an error (#486) — and a record with no fields
+    /// is still a row (#533), on this transport as on every other.
     #[tokio::test]
-    async fn test_unsupported_format_rejected() {
+    async fn test_json_document_reads_a_bare_object_as_one_row() {
         let source = BytesSource::new(
             bytes::Bytes::from_static(b"{}"),
             AsyncSourceInfo::new("json-test", FileFormat::Json),
         );
-        let profiler = AsyncStreamingProfiler::new();
-        let result = profiler.analyze_stream(source).await;
-        assert!(result.is_err());
+        let report = AsyncStreamingProfiler::new()
+            .analyze_stream(source)
+            .await
+            .expect("a bare object is a valid JSON document");
+
+        assert_eq!(report.execution.rows_processed, 1);
+        assert_eq!(report.execution.error_count, 0);
+        assert!(report.column_profiles.is_empty());
     }
 
     #[tokio::test]

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -68,7 +68,8 @@ fn peek_non_whitespace<R: std::io::BufRead>(
 fn json_document_error(err: &serde_json::Error) -> DataProfilerError {
     DataProfilerError::JsonParsingError {
         message: format!(
-            "malformed JSON document: {err}. A JSON source must hold exactly one              array or object; for one record per line use format=\"jsonl\""
+            // One source line on purpose: see dataprof_json::json_document_error.
+            "malformed JSON document: {err}. A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
         ),
     }
 }
@@ -828,7 +829,7 @@ impl AsyncStreamingProfiler {
                                 // and so is also the column in the source.
                                 return Err(DataProfilerError::JsonParsingError {
                                     message: format!(
-                                        "malformed JSON record on line {line_number}, column {}:                                          a JSONL record must be one complete JSON value on one line",
+                                        "malformed JSON record on line {line_number}, column {}: a JSONL record must be one complete JSON value on one line",
                                         e.column()
                                     ),
                                 });

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -409,8 +409,11 @@ where
         return Ok((0, 0));
     }
 
-    // A row cap of zero asks for no records; the document is still well-formed,
-    // so this is a truncated read rather than a malformed one.
+    // A row cap of zero asks for no records, so the document is not read. It is
+    // still well-formed, so this is not a malformed result — but note the report
+    // does not carry a truncation reason either, because the `rows_read == 0`
+    // path in `analyze_json_file_with_options` returns before applying one. That
+    // gap is shared by all three shapes and is tracked separately.
     if config.max_rows == Some(0) {
         return Ok((0, 0));
     }
@@ -589,8 +592,7 @@ fn malformed_record_error(err: &serde_json::Error) -> DataProfilerError {
 fn malformed_jsonl_record_error(line: usize, err: &serde_json::Error) -> DataProfilerError {
     DataProfilerError::JsonParsingError {
         message: format!(
-            "malformed JSON record on line {line}, column {}: a JSONL record must be one \
-             complete JSON value on one line",
+            "malformed JSON record on line {line}, column {}: a JSONL record must be one complete JSON value on one line",
             err.column()
         ),
     }
@@ -611,8 +613,10 @@ fn malformed_array_error(message: &str) -> DataProfilerError {
 fn json_document_error(err: &serde_json::Error) -> DataProfilerError {
     DataProfilerError::JsonParsingError {
         message: format!(
-            "malformed JSON document: {err}. A JSON source must hold exactly one \
-             array or object; for one record per line use format=\"jsonl\""
+            // One source line on purpose: rustfmt may join a `\`-continued
+            // literal and leave its indentation inside the string, which silently
+            // corrupted this very message once.
+            "malformed JSON document: {err}. A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
         ),
     }
 }
@@ -873,8 +877,7 @@ pub fn analyze_json_file_with_options(
             // is JSONL, so say so here too: under the default skip policy this
             // is the only error the caller sees.
             let hint = if read_as_json_document {
-                ". A JSON source must hold exactly one array or object; \
-                 for one record per line use format=\"jsonl\""
+                ". A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
             } else {
                 ""
             };

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -13,19 +13,33 @@ use dataprof_runtime::{
 use serde::Deserialize;
 use serde_json::Value;
 
-/// JSON/JSONL format hint.
+/// Which grammar a JSON source is read with.
+///
+/// The two are deliberately distinct: whitespace is insignificant inside a
+/// standard JSON document and load-bearing in JSONL, so one input cannot be
+/// valid under both readings and mean the same thing. Callers pick with
+/// `format="json"` / `format="jsonl"`, or by file extension.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JsonFormat {
-    /// Standard JSON array of objects (`[{...}, {...}]`).
-    JsonArray,
-    /// JSON Lines — one JSON object per line.
+    /// A standard JSON document, in either of the two shapes that carry
+    /// records: an array of objects (`[{...}, {...}]`), or a single object
+    /// (`{...}`) as one record. Values may span lines and be pretty-printed,
+    /// and exactly one document must fill the whole input.
+    Json,
+    /// JSON Lines — one record per physical line. A record may not span lines,
+    /// and a line may not hold more than one value.
     Jsonl,
 }
 
 /// Configuration for JSON/JSONL parsing and scanning.
 #[derive(Debug, Clone, Default)]
 pub struct JsonParserConfig {
-    /// Force a specific format (None = auto-detect from content).
+    /// The grammar to read with. `None` detects it from the first byte, which
+    /// resolves `[` to [`JsonFormat::Json`] and everything else to
+    /// [`JsonFormat::Jsonl`] — a leading `{` opens both a JSON object document
+    /// and a JSONL file, so callers that know which they have (from the file
+    /// extension or an explicit `format=`) should say so rather than rely on
+    /// detection.
     pub format: Option<JsonFormat>,
     /// Maximum rows to process (None = all rows).
     pub max_rows: Option<usize>,
@@ -46,7 +60,7 @@ impl JsonParserConfig {
         self
     }
 
-    /// Force JSONL format.
+    /// Read as JSON Lines: one record per physical line.
     pub fn jsonl() -> Self {
         Self {
             format: Some(JsonFormat::Jsonl),
@@ -54,12 +68,19 @@ impl JsonParserConfig {
         }
     }
 
-    /// Force JSON array format.
-    pub fn json_array() -> Self {
+    /// Read as a standard JSON document: an array of records, or a single
+    /// object as one record.
+    pub fn json_document() -> Self {
         Self {
-            format: Some(JsonFormat::JsonArray),
+            format: Some(JsonFormat::Json),
             ..Default::default()
         }
+    }
+
+    /// Set the grammar explicitly.
+    pub fn with_format(mut self, format: JsonFormat) -> Self {
+        self.format = Some(format);
+        self
     }
 }
 
@@ -88,8 +109,13 @@ pub struct JsonScanSummary {
 
 /// Scan JSON or JSONL input and invoke `on_object` for each object record.
 ///
-/// - **JSONL**: scans one top-level JSON value at a time from the reader.
-/// - **JSON array**: streams array elements without buffering the entire input.
+/// - **JSONL**: one record per physical line. A record may not span lines and a
+///   line may not hold more than one value, so a concatenation whose delimiter
+///   was lost is reported rather than read as several clean records. Blank lines
+///   are separators: neither records nor errors.
+/// - **JSON**: one standard document. An array of objects streams element by
+///   element without buffering the whole input; a single object is read whole
+///   and is one record, which is why it may be pretty-printed across lines.
 ///
 /// # Record policy
 ///
@@ -110,8 +136,11 @@ where
 {
     let mut reader = Utf8BomReader::new(reader).map_err(DataProfilerError::from)?;
     let format = match config.format {
-        Some(JsonFormat::JsonArray) => FileFormat::Json,
+        Some(JsonFormat::Json) => FileFormat::Json,
         Some(JsonFormat::Jsonl) => FileFormat::Jsonl,
+        // A leading `{` is the first byte of both a JSON object document and a
+        // JSONL file, so detection can only resolve the array case and has to
+        // fall back to JSONL. Callers that know better pass `format`.
         None => match consume_leading_whitespace(&mut reader)? {
             Some(b'[') => FileFormat::Json,
             _ => FileFormat::Jsonl,
@@ -123,83 +152,70 @@ where
     let mut truncated = false;
 
     match format {
-        FileFormat::Jsonl => loop {
-            if let Some(max) = config.max_rows
-                && rows_read >= max
-            {
-                // Reaching the cap is not truncation unless a record actually
-                // remains: a file with exactly `max_rows` rows was read in full.
-                truncated = consume_leading_whitespace(&mut reader)?.is_some();
-                break;
-            }
-
-            // `serde_json` classifies both a clean end of input and an
-            // incomplete trailing value as `Category::Eof`. Check whether a
-            // non-whitespace value actually starts here so only the former is
-            // treated as normal exhaustion.
-            let Some(first) = consume_leading_whitespace(&mut reader)? else {
-                break;
-            };
-
-            match read_json_record(&mut reader, first)? {
-                JsonRecord::Object(obj) => {
-                    on_object(&obj);
-                    rows_read += 1;
-                }
-                JsonRecord::NonObject(kind) => {
-                    if config.error_policy == JsonErrorPolicy::Strict {
-                        return Err(non_object_record_error(
-                            kind,
-                            rows_read + malformed_lines + 1,
-                        ));
-                    }
-                    malformed_lines += 1;
-                }
-                JsonRecord::Malformed(err) => {
-                    if config.error_policy == JsonErrorPolicy::Strict {
-                        return Err(malformed_record_error(&err));
-                    }
-                    malformed_lines += 1;
-                    if err.classify() == serde_json::error::Category::Eof {
-                        break;
-                    }
-                    skip_to_next_line(&mut reader)?;
-                }
-            }
-        },
-        FileFormat::Json => {
-            let mut found_array = false;
+        // JSONL is line-delimited: exactly one record per non-blank physical
+        // line. Reading it as a whitespace-delimited stream of values instead
+        // made `{"a":1}{"b":2}` — a concatenation with the delimiter lost —
+        // profile as two clean rows, which is precisely the corruption a
+        // profiler exists to surface.
+        FileFormat::Jsonl => {
+            let mut line = String::new();
+            let mut line_number = 0;
             loop {
-                let mut consume = 0;
+                if let Some(max) = config.max_rows
+                    && rows_read >= max
                 {
-                    let buf = reader.fill_buf().map_err(DataProfilerError::from)?;
-                    if buf.is_empty() {
-                        break;
-                    }
-                    for &byte in buf {
-                        consume += 1;
-                        if byte == b'[' {
-                            found_array = true;
-                            break;
-                        } else if !byte.is_ascii_whitespace() {
-                            break;
-                        }
-                    }
-                }
-                reader.consume(consume);
-                if found_array || consume == 0 {
+                    // Reaching the cap is not truncation unless a record
+                    // actually remains: a file with exactly `max_rows` records
+                    // was read in full. Blank lines are not records.
+                    truncated = next_record_line(&mut reader, &mut line, &mut line_number)?;
                     break;
                 }
+
+                if !next_record_line(&mut reader, &mut line, &mut line_number)? {
+                    break;
+                }
+
+                match read_jsonl_line(&line) {
+                    JsonRecord::Object(obj) => {
+                        on_object(&obj);
+                        rows_read += 1;
+                    }
+                    JsonRecord::NonObject(kind) => {
+                        if config.error_policy == JsonErrorPolicy::Strict {
+                            return Err(non_object_record_error(
+                                kind,
+                                rows_read + malformed_lines + 1,
+                            ));
+                        }
+                        malformed_lines += 1;
+                    }
+                    JsonRecord::Malformed(err) => {
+                        if config.error_policy == JsonErrorPolicy::Strict {
+                            return Err(malformed_jsonl_record_error(line_number, &err));
+                        }
+                        malformed_lines += 1;
+                    }
+                }
             }
+        }
+        FileFormat::Json => {
+            // Which of the two record-carrying shapes this document is. The
+            // first non-whitespace byte decides, and is left unconsumed so the
+            // object branch still sees the value it opens.
+            let found_array = consume_leading_whitespace(&mut reader)? == Some(b'[');
 
             if !found_array {
-                if config.format.is_some() {
-                    return Err(DataProfilerError::JsonParsingError {
-                        message: "Expected JSON array (starts with '[') but input does not match"
-                            .to_string(),
-                    });
-                }
+                // The other shape a standard JSON document takes: a single
+                // object, which is one record. It may be pretty-printed across
+                // lines, which is why this is not the JSONL grammar.
+                let (object_rows, object_malformed) =
+                    scan_single_json_object(&mut reader, config, &mut on_object)?;
+                rows_read += object_rows;
+                malformed_lines += object_malformed;
             } else {
+                // The array loop starts after the opening bracket.
+                consume_peeked(&mut reader)?;
+
                 let mut expect_value = true;
                 let mut allow_end = true;
                 let mut array_closed = false;
@@ -229,7 +245,7 @@ where
                                 drain_remainder = true;
                                 break;
                             }
-                            reader.consume(1);
+                            consume_peeked(&mut reader)?;
                             array_closed = true;
                             break;
                         }
@@ -284,12 +300,12 @@ where
                     } else {
                         match next {
                             b',' => {
-                                reader.consume(1);
+                                consume_peeked(&mut reader)?;
                                 expect_value = true;
                                 allow_end = false;
                             }
                             b']' => {
-                                reader.consume(1);
+                                consume_peeked(&mut reader)?;
                                 array_closed = true;
                                 break;
                             }
@@ -329,6 +345,94 @@ where
         format,
         truncated,
     })
+}
+
+/// Read the next line that holds a record into `line`, skipping blank ones.
+///
+/// Returns whether a record line was found. Blank lines are separators, not
+/// records: they are skipped without counting as rows or as errors. `line_number`
+/// counts every physical line read, blank ones included, so a diagnostic points
+/// at the line the user would open the file to.
+fn next_record_line<R: BufRead>(
+    reader: &mut R,
+    line: &mut String,
+    line_number: &mut usize,
+) -> Result<bool, DataProfilerError> {
+    loop {
+        line.clear();
+        let read = reader.read_line(line).map_err(DataProfilerError::from)?;
+        if read == 0 {
+            return Ok(false);
+        }
+        *line_number += 1;
+        if !line.trim().is_empty() {
+            return Ok(true);
+        }
+    }
+}
+
+/// Parse one JSONL line as exactly one JSON value.
+///
+/// `serde_json::from_str` requires the value to fill the whole input, so a line
+/// carrying two adjacent or space-separated values is a malformed record rather
+/// than two clean ones — the boundary rule that separates JSONL from a stream of
+/// JSON values.
+fn read_jsonl_line(line: &str) -> JsonRecord {
+    match serde_json::from_str::<Value>(line.trim()) {
+        Ok(Value::Object(obj)) => JsonRecord::Object(obj),
+        Ok(value) => JsonRecord::NonObject(json_value_kind(&value)),
+        Err(err) => JsonRecord::Malformed(err),
+    }
+}
+
+/// Read a whole-input single JSON object as one record.
+///
+/// Returns `(rows_read, malformed)`. Anything that is not exactly one object
+/// filling the input is an error under [`JsonErrorPolicy::Strict`] and a counted
+/// malformed record otherwise, so a truncated or concatenated document never
+/// profiles as clean.
+fn scan_single_json_object<R, F>(
+    reader: &mut R,
+    config: &JsonParserConfig,
+    on_object: &mut F,
+) -> Result<(usize, usize), DataProfilerError>
+where
+    R: BufRead,
+    F: FnMut(&JsonObject),
+{
+    let mut text = String::new();
+    reader
+        .read_to_string(&mut text)
+        .map_err(DataProfilerError::from)?;
+
+    if text.trim().is_empty() {
+        return Ok((0, 0));
+    }
+
+    // A row cap of zero asks for no records; the document is still well-formed,
+    // so this is a truncated read rather than a malformed one.
+    if config.max_rows == Some(0) {
+        return Ok((0, 0));
+    }
+
+    match serde_json::from_str::<Value>(text.trim()) {
+        Ok(Value::Object(obj)) => {
+            on_object(&obj);
+            Ok((1, 0))
+        }
+        Ok(value) => {
+            if config.error_policy == JsonErrorPolicy::Strict {
+                return Err(non_object_record_error(json_value_kind(&value), 1));
+            }
+            Ok((0, 1))
+        }
+        Err(err) => {
+            if config.error_policy == JsonErrorPolicy::Strict {
+                return Err(json_document_error(&err));
+            }
+            Ok((0, 1))
+        }
+    }
 }
 
 /// One record read from a JSON or JSONL source.
@@ -408,6 +512,20 @@ fn is_json_number_byte(byte: u8) -> bool {
     byte.is_ascii_digit() || matches!(byte, b'-' | b'+' | b'.' | b'e' | b'E')
 }
 
+/// Consume the byte [`consume_leading_whitespace`] just reported, along with the
+/// whitespace it looked past.
+///
+/// That function only peeks — it leaves the whitespace queued so serde keeps its
+/// line and column context — so consuming one byte would eat a space rather than
+/// the delimiter. Getting this wrong made a pretty-printed JSON array report a
+/// phantom malformed record, because the `]` survived the consume and then
+/// looked like content after the closing bracket.
+fn consume_peeked<R: BufRead>(reader: &mut R) -> Result<(), DataProfilerError> {
+    skip_ascii_whitespace(reader)?;
+    reader.consume(1);
+    Ok(())
+}
+
 /// Advance the reader past any ASCII whitespace at its current position.
 fn skip_ascii_whitespace<R: BufRead>(reader: &mut R) -> Result<(), DataProfilerError> {
     loop {
@@ -461,9 +579,41 @@ fn malformed_record_error(err: &serde_json::Error) -> DataProfilerError {
     }
 }
 
+/// Build a strict-mode parse error for a JSONL record, located by its physical
+/// line.
+///
+/// Each line is parsed on its own, so the decoder's own line number is always 1
+/// and would be misleading; the column it reports is within the line and so is
+/// also the column in the file. The record's text is never included. Matches the
+/// phrasing the Python bytes reader uses for the same failure.
+fn malformed_jsonl_record_error(line: usize, err: &serde_json::Error) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!(
+            "malformed JSON record on line {line}, column {}: a JSONL record must be one \
+             complete JSON value on one line",
+            err.column()
+        ),
+    }
+}
+
 fn malformed_array_error(message: &str) -> DataProfilerError {
     DataProfilerError::JsonParsingError {
         message: format!("malformed JSON array: {message}"),
+    }
+}
+
+/// Build a strict-mode error for a standard JSON document that is not exactly
+/// one value.
+///
+/// The most common cause is JSONL read with the JSON grammar — several objects
+/// back to back parse as one value plus trailing characters — so the message
+/// names the option that would read it correctly.
+fn json_document_error(err: &serde_json::Error) -> DataProfilerError {
+    DataProfilerError::JsonParsingError {
+        message: format!(
+            "malformed JSON document: {err}. A JSON source must hold exactly one \
+             array or object; for one record per line use format=\"jsonl\""
+        ),
     }
 }
 
@@ -499,14 +649,6 @@ fn consume_leading_whitespace<R: BufRead>(reader: &mut R) -> Result<Option<u8>, 
 
         reader.consume(bytes_to_consume);
     }
-}
-
-fn skip_to_next_line<R: BufRead>(reader: &mut R) -> Result<(), DataProfilerError> {
-    let mut discarded = Vec::new();
-    reader
-        .read_until(b'\n', &mut discarded)
-        .map_err(DataProfilerError::from)?;
-    Ok(())
 }
 
 /// Convert a JSON [`Value`] to a flat string for column storage.
@@ -700,6 +842,13 @@ pub fn analyze_json_file_with_options(
     config: &JsonParserConfig,
     options: &AnalysisOptions,
 ) -> Result<ProfileReport, DataProfilerError> {
+    // An explicit grammar wins; otherwise the file name gets a say before
+    // content sniffing, which cannot tell a JSON object from a JSONL stream.
+    let mut config = config.clone();
+    if config.format.is_none() {
+        config.format = grammar_for_extension(file_path);
+    }
+    let config = &config;
     let metadata = std::fs::metadata(file_path).map_err(|error| map_io_error(file_path, error))?;
     let start = std::time::Instant::now();
 
@@ -708,6 +857,7 @@ pub fn analyze_json_file_with_options(
 
     let (column_profiles, column_stats, rows_read, malformed_lines, format, truncated) =
         analyze_json_from_reader_full(buf_reader, config, options)?;
+    let read_as_json_document = format == FileFormat::Json;
 
     let file_source = DataSource::File {
         path: file_path.display().to_string(),
@@ -719,10 +869,20 @@ pub fn analyze_json_file_with_options(
 
     if rows_read == 0 {
         if malformed_lines > 0 {
+            // Nothing parsed under the JSON grammar most often means the source
+            // is JSONL, so say so here too: under the default skip policy this
+            // is the only error the caller sees.
+            let hint = if read_as_json_document {
+                ". A JSON source must hold exactly one array or object; \
+                 for one record per line use format=\"jsonl\""
+            } else {
+                ""
+            };
             return Err(DataProfilerError::JsonParsingError {
-                message: "No valid JSON records found in file \
-                          (every record was malformed or not a JSON object)"
-                    .to_string(),
+                message: format!(
+                    "No valid JSON records found in file \
+                     (every record was malformed or not a JSON object){hint}"
+                ),
             });
         }
         return Ok(ReportAssembler::new(
@@ -759,6 +919,24 @@ pub fn analyze_json_file_with_options(
         .build())
 }
 
+/// The grammar a file name advertises, if it advertises one.
+///
+/// Content sniffing resolves a leading `[` on its own, but not a leading `{`:
+/// that is the first byte of both a JSON object document and a JSONL file. The
+/// extension is the evidence that separates them, and a `.json` file holding one
+/// pretty-printed object is an ordinary thing to profile. `None` means the name
+/// says nothing and the content decides.
+fn grammar_for_extension(file_path: &Path) -> Option<JsonFormat> {
+    let extension = file_path.extension().and_then(|ext| ext.to_str())?;
+    if extension.eq_ignore_ascii_case("json") {
+        Some(JsonFormat::Json)
+    } else if extension.eq_ignore_ascii_case("jsonl") || extension.eq_ignore_ascii_case("ndjson") {
+        Some(JsonFormat::Jsonl)
+    } else {
+        None
+    }
+}
+
 fn map_io_error(file_path: &Path, error: std::io::Error) -> DataProfilerError {
     if error.kind() == std::io::ErrorKind::NotFound {
         DataProfilerError::FileNotFound {
@@ -775,8 +953,19 @@ mod tests {
     use std::io::{Cursor, Write};
     use tempfile::NamedTempFile;
 
+    /// A temp file with no extension, so `analyze_json_file` falls back to the
+    /// JSONL grammar the way an unnamed stream does.
     fn write_file(content: &str) -> NamedTempFile {
         let mut file = NamedTempFile::new().unwrap();
+        write!(file, "{}", content).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    /// A temp file named `.json`, so `analyze_json_file` reads it as a standard
+    /// JSON document — the grammar the extension advertises.
+    fn write_json_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::with_suffix(".json").unwrap();
         write!(file, "{}", content).unwrap();
         file.flush().unwrap();
         file
@@ -895,13 +1084,14 @@ mod tests {
         ];
 
         for (data, expected_rows, case) in cases {
-            let skip = JsonParserConfig::json_array();
+            let skip = JsonParserConfig::json_document();
             let summary =
                 scan_json_from_reader(Cursor::new(data), &skip, |_| {}).expect("tolerant scan");
             assert_eq!(summary.rows_read, expected_rows, "{case}");
             assert_eq!(summary.malformed_lines, 1, "{case}");
 
-            let strict = JsonParserConfig::json_array().with_error_policy(JsonErrorPolicy::Strict);
+            let strict =
+                JsonParserConfig::json_document().with_error_policy(JsonErrorPolicy::Strict);
             let err = scan_json_from_reader(Cursor::new(data), &strict, |_| {})
                 .expect_err("strict mode must reject invalid array grammar");
             assert!(
@@ -916,7 +1106,7 @@ mod tests {
     #[test]
     fn test_json_array_max_rows_does_not_validate_unread_values() {
         let data = br#"[{"x":1},not-valid-json"#;
-        let config = JsonParserConfig::json_array().with_max_rows(1);
+        let config = JsonParserConfig::json_document().with_max_rows(1);
         let summary = scan_json_from_reader(Cursor::new(data.as_ref()), &config, |_| {}).unwrap();
 
         assert_eq!(summary.rows_read, 1);
@@ -957,8 +1147,13 @@ mod tests {
         assert_eq!(rows, 2);
     }
 
+    /// A pretty-printed root object is one record under the JSON grammar and a
+    /// malformed record under JSONL (#486). It cannot be both: whitespace is
+    /// insignificant in a JSON document and is the record delimiter in JSONL, so
+    /// reading a multi-line object as JSONL would mean each of its lines is a
+    /// record — none of which is valid JSON on its own.
     #[test]
-    fn test_scan_pretty_printed_root_object_is_one_jsonl_row() {
+    fn test_pretty_printed_root_object_is_one_row_under_the_json_grammar() {
         let data = br#"{
     "type": "FeatureCollection",
     "features": [
@@ -970,15 +1165,33 @@ mod tests {
 
         let summary = scan_json_from_reader(
             Cursor::new(data.as_ref()),
-            &JsonParserConfig::default(),
+            &JsonParserConfig::json_document(),
             |obj| object_field_counts.push(obj.len()),
         )
         .unwrap();
 
-        assert_eq!(summary.format, FileFormat::Jsonl);
+        assert_eq!(summary.format, FileFormat::Json);
         assert_eq!(summary.rows_read, 1);
         assert_eq!(summary.malformed_lines, 0);
         assert_eq!(object_field_counts, vec![2]);
+    }
+
+    #[test]
+    fn test_pretty_printed_root_object_is_not_valid_jsonl() {
+        let data = br#"{
+    "type": "FeatureCollection"
+}"#;
+        let err = scan_json_from_reader(
+            Cursor::new(data.as_ref()),
+            &JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict),
+            |_| {},
+        )
+        .expect_err("a record spanning lines is not JSONL");
+
+        assert!(
+            err.to_string().contains("malformed JSON record"),
+            "{err}, expected the malformed category"
+        );
     }
 
     /// Every JSON value that is not an object, so none of them can be a row.
@@ -1020,7 +1233,7 @@ mod tests {
 
             let summary = scan_json_from_reader(
                 Cursor::new(data.as_bytes()),
-                &JsonParserConfig::json_array(),
+                &JsonParserConfig::json_document(),
                 |_| rows += 1,
             )
             .unwrap();
@@ -1040,7 +1253,7 @@ mod tests {
                     format!("{{\"id\":1}}\n{value}\n{{\"id\":2}}\n"),
                 ),
                 (
-                    JsonParserConfig::json_array(),
+                    JsonParserConfig::json_document(),
                     format!("[{{\"id\":1}}, {value}, {{\"id\":2}}]"),
                 ),
             ] {
@@ -1065,7 +1278,7 @@ mod tests {
 
         let summary = scan_json_from_reader(
             Cursor::new(data.as_ref()),
-            &JsonParserConfig::json_array(),
+            &JsonParserConfig::json_document(),
             |_| rows += 1,
         )
         .unwrap();
@@ -1103,16 +1316,39 @@ mod tests {
     }
 
     #[test]
-    fn test_forced_json_array_requires_opening_bracket() {
+    /// The JSON grammar accepts both shapes that carry records, so a bare object
+    /// is one row rather than an error (#486).
+    fn test_json_grammar_reads_a_bare_object_as_one_row() {
         let data = br#"{"x":1}"#;
+        let mut rows = 0;
+        let summary = scan_json_from_reader(
+            Cursor::new(data.as_ref()),
+            &JsonParserConfig::json_document(),
+            |_| rows += 1,
+        )
+        .unwrap();
+
+        assert_eq!(summary.rows_read, 1);
+        assert_eq!(summary.malformed_lines, 0);
+        assert_eq!(rows, 1);
+    }
+
+    #[test]
+    /// Several objects back to back are not a JSON document. The error names
+    /// the option that reads them, because this is what a JSONL file looks like
+    /// when it is read with the wrong grammar.
+    fn test_json_grammar_rejects_concatenated_objects() {
+        let data = br#"{"x":1}{"x":2}"#;
         let err = scan_json_from_reader(
             Cursor::new(data.as_ref()),
-            &JsonParserConfig::json_array(),
+            &JsonParserConfig::json_document().with_error_policy(JsonErrorPolicy::Strict),
             |_| {},
         )
-        .expect_err("forced json array should reject non-array input");
+        .expect_err("two objects are not one JSON document");
 
-        assert!(err.to_string().contains("Expected JSON array"));
+        let message = err.to_string();
+        assert!(message.contains("malformed JSON document"), "{message}");
+        assert!(message.contains("format=\"jsonl\""), "{message}");
     }
 
     #[test]
@@ -1473,7 +1709,7 @@ mod tests {
     fn test_bom_prefixed_file_preserves_source_size() {
         let data = b"\xEF\xBB\xBF[{\"x\":1}]";
         let json = write_bytes(data);
-        let report = analyze_json_file(json.path(), &JsonParserConfig::json_array()).unwrap();
+        let report = analyze_json_file(json.path(), &JsonParserConfig::json_document()).unwrap();
 
         assert_eq!(report.execution.rows_processed, 1);
         assert!(matches!(
@@ -1550,7 +1786,8 @@ mod tests {
 
     #[test]
     fn test_single_root_object_via_analyze_json_file() {
-        let file = write_file(r#"{"type":"FeatureCollection","features":[{"id":1},{"id":2}]}"#);
+        let file =
+            write_json_file(r#"{"type":"FeatureCollection","features":[{"id":1},{"id":2}]}"#);
         let config = JsonParserConfig::default();
         let report = analyze_json_file(file.path(), &config).unwrap();
 
@@ -1568,11 +1805,13 @@ mod tests {
   ]
 }"#;
         let cursor = Cursor::new(data.as_ref());
-        let config = JsonParserConfig::default();
+        // A reader has no file name, so the grammar cannot be inferred and is
+        // named explicitly; `analyze_json_file` takes it from the extension.
+        let config = JsonParserConfig::json_document();
 
         let (profiles, _stats, rows, malformed, format) =
             analyze_json_from_reader(cursor, &config).unwrap();
-        assert_eq!(format, FileFormat::Jsonl);
+        assert_eq!(format, FileFormat::Json);
         assert_eq!(rows, 1);
         assert_eq!(malformed, 0);
         assert_eq!(profiles.len(), 2);
@@ -1580,7 +1819,7 @@ mod tests {
 
     #[test]
     fn test_single_root_object_pretty_printed_via_analyze_json_file() {
-        let file = write_file(
+        let file = write_json_file(
             "{\n  \"type\": \"FeatureCollection\",\n  \"features\": [\n    {\"id\": 1},\n    {\"id\": 2}\n  ]\n}\n",
         );
         let config = JsonParserConfig::default();

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -278,7 +278,7 @@ fn infer_schema_from_json_reader<R: BufRead>(
 ) -> Result<SchemaResult, DataProfilerError> {
     let config = match format {
         FileFormat::Jsonl => JsonParserConfig::jsonl().with_max_rows(SCHEMA_SAMPLE_ROWS),
-        FileFormat::Json => JsonParserConfig::json_array().with_max_rows(SCHEMA_SAMPLE_ROWS),
+        FileFormat::Json => JsonParserConfig::json_document().with_max_rows(SCHEMA_SAMPLE_ROWS),
         _ => JsonParserConfig::default().with_max_rows(SCHEMA_SAMPLE_ROWS),
     };
     let (_profiles, column_stats, rows_read, _malformed_lines, _detected_format) =
@@ -840,7 +840,7 @@ fn analyze_structure_json(
     let reader = BufReader::new(file);
     let config = match format {
         FileFormat::Jsonl => JsonParserConfig::jsonl().with_max_rows(max_rows),
-        FileFormat::Json => JsonParserConfig::json_array().with_max_rows(max_rows),
+        FileFormat::Json => JsonParserConfig::json_document().with_max_rows(max_rows),
         _ => JsonParserConfig::default().with_max_rows(max_rows),
     };
 

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -569,6 +569,19 @@ impl Profiler {
     }
 
     /// A JSON parser config carrying the configured row cap and error policy.
+    /// A JSON parser config for `format`, carrying the row cap and error policy.
+    ///
+    /// The grammar is passed explicitly rather than sniffed: a leading `{` opens
+    /// both a JSON object document and a JSONL file, and only the caller — via
+    /// the file extension or an explicit `.format()` — knows which it has.
+    fn json_config_for(&self, format: FileFormat) -> dataprof_json::JsonParserConfig {
+        let grammar = match format {
+            FileFormat::Json => dataprof_json::JsonFormat::Json,
+            _ => dataprof_json::JsonFormat::Jsonl,
+        };
+        self.json_config_for_stop().with_format(grammar)
+    }
+
     fn json_config_for_stop(&self) -> dataprof_json::JsonParserConfig {
         let config = dataprof_json::JsonParserConfig::default()
             .with_error_policy(self.config.json_error_policy);
@@ -616,7 +629,7 @@ impl Profiler {
                 self.ensure_no_sampling("the JSON parser")?;
                 dataprof_json::analyze_json_file_with_options(
                     file_path,
-                    &self.json_config_for_stop(),
+                    &self.json_config_for(format),
                     &options,
                 )
             }
@@ -691,7 +704,7 @@ impl Profiler {
                 self.ensure_no_sampling("the JSON parser")?;
                 return dataprof_json::analyze_json_file_with_options(
                     file_path,
-                    &self.json_config_for_stop(),
+                    &self.json_config_for(format),
                     &options,
                 );
             }
@@ -767,7 +780,7 @@ impl Profiler {
             FileFormat::Json | FileFormat::Jsonl => {
                 return dataprof_json::analyze_json_file_with_options(
                     file_path,
-                    &self.json_config_for_stop(),
+                    &self.json_config_for(format),
                     &options,
                 );
             }

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -568,7 +568,6 @@ impl Profiler {
         self.config.stop_condition.max_rows().map(|n| n as usize)
     }
 
-    /// A JSON parser config carrying the configured row cap and error policy.
     /// A JSON parser config for `format`, carrying the row cap and error policy.
     ///
     /// The grammar is passed explicitly rather than sniffed: a leading `{` opens
@@ -582,6 +581,8 @@ impl Profiler {
         self.json_config_for_stop().with_format(grammar)
     }
 
+    /// A JSON parser config carrying the configured row cap and error policy,
+    /// leaving the grammar to be detected.
     fn json_config_for_stop(&self) -> dataprof_json::JsonParserConfig {
         let config = dataprof_json::JsonParserConfig::default()
             .with_error_policy(self.config.json_error_policy);

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -184,12 +184,35 @@ report = dp.profile("messy.csv", csv_flexible=True)
 
 ### JSON and JSONL
 
-JSON files should contain an array of objects. JSONL files should have one JSON object per line.
+These are two different grammars, and dataprof holds you to whichever one you
+asked for.
+
+**`.json` — a standard JSON document.** Exactly one array of objects
+(`[{...}, {...}]`) or one object (`{...}`) as a single record. Whitespace is
+insignificant, so the document may be pretty-printed across as many lines as
+you like.
+
+**`.jsonl` — JSON Lines.** One record per physical line. A record may not span
+lines, and a line may not hold more than one value. Blank lines are separators
+and are neither records nor errors.
 
 ```python
 report = dp.profile("users.json")
 report = dp.profile("events.jsonl")
+
+# Bytes need the grammar named, since there is no extension to read it from.
+report = dp.profile(payload, format="jsonl")
 ```
+
+The distinction matters most where the two would otherwise disagree. Objects
+written back to back with the newline lost — `{"a":1}{"b":2}` — are not two
+records under either grammar: as JSONL the line holds two values, and as JSON
+the input holds two documents. Both are reported rather than profiled, because
+a concatenation that silently reads as clean data is the failure a profiler
+exists to catch.
+
+Every transport applies the same rule: file paths, byte buffers, and the async
+entry points all agree on what a record is.
 
 ### Parquet
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1056,6 +1056,12 @@ def profile_file(
             columnar and async engines. Bounds retained per-column state;
             it does not drop rows.
         format: Override format detection ("csv", "json", "jsonl", "parquet").
+            "json" reads one standard JSON document — an array of objects, or
+            one object as a single record — which may be pretty-printed across
+            lines. "jsonl" reads one record per physical line: a record may not
+            span lines, and a line may not hold more than one value. Byte
+            sources have no extension to read the grammar from, so they require
+            this argument.
         max_rows: Maximum rows to process before stopping.
         csv_delimiter: Single-character CSV delimiter (default: detected
             from the data).
@@ -1171,6 +1177,12 @@ def profile(
             columnar and async engines. Bounds retained per-column state;
             it does not drop rows.
         format: Override format detection ("csv", "json", "jsonl", "parquet").
+            "json" reads one standard JSON document — an array of objects, or
+            one object as a single record — which may be pretty-printed across
+            lines. "jsonl" reads one record per physical line: a record may not
+            span lines, and a line may not hold more than one value. Byte
+            sources have no extension to read the grammar from, so they require
+            this argument.
         max_rows: Maximum rows to process before stopping.
         name: Name for DataFrame sources in the report.
         csv_delimiter: Single-character CSV delimiter (default: detected

--- a/python/tests/test_json_record_boundaries.py
+++ b/python/tests/test_json_record_boundaries.py
@@ -1,0 +1,199 @@
+"""JSONL record boundaries mean the same thing on every transport (#486).
+
+`format="jsonl"` is **one record per physical line**: a record may not span
+lines, and a line may not hold more than one value. `format="json"` is a
+**standard JSON document**: one array of records, or one object as a single
+record, either of which may be pretty-printed.
+
+Before this was settled, the file and async scanners read JSONL as a
+whitespace-delimited stream of JSON values while the synchronous bytes reader
+split on lines. The same payload therefore had incompatible answers:
+`b'{"x":1}{"x":2}'` — a concatenation with the delimiter lost — profiled as two
+clean rows on one path and failed on another.
+
+Every case below is checked on all four transports at once, because the bug was
+never visible from any single one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import dataprof as dp
+import pytest
+from dataprof.asyncio import (
+    profile_bytes as profile_bytes_async,
+    profile_file as profile_file_async,
+)
+
+requires_async = pytest.mark.skipif(
+    not dp.capabilities().async_streaming,
+    reason="Async streaming not compiled. Build with --features "
+    "'python,python-async,async-streaming'.",
+)
+
+#: Sentinel for "this input is rejected", so an error compares equal across
+#: transports without depending on each one's message.
+REJECTED = "rejected"
+
+#: What one transport reported: `(rows, error_count)`, or `REJECTED`.
+Outcome = str | tuple[int, int]
+
+
+def _outcome(call) -> Outcome:
+    """`(rows, error_count)` for a profile that succeeded, else `REJECTED`."""
+    try:
+        report = call()
+    except ValueError:
+        return REJECTED
+    return (report.rows, report.error_count)
+
+
+def _all_transports(payload: bytes, fmt: str, tmp_path, **kwargs) -> dict[str, Outcome]:
+    path = tmp_path / f"fixture.{fmt}"
+    path.write_bytes(payload)
+    transports = {
+        "file": lambda: dp.profile(path, **kwargs),
+        "bytes": lambda: dp.profile(payload, format=fmt, **kwargs),
+    }
+    if dp.capabilities().async_streaming:
+        transports["async file"] = lambda: asyncio.run(profile_file_async(path, **kwargs))
+        transports["async bytes"] = lambda: asyncio.run(
+            profile_bytes_async(payload, format=fmt, **kwargs)
+        )
+    return {name: _outcome(call) for name, call in transports.items()}
+
+
+def _agree(results: dict[str, Outcome]) -> Outcome:
+    """Assert every transport reached the same answer, and return it."""
+    distinct = set(results.values())
+    assert len(distinct) == 1, f"transports disagree: {results}"
+    return next(iter(distinct))
+
+
+# ---------------------------------------------------------------------------
+# JSONL: one record per physical line
+# ---------------------------------------------------------------------------
+
+JSONL_CASES = [
+    # (label, payload, expected)
+    # A concatenation with the delimiter lost. Reading it as a value stream
+    # produced two clean rows and hid the damage; it is now rejected.
+    ("adjacent values", b'{"x":1}{"x":2}', REJECTED),
+    # The same fault followed by a good record: the bad line is counted, the
+    # good one still profiles.
+    ("adjacent then valid", b'{"x":1}{"x":2}\n{"x":3}\n', (1, 1)),
+    ("space separated on one line", b'{"x":1} {"x":2}\n', REJECTED),
+    # A record that spans lines is not JSONL, however valid the JSON is.
+    ("pretty-printed object", b'{\n  "x": 1\n}\n', REJECTED),
+    ("clean records", b'{"x":1}\n{"x":2}\n', (2, 0)),
+    # Blank lines are separators, not records: no rows and no errors.
+    ("blank lines between records", b'{"x":1}\n\n\n{"x":2}\n', (2, 0)),
+    ("malformed first record", b'nope\n{"x":1}\n', (1, 1)),
+    ("malformed middle record", b'{"x":1}\nnope\n{"x":2}\n', (2, 1)),
+    ("malformed last record", b'{"x":1}\nnope\n', (1, 1)),
+    ("truncated last record", b'{"x":1}\n{"x":2', (1, 1)),
+    # A record with no fields is still a record (#533).
+    ("fieldless record", b'{}\n{"x":1}\n', (2, 0)),
+    ("no trailing newline", b'{"x":1}\n{"x":2}', (2, 0)),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "payload", "expected"),
+    JSONL_CASES,
+    ids=[case[0] for case in JSONL_CASES],
+)
+def test_jsonl_record_boundaries_agree_on_every_transport(label, payload, expected, tmp_path):
+    results = _all_transports(payload, "jsonl", tmp_path)
+    assert _agree(results) == expected, f"{label}: {results}"
+
+
+# ---------------------------------------------------------------------------
+# JSON: one document, array or single object
+# ---------------------------------------------------------------------------
+
+JSON_CASES = [
+    ("array of records", b'[{"x":1},{"x":2}]', (2, 0)),
+    # Whitespace is insignificant inside a JSON document, so pretty-printing
+    # changes nothing — including the error count, which used to gain a phantom
+    # malformed record from the newline before `]`.
+    ("pretty-printed array", b'[\n  {"x": 1},\n  {"x": 2}\n]\n', (2, 0)),
+    ("single object", b'{"type":"FC","n":2}', (1, 0)),
+    ("pretty-printed single object", b'{\n  "type": "FC",\n  "n": 2\n}\n', (1, 0)),
+    ("fieldless object", b"{}", (1, 0)),
+    # This is what a JSONL file looks like when read with the JSON grammar.
+    ("concatenated objects", b'{"x":1}{"x":2}', REJECTED),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "payload", "expected"),
+    JSON_CASES,
+    ids=[case[0] for case in JSON_CASES],
+)
+def test_json_document_shapes_agree_on_every_transport(label, payload, expected, tmp_path):
+    results = _all_transports(payload, "json", tmp_path)
+    assert _agree(results) == expected, f"{label}: {results}"
+
+
+# ---------------------------------------------------------------------------
+# The two grammars are distinct, and strict mode rejects rather than counts
+# ---------------------------------------------------------------------------
+
+
+def test_the_same_payload_reads_differently_under_each_grammar(tmp_path):
+    # A pretty-printed object is one record as JSON and not JSONL at all. That
+    # is the whole point of having two grammars rather than one lenient reader.
+    payload = b'{\n  "x": 1,\n  "y": 2\n}\n'
+
+    assert _agree(_all_transports(payload, "json", tmp_path)) == (1, 0)
+    assert _agree(_all_transports(payload, "jsonl", tmp_path)) is REJECTED
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("adjacent values", b'{"x":1}{"x":2}\n{"x":3}\n'),
+        ("malformed record", b'{"x":1}\nnope\n'),
+    ],
+)
+def test_strict_mode_rejects_what_skip_mode_counts(label, payload, tmp_path):
+    skipped = _agree(_all_transports(payload, "jsonl", tmp_path))
+    assert isinstance(skipped, tuple), f"{label}: skip mode should have counted the fault"
+    assert skipped[1] > 0, f"{label}: skip mode must report the fault, got {skipped}"
+
+    strict = _all_transports(payload, "jsonl", tmp_path, jsonl_on_error="strict")
+    assert _agree(strict) is REJECTED, f"{label}: {strict}"
+
+
+def test_a_malformed_record_is_located_by_its_physical_line(tmp_path):
+    # Each line is parsed on its own, so the decoder's own line number is always
+    # 1; the diagnostic must name the line in the file instead.
+    payload = b'{"x":1}\n\n{"x":2}\nnope\n'
+    path = tmp_path / "fixture.jsonl"
+    path.write_bytes(payload)
+
+    with pytest.raises(ValueError) as excinfo:
+        dp.profile(path, jsonl_on_error="strict")
+    assert "line 4" in str(excinfo.value), str(excinfo.value)
+
+
+def test_the_json_grammar_error_points_at_the_jsonl_option(tmp_path):
+    # Reading a JSONL file as JSON is the likely mistake, so the error names the
+    # option that reads it correctly.
+    path = tmp_path / "fixture.json"
+    path.write_bytes(b'{"x":1}\n{"x":2}\n')
+
+    with pytest.raises(ValueError) as excinfo:
+        dp.profile(path)
+    assert "jsonl" in str(excinfo.value).lower(), str(excinfo.value)
+
+
+@requires_async
+def test_async_and_sync_agree_on_a_large_jsonl_stream(tmp_path):
+    # Chunk boundaries are where a line-based reader would most plausibly split a
+    # record; profile enough rows to cross several.
+    payload = b"".join(b'{"id":%d,"name":"row-%d"}\n' % (i, i) for i in range(5_000))
+    results = _all_transports(payload, "jsonl", tmp_path)
+    assert _agree(results) == (5_000, 0)

--- a/tests/public_api_facade.rs
+++ b/tests/public_api_facade.rs
@@ -60,8 +60,8 @@ fn parser_and_metrics_reexports_compile() {
     let jsonl_config = JsonParserConfig::jsonl().with_max_rows(10);
     assert_eq!(jsonl_config.format, Some(JsonFormat::Jsonl));
     assert_eq!(
-        JsonParserConfig::json_array().format,
-        Some(JsonFormat::JsonArray)
+        JsonParserConfig::json_document().format,
+        Some(JsonFormat::Json)
     );
 }
 


### PR DESCRIPTION
Closes #486.

## The decision

#486 asked for a product decision before code, and this is it:

- **`format="jsonl"` — one record per physical line.** A record may not span
  lines; a line may not hold more than one value. Blank lines are separators,
  neither records nor errors.
- **`format="json"` — one standard JSON document.** An array of objects, *or* a
  single object as one record. Whitespace is insignificant, so either may be
  pretty-printed across lines.

Whitespace is insignificant in one grammar and load-bearing in the other, so an
input cannot be valid under both and mean the same thing. That is what makes the
two unambiguous.

## What was wrong

The file and async scanners read JSONL as a whitespace-delimited stream of
top-level JSON values; the synchronous bytes reader split on lines. Same payload,
incompatible answers — verified on master before touching anything:

| input, as `.jsonl` | file & async | bytes |
| --- | --- | --- |
| `{"x":1}{"x":2}` | 2 rows, 0 errors | rejected |
| `{"x":1}{"x":2}\n{"x":3}\n` | 3 rows, 0 errors | 1 row, 1 error |
| `{"x":1} {"x":2}\n` | 2 rows, 0 errors | rejected |
| pretty-printed object | 1 row, 0 errors | rejected |

The first row is the one that matters: a concatenation whose delimiter was lost
profiled as two clean rows. Silently reading damaged data as clean is the
failure a profiler exists to catch.

## What changed

`JsonFormat` is now `Json` (standard document, array or single object) and
`Jsonl` (strict lines). The JSONL branch of both scanners reads a line at a time
and parses it with `from_str`, which requires the value to fill the input — so a
line holding two values is one malformed record, not two clean ones. The JSON
branch gained the single-object shape, which is what lets pretty-printed
documents work without JSONL having to accept multi-line records.

A leading `{` opens both grammars, so sniffing cannot separate them and the
caller says which it has: the facade passes the resolved `FileFormat`, and
`analyze_json_file` falls back to the file extension. A leading `[` is still
resolved from content.

**Two latent bugs surfaced on the way, both fixed here:**

1. The sync array reader called `reader.consume(1)` after
   `consume_leading_whitespace`, which only *peeks*. With whitespace before `]`
   it ate a newline and left the bracket, which then looked like content after
   the closing bracket — so **every pretty-printed JSON array reported a phantom
   `error_count = 1`**. Confirmed pre-existing on master, not introduced here.
2. Per-line parsing makes the decoder's own line number always 1. Malformed
   JSONL records are now located by their physical line, matching what the
   Python bytes reader already did.

## Verification

`python/tests/test_json_record_boundaries.py` (24 tests) checks every case on
**all four transports at once** — file, bytes, async file, async bytes — because
the bug was never visible from any single one. Cases cover adjacent values,
same-line whitespace separation, pretty-printed objects and arrays, blank lines,
malformed first/middle/last records, truncated records, fieldless records, and a
5,000-row stream that crosses chunk boundaries.

**13 of the 24 fail against unfixed code.** The 11 that pass are the
already-correct cases the change must preserve.

A full sweep after the change shows 0 mismatches across 16 payloads × 4
transports × both grammars.

## Behaviour changes to be aware of

- A `.jsonl` file with adjacent or space-separated values on one line is now an
  error (skip mode: counted; strict: raised). **This is the point of the change**,
  but it will fail inputs that previously profiled clean.
- A pretty-printed object read as `.jsonl` is now rejected; read as `.json` it is
  one record. The `dataprof-json` test that asserted the old "pretty object is
  one JSONL row" behaviour is replaced by tests for both halves of the new rule.
- `JsonFormat::JsonArray` → `JsonFormat::Json`, and
  `JsonParserConfig::json_array()` → `json_document()`, now accepting a bare
  object as well as an array.
- Pretty-printed JSON arrays report `error_count = 0` instead of `1`.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets --all-features -- -D warnings
cargo test --workspace --all-features          # 39 suites, 829 tests
uv run maturin develop --features "python,python-async,async-streaming,database,sqlite"
uv run ruff format / ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
uv run pytest python/tests/                    # 936 passed, 4 skipped, 1 xfailed
```
