### PR TITLE
fix(engines): honour and disclose a row cap of zero

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -1162,6 +1162,17 @@ impl AsyncStreamingProfiler {
             let mut hit_row_limit = false;
 
             for (row_idx, values) in chunk.records.into_iter().enumerate() {
+                // A cap of zero rows is met before any row is read. The check
+                // below runs after a row is processed, which is right for every
+                // positive cap but would let `max_rows(0)` return one row — a
+                // cap the caller set and the report then claims to have
+                // honoured.
+                if row_limit == Some(0) {
+                    rows_consumed = row_idx;
+                    hit_row_limit = true;
+                    break;
+                }
+
                 if !sampler.accept(RowView::new(&headers, &values)) {
                     continue;
                 }

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -177,6 +177,18 @@ impl IncrementalProfiler {
                     header_record.iter().map(|s| s.to_string()).collect();
 
                 for (row_idx, record) in records.iter().enumerate() {
+                    // A cap of zero rows is met before any row is read. The
+                    // check below runs after a row is processed, which is right
+                    // for every positive cap but would let `max_rows(0)` return
+                    // one row — a cap the caller set and the report then claims
+                    // to have honoured.
+                    if row_limit == Some(0) {
+                        hit_row_limit = true;
+                        source_exhausted = false;
+                        stop_eval.update(0, 0, 0.0);
+                        break;
+                    }
+
                     // A record whose field count differs from the header is a
                     // structural violation. It is still recovered below (padded
                     // or truncated to header width), but must not vanish from

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -185,7 +185,11 @@ impl IncrementalProfiler {
                     if row_limit == Some(0) {
                         hit_row_limit = true;
                         source_exhausted = false;
-                        stop_eval.update(0, 0, 0.0);
+                        // No rows were consumed, but this chunk was read off
+                        // disk to discover that. Reporting zero bytes here would
+                        // contradict `source_exhausted: false` — a scan that
+                        // stopped early having read nothing at all.
+                        stop_eval.update(0, actual_bytes as u64, 0.0);
                         break;
                     }
 

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -208,10 +208,11 @@ where
                 // The other shape a standard JSON document takes: a single
                 // object, which is one record. It may be pretty-printed across
                 // lines, which is why this is not the JSONL grammar.
-                let (object_rows, object_malformed) =
+                let (object_rows, object_malformed, object_truncated) =
                     scan_single_json_object(&mut reader, config, &mut on_object)?;
                 rows_read += object_rows;
                 malformed_lines += object_malformed;
+                truncated |= object_truncated;
             } else {
                 // The array loop starts after the opening bracket.
                 consume_peeked(&mut reader)?;
@@ -387,7 +388,7 @@ fn read_jsonl_line(line: &str) -> JsonRecord {
 
 /// Read a whole-input single JSON object as one record.
 ///
-/// Returns `(rows_read, malformed)`. Anything that is not exactly one object
+/// Returns `(rows_read, malformed, truncated)`. Anything that is not exactly one object
 /// filling the input is an error under [`JsonErrorPolicy::Strict`] and a counted
 /// malformed record otherwise, so a truncated or concatenated document never
 /// profiles as clean.
@@ -395,7 +396,7 @@ fn scan_single_json_object<R, F>(
     reader: &mut R,
     config: &JsonParserConfig,
     on_object: &mut F,
-) -> Result<(usize, usize), DataProfilerError>
+) -> Result<(usize, usize, bool), DataProfilerError>
 where
     R: BufRead,
     F: FnMut(&JsonObject),
@@ -406,34 +407,33 @@ where
         .map_err(DataProfilerError::from)?;
 
     if text.trim().is_empty() {
-        return Ok((0, 0));
+        return Ok((0, 0, false));
     }
 
-    // A row cap of zero asks for no records, so the document is not read. It is
-    // still well-formed, so this is not a malformed result — but note the report
-    // does not carry a truncation reason either, because the `rows_read == 0`
-    // path in `analyze_json_file_with_options` returns before applying one. That
-    // gap is shared by all three shapes and is tracked separately.
+    // A row cap of zero asks for no records, so the document is not read. The
+    // record it holds is left unread, which is a truncation and has to be
+    // reported as one — an unread record and an empty source must not produce
+    // the same report.
     if config.max_rows == Some(0) {
-        return Ok((0, 0));
+        return Ok((0, 0, true));
     }
 
     match serde_json::from_str::<Value>(text.trim()) {
         Ok(Value::Object(obj)) => {
             on_object(&obj);
-            Ok((1, 0))
+            Ok((1, 0, false))
         }
         Ok(value) => {
             if config.error_policy == JsonErrorPolicy::Strict {
                 return Err(non_object_record_error(json_value_kind(&value), 1));
             }
-            Ok((0, 1))
+            Ok((0, 1, false))
         }
         Err(err) => {
             if config.error_policy == JsonErrorPolicy::Strict {
                 return Err(json_document_error(&err));
             }
-            Ok((0, 1))
+            Ok((0, 1, false))
         }
     }
 }
@@ -888,14 +888,20 @@ pub fn analyze_json_file_with_options(
                 ),
             });
         }
-        return Ok(ReportAssembler::new(
-            file_source,
-            ExecutionMetadata::new(0, 0, start.elapsed().as_millis()).with_engine("json"),
-        )
-        .columns(column_profiles)
-        .with_quality_data(HashMap::new())
-        .with_analysis_options(options)
-        .build());
+        // A row cap that stopped the scan before the first record still has to
+        // be disclosed. Without this the report reads exactly like a complete
+        // profile of an empty source, which is the one thing a truncated scan
+        // must never be mistaken for.
+        let mut execution =
+            ExecutionMetadata::new(0, 0, start.elapsed().as_millis()).with_engine("json");
+        if truncated && let Some(max) = config.max_rows {
+            execution = execution.with_truncation(TruncationReason::MaxRows(max as u64));
+        }
+        return Ok(ReportAssembler::new(file_source, execution)
+            .columns(column_profiles)
+            .with_quality_data(HashMap::new())
+            .with_analysis_options(options)
+            .build());
     }
 
     let sample_columns = profile_builder::quality_check_samples(&column_stats);

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -324,3 +324,111 @@ def test_async_parquet_rejects_unsupported_stop_condition(tmp_path):
 
     with pytest.raises(ValueError, match="only row-limit"):
         asyncio.run(_inner())
+
+
+# ---------------------------------------------------------------------------
+# A cap of zero rows (#541)
+# ---------------------------------------------------------------------------
+#
+# ``max_rows=0`` is the boundary where the two promises above meet: it must read
+# no rows, and it must say the source was cut short. Both halves were broken,
+# differently per path. The CSV and async readers checked the cap *after*
+# processing a row, so a cap of zero returned one row — every positive cap was
+# exact, which is why this hid. The JSON file path counted the truncation
+# correctly and then dropped it, returning a report indistinguishable from a
+# complete profile of an empty source.
+
+
+def _json_fixtures(tmp_path: Path) -> dict[str, tuple[Path, bytes, str]]:
+    """The same two records in each shape, plus the single-object document."""
+    shapes = {
+        "csv": ("data.csv", b"x\n1\n2\n", "csv"),
+        "jsonl": ("data.jsonl", b'{"x":1}\n{"x":2}\n', "jsonl"),
+        "json array": ("array.json", b'[{"x":1},{"x":2}]', "json"),
+        # One record, so "nothing was read" is unambiguous rather than partial.
+        "json object": ("object.json", b'{"x":1}', "json"),
+    }
+    out = {}
+    for label, (name, payload, fmt) in shapes.items():
+        path = tmp_path / name
+        path.write_bytes(payload)
+        out[label] = (path, payload, fmt)
+    return out
+
+
+@pytest.mark.parametrize("label", ["csv", "jsonl", "json array", "json object"])
+def test_max_rows_zero_reads_nothing_and_says_so(label, tmp_path):
+    path, payload, fmt = _json_fixtures(tmp_path)[label]
+
+    for transport, report in [
+        ("file", dp.profile(path, max_rows=0)),
+        ("bytes", dp.profile(payload, format=fmt, max_rows=0)),
+    ]:
+        assert report.rows == 0, f"{label} {transport}: a cap of zero is a hard cap"
+        assert report.truncation_reason == "max_rows(0)", (
+            f"{label} {transport}: a scan cut short before the first record must say so, "
+            f"got {report.truncation_reason!r}"
+        )
+        assert not report.source_exhausted, f"{label} {transport}: records remained unread"
+
+
+def test_max_rows_zero_on_parquet_reads_nothing_and_says_so(tmp_path):
+    pa = pytest.importorskip("pyarrow", reason="pyarrow writes the fixture")
+    pq = pytest.importorskip("pyarrow.parquet", reason="pyarrow writes the fixture")
+
+    path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"x": [1, 2]}), path)
+
+    report = dp.profile(path, max_rows=0)
+    assert report.rows == 0
+    assert report.truncation_reason == "max_rows(0)"
+
+
+@requires_async
+@pytest.mark.parametrize("label", ["csv", "jsonl", "json array", "json object"])
+def test_max_rows_zero_on_async_reads_nothing_and_says_so(label, tmp_path):
+    path, _payload, _fmt = _json_fixtures(tmp_path)[label]
+
+    from dataprof.asyncio import profile_file
+
+    report = asyncio.run(profile_file(path, max_rows=0))
+    assert report.rows == 0, f"{label}: a cap of zero is a hard cap"
+    assert report.truncation_reason == "max_rows(0)", f"{label}: got {report.truncation_reason!r}"
+
+
+@pytest.mark.parametrize(
+    ("label", "name", "payload"),
+    [
+        ("csv header only", "empty.csv", b"x\n"),
+        ("jsonl no records", "empty.jsonl", b""),
+        ("json empty array", "empty.json", b"[]"),
+    ],
+)
+def test_an_empty_source_is_not_a_truncated_one(label, name, payload, tmp_path):
+    # The counterpart that makes the assertion above meaningful: reporting
+    # truncation unconditionally would satisfy those tests and lie here.
+    path = tmp_path / name
+    path.write_bytes(payload)
+
+    report = dp.profile(path, max_rows=0)
+    assert report.rows == 0
+    assert report.truncation_reason is None, (
+        f"{label}: nothing was left unread, so nothing was truncated"
+    )
+
+
+@pytest.mark.parametrize("cap", [1, 2, 5, 9])
+def test_positive_caps_are_unchanged(cap, tmp_path):
+    # The zero fix must not shift any other cap by one in either direction.
+    rows = 5
+    csv_path = Path(_write_csv(tmp_path, rows))
+    jsonl_path = tmp_path / "data.jsonl"
+    jsonl_path.write_bytes(b"".join(b'{"x":%d}\n' % i for i in range(rows)))
+
+    expected = min(cap, rows)
+    assert dp.profile(csv_path, max_rows=cap).rows == expected
+    assert dp.profile(jsonl_path, max_rows=cap).rows == expected
+    if _HAS_ASYNC:
+        from dataprof.asyncio import profile_file
+
+        assert asyncio.run(profile_file(csv_path, max_rows=cap)).rows == expected

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -417,6 +417,23 @@ def test_an_empty_source_is_not_a_truncated_one(label, name, payload, tmp_path):
     )
 
 
+@pytest.mark.parametrize("engine", ["auto", "incremental"])
+def test_max_rows_zero_still_reports_the_bytes_it_read(engine, tmp_path):
+    # Stopping before the first row does not mean nothing was read: a chunk came
+    # off disk to discover the cap was already met. Reporting zero bytes here
+    # would contradict `source_exhausted=False` — a scan that stopped early
+    # having read nothing at all — which is exactly the contradiction
+    # `_assert_consistent` exists to catch.
+    rows = 500
+    path = Path(_write_csv(tmp_path, rows))
+    size = path.stat().st_size
+
+    report = dp.profile(path, engine=engine, max_rows=0)
+
+    assert report.rows == 0
+    _assert_consistent(report, size, f"{engine} max_rows=0")
+
+
 @pytest.mark.parametrize("cap", [1, 2, 5, 9])
 def test_positive_caps_are_unchanged(cap, tmp_path):
     # The zero fix must not shift any other cap by one in either direction.


### PR DESCRIPTION
Closes #541.

## The problem

`max_rows=0` broke both halves of the execution contract, and differently
depending on the path. Measured on master before touching anything:

| path | rows returned | truncation reason |
| --- | ---: | --- |
| sync bytes (csv/jsonl/json) | 0 | `max_rows(0)` ✅ |
| columnar CSV | 0 | `max_rows(0)` ✅ |
| Parquet | 0 | `max_rows(0)` ✅ |
| **sync file JSON** (all three shapes) | 0 | **`None`** ❌ |
| **sync file CSV** (auto/incremental) | **1** ❌ | `max_rows(0)` |
| **async** (csv/jsonl/json) | **1** ❌ | `max_rows(0)` |

So two separate defects, both under the same contract:

1. **The cap was not honoured.** The CSV and async readers check the cap *after*
   processing a row. That is correct for every positive cap — which is exactly
   why this hid — but a cap of zero is already met before the first row, so they
   returned one row while the report claimed the cap had been applied. Verified
   the overshoot is zero-only: caps 1, 2, 3, 5 and 9 were all exact.

2. **The truncation was not disclosed.** The JSON file path computes `truncated`
   correctly, then throws it away — the `rows_read == 0` branch returns an empty
   report before any truncation reason is applied. The result is byte-identical
   to a complete profile of an empty source, which is the one thing a truncated
   scan must never be mistaken for. This is the defect #541 was filed for; note
   it affects arrays and JSONL too, not just the single-object shape the original
   review comment guessed at.

## The fix

Both readers now check a zero cap before consuming a row. The JSON empty-report
path carries the truncation reason, and `scan_single_json_object` reports whether
the document it declined to read was non-empty — so the single-object shape can
distinguish a skipped record from no record at all.

## Verification

New tests in `python/tests/test_execution_controls.py`, which already carries the
"row caps are hard caps" promise. They assert, for CSV, JSONL, JSON arrays,
single JSON objects and Parquet, across file / bytes / async:

- `max_rows=0` on a non-empty source → `rows == 0`, `truncation_reason ==
  "max_rows(0)"`, `source_exhausted` false;
- an **empty** source with `max_rows=0` → no truncation reason. This is the
  counterpart that makes the rest meaningful: reporting truncation
  unconditionally would satisfy every other assertion and lie here;
- positive caps (1, 2, 5, 9) on a 5-row source are unchanged, so the zero fix
  cannot have shifted any other cap by one.

**8 of the 46 tests in the file fail against unfixed code**, covering both defects
across all four shapes and the async path. The empty-source and positive-cap tests
pass either way by design.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets --all-features -- -D warnings
cargo test --workspace --all-features          # exit 0, 39 suites
uv run maturin develop --features "python,python-async,async-streaming,database,sqlite"
uv run ruff format / ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
uv run pytest python/tests/                    # 952 passed, 4 skipped, 1 xfailed
```
