### PR TITLE
fix(engines): count ragged rows on the columnar CSV engine

### DIFF
--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -21,6 +21,16 @@ use std::sync::Arc;
 /// Sample cap for numeric columns (matches SAMPLE_THRESHOLD in stats::numeric)
 const NUMERIC_SAMPLE_CAP: usize = 10_000;
 
+/// What a pass with the `csv` crate learns about a file that Arrow cannot
+/// report on its own: see [`ArrowProfiler::pre_scan`].
+struct CsvPreScan {
+    headers: csv::StringRecord,
+    /// Rows whose field count differs from the header, in either direction.
+    ragged_row_count: usize,
+    /// Width of the widest record, never less than the header width.
+    max_fields: usize,
+}
+
 /// Columnar profiler using Apache Arrow for efficient column-oriented processing
 pub struct ArrowProfiler {
     batch_size: usize,
@@ -80,37 +90,99 @@ impl ArrowProfiler {
         self
     }
 
+    /// One `csv`-crate pass over the file, taken before Arrow decodes it.
+    ///
+    /// Arrow cannot report either half of the ragged-row contract. A short row
+    /// is padded to null, and Arrow's own output cannot tell that padding apart
+    /// from a genuinely empty trailing field — both arrive as null — so the
+    /// count is unrecoverable after the fact. An over-long row is not decoded at
+    /// all. This pass answers both questions before the decode starts.
+    ///
+    /// It is a second read of the file on the engine chosen for speed, so the
+    /// cost was measured rather than assumed: on a 218 MB / 2M-row CSV it adds
+    /// ~0.3s to a ~9s profile, about 3%. Parsing is not what this engine spends
+    /// its time on; the per-value analysis is.
+    fn pre_scan(&self, file_path: &Path) -> Result<CsvPreScan, DataProfilerError> {
+        let mut builder = csv::ReaderBuilder::new();
+        builder.has_headers(true);
+        let (flexible, max_rows) = match self.csv_config {
+            Some(ref config) => {
+                if let Some(delim) = config.delimiter {
+                    builder.delimiter(delim);
+                }
+                builder.quote(config.quote_char);
+                if config.trim_whitespace {
+                    builder.trim(csv::Trim::All);
+                }
+                (config.flexible, config.max_rows)
+            }
+            None => (false, None),
+        };
+        // Strict parsing rejects here, one reader earlier than Arrow would, so
+        // the caller gets the same field-count diagnostic as every other path
+        // instead of Arrow's "incorrect number of fields".
+        builder.flexible(flexible);
+
+        let mut reader = builder.from_path(file_path)?;
+        let headers = reader.headers()?.clone();
+        let header_width = headers.len();
+
+        let mut ragged_row_count = 0;
+        let mut max_fields = header_width;
+        // The row cap bounds the count too: a ragged row this profile never
+        // reaches is not part of it and must not show up in its report.
+        let mut rows_scanned = 0;
+        let mut record = csv::ByteRecord::new();
+        while max_rows.is_none_or(|max| rows_scanned < max)
+            && reader.read_byte_record(&mut record)?
+        {
+            rows_scanned += 1;
+            if record.len() != header_width {
+                ragged_row_count += 1;
+                max_fields = max_fields.max(record.len());
+            }
+        }
+
+        Ok(CsvPreScan {
+            headers,
+            ragged_row_count,
+            max_fields,
+        })
+    }
+
     pub fn analyze_csv_file(&self, file_path: &Path) -> Result<ProfileReport, DataProfilerError> {
         let start = std::time::Instant::now();
         let file = File::open(file_path)?;
         let file_size_bytes = file.metadata()?.len();
         let _file_size_mb = file_size_bytes as f64 / 1_048_576.0;
 
-        // Read first to infer schema from headers
-        let mut header_builder = csv::ReaderBuilder::new();
-        header_builder.has_headers(true);
-        if let Some(ref config) = self.csv_config {
-            if let Some(delim) = config.delimiter {
-                header_builder.delimiter(delim);
-            }
-            header_builder.flexible(config.flexible);
-            header_builder.quote(config.quote_char);
-            if config.trim_whitespace {
-                header_builder.trim(csv::Trim::All);
-            }
-        }
-        let mut reader = header_builder.from_path(file_path)?;
+        // Read the header and the field-count shape of the body up front; see
+        // `pre_scan` for why Arrow cannot supply either.
+        let scan = self.pre_scan(file_path)?;
+        let headers = scan.headers;
 
-        // Get headers to create Arrow schema
-        let headers = reader.headers()?.clone();
         // Reject duplicate headers before building the name-keyed analyzer map,
         // which would otherwise merge two columns into one profile.
         let header_names: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
         dataprof_core::validate_unique_column_names(&header_names, "CSV header")?;
+        let header_width = header_names.len();
+
         let mut fields = Vec::new();
         for header in headers.iter() {
             // Start with string type, Arrow will convert during processing
             fields.push(Field::new(header, arrow::datatypes::DataType::Utf8, true));
+        }
+        // `arrow-csv` has no counterpart to `with_truncated_rows` for a row that
+        // is *wider* than the schema — it aborts the scan. Widening the schema to
+        // the widest record in the file gives those surplus fields somewhere to
+        // land; they are projected away below, which is the same recovery the
+        // incremental engine performs when it truncates a record to header width.
+        for overflow in header_width..scan.max_fields {
+            fields.push(Field::new(
+                format!("__dataprof_overflow_{overflow}"),
+                arrow::datatypes::DataType::Utf8,
+                true,
+            ));
         }
         let schema = Arc::new(Schema::new(fields));
 
@@ -135,10 +207,10 @@ impl ArrowProfiler {
         let mut column_analyzers: std::collections::HashMap<String, ColumnAnalyzer> =
             std::collections::HashMap::new();
 
-        for field in schema.fields() {
+        for name in &header_names {
             column_analyzers.insert(
-                field.name().to_string(),
-                ColumnAnalyzer::new(field.data_type()),
+                name.clone(),
+                ColumnAnalyzer::new(&arrow::datatypes::DataType::Utf8),
             );
         }
 
@@ -157,8 +229,22 @@ impl ArrowProfiler {
         let mut truncated = false;
         let mut memory_sampler = PeakMemorySampler::new();
 
+        let projection: Vec<usize> = (0..header_width).collect();
+
         for batch_result in csv_reader {
             let mut batch = batch_result.map_err(|error| map_arrow_csv_error(file_path, &error))?;
+
+            // Drop the overflow columns before anything observes the batch, so
+            // duplicate tracking, hint bindings and the profiles themselves all
+            // see exactly the columns the header declared.
+            if batch.num_columns() > header_width {
+                batch =
+                    batch
+                        .project(&projection)
+                        .map_err(|error| DataProfilerError::ArrowError {
+                            message: error.to_string(),
+                        })?;
+            }
 
             if let Some(max) = max_rows {
                 if total_rows >= max {
@@ -226,8 +312,9 @@ impl ArrowProfiler {
         let num_columns = column_profiles.len();
 
         memory_sampler.sample();
-        let mut execution =
-            ExecutionMetadata::new(total_rows, num_columns, scan_time_ms).with_engine("columnar");
+        let mut execution = ExecutionMetadata::new(total_rows, num_columns, scan_time_ms)
+            .with_engine("columnar")
+            .with_ragged_row_count(scan.ragged_row_count);
         if let Some(peak_mb) = memory_sampler.peak_mb() {
             execution = execution.with_memory_peak_mb(peak_mb);
         }
@@ -271,7 +358,7 @@ fn map_arrow_csv_error(file_path: &Path, error: &arrow::error::ArrowError) -> Da
         return DataProfilerError::CsvParsingError {
             message,
             suggestion: format!(
-                "The explicit columnar CSV engine currently requires rectangular rows. '{}' contains ragged records that the Arrow backend cannot recover from. Use engine='auto' or engine='incremental' for malformed CSV, or clean the file before forcing engine='columnar'.",
+                "The columnar engine sizes its schema from a pre-scan of '{}', so a row Arrow still finds ragged means the two parsers disagree on where records end — most often unbalanced quotes or an embedded newline. Use engine='auto' or engine='incremental', which parse the file only once.",
                 file_path.display()
             ),
         };
@@ -1082,31 +1169,113 @@ mod tests {
         assert_eq!(report.column_profiles.len(), 3);
         assert_eq!(city_col.total_count, 2);
         assert_eq!(city_col.null_count, 1);
+        // Padding the row is the recovery; reporting it is the contract (#470).
+        assert_eq!(report.execution.ragged_row_count, 1);
 
         Ok(())
     }
 
     #[test]
-    fn test_arrow_profiler_reports_clear_error_for_extra_fields() {
+    fn test_arrow_profiler_recovers_and_counts_extra_fields() -> Result<(), DataProfilerError> {
+        // Arrow aborts on a row wider than its schema, so the pre-scan widens
+        // the schema and the surplus fields are projected away — the same
+        // recovery the incremental engine performs, with the same count.
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "name,age,city")?;
+        writeln!(temp_file, "Alice,25,Rome")?;
+        writeln!(temp_file, "Bob,30,Milan,unexpected")?;
+        temp_file.flush()?;
+
+        let profiler = ArrowProfiler::new().csv_config(CsvParserConfig::default());
+        let report = profiler.analyze_csv_file(temp_file.path())?;
+
+        assert_eq!(report.column_profiles.len(), 3);
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.ragged_row_count, 1);
+
+        let city_col = report
+            .column_profiles
+            .iter()
+            .find(|p| p.name == "city")
+            .expect("city column should exist");
+        assert_eq!(city_col.total_count, 2);
+        assert_eq!(
+            city_col.null_count, 0,
+            "the dropped field is the 4th, not city"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_profiler_ragged_count_respects_the_row_cap() -> Result<(), DataProfilerError> {
+        // The ragged row sits past the cap, so this profile never reads it and
+        // must not report it.
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "name,age,city")?;
+        writeln!(temp_file, "Alice,25,Rome")?;
+        writeln!(temp_file, "Bob,30")?;
+        temp_file.flush()?;
+
+        let config = CsvParserConfig {
+            max_rows: Some(1),
+            ..CsvParserConfig::default()
+        };
+        let report = ArrowProfiler::new()
+            .csv_config(config)
+            .analyze_csv_file(temp_file.path())?;
+
+        assert_eq!(report.execution.rows_processed, 1);
+        assert_eq!(report.execution.ragged_row_count, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_profiler_counts_nothing_for_a_rectangular_file() -> Result<(), DataProfilerError>
+    {
+        // A trailing empty field is a present field. Arrow renders it as null,
+        // exactly like a padded one, which is why the count cannot come from
+        // Arrow's output — and why this case has to be pinned.
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "name,age,city")?;
+        writeln!(temp_file, "Alice,25,Rome")?;
+        writeln!(temp_file, "Carol,35,")?;
+        temp_file.flush()?;
+
+        let report = ArrowProfiler::new()
+            .csv_config(CsvParserConfig::default())
+            .analyze_csv_file(temp_file.path())?;
+
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.ragged_row_count, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_profiler_strict_rejects_ragged_rows_with_field_counts() {
+        // Strict parsing still rejects, but the pre-scan gets there first, so
+        // the diagnostic names the field counts the way every other path does
+        // instead of Arrow's opaque "incorrect number of fields".
         let mut temp_file = NamedTempFile::new().expect("temp file should be created");
         writeln!(temp_file, "name,age,city").expect("header should write");
         writeln!(temp_file, "Alice,25,Rome").expect("row should write");
         writeln!(temp_file, "Bob,30,Milan,unexpected").expect("ragged row should write");
         temp_file.flush().expect("temp file should flush");
 
-        let profiler = ArrowProfiler::new().csv_config(CsvParserConfig::default());
-        let error = profiler
+        let config = CsvParserConfig {
+            flexible: false,
+            ..CsvParserConfig::default()
+        };
+        let error = ArrowProfiler::new()
+            .csv_config(config)
             .analyze_csv_file(temp_file.path())
-            .expect_err("extra fields should still fail in the Arrow CSV backend");
+            .expect_err("strict parsing must reject a ragged row");
 
         match error {
-            DataProfilerError::CsvParsingError {
-                message,
-                suggestion,
-            } => {
-                assert!(message.contains("incorrect number of fields"));
-                assert!(suggestion.contains("engine='auto'"));
-                assert!(suggestion.contains("engine='incremental'"));
+            DataProfilerError::CsvParsingError { message, .. } => {
+                assert!(message.contains("3 fields"), "{message}");
             }
             other => panic!("expected CsvParsingError, got {other:?}"),
         }

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -197,7 +197,7 @@ Returned by `profile()` and all analysis functions.
 | `memory_peak_mb` | `float \| None` | Peak memory usage |
 | `truncation_reason` | `str \| None` | Why processing stopped early |
 | `source_exhausted` | `bool` | Whether the entire source was read |
-| `ragged_row_count` | `int` | Rows whose field count differed from the header (`0` = clean parse). Reported for file and async CSV inputs; not by `engine="columnar"` |
+| `ragged_row_count` | `int` | Rows whose field count differed from the header (`0` = clean parse). Reported for file, async and columnar CSV inputs |
 | `sampling_applied` | `bool` | Whether sampling was used |
 | `sampling_ratio` | `float \| None` | Fraction of data sampled |
 

--- a/python/tests/test_ragged_csv_policy.py
+++ b/python/tests/test_ragged_csv_policy.py
@@ -1,4 +1,4 @@
-"""Ragged CSV policy parity across file, bytes, and async inputs (#418, #462).
+"""Ragged CSV policy parity across file, bytes, and async inputs (#418, #462, #470).
 
 A row whose field count differs from the header is a structural violation. The
 shipped policy per transport is deliberately not uniform, and this file is the
@@ -7,11 +7,11 @@ record of which difference is intended:
 ====================  =========================================================
 file (auto/increm.)   recover, count in ``execution.ragged_row_count``
 async bytes / URL     recover, count — same signal as the file path
+``engine="columnar"`` recover, count — identical numbers to the file path, in
+                      both directions (missing *and* extra fields)
 sync bytes            reject with a ValueError naming the row (no flexible
                       engine behind the pure-Python bytes reader)
-``csv_flexible``      ``False`` rejects on file *and* async paths
-``engine="columnar"`` **not covered** — rejects extra fields, but pads missing
-                      ones and still reports 0. Tracked in #470.
+``csv_flexible``      ``False`` rejects on the file, async and columnar paths
 ====================  =========================================================
 
 What no covered path may do is recover silently: a repaired scan must never
@@ -86,27 +86,58 @@ def test_async_bytes_match_the_file_path(tmp_path):
     assert from_async.ragged_row_count == from_file.ragged_row_count
 
 
-# --- The columnar engine is a documented gap, not a covered path ------------
+# --- The columnar engine is now a covered path (#470) -----------------------
 
 
-def test_columnar_rejects_extra_fields(tmp_path):
-    with pytest.raises(ValueError) as excinfo:
-        dp.profile(_write(tmp_path, RAGGED), engine="columnar")
-    assert "incorrect number of fields" in str(excinfo.value)
+def test_columnar_recovers_and_counts_both_directions(tmp_path):
+    # Arrow pads a short row to null and cannot decode an over-long one at all,
+    # so neither half of the count survives the decode. A `csv`-crate pre-scan
+    # supplies both before Arrow starts — measured at ~3% of the engine's wall
+    # time, because the per-value analysis dominates, not the parse.
+    report = dp.profile(_write(tmp_path, RAGGED), engine="columnar")
+
+    assert report.rows == 4
+    assert report.columns == 3, "the surplus field must not become a column"
+    assert report.ragged_row_count == 2
 
 
-def test_columnar_pads_missing_fields_without_counting(tmp_path):
-    # Pins the #470 gap rather than endorsing it: the Arrow backend pads a short
-    # row to null and reports a clean parse, so `engine="columnar"` is still a
-    # silent-clean path. When #470 lands this assertion must flip to 1 and the
-    # policy table at the top of this module must be updated with it.
+def test_columnar_matches_the_default_engine(tmp_path):
+    # Engine choice is a performance knob. It must not change the numbers.
+    path = _write(tmp_path, RAGGED)
+    from_default = dp.profile(path)
+    from_columnar = dp.profile(path, engine="columnar")
+
+    assert from_columnar.rows == from_default.rows
+    assert from_columnar.columns == from_default.columns
+    assert from_columnar.ragged_row_count == from_default.ragged_row_count
+
+
+def test_columnar_counts_missing_fields(tmp_path):
+    # The regression this file used to pin: a short row padded to null and
+    # reported as a clean parse, so the file scored a perfect consistency.
     short_only = b"name,age,city\nAlice,25,NYC\nBob,30\n"
-    report = dp.profile(_write(tmp_path, short_only), engine="columnar")
+    path = _write(tmp_path, short_only)
 
+    report = dp.profile(path, engine="columnar")
     assert report.rows == 2
-    assert report.ragged_row_count == 0
-    # The default path sees the same file honestly.
-    assert dp.profile(_write(tmp_path, short_only)).ragged_row_count == 1
+    assert report.ragged_row_count == 1
+    assert dp.profile(path).ragged_row_count == 1
+
+
+def test_columnar_clean_reports_zero(tmp_path):
+    # A trailing empty field is a present field, and Arrow renders it as null
+    # exactly like a padded one — so the count must not be inferred from nulls.
+    trailing_empty = b"name,age,city\nAlice,25,NYC\nCarol,35,\n"
+    assert dp.profile(_write(tmp_path, trailing_empty), engine="columnar").ragged_row_count == 0
+
+
+def test_columnar_csv_flexible_false_rejects(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        dp.profile(_write(tmp_path, RAGGED), engine="columnar", csv_flexible=False)
+    message = str(excinfo.value)
+    # The pre-scan rejects before Arrow does, so strict parsing reports the same
+    # field counts here as on the file path instead of Arrow's opaque wording.
+    assert "3 fields" in message, message
 
 
 # --- Clean input stays clean ------------------------------------------------

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -893,3 +893,74 @@ fn test_unique_headers_preserve_column_count_and_totals() {
         }
     }
 }
+
+/// A ragged row must read the same through either engine (#470).
+///
+/// The columnar engine used to pad a short row to null and report a clean
+/// parse, while rejecting an over-long one outright — so `engine="columnar"`
+/// was both the only silently-clean CSV path and the only one that refused
+/// data the default engine handled. Both directions now recover and count.
+#[test]
+fn ragged_rows_report_identically_across_engines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "name,age,city").unwrap();
+    writeln!(f, "Alice,25,Rome").unwrap();
+    writeln!(f, "Bob,30").unwrap(); // short: two fields
+    writeln!(f, "Carol,35,LA,EXTRA").unwrap(); // over-long: four fields
+    writeln!(f, "Dave,40,SF").unwrap();
+    f.flush().unwrap();
+
+    let incremental = Profiler::new()
+        .engine(EngineType::Incremental)
+        .analyze_file(f.path())
+        .expect("incremental recovers ragged rows");
+    let columnar = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(f.path())
+        .expect("columnar recovers ragged rows");
+
+    assert_eq!(incremental.execution.rows_processed, 4);
+    assert_eq!(
+        columnar.execution.rows_processed, incremental.execution.rows_processed,
+        "both engines must see every row"
+    );
+    assert_eq!(incremental.execution.ragged_row_count, 2);
+    assert_eq!(
+        columnar.execution.ragged_row_count, incremental.execution.ragged_row_count,
+        "the columnar engine must not report a repaired scan as a clean one"
+    );
+    assert_eq!(
+        columnar.column_profiles.len(),
+        3,
+        "the surplus field must not become a fourth column"
+    );
+}
+
+/// Recovery truncates an over-long row to header width, so two rows differing
+/// only past the header are the same row. The fields the columnar engine has
+/// to decode somewhere must not leak into duplicate tracking (#470).
+#[test]
+fn surplus_fields_do_not_leak_into_duplicate_detection() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "name,age,city").unwrap();
+    writeln!(f, "Alice,25,Rome").unwrap();
+    writeln!(f, "Alice,25,Rome,X").unwrap();
+    f.flush().unwrap();
+
+    for engine in [EngineType::Incremental, EngineType::Columnar] {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(f.path())
+            .expect("ragged rows profile");
+        let uniqueness = report
+            .quality
+            .as_ref()
+            .and_then(|q| q.metrics.uniqueness.as_ref())
+            .unwrap_or_else(|| panic!("{engine:?} uniqueness should be assessed"));
+
+        assert_eq!(
+            uniqueness.duplicate_rows, 1,
+            "{engine:?} must see the truncated row as a duplicate"
+        );
+    }
+}


### PR DESCRIPTION
Closes #470. Follow-up to #462. Important as it will improve how arrow-rs behaves directly for downstream consumers.

> **This is a workaround, and part of it is meant to be temporary.**
>
> The pre-scan exists because `arrow-csv` discards the information before we can
> read it. Both halves are now filed upstream, with a PR open for the first:
>
> * [apache/arrow-rs#10577](https://github.com/apache/arrow-rs/issues/10577) and
>   [PR #10579](https://github.com/apache/arrow-rs/pull/10579), report the number
>   of rows padded by `with_truncated_rows`. A maintainer has said the approach
>   sounds reasonable. Once this lands and we upgrade, the pre-scan can be dropped
>   for the short-row half of the count.
> * [apache/arrow-rs#10578](https://github.com/apache/arrow-rs/issues/10578),
>   opt-in recovery for rows with more fields than the schema. Filed at a
>   maintainer's suggestion, still under consideration. If it lands, the schema
>   widening and the overflow projection go away too.
>
> Until then this PR is what makes the columnar engine tell the truth, and the
> behaviour it ships is the behaviour we want to keep either way. Only the
> mechanism behind it should change.


## The problem

`engine="columnar"` was the last CSV path that could report a repaired scan as
a clean one, and it disagreed with itself about which direction of raggedness
counted:

| Input | Columnar (before) | Default (auto/incremental) |
|---|---|---|
| row with **missing** fields | pads to null, `ragged_row_count=0` | recovers, `ragged_row_count=1` |
| row with **extra** fields | rejects with `CsvParsingError` | recovers, `ragged_row_count=1` |

So a short-row file profiled at a perfect consistency score through the
columnar engine — exactly the failure #418 and #462 removed everywhere else —
while an over-long row was refused outright, data the default engine handles
without complaint. Engine selection is a performance knob; it must not change
the numbers.

## Why #462 deferred it, and what changed

#462 documented the gap rather than guessing at the trade-off. Two things
needed establishing first.

**Arrow cannot supply either half of the answer.** Verified directly against
`arrow-csv` 59.1.0: a genuinely empty trailing field and a padded missing one
both arrive as `NULL`, indistinguishable, so the count is unrecoverable from
Arrow's output after the fact.

    name,age,city
    Alice,25,Rome    ->  ["Alice", "25", "Rome"]
    Carol,35,        ->  ["Carol", "35", NULL]   <- present but empty
    Bob,30           ->  ["Bob",   "30", NULL]   <- missing, padded

And `arrow-csv` has no counterpart to `with_truncated_rows` for a row *wider*
than the schema — `RecordDecoder` aborts the scan (`reader/records.rs:131`).

**The pre-scan cost was measured, not assumed.** The issue's concern was that a
second full read would be paid on the engine chosen precisely for speed. On a
218 MB / 2M-row CSV, three trials:

| | columnar profile | `csv`-crate pre-scan | overhead |
|---|---|---|---|
| trial 0 | 9778 ms | 301 ms | 3% |
| trial 1 | 9061 ms | 311 ms | 3% |
| trial 2 | 8915 ms | 307 ms | 3% |

This engine spends its time on per-value analysis, not on parsing. At 3% the
trade-off is not close, so the count is produced rather than the rows rejected.

## The fix

One `csv`-crate pass runs before Arrow decodes, replacing the header-only read
that was already there. It yields the exact ragged count and the widest record
in the file. The Arrow schema is widened to that width so surplus fields have
somewhere to land, and they are projected away before anything observes the
batch — the same recovery the incremental engine performs when it truncates a
record to header width, with the same effect on duplicate tracking.

The row cap bounds the pre-scan too, so a ragged row past the cap is not
counted in a profile that never read it.

`csv_flexible=false` now rejects on this path via the pre-scan, one reader
earlier than Arrow would, so the error names the field counts the way the file
and async paths do instead of reporting Arrow's "incorrect number of fields".

Both directions now match the default engine exactly:

```python
dp.profile(path, engine="columnar").ragged_row_count  # 2
dp.profile(path).ragged_row_count                     # 2
```

## Verification

Each of the three parts was reverted separately and confirmed to fail its own
test — reverting them together would only prove the suite catches *something*:

| Reverted part | Test that fails |
|---|---|
| reporting the pre-scan count | `test_arrow_profiler_allows_truncated_rows_when_flexible`, `test_arrow_profiler_recovers_and_counts_extra_fields` |
| schema widening | `test_arrow_profiler_recovers_and_counts_extra_fields` |
| batch projection | `surplus_fields_do_not_leak_into_duplicate_detection` |

The projection's only observable effect is duplicate detection; the other tests
do **not** discriminate it, which is why it has a dedicated guard.

New coverage: cross-engine ragged parity and duplicate-detection parity in
`tests/cross_engine_consistency.rs`; row-cap bounding and the
trailing-empty-field case (the one that proves the count cannot be inferred
from nulls) in the crate's unit tests; the columnar section of
`python/tests/test_ragged_csv_policy.py` rewritten from pinning the gap to
covering the path.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace --exclude dataprof-python
uv run pytest python/tests -q            # 930 passed, 9 skipped, 1 xfailed
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check  python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```

## Notes

`docs/release-notes.md` is deliberately untouched: it is the 0.10.0 document,
rewritten at release-prep time. The columnar caveat it still carries should be
dropped when the 0.11.0 notes are written. `docs/python/README.md` is API
reference and is updated here.
