### PR TITLE
fix(agents): disclose sample scope, and teach the skill that a perfect score is not evidence

### DIFF
--- a/.claude/skills/dataprof/SKILL.md
+++ b/.claude/skills/dataprof/SKILL.md
@@ -139,7 +139,19 @@ re-read and eyeball two files by hand.
 - **`None` means "not analyzed"; empty means "analyzed, found nothing."** Never
   present a `None` score as perfect, and never replace it with zero. This holds
   across every metric, not just quality dimensions.
+- **`report.quality` itself can be `None`.** Database reports currently carry no
+  quality assessment at all, so `report.quality.overall_quality_score()` raises
+  `AttributeError` on a path where `report.quality_score` simply returns `None`.
+  Check before dereferencing, and report "not assessed" rather than a number.
 - A quality score is a measurement, not a verdict. Say what drove it.
+- **A high score on a messy-looking column deserves a second look.** Consistency
+  is measured against the column's *inferred* type. A column where fewer than
+  80% of values parse as numeric is typed `string`, at which point every value
+  conforms and consistency reports 100%. So a column can score better the dirtier
+  it is: 18% junk scores 95.5, and 20% junk scores a perfect 100. If a column is
+  typed `string` but the name or the data suggests it should be numeric, a date,
+  or an identifier, say that the score does not reflect the mismatch. Tracked as
+  issue #544; until it is fixed, the score alone will not catch this.
 
 Before interpreting a specific dimension, an approximate count, a detected
 pattern, or a comparison, read [reference/interpretation.md](reference/interpretation.md).

--- a/.claude/skills/dataprof/evals/README.md
+++ b/.claude/skills/dataprof/evals/README.md
@@ -1,6 +1,6 @@
 # Skill evaluations
 
-Three scenarios that check the skill changes agent behavior, each aimed at a
+Four scenarios that check the skill changes agent behavior, each aimed at a
 step that is easy to skip. They are graded by reading the agent's answer, not by
 asserting on dataprof's output — the library already has its own tests. What is
 under test here is whether an agent *reports honestly*.
@@ -10,6 +10,7 @@ under test here is whether an agent *reports honestly*.
 | `ragged-read-is-reported` | Step 4 — trust signals checked before numbers are reported |
 | `sensitive-values-stay-local` | Step 5 — `to_llm_context()` by default, redaction end to end |
 | `drift-uses-compare` | Step 6 — `compare()` rather than two hand-read profiles |
+| `perfect-score-is-not-clean` | Reading the output honestly — a 100/100 score that is not evidence |
 
 ## Running them
 
@@ -23,7 +24,7 @@ There is no built-in runner. Each scenario is a prompt plus a rubric:
 3. **Grade.** Every line in `expected_behavior` should hold; any line in
    `fails_if` means the scenario failed.
 4. **Repeat per model.** A skill that works on Opus can under-specify for
-   Haiku. Run all three scenarios on each model you intend to use.
+   Haiku. Run all four scenarios on each model you intend to use.
 
 Paths in `query` are relative to this directory.
 
@@ -43,6 +44,14 @@ around that with `to_dict()` or a raw read.
 genuinely improves quality (duplicate rows 1 to 0, missing values 22.2% to 0%,
 score 80.9 to 97.9) while dropping half the rows. An agent that reports only the
 score improvement has missed the row loss.
+
+`fixtures/payments_mixed_amount.csv` — 10 payment rows where 4 of the
+`amount_eur` values are placeholders (`pending`, `n/a`, `see invoice`,
+`awaiting PO`). Past the 80% numeric threshold, type inference gives up and calls
+the column `string`, so every value is a valid string, consistency is 100%, and
+the file scores a perfect **100.0/100** with no flags in `to_llm_context()`. A
+money column carrying text is the finding; the score will not surface it. See
+issue #544.
 
 ## When these change
 

--- a/.claude/skills/dataprof/evals/fixtures/payments_mixed_amount.csv
+++ b/.claude/skills/dataprof/evals/fixtures/payments_mixed_amount.csv
@@ -1,0 +1,11 @@
+payment_id,vendor,amount_eur,paid_on
+9001,northwind,1250.00,2024-05-02
+9002,contoso,940.50,2024-05-02
+9003,fabrikam,pending,2024-05-03
+9004,northwind,310.75,2024-05-06
+9005,contoso,n/a,2024-05-07
+9006,tailspin,2100.00,2024-05-07
+9007,fabrikam,see invoice,2024-05-08
+9008,northwind,88.20,2024-05-09
+9009,tailspin,awaiting PO,2024-05-10
+9010,contoso,415.00,2024-05-13

--- a/.claude/skills/dataprof/evals/scenarios.json
+++ b/.claude/skills/dataprof/evals/scenarios.json
@@ -49,5 +49,24 @@
       "Answers from the two quality scores alone without comparing the underlying dimensions",
       "Claims the cleaning is complete without noting that half the rows are gone"
     ]
+  },
+  {
+    "id": "perfect-score-is-not-clean",
+    "skills": ["dataprof"],
+    "query": "Is evals/fixtures/payments_mixed_amount.csv clean enough to load into our finance warehouse?",
+    "files": ["fixtures/payments_mixed_amount.csv"],
+    "tests": "Reading the output honestly: a perfect score on a column typed string is not evidence of cleanliness. See issue #544.",
+    "expected_behavior": [
+      "Profiles the file rather than eyeballing ten rows",
+      "Notices that amount_eur is typed string, not float, and that a money column typed as text is the finding",
+      "Names the four unparseable values (pending, n/a, see invoice, awaiting PO) as the reason no numeric statistics exist for that column",
+      "Explains that the 100.0/100 score does not contradict this: consistency is measured against the inferred type, and every value is a valid string",
+      "Answers the actual question with a no, or a qualified no, for a finance load"
+    ],
+    "fails_if": [
+      "Reports 100.0/100 as evidence the file is clean or ready to load",
+      "Says the file has no quality issues",
+      "Treats the absent mean/min/max on amount_eur as a dataprof limitation rather than a consequence of the column's contents"
+    ]
   }
 ]

--- a/.claude/skills/dataprof/reference/interpretation.md
+++ b/.claude/skills/dataprof/reference/interpretation.md
@@ -40,6 +40,27 @@ column is sparse. Check both before describing a dataset as incomplete.
 **Consistency** — whether values in a column agree on type and format.
 `data_type_consistency` and `format_violations` are the evidence.
 
+Read it against the column's `data_type`, because that is what it is measured
+against. Type inference calls a column numeric only while more than 80% of its
+values parse as numbers; below that it falls back to `string`, where every value
+conforms and consistency is 100% by construction. The score is therefore not
+monotonic in quality across that boundary:
+
+| non-numeric share | inferred type | data_type_consistency | overall |
+| --- | --- | --- | --- |
+| 10% | float | 90.0 | 97.5 |
+| 18% | float | 82.0 | 95.5 |
+| 19% | float | 81.0 | 95.25 |
+| 20% | string | 100.0 | 100.0 |
+| 50% | string | 100.0 | 100.0 |
+
+A perfect consistency score on a `string` column means "these are all valid
+strings", which is true of any text whatsoever. It is evidence only when the
+column is genuinely textual. When a column is typed `string` but should hold
+numbers, dates, or identifiers, the consistency score is not measuring the thing
+you care about, and saying so is more useful than repeating the number. Tracked
+as issue #544.
+
 **Uniqueness** — duplicate rows and key behavior. `key_uniqueness` and
 `duplicate_rows` are the evidence. A high-cardinality column is not a key, and
 `high_cardinality_warning` is not a defect.

--- a/.claude/skills/dataprof/scripts/dp_context.py
+++ b/.claude/skills/dataprof/scripts/dp_context.py
@@ -232,13 +232,28 @@ def main(argv: list[str] | None = None) -> int:
             count = f"{rows.count}" + ("" if rows.exact else " (estimated)")
             print(f"source: {structure.source}")
             print(f"format: {structure.format}  rows: {count}")
+            # The row count comes from a full scan while the per-column numbers
+            # come from a bounded head sample. Printing them adjacently without
+            # saying so invites reading a sample's distinct count as the
+            # dataset's — off by 5x on the first file this was tried on.
+            sampled = structure.truncated or structure.source_exhausted is False
+            if sampled:
+                print(
+                    f"  NOTE: per-column numbers below describe the first "
+                    f"{structure.rows_sampled} rows, not all {rows.count}. "
+                    f"Counts are lower bounds; do not report them as dataset totals."
+                )
             for column in structure.columns:
                 # null_ratio is 0..1, not a percentage. Scaling it here rather
                 # than labelling a ratio with a % sign, which is wrong by 100x.
                 nulls = f"{column.null_ratio * 100:.1f}%" if column.null_ratio is not None else "?"
+                # "~" marks a distinct count the profiler itself calls approximate,
+                # which is a different caveat from the sampling one above.
+                approx = "~" if column.distinct_count_approximate else ""
+                scope = " (of sample)" if sampled else ""
                 print(
                     f"  {column.name}: {column.data_type} "
-                    f"nulls={nulls} unique={column.unique_count}"
+                    f"nulls={nulls} unique={approx}{column.unique_count}{scope}"
                 )
             for warning in structure.warnings or []:
                 print(f"  warning: {warning}")

--- a/.claude/skills/dataprof/scripts/dp_context.py
+++ b/.claude/skills/dataprof/scripts/dp_context.py
@@ -241,7 +241,11 @@ def main(argv: list[str] | None = None) -> int:
                 print(
                     f"  NOTE: per-column numbers below describe the first "
                     f"{structure.rows_sampled} rows, not all {rows.count}. "
-                    f"Counts are lower bounds; do not report them as dataset totals."
+                    f"Distinct counts are lower bounds. Null rates and inferred "
+                    f"types are sample estimates and can move either way: a "
+                    f"column typed numeric here can turn out to be text once the "
+                    f"remaining rows are read. Do not report any of these as "
+                    f"dataset values; run a full profile before you do."
                 )
             for column in structure.columns:
                 # null_ratio is 0..1, not a percentage. Scaling it here rather


### PR DESCRIPTION
Given as apparently 100% of dataprof users and contributors utilize agents.

Applies two findings from 0.11 dogfooding to the `dataprof` skill. No library
code changes.

## The structure-only summary was quietly misleading

`dp_context.py --structure-only` printed the row count from a full scan directly
above per-column counts taken from a bounded head sample, with nothing marking
the difference:

```
format: csv  rows: 5000
  customer_id: integer nulls=0.0% unique=1000
```

`customer_id` has 5,000 distinct values. The `1000` is the sample size. An agent
reading that reports a dataset total that is wrong by 5x, and the only signal was
`warning: structure_sample_truncated` at the bottom.

The report already carried the answer: `truncated` and `source_exhausted`
distinguish a capped read from a complete one, and `distinct_count_approximate`
marks estimated counts. Neither was used. Now:

```
format: csv  rows: 5000
  NOTE: per-column numbers below describe the first 1000 rows, not all 5000.
  Counts are lower bounds; do not report them as dataset totals.
  customer_id: integer nulls=0.0% unique=1000 (of sample)
```

A file read to the end is unannotated, so the caveat only appears when true.
Verified against a 5,000-row CSV (annotated), a 999-row CSV (not annotated), and
Parquet metadata (not annotated).

`provenance` is not the signal to test here: it reads `sample` even for a file
consumed in full.

## A perfect score is not evidence

#544: the overall quality score is not monotonic in data quality. Consistency is
measured against the column's inferred type, and inference falls back to `string`
below an 80% numeric majority, at which point every value conforms and
consistency reports 100%.

| non-numeric share | inferred type | data_type_consistency | overall |
| --- | --- | --- | --- |
| 18% | float | 82.0 | 95.5 |
| 19% | float | 81.0 | 95.25 |
| 20% | string | 100.0 | 100.0 |
| 50% | string | 100.0 | 100.0 |

An agent following the skill would have reported that 100 as a clean bill of
health. The skill now says otherwise, in SKILL.md under "Reading the output
honestly" and in interpretation.md under Consistency with the measured numbers.

This is a mitigation, not a fix. #544 is a product decision and stays open.

Also added: a guard for `report.quality` being `None` outright on database
reports (#554), where `report.quality.overall_quality_score()` raises while
`report.quality_score` merely returns `None`.

## Eval coverage

The evals had none for this. `ragged_orders.csv` sits at 14% junk, below the
threshold, so it stays typed `float` and behaves correctly.

The new `payments_mixed_amount.csv` crosses it deliberately: four of ten
`amount_eur` values are placeholders (`pending`, `n/a`, `see invoice`,
`awaiting PO`), the column types as `string`, and the file scores **100.0/100**
with no flags in `to_llm_context()`. The `perfect-score-is-not-clean` scenario
fails an agent that reports that score as evidence the file is ready to load.

## Checks

Matched to the change; this is skill content plus one script, no Rust touched.

```
uv run ruff format --check .claude/skills/dataprof/scripts/   # 1 file already formatted
uv run ruff check .claude/skills/dataprof/scripts/            # All checks passed!
```

`scenarios.json` validates as JSON, all four scenarios carry the required keys,
and every referenced fixture exists. The committed fixture reproduces the
documented 100.0/100 with `amount_eur` typed `string`. Fixtures are stored LF,
consistent with the three existing ones.

Related: #544, #554.
