### PR TITLE
fix(partial): preserve header-only CSV schema

### DIFF
--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -1039,13 +1039,17 @@ fn schema_from_streaming_stats(
 ) -> SchemaResult {
     let columns = headers
         .iter()
-        .filter_map(|name| {
-            column_stats
-                .get_column_stats(name)
-                .map(|stats| ColumnSchema {
-                    name: name.clone(),
-                    data_type: profile_builder::infer_data_type_streaming(stats),
-                })
+        .map(|name| {
+            // A header can declare a column before any row creates statistics.
+            // String is the existing type convention when no values were observed.
+            let data_type = column_stats.get_column_stats(name).map_or(
+                dataprof_core::DataType::String,
+                profile_builder::infer_data_type_streaming,
+            );
+            ColumnSchema {
+                name: name.clone(),
+                data_type,
+            }
         })
         .collect();
 
@@ -1252,6 +1256,51 @@ mod tests {
         assert_eq!(result.columns[2].name, "salary");
         assert_eq!(result.columns[2].data_type, DataType::Float);
         assert!(result.rows_sampled > 0);
+    }
+
+    #[test]
+    fn test_infer_schema_header_only_csv_preserves_declared_columns() {
+        let f = write_temp_csv("name,age\n");
+
+        let schema = infer_schema(f.path()).unwrap();
+        let structure = analyze_structure(f.path(), None).unwrap();
+
+        assert_eq!(schema.rows_sampled, 0);
+        assert!(schema.schema_stable);
+        assert_eq!(
+            schema
+                .columns
+                .iter()
+                .map(|column| (column.name.as_str(), column.data_type.clone()))
+                .collect::<Vec<_>>(),
+            vec![("name", DataType::String), ("age", DataType::String),]
+        );
+        assert_eq!(
+            schema
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>(),
+            structure
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_infer_schema_empty_json_formats_have_no_columns() {
+        for (label, file) in [
+            ("json", write_temp_json("[]")),
+            ("jsonl", write_temp_jsonl("")),
+        ] {
+            let schema = infer_schema(file.path()).unwrap();
+
+            assert_eq!(schema.rows_sampled, 0, "{label}");
+            assert!(schema.schema_stable, "{label}");
+            assert!(schema.columns.is_empty(), "{label}");
+        }
     }
 
     #[test]
@@ -1884,6 +1933,23 @@ mod async_tests {
         assert_eq!(result.columns[2].data_type, DataType::Float);
         assert!(result.rows_sampled > 0);
         assert!(result.schema_stable); // small data — all rows consumed
+    }
+
+    #[tokio::test]
+    async fn test_infer_schema_stream_header_only_csv_preserves_declared_columns() {
+        let source = csv_source(b"name,age\n");
+        let result = infer_schema_stream(source).await.unwrap();
+
+        assert_eq!(result.rows_sampled, 0);
+        assert!(result.schema_stable);
+        assert_eq!(
+            result
+                .columns
+                .iter()
+                .map(|column| (column.name.as_str(), column.data_type.clone()))
+                .collect::<Vec<_>>(),
+            vec![("name", DataType::String), ("age", DataType::String),]
+        );
     }
 
     #[tokio::test]

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1533,6 +1533,21 @@ class TestPartialAnalysis:
         assert len(result.column_names) == result.num_columns
         assert result.rows_sampled > 0
 
+    def test_header_only_csv_surfaces_agree_on_declared_schema(self, tmp_path):
+        path = tmp_path / "header_only.csv"
+        path.write_text("name,age\n")
+
+        profile = dataprof.profile(path)
+        schema = dataprof.infer_schema(path)
+        structure = dataprof.analyze_structure(path)
+
+        expected_names = ["name", "age"]
+        assert profile.rows == schema.rows_sampled == structure.rows_sampled == 0
+        assert list(profile) == list(schema.column_names) == expected_names
+        assert [column.name for column in structure.columns] == expected_names
+        assert [column["data_type"] for column in schema.columns] == ["string", "string"]
+        assert schema.schema_stable is True
+
     def test_infer_schema_path_object(self):
         result = dataprof.infer_schema(Path(CSV_FILE))
         assert result.num_columns > 0

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1546,6 +1546,8 @@ class TestPartialAnalysis:
         assert list(profile) == list(schema.column_names) == expected_names
         assert [column.name for column in structure.columns] == expected_names
         assert [column["data_type"] for column in schema.columns] == ["string", "string"]
+        assert [profile[name].data_type for name in expected_names] == ["string", "string"]
+        assert [column.data_type for column in structure.columns] == ["string", "string"]
         assert schema.schema_stable is True
 
     def test_infer_schema_path_object(self):


### PR DESCRIPTION
# Pull Request

## 📝 Summary

Preserve declared CSV columns in partial schema inference when a file or stream contains headers but no data rows. This brings `infer_schema` into line with `profile` and `analyze_structure`: columns without observations use the existing no-evidence `String` type, while empty JSON and JSONL inputs continue to produce zero columns.

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🚨 Breaking change (would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🎨 Code refactoring (no functional changes)

## 📋 Changes Made

- map every declared header into `SchemaResult` instead of dropping columns without streaming statistics
- fall back to the existing `DataType::String` no-evidence convention
- cover sync and async header-only CSV paths plus exact name/type parity across Python `profile`, `infer_schema`, and `analyze_structure`
- preserve zero-column behavior for empty JSON arrays and blank JSONL

**Related Issue:** Closes #552

## 🧪 Testing

### How did you test this?

- [x] Tested locally with `cargo test`
- [x] Added new tests for this feature
- [x] All existing tests pass in the affected package and focused Python class
- [x] Tested with sample in-memory CSV/JSON/JSONL data
- [x] Tested empty/header-only edge cases

### Test Commands Run

```bash
cargo test -p dataprof-partial --no-default-features
cargo test -p dataprof-partial --all-features
uv run maturin develop
uv run pytest python/tests/test_python_api.py::TestPartialAnalysis -q
cargo fmt --all -- --check
uv run ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
cargo clippy --all --all-targets -- -D warnings
git diff --check
```

Results: 31 unit + 2 doc tests pass without default features; 44 unit + 4 doc tests pass with all features; the Python `TestPartialAnalysis` class passes 11/11.

## 📖 Documentation

- [ ] Updated README.md if user-facing changes
- [ ] Added/updated inline code comments
- [ ] Updated docs/ folder if architectural changes
- [x] No documentation changes needed

## ⚡ Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance may be affected (explain below)

## 🚨 Breaking Changes

- [x] No breaking changes

## 📌 Additional Notes

The change is confined to partial schema construction. It does not initialize global parser statistics or alter profile/quality calculations. The direct `analyze_csv_file` parser path is tracked separately in #558.

## ✅ Checklist

- [x] Code builds without warnings
- [x] No linting errors (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] All relevant tests pass
- [x] Self-reviewed my code
- [x] Comments added where the no-evidence fallback is non-obvious
- [x] No hardcoded secrets or sensitive data
