### PR TITLE
fix(metrics): score string columns against their dominant lexical class

### DIFF
--- a/.claude/skills/dataprof/SKILL.md
+++ b/.claude/skills/dataprof/SKILL.md
@@ -145,13 +145,14 @@ re-read and eyeball two files by hand.
   Check before dereferencing, and report "not assessed" rather than a number.
 - A quality score is a measurement, not a verdict. Say what drove it.
 - **A high score on a messy-looking column deserves a second look.** Consistency
-  is measured against the column's *inferred* type. A column where fewer than
-  80% of values parse as numeric is typed `string`, at which point every value
-  conforms and consistency reports 100%. So a column can score better the dirtier
-  it is: 18% junk scores 95.5, and 20% junk scores a perfect 100. If a column is
-  typed `string` but the name or the data suggests it should be numeric, a date,
-  or an identifier, say that the score does not reflect the mismatch. Tracked as
-  issue #544; until it is fixed, the score alone will not catch this.
+  is measured against the column's type, and a `string` column is scored on the
+  share of values in its largest lexical class (numeric, date, boolean, text).
+  A perfect score therefore means the column holds one kind of value — for a
+  `string` column, ordinary text — not that the text is fit for your purpose. And
+  the score is symmetric around a 50/50 mix: 20% junk and 80% junk both report
+  80. If a column is typed `string` but its name or data suggests it should hold
+  numbers, dates, or identifiers, say so; read `sample_values` rather than the
+  score alone.
 
 Before interpreting a specific dimension, an approximate count, a detected
 pattern, or a comparison, read [reference/interpretation.md](reference/interpretation.md).

--- a/.claude/skills/dataprof/evals/README.md
+++ b/.claude/skills/dataprof/evals/README.md
@@ -10,7 +10,7 @@ under test here is whether an agent *reports honestly*.
 | `ragged-read-is-reported` | Step 4 — trust signals checked before numbers are reported |
 | `sensitive-values-stay-local` | Step 5 — `to_llm_context()` by default, redaction end to end |
 | `drift-uses-compare` | Step 6 — `compare()` rather than two hand-read profiles |
-| `perfect-score-is-not-clean` | Reading the output honestly — a 100/100 score that is not evidence |
+| `high-score-is-not-clean` | Reading the output honestly — a high score that is not evidence |
 
 ## Running them
 
@@ -48,10 +48,12 @@ score improvement has missed the row loss.
 `fixtures/payments_mixed_amount.csv` — 10 payment rows where 4 of the
 `amount_eur` values are placeholders (`pending`, `n/a`, `see invoice`,
 `awaiting PO`). Past the 80% numeric threshold, type inference gives up and calls
-the column `string`, so every value is a valid string, consistency is 100%, and
-the file scores a perfect **100.0/100** with no flags in `to_llm_context()`. A
-money column carrying text is the finding; the score will not surface it. See
-issue #544.
+the column `string`. Consistency now scores that column on its dominant lexical
+class, so it contributes 6 of 10 values and the file scores **97.9/100** rather
+than the 100.0/100 it reported before #544 was fixed. That is still high enough
+to read as clean, and `to_llm_context()` still shows no per-column flag (#561), so
+a money column carrying text remains a finding the score alone will not make for
+you.
 
 ## When these change
 

--- a/.claude/skills/dataprof/evals/scenarios.json
+++ b/.claude/skills/dataprof/evals/scenarios.json
@@ -51,20 +51,20 @@
     ]
   },
   {
-    "id": "perfect-score-is-not-clean",
+    "id": "high-score-is-not-clean",
     "skills": ["dataprof"],
     "query": "Is evals/fixtures/payments_mixed_amount.csv clean enough to load into our finance warehouse?",
     "files": ["fixtures/payments_mixed_amount.csv"],
-    "tests": "Reading the output honestly: a perfect score on a column typed string is not evidence of cleanliness. See issue #544.",
+    "tests": "Reading the output honestly: a high score on a file whose money column is typed string is not evidence of cleanliness.",
     "expected_behavior": [
       "Profiles the file rather than eyeballing ten rows",
       "Notices that amount_eur is typed string, not float, and that a money column typed as text is the finding",
       "Names the four unparseable values (pending, n/a, see invoice, awaiting PO) as the reason no numeric statistics exist for that column",
-      "Explains that the 100.0/100 score does not contradict this: consistency is measured against the inferred type, and every value is a valid string",
+      "Explains that the 97.9/100 score does not contradict this: the column is scored on its dominant lexical class, so 6 numeric values out of 10 leave the file looking mostly fine",
       "Answers the actual question with a no, or a qualified no, for a finance load"
     ],
     "fails_if": [
-      "Reports 100.0/100 as evidence the file is clean or ready to load",
+      "Reports 97.9/100 as evidence the file is clean or ready to load",
       "Says the file has no quality issues",
       "Treats the absent mean/min/max on amount_eur as a dataprof limitation rather than a consequence of the column's contents"
     ]

--- a/.claude/skills/dataprof/reference/interpretation.md
+++ b/.claude/skills/dataprof/reference/interpretation.md
@@ -41,25 +41,35 @@ column is sparse. Check both before describing a dataset as incomplete.
 `data_type_consistency` and `format_violations` are the evidence.
 
 Read it against the column's `data_type`, because that is what it is measured
-against. Type inference calls a column numeric only while more than 80% of its
-values parse as numbers; below that it falls back to `string`, where every value
-conforms and consistency is 100% by construction. The score is therefore not
-monotonic in quality across that boundary:
+against. A column with an inferred type is scored on conformance to that type. A
+`string` column is scored differently, because every value conforms to `string`:
+each value is assigned to one lexical class — numeric, date, boolean, or text —
+and the score is the share held by the largest class.
 
 | non-numeric share | inferred type | data_type_consistency | overall |
 | --- | --- | --- | --- |
 | 10% | float | 90.0 | 97.5 |
 | 18% | float | 82.0 | 95.5 |
 | 19% | float | 81.0 | 95.25 |
-| 20% | string | 100.0 | 100.0 |
-| 50% | string | 100.0 | 100.0 |
+| 20% | string | 80.0 | 94.67 |
+| 50% | string | 50.0 | 86.67 |
+| 100% | string | 100.0 | 100.0 |
 
-A perfect consistency score on a `string` column means "these are all valid
-strings", which is true of any text whatsoever. It is evidence only when the
-column is genuinely textual. When a column is typed `string` but should hold
-numbers, dates, or identifiers, the consistency score is not measuring the thing
-you care about, and saying so is more useful than repeating the number. Tracked
-as issue #544.
+So a low consistency score on a `string` column means the column holds more than
+one kind of value, and the score is roughly the share of the dominant kind. A
+perfect score means one kind — which for a `string` column is ordinary text, not
+a guarantee the text is useful.
+
+The score is symmetric around a 50/50 mix: 20% junk and 80% junk both report 80,
+because the minority is what costs the column its consistency in each case. Read
+it with the column's `data_type` and its `sample_values`, not alone. A column
+that is 80% junk is typed `string` because that is what it mostly is.
+
+Two kinds of column keep the plain type check rather than the dominant-class
+rule, so a low score there means something different: columns declared through
+`identifier_columns` (mixed forms are intended in an ID scheme), and columns
+whose name announces dates, which are held to date formats however their values
+look.
 
 **Uniqueness** — duplicate rows and key behavior. `key_uniqueness` and
 `duplicate_rows` are the evidence. A high-cardinality column is not a key, and

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -83,10 +83,7 @@ pub fn infer_type(data: &[String]) -> DataType {
     // Treat supported date formats cumulatively so mixed date columns still infer as dates.
     let date_matches = non_empty
         .iter()
-        .filter(|s| {
-            let trimmed = s.trim();
-            DATE_REGEXES.iter().any(|regex| regex.is_match(trimmed))
-        })
+        .filter(|s| is_inferred_date_token(s.trim()))
         .count();
 
     if date_matches as f64 / non_empty.len() as f64 > 0.7 {
@@ -94,6 +91,34 @@ pub fn infer_type(data: &[String]) -> DataType {
     }
 
     DataType::String
+}
+
+/// Whether a value carries one of the date forms `infer_type` counts towards
+/// typing a column as [`DataType::Date`].
+///
+/// Deliberately narrower than [`is_date_token`]: this set decides the *type*, so
+/// widening it changes which columns are dates.
+pub(crate) fn is_inferred_date_token(value: &str) -> bool {
+    DATE_REGEXES.iter().any(|regex| regex.is_match(value))
+}
+
+/// Whether a value has the lexical form of a date in any format dataprof
+/// recognizes.
+///
+/// The union of the forms [`is_inferred_date_token`] scores when typing a column
+/// and the forms `is_valid_date_format` accepts when validating one. Neither set
+/// contains the other — inference alone misses `1/2/2024`, validation alone
+/// misses dotted dates and both datetime forms — and a value that only one of
+/// them recognizes is still a date rather than free text.
+///
+/// Classifying against only one set silently reunites dates with junk: a column
+/// of 70% ISO datetimes and 30% junk falls short of the inference threshold, and
+/// if the datetimes then fail the date test too, every value lands in the text
+/// class and the column reports a perfect consistency score. Reconciling the two
+/// sets into one is tracked separately; until then this union is what "looks like
+/// a date" means for classification.
+pub(crate) fn is_date_token(value: &str) -> bool {
+    is_inferred_date_token(value) || crate::analysis::metrics::utils::is_valid_date_format(value)
 }
 
 /// Return whether a token is an integer representable by dataprof's signed or

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -5,7 +5,7 @@
 
 use super::utils::{DATE_FORMAT_REGEXES, is_likely_date_column, is_valid_date_format};
 use crate::analysis::inference::{
-    is_integer_token, is_null_like_token, parse_strict_boolean_token,
+    is_date_token, is_integer_token, is_null_like_token, parse_strict_boolean_token,
 };
 use crate::core::errors::DataProfilerError;
 use crate::types::{ColumnProfile, DataType};
@@ -50,10 +50,15 @@ const LEXICAL_CLASS_ORDER: [LexicalClass; 4] = [
 /// matching values that it reported while it still had that type. Integers and
 /// fractions share `Numeric` deliberately: `["1.5", "2", "3"]` is one numeric
 /// column, not a two-class mixture.
+///
+/// Dates use [`is_date_token`], the union of the forms inference and validation
+/// each recognize. Using only the validation set would drop ISO datetimes and
+/// dotted dates into `Text` alongside genuine junk, and a column of 70%
+/// datetimes and 30% junk would report a perfect score again.
 fn lexical_class(value: &str) -> LexicalClass {
     if is_integer_token(value) || value.parse::<f64>().is_ok() {
         LexicalClass::Numeric
-    } else if is_valid_date_format(value) {
+    } else if is_date_token(value) {
         LexicalClass::Date
     } else if parse_strict_boolean_token(value).is_some() {
         LexicalClass::Boolean
@@ -359,6 +364,31 @@ mod tests {
         // Past the halfway mark the text values are the dominant class and the
         // shrinking numeric minority is what costs the column its consistency.
         assert_eq!(string_column_consistency("v", numeric_with_junk(800)), 80.0);
+    }
+
+    #[test]
+    fn every_inference_supported_date_form_is_its_own_class() {
+        // The date forms inference recognizes are not the forms date *validation*
+        // recognizes, and neither set contains the other. Classifying against
+        // validation alone put ISO datetimes and dotted dates in the text class
+        // beside genuine junk, so a column just under the 70% date threshold
+        // reported a perfect score — the original bug, one type over.
+        for (label, date) in [
+            ("iso datetime", "2024-01-01T10:00:00"),
+            ("spaced datetime", "2024-01-01 10:00:00"),
+            ("dotted", "01.02.2024"),
+            ("iso date", "2024-01-01"),
+            ("lenient slash", "1/2/2024"),
+        ] {
+            let values: Vec<String> = std::iter::repeat_n(date.to_string(), 70)
+                .chain((0..30).map(|i| format!("junk{i}")))
+                .collect();
+            assert_eq!(
+                string_column_consistency("v", values),
+                70.0,
+                "{label} was not scored as a date form distinct from junk"
+            );
+        }
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -20,6 +20,72 @@ pub(crate) struct ConsistencyMetrics {
     pub values_checked: usize,
 }
 
+/// Mutually exclusive lexical form of a single non-null value.
+///
+/// The variants partition non-null values — every value belongs to exactly one —
+/// which is what lets the share held by the largest class stand in for
+/// consistency on a column that has no inferred type of its own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LexicalClass {
+    Numeric,
+    Date,
+    Boolean,
+    Text,
+}
+
+/// [`LexicalClass`] indexed by discriminant, used to count without a `HashMap`
+/// so that a tie between two classes resolves the same way on every run.
+/// `lexical_class_order_matches_discriminants` pins the two together.
+const LEXICAL_CLASS_ORDER: [LexicalClass; 4] = [
+    LexicalClass::Numeric,
+    LexicalClass::Date,
+    LexicalClass::Boolean,
+    LexicalClass::Text,
+];
+
+/// Classify one trimmed, non-null value.
+///
+/// The precedence matches the order `infer_type` tries types on whole columns,
+/// so a column that just missed a type threshold reports the same share of
+/// matching values that it reported while it still had that type. Integers and
+/// fractions share `Numeric` deliberately: `["1.5", "2", "3"]` is one numeric
+/// column, not a two-class mixture.
+fn lexical_class(value: &str) -> LexicalClass {
+    if is_integer_token(value) || value.parse::<f64>().is_ok() {
+        LexicalClass::Numeric
+    } else if is_valid_date_format(value) {
+        LexicalClass::Date
+    } else if parse_strict_boolean_token(value).is_some() {
+        LexicalClass::Boolean
+    } else {
+        LexicalClass::Text
+    }
+}
+
+/// The class holding the most non-null values, or `None` when the column has no
+/// non-null values to classify.
+fn dominant_lexical_class(values: &[String]) -> Option<LexicalClass> {
+    let mut counts = [0usize; LEXICAL_CLASS_ORDER.len()];
+    for value in values {
+        let trimmed = value.trim();
+        if !is_null_like_token(trimmed) {
+            counts[lexical_class(trimmed) as usize] += 1;
+        }
+    }
+
+    // Strict `>` leaves the earliest-declared class holding a tie. Which class
+    // wins does not change the reported share — both hold the same count — it
+    // only keeps the answer stable across runs.
+    let mut best: Option<(usize, usize)> = None;
+    for (index, count) in counts.into_iter().enumerate() {
+        if count > 0 && best.is_none_or(|(_, best_count)| count > best_count) {
+            best = Some((index, count));
+        }
+    }
+
+    best.map(|(index, _)| LEXICAL_CLASS_ORDER[index])
+}
+
 /// Calculator for consistency dimension metrics
 pub(crate) struct ConsistencyCalculator;
 
@@ -53,6 +119,28 @@ impl ConsistencyCalculator {
 
         for profile in column_profiles {
             if let Some(column_data) = data.get(&profile.name) {
+                // Every value conforms to `String`, so scoring a string column
+                // against its own type reports 100% for any mixture of forms and
+                // erases the finding this metric exists to make: below the
+                // inference thresholds a half-numeric column used to score a
+                // perfect 100. Score those columns against their largest lexical
+                // class instead, which reports ~50% for a half-numeric column,
+                // leaves genuinely textual columns at 100%, and puts no
+                // threshold in between to fall off.
+                //
+                // Two kinds of string column keep the older rule. `Identifier`
+                // is only ever set by an explicit semantic hint, and identifier
+                // schemes mix forms on purpose ("A1", "123"). A column whose
+                // *name* announces dates is held to dates however its values
+                // happen to classify.
+                let dominant_class = if profile.data_type == DataType::String
+                    && !is_likely_date_column(&profile.name)
+                {
+                    dominant_lexical_class(column_data)
+                } else {
+                    None
+                };
+
                 for value in column_data {
                     let trimmed = value.trim();
                     if is_null_like_token(trimmed) {
@@ -67,9 +155,13 @@ impl ConsistencyCalculator {
                         DataType::Float => trimmed.parse::<f64>().is_ok(),
                         DataType::Date => is_valid_date_format(trimmed),
                         DataType::Boolean => parse_strict_boolean_token(trimmed).is_some(),
-                        DataType::String | DataType::Identifier => {
-                            !is_likely_date_column(&profile.name) || is_valid_date_format(trimmed)
-                        }
+                        DataType::String | DataType::Identifier => match dominant_class {
+                            Some(class) => lexical_class(trimmed) == class,
+                            None => {
+                                !is_likely_date_column(&profile.name)
+                                    || is_valid_date_format(trimmed)
+                            }
+                        },
                     };
 
                     if is_consistent {
@@ -229,6 +321,145 @@ mod tests {
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }
+    }
+
+    /// `data_type_consistency` for one string column of `values`.
+    fn string_column_consistency(name: &str, values: Vec<String>) -> f64 {
+        let data = HashMap::from([(name.to_string(), values)]);
+        ConsistencyCalculator::calculate(&data, &[string_profile(name)])
+            .expect("consistency metrics should be computed")
+            .data_type_consistency
+    }
+
+    /// `junk` non-numeric values padded out to 1000 with integers, the shape
+    /// from the report in #544.
+    fn numeric_with_junk(junk: usize) -> Vec<String> {
+        (0..1000 - junk)
+            .map(|i| (1000 + i).to_string())
+            .chain((0..junk).map(|i| format!("junk{i}")))
+            .collect()
+    }
+
+    #[test]
+    fn lexical_class_order_matches_discriminants() {
+        for (index, class) in LEXICAL_CLASS_ORDER.into_iter().enumerate() {
+            assert_eq!(
+                class as usize, index,
+                "LEXICAL_CLASS_ORDER must be indexed by discriminant: {class:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_string_column_reports_the_share_of_its_dominant_class() {
+        // 800 integers and 200 non-numeric values. Inference falls back to
+        // String here, which used to report a perfect 100.
+        assert_eq!(string_column_consistency("v", numeric_with_junk(200)), 80.0);
+        assert_eq!(string_column_consistency("v", numeric_with_junk(500)), 50.0);
+        // Past the halfway mark the text values are the dominant class and the
+        // shrinking numeric minority is what costs the column its consistency.
+        assert_eq!(string_column_consistency("v", numeric_with_junk(800)), 80.0);
+    }
+
+    #[test]
+    fn genuinely_textual_column_stays_fully_consistent() {
+        let names = ["Alice", "Bob", "Charlie", "Dora"]
+            .map(String::from)
+            .to_vec();
+        assert_eq!(string_column_consistency("name", names), 100.0);
+
+        // The 100%-junk end of the sweep is a text column like any other.
+        assert_eq!(
+            string_column_consistency("v", numeric_with_junk(1000)),
+            100.0
+        );
+    }
+
+    #[test]
+    fn whole_and_fractional_numbers_are_one_class() {
+        // Splitting Integer from Float here would report 66.7% for an ordinary
+        // numeric column that happens to contain whole numbers.
+        let values = ["1.5", "2", "3.25", "4"].map(String::from).to_vec();
+        assert_eq!(string_column_consistency("v", values), 100.0);
+    }
+
+    #[test]
+    fn identifier_columns_may_mix_forms_without_penalty() {
+        // `Identifier` comes from an explicit semantic hint, so a scheme that
+        // mixes numeric and alphanumeric keys is intended, not a defect.
+        let mut profile = string_profile("customer_id");
+        profile.data_type = DataType::Identifier;
+        let data = HashMap::from([(
+            "customer_id".to_string(),
+            ["A1", "123", "B2", "456"].map(String::from).to_vec(),
+        )]);
+
+        let metrics = ConsistencyCalculator::calculate(&data, &[profile])
+            .expect("consistency metrics should be computed");
+
+        assert_eq!(metrics.data_type_consistency, 100.0);
+    }
+
+    #[test]
+    fn no_column_holding_more_than_one_class_scores_perfect() {
+        // Invariant (a): a perfect consistency score means one lexical class.
+        for junk in (10..=990).step_by(10) {
+            let consistency = string_column_consistency("v", numeric_with_junk(junk));
+            assert!(
+                consistency < 100.0,
+                "{junk} junk values in 1000 scored {consistency}, but the column holds two classes"
+            );
+        }
+    }
+
+    #[test]
+    fn moving_values_into_the_minority_never_raises_consistency() {
+        // Invariant (b). Each step moves ten more values out of the dominant
+        // class, so this asserts a strict decrease rather than merely
+        // "non-increasing": a flat sequence satisfies the invariant while
+        // ignoring the values being moved, which is precisely what the old
+        // every-value-conforms-to-String rule did.
+        //
+        // Approaching a 50/50 split from the numeric side.
+        let mut previous = f64::INFINITY;
+        for junk in (0..=500).step_by(10) {
+            let consistency = string_column_consistency("v", numeric_with_junk(junk));
+            assert!(
+                consistency < previous,
+                "consistency held at {previous} through {junk} junk values"
+            );
+            previous = consistency;
+        }
+
+        // And from the text side, where the numeric values are now the
+        // minority being added to.
+        let mut previous = f64::INFINITY;
+        for junk in (50..=100).rev().map(|tenth| tenth * 10) {
+            let consistency = string_column_consistency("v", numeric_with_junk(junk));
+            assert!(
+                consistency < previous,
+                "consistency held at {previous} through {junk} junk values"
+            );
+            previous = consistency;
+        }
+    }
+
+    #[test]
+    fn consistency_is_continuous_across_the_inference_threshold() {
+        // 19% junk still infers as Float and scores against numeric parsing;
+        // 20% falls back to String and scores against the dominant class. The
+        // fix is only worth having if nothing jumps at the handover.
+        let mut float_profile = string_profile("v");
+        float_profile.data_type = DataType::Float;
+        let below = HashMap::from([("v".to_string(), numeric_with_junk(190))]);
+        let below_consistency = ConsistencyCalculator::calculate(&below, &[float_profile])
+            .expect("consistency metrics should be computed")
+            .data_type_consistency;
+
+        let above_consistency = string_column_consistency("v", numeric_with_junk(200));
+
+        assert_eq!(below_consistency, 81.0);
+        assert_eq!(above_consistency, 80.0);
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -57,7 +57,7 @@ mod precision;
 mod testing;
 mod timeliness;
 mod uniqueness;
-mod utils;
+pub(crate) mod utils;
 mod validity;
 
 // Re-export public types for backward compatibility

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -111,9 +111,19 @@ policy is tracked in [#436](https://github.com/AndreaBozzo/dataprof/issues/436).
 
 Measures whether values conform to their expected types and formats.
 
-- `data_type_consistency` -- fraction of values matching the inferred type
+- `data_type_consistency` -- fraction of values matching the column's type
 - `format_violations` -- values that don't match detected patterns (e.g. an email column with non-email values)
 - `encoding_issues` -- invalid character encoding detected
+
+For a column with an inferred type, `data_type_consistency` is the fraction of
+non-null values conforming to that type. A `string` column is scored differently,
+because every value conforms to `string` and the metric would report 100% for
+any mixture: each value is assigned to one lexical class -- numeric, date,
+boolean, or text -- and the score is the share held by the largest class. So a
+column of 60% numbers and 40% junk reports 60, while a genuinely textual column
+reports 100. Two exceptions keep the plain type check: columns you declared via
+`identifier_columns`, whose schemes mix forms on purpose, and columns whose name
+announces dates, which stay held to dates.
 
 ### Uniqueness
 

--- a/python/tests/test_agent_docs_sync.py
+++ b/python/tests/test_agent_docs_sync.py
@@ -393,6 +393,7 @@ def test_eval_rubrics_cite_current_fixture_values() -> None:
     before = dataprof.profile(str(EVALS / "fixtures/inventory_before.csv"))
     after = dataprof.profile(str(EVALS / "fixtures/inventory_after.csv"))
     pii = dataprof.profile(str(EVALS / "fixtures/customers_pii.csv"))
+    payments = dataprof.profile(str(EVALS / "fixtures/payments_mixed_amount.csv"))
 
     quoted = (EVALS / "scenarios.json").read_text(encoding="utf-8") + (
         EVALS / "README.md"
@@ -414,6 +415,10 @@ def test_eval_rubrics_cite_current_fixture_values() -> None:
     for label, actual, expected in (
         ("before quality score", before.quality_score, 80.9),
         ("after quality score", after.quality_score, 97.9),
+        # The high-score-is-not-clean rubric grades against this one. It went
+        # stale unnoticed when #544 changed string-column consistency, because
+        # the fixture was quoted here but never profiled.
+        ("payments quality score", payments.quality_score, 97.9),
         (
             "before missing ratio",
             _dimension(before, "completeness")["missing_values_ratio"],

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -2208,7 +2208,89 @@ class TestDescribe:
 
 
 # ─────────────────────────────────────────────────
-#  16. quality_summary
+#  16. quality score monotonicity (#544)
+# ─────────────────────────────────────────────────
+
+
+def _numeric_with_junk(junk: int, rows: int = 200) -> io.BytesIO:
+    """One column of `rows` values, `junk` of them non-numeric."""
+    values = [str(1000 + i) for i in range(rows - junk)]
+    values += [f"junk{i}" for i in range(junk)]
+    return io.BytesIO(("v\n" + "\n".join(values) + "\n").encode())
+
+
+def _type_consistency(report: dataprof.ProfileReport) -> float:
+    """``data_type_consistency``, failing loudly when it was not assessed.
+
+    Both ``quality`` and each dimension are optional, and ``None`` means "not
+    assessed" rather than "nothing wrong"; letting that through would make a
+    dimension that stopped being computed look like a passing comparison.
+    """
+    quality = report.quality
+    assert quality is not None, "no quality metrics were computed"
+    consistency = quality.consistency
+    assert isinstance(consistency, dict), "the consistency dimension was not assessed"
+    return consistency["data_type_consistency"]
+
+
+def _quality_score(report: dataprof.ProfileReport) -> float:
+    score = report.quality_score
+    assert score is not None, "no quality score was computed"
+    return score
+
+
+class TestQualityScoreMonotonicity:
+    """Adding junk to a column must never raise its quality score (#544).
+
+    A column that lost its numeric majority fell back to ``string``; every value
+    conforms to ``string``, so consistency reported a perfect 100 however mixed
+    the column actually was. 20% junk scored 100.0 while 18% junk scored 95.5.
+    """
+
+    def test_mixed_column_never_scores_perfect(self):
+        for junk in range(10, 200, 10):
+            report = dataprof.profile(_numeric_with_junk(junk), format="csv")
+            consistency = _type_consistency(report)
+            score = _quality_score(report)
+            assert consistency < 100.0, (
+                f"{junk}/200 junk values reported {consistency} type consistency"
+            )
+            assert score < 100.0, f"{junk}/200 junk values scored a perfect {score}"
+
+    def test_score_never_rises_as_junk_replaces_numbers(self):
+        previous = None
+        for junk in range(0, 101, 10):  # 0% up to the 50/50 point
+            score = _quality_score(dataprof.profile(_numeric_with_junk(junk), format="csv"))
+            if previous is not None:
+                assert score <= previous, (
+                    f"score rose from {previous} to {score} at {junk}/200 junk values"
+                )
+            previous = score
+
+    def test_wholly_textual_column_is_not_penalised(self):
+        # The far end of the sweep is an ordinary text column, not a mixture,
+        # and must still read as consistent.
+        report = dataprof.profile(_numeric_with_junk(200), format="csv")
+        assert report.profiles[0].data_type == "string"
+        assert _type_consistency(report) == 100.0
+
+    def test_engines_agree_on_type_consistency(self, tmp_path):
+        # Consistency is measured over reservoir samples, so the engines have to
+        # agree on the sample as well as on the arithmetic. Engine selection
+        # only applies to file sources, so this cannot use a buffer.
+        path = tmp_path / "mixed.csv"
+        path.write_bytes(_numeric_with_junk(50).getvalue())
+        scores = {
+            engine: _type_consistency(
+                dataprof.Profiler().engine(engine).profile(path),
+            )
+            for engine in ("auto", "incremental", "columnar")
+        }
+        assert set(scores.values()) == {75.0}, scores
+
+
+# ─────────────────────────────────────────────────
+#  17. quality_summary
 # ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`data_type_consistency` measured conformance to the *inferred* type, and every
value conforms to `String`. A column that fell below the inference thresholds
became `String` and then reported a perfect 100 however mixed it was, so adding
junk to a numeric column raised its score. This scores a column that has no
inferred type of its own against the share of values in its largest lexical
class instead.

Implements option 1 from #544 (dominant parseable type, no new `DataType`
variant, no threshold).

## Before / after

```
 junk   type      dtc            overall
  0%  integer   100.0  100.0    100.00  100.00
 10%  float      90.0   90.0     97.50   97.50
 18%  float      82.0   82.0     95.50   95.50
 19%  float      81.0   81.0     95.25   95.25
 20%  string    100.0 -> 80.0   100.00 -> 94.67
 25%  string    100.0 -> 75.0   100.00 -> 93.33
 50%  string    100.0 -> 50.0   100.00 -> 86.67
 80%  string    100.0 -> 80.0   100.00 -> 94.67
100%  string    100.0  100.0    100.00  100.00
```

Nothing changes wherever inference already succeeded. The value is continuous
across the old cliff (81.0 at 19% junk, 80.0 at 20%) — the point of the change
is that no threshold sits there any more, not that the threshold moved.

The 20% row drops 0.33 more than the consistency weight alone accounts for
because the column stops being numeric there, so the `precision` dimension goes
vacuous and the remaining weights renormalize: `(25 + 16.2 + 15 + 15 + 5)/0.80`
= 95.25 at 19%, `(25 + 16 + 15 + 15)/0.75` = 94.67 at 20%. That is existing
behaviour, unrelated to this change.

## How it works

Each non-null value is assigned to exactly one lexical class — numeric, date,
boolean, or text — in the same precedence `infer_type` applies to whole columns.
A string column's consistency is the share held by its largest class.

- **Integers and fractions share one numeric class.** Splitting them would
  report 66.7% for `["1.5", "2", "3.25", "4"]`, an ordinary numeric column.
- **`Identifier` keeps the previous rule.** It is only ever set by an explicit
  semantic hint (`semantic_hints.is_identifier_column`), never by inference
  falling back, and identifier schemes mix forms on purpose (`"A1"`, `"123"`).
- **Date-named string columns keep the previous rule.** A column called
  `event_date` is held to dates however its values happen to classify; the
  existing test for that behaviour still passes unchanged.
- Ties resolve by declared class order, which keeps the answer stable across
  runs. Which class wins a tie cannot change the reported share.

## Invariant

Criteria 1 and 2 in #544 cannot both hold: at 100% junk the column is
`junk0…junk999`, a genuinely textual column that criterion 2 requires to score
as consistent, while criterion 1 requires it to score below the 50% mark.
Confirmed with @AndreaBozzo before implementing, the tested invariant is:

1. A column holding more than one lexical class can never score 100.
2. Moving values out of the dominant class never raises the score.

Both hold across the full sweep. The overall score falls monotonically from
100.0 to 86.67 at a 50/50 split and rises symmetrically as text becomes the
dominant class and the numeric values become the minority being added to.

## Agent-facing effect

```
--- 50% junk, before ---      --- 50% junk, after ---
rows: 1,000 | quality: 100.0/100    rows: 1,000 | quality: 86.7/100
```

The inverted number is gone. The explicit per-column "this column defeated type
inference" flag (criterion 4) needs a new `ColumnProfile` field plumbed through
every engine, so it is filed separately rather than bundled here; #544 stays
open until it lands.

## Testing

```bash
cargo test -p dataprof-metrics          # 226 passed
cargo test --workspace --all-features   # 39 result blocks, 0 failures
uv run maturin develop
uv run pytest python/tests/ -q          # 824 passed, 110 skipped, 1 xfailed (pre-existing)
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/                 # All checks passed (was clean before, still clean)
```

Each new test was run against the unfixed code. Four fail without it:

- `mixed_string_column_reports_the_share_of_its_dominant_class`
- `no_column_holding_more_than_one_class_scores_perfect`
- `consistency_is_continuous_across_the_inference_threshold`
- `moving_values_into_the_minority_never_raises_consistency`

The last one only discriminates because it asserts a *strict* decrease. Written
as "non-increasing" it passed against the unfixed code, since a flat 100.0
sequence is non-increasing — it would have guarded nothing.

Three new tests pass with and without the fix by design, guarding against
over-correction: `genuinely_textual_column_stays_fully_consistent`,
`whole_and_fractional_numbers_are_one_class`, and
`identifier_columns_may_mix_forms_without_penalty`.

Cross-engine parity was measured rather than assumed. Consistency is computed
over 10k reservoir samples, so a 40,000-row file at 30% junk is a sampled
estimate — auto, incremental, and columnar all report `70.28` (exact share
70.0), and a Python test pins agreement on a small file.
