### PR TITLE
fix(metrics): validate date columns against the forms that typed them

### DIFF
--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -151,6 +151,7 @@ pub fn parse_strict_boolean_token(value: &str) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
 
     #[test]
     fn test_infer_integer() {
@@ -449,19 +450,36 @@ mod tests {
         assert_eq!(DATE_REGEXES.len(), 8);
     }
 
-    /// One example per date form dataprof recognizes, across both regex sets.
-    const DATE_FORM_EXAMPLES: [&str; 11] = [
-        "2024-01-15",
-        "15/01/2024",
-        "15-01-2024",
-        "2024/01/15",
-        "15.01.2024",
-        "2024-01-15T10:30:00",
-        "2024-01-15 10:30:00",
-        "15/01/2024 10:30:00",
-        "1/2/2024",
-        "2024-1-5",
-        "1-2-2024",
+    /// Every date pattern dataprof recognizes, paired with an example of it.
+    ///
+    /// Keyed by regex source rather than by example, because the two sets
+    /// overlap: the lenient `^\d{1,2}/\d{1,2}/\d{4}$` also matches `15/01/2024`,
+    /// so a table checked only by "some example matches this pattern" stays green
+    /// when a pattern is added or its example deleted. Pinning the pattern set
+    /// makes any change to either set fail here until this table is updated.
+    ///
+    /// The four patterns the two sets share appear once, so this is the union.
+    const DATE_FORM_EXAMPLES: [(&str, &str); 11] = [
+        (r"^\d{4}-\d{2}-\d{2}$", "2024-01-15"),
+        (r"^\d{2}/\d{2}/\d{4}$", "15/01/2024"),
+        (r"^\d{2}-\d{2}-\d{4}$", "15-01-2024"),
+        (r"^\d{4}/\d{2}/\d{2}$", "2024/01/15"),
+        (r"^\d{2}\.\d{2}\.\d{4}$", "15.01.2024"),
+        (
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$",
+            "2024-01-15T10:30:00",
+        ),
+        (
+            r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$",
+            "2024-01-15 10:30:00",
+        ),
+        (
+            r"^\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}$",
+            "15/01/2024 10:30:00",
+        ),
+        (r"^\d{1,2}/\d{1,2}/\d{4}$", "1/2/2024"),
+        (r"^\d{4}-\d{1,2}-\d{1,2}$", "2024-1-5"),
+        (r"^\d{1,2}-\d{1,2}-\d{4}$", "1-2-2024"),
     ];
 
     #[test]
@@ -471,19 +489,37 @@ mod tests {
         // used independently a column of clean ISO datetimes was typed `Date` on
         // one set and then failed every value against the other, scoring 0%
         // consistency. `is_date_token` is the union both jobs now share.
-        for example in DATE_FORM_EXAMPLES {
-            assert!(is_date_token(example), "{example} is not a recognized date");
-        }
+        let validation = &crate::analysis::metrics::utils::DATE_VALIDATION_REGEXES;
+        let recognized: BTreeSet<&str> = DATE_REGEXES
+            .iter()
+            .chain(validation.iter())
+            .map(|regex| regex.as_str())
+            .collect();
+        let covered: BTreeSet<&str> = DATE_FORM_EXAMPLES
+            .iter()
+            .map(|(pattern, _)| *pattern)
+            .collect();
 
-        // Every regex in either set has an example above, so a date form cannot
-        // be added to dataprof without this test being extended to cover it.
-        let validation = crate::analysis::metrics::utils::DATE_VALIDATION_REGEXES.iter();
-        for regex in DATE_REGEXES.iter().chain(validation) {
+        // Adding, removing, or editing a pattern in either set fails here until
+        // this table is updated, so no date form can arrive without an example.
+        assert_eq!(
+            recognized, covered,
+            "the recognized date patterns and the examples below have diverged"
+        );
+
+        for (pattern, example) in DATE_FORM_EXAMPLES {
+            let regex = DATE_REGEXES
+                .iter()
+                .chain(validation.iter())
+                .find(|regex| regex.as_str() == pattern)
+                .expect("checked by the set equality above");
             assert!(
-                DATE_FORM_EXAMPLES
-                    .iter()
-                    .any(|example| regex.is_match(example)),
-                "no example matches {regex}, so nothing checks that consistency scores it"
+                regex.is_match(example),
+                "{example:?} is not an example of {pattern}"
+            );
+            assert!(
+                is_date_token(example),
+                "{example:?} is a recognized date form but is_date_token rejects it"
             );
         }
     }

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -448,4 +448,60 @@ mod tests {
         // This test will fail at initialization if any pattern is invalid
         assert_eq!(DATE_REGEXES.len(), 8);
     }
+
+    /// One example per date form dataprof recognizes, across both regex sets.
+    const DATE_FORM_EXAMPLES: [&str; 11] = [
+        "2024-01-15",
+        "15/01/2024",
+        "15-01-2024",
+        "2024/01/15",
+        "15.01.2024",
+        "2024-01-15T10:30:00",
+        "2024-01-15 10:30:00",
+        "15/01/2024 10:30:00",
+        "1/2/2024",
+        "2024-1-5",
+        "1-2-2024",
+    ];
+
+    #[test]
+    fn is_date_token_accepts_every_form_either_regex_set_recognizes() {
+        // The two sets exist for different jobs — one types a column, the other
+        // validates its values — and neither contains the other. When they were
+        // used independently a column of clean ISO datetimes was typed `Date` on
+        // one set and then failed every value against the other, scoring 0%
+        // consistency. `is_date_token` is the union both jobs now share.
+        for example in DATE_FORM_EXAMPLES {
+            assert!(is_date_token(example), "{example} is not a recognized date");
+        }
+
+        // Every regex in either set has an example above, so a date form cannot
+        // be added to dataprof without this test being extended to cover it.
+        let validation = crate::analysis::metrics::utils::DATE_VALIDATION_REGEXES.iter();
+        for regex in DATE_REGEXES.iter().chain(validation) {
+            assert!(
+                DATE_FORM_EXAMPLES
+                    .iter()
+                    .any(|example| regex.is_match(example)),
+                "no example matches {regex}, so nothing checks that consistency scores it"
+            );
+        }
+    }
+
+    #[test]
+    fn a_value_that_is_not_a_date_is_not_a_date_token() {
+        // The union must not become a predicate that accepts anything; a date
+        // column full of malformed values still has to lose consistency.
+        for value in [
+            "not-a-date",
+            "2024",
+            "15/01",
+            "2024-13-45x",
+            "",
+            "junk1",
+            "10:30:00",
+        ] {
+            assert!(!is_date_token(value), "{value:?} was accepted as a date");
+        }
+    }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -154,12 +154,16 @@ impl ConsistencyCalculator {
 
                     total_values += 1;
 
-                    // Check if value is consistent with inferred type. Dates use
-                    // `is_date_token`, the same predicate that types a column as
-                    // `Date` in the first place. Validating against a narrower
-                    // set scored a column of clean ISO datetimes or dotted dates
-                    // at 0%: inference typed it `Date` on forms the validation
-                    // regexes did not accept, so every value in it failed.
+                    // Check if value is consistent with inferred type. Dates are
+                    // validated against `is_date_token`, the union of the forms
+                    // inference recognizes and the forms date validation accepts.
+                    // `infer_type` keeps typing columns on the narrower
+                    // `is_inferred_date_token`, so the union is a superset of
+                    // every form that can make a column `Date` — which is the
+                    // property that matters here. Validating against the other
+                    // set instead scored a column of clean ISO datetimes or
+                    // dotted dates at 0%, because inference had typed it on forms
+                    // that set does not accept and every value then failed.
                     let is_consistent = match profile.data_type {
                         DataType::Integer => is_integer_token(trimmed),
                         DataType::Float => trimmed.parse::<f64>().is_ok(),

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -3,7 +3,7 @@
 //! Measures the coherence and contradiction-free nature of data.
 //! Key metrics: data type consistency, format violations, encoding issues.
 
-use super::utils::{DATE_FORMAT_REGEXES, is_likely_date_column, is_valid_date_format};
+use super::utils::{DATE_FORMAT_REGEXES, is_likely_date_column};
 use crate::analysis::inference::{
     is_date_token, is_integer_token, is_null_like_token, parse_strict_boolean_token,
 };
@@ -154,18 +154,20 @@ impl ConsistencyCalculator {
 
                     total_values += 1;
 
-                    // Check if value is consistent with inferred type
+                    // Check if value is consistent with inferred type. Dates use
+                    // `is_date_token`, the same predicate that types a column as
+                    // `Date` in the first place. Validating against a narrower
+                    // set scored a column of clean ISO datetimes or dotted dates
+                    // at 0%: inference typed it `Date` on forms the validation
+                    // regexes did not accept, so every value in it failed.
                     let is_consistent = match profile.data_type {
                         DataType::Integer => is_integer_token(trimmed),
                         DataType::Float => trimmed.parse::<f64>().is_ok(),
-                        DataType::Date => is_valid_date_format(trimmed),
+                        DataType::Date => is_date_token(trimmed),
                         DataType::Boolean => parse_strict_boolean_token(trimmed).is_some(),
                         DataType::String | DataType::Identifier => match dominant_class {
                             Some(class) => lexical_class(trimmed) == class,
-                            None => {
-                                !is_likely_date_column(&profile.name)
-                                    || is_valid_date_format(trimmed)
-                            }
+                            None => !is_likely_date_column(&profile.name) || is_date_token(trimmed),
                         },
                     };
 
@@ -336,6 +338,16 @@ mod tests {
             .data_type_consistency
     }
 
+    /// `data_type_consistency` for one column of `values` typed `data_type`.
+    fn typed_column_consistency(name: &str, data_type: DataType, values: Vec<String>) -> f64 {
+        let mut profile = string_profile(name);
+        profile.data_type = data_type;
+        let data = HashMap::from([(name.to_string(), values)]);
+        ConsistencyCalculator::calculate(&data, &[profile])
+            .expect("consistency metrics should be computed")
+            .data_type_consistency
+    }
+
     /// `junk` non-numeric values padded out to 1000 with integers, the shape
     /// from the report in #544.
     fn numeric_with_junk(junk: usize) -> Vec<String> {
@@ -364,6 +376,53 @@ mod tests {
         // Past the halfway mark the text values are the dominant class and the
         // shrinking numeric minority is what costs the column its consistency.
         assert_eq!(string_column_consistency("v", numeric_with_junk(800)), 80.0);
+    }
+
+    #[test]
+    fn a_date_column_is_validated_against_the_forms_that_typed_it() {
+        // Inference types a column `Date` on forms the validation regexes do not
+        // accept, so validating against the narrower set failed every value in a
+        // clean column: 28 identical ISO datetimes scored 0.0 consistency, and
+        // the file's overall score came out at 60.94 for perfect data.
+        for (label, date) in [
+            ("iso datetime", "2024-01-15T10:30:00"),
+            ("fractional iso datetime", "2024-01-15T10:30:00.123"),
+            ("spaced datetime", "2024-01-15 10:30:00"),
+            ("dotted", "15.01.2024"),
+            ("slashed datetime", "15/01/2024 10:30:00"),
+            ("iso date", "2024-01-15"),
+        ] {
+            let values = vec![date.to_string(); 28];
+            assert_eq!(
+                typed_column_consistency("ts", DataType::Date, values),
+                100.0,
+                "a column of {label} values is typed Date but scored as malformed"
+            );
+        }
+    }
+
+    #[test]
+    fn a_date_column_of_malformed_values_still_loses_consistency() {
+        // Sharing one predicate must not turn the date branch permissive.
+        let values = ["2024-01-15", "not-a-date", "2024", "2024-01-16"]
+            .map(String::from)
+            .to_vec();
+        assert_eq!(typed_column_consistency("ts", DataType::Date, values), 50.0);
+    }
+
+    #[test]
+    fn a_date_named_string_column_accepts_every_recognized_date_form() {
+        // The date-named string column keeps its stricter name-driven rule, but
+        // "is this a date" has to mean the same thing there too.
+        let values = [
+            "2024-01-15T10:30:00",
+            "15.01.2024",
+            "2024-01-15 10:30:00",
+            "2024-01-15",
+        ]
+        .map(String::from)
+        .to_vec();
+        assert_eq!(string_column_consistency("event_date", values), 100.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A column of clean, uniform ISO datetimes or dotted dates was typed `date` and then
scored **0.0** type consistency, putting perfect data at 60.94 overall. Fixes #562
by validating a date column against the same predicate that typed it.

## Before / after

```
                       type    dtc              overall
100% ISO datetime      date    0.00 -> 100.00   60.94 -> 85.94
100% dotted DD.MM.YYYY date    0.00 -> 100.00   60.94 -> 85.94
100% plain YYYY-MM-DD  date  100.00    100.00   85.94    85.94   (unchanged)
21 dates + 7 non-dates date            75.00             83.48   (still penalised)
```

## Cause

Two regex sets answer "is this a date", and neither contains the other:

| form | inference (`DATE_REGEXES`) | validation (`DATE_VALIDATION_REGEXES`) |
| --- | --- | --- |
| `YYYY-MM-DD`, `DD/MM/YYYY`, `DD-MM-YYYY`, `YYYY/MM/DD` | yes | yes |
| `DD.MM.YYYY`, `…THH:MM:SS`, `… HH:MM:SS`, `DD/MM/YYYY HH:MM:SS` | **yes** | no |
| `M/D/YYYY`, `YYYY-M-D`, `M-D-YYYY` | no | **yes** |

`infer_type` typed the column `date` on the first set; the consistency calculator
validated against the second. For a column made entirely of a form only inference
recognizes, every value failed.

## Change

Both consistency arms that ask "is this a date" now use `is_date_token`, the union
already introduced for lexical classification in #560:

- the `DataType::Date` arm — the reported bug;
- the stricter name-driven rule for date-named `string` columns, which had the
  same defect for the same reason. A column called `event_date` holding ISO
  datetimes counted every value as inconsistent.

`infer_type` keeps its own narrower set. Widening that would newly type
1-digit-component columns as dates, which is an inference change rather than a
consistency one and deserves its own decision.

`is_valid_date_format` is no longer called directly here; it remains one half of
`is_date_token`.

## Drift guard

Per the issue's acceptance criteria, `is_date_token_accepts_every_form_either_regex_set_recognizes`
walks both regex sets and asserts every one of them matches at least one example
in the test's table. A date form cannot be added to dataprof without extending
that table, so the two sets cannot silently diverge again.
`a_value_that_is_not_a_date_is_not_a_date_token` pins the other direction, so the
union cannot decay into a predicate that accepts anything.

## Testing

```bash
cargo test -p dataprof-metrics                   # 232 passed
cargo test --workspace --all-features            # 39 result blocks, 848 passed, 0 failed
uv run pytest python/tests/ -q                   # 824 passed, 110 skipped, 1 pre-existing xfail
cargo fmt --all
cargo clippy --all --all-targets --all-features  # 0 findings
uv run ruff check ... && uv run ty check python/ # clean
```

The two changed lines were reverted **separately** to confirm each has a test that
catches it, rather than one test covering both:

| reverted line | failing test |
| --- | --- |
| `DataType::Date` arm | `a_date_column_is_validated_against_the_forms_that_typed_it` |
| date-named string fallback | `a_date_named_string_column_accepts_every_recognized_date_form` |

`a_date_column_of_malformed_values_still_loses_consistency` passes either way by
design — it guards against over-correcting the branch into permissiveness.

## Review follow-up (23e7c86)

Both review comments were right and are fixed.

The comment on the `Date` arm claimed `is_date_token` is the predicate that types a
column. It is not — `infer_type` keeps using the narrower `is_inferred_date_token`
— so the comment misstated the code and contradicted this PR's own decision.
Reworded to the property that holds: the union is a *superset* of every form that
can make a column `Date`, which is what guarantees a column is never typed on a
form its own validation rejects.

The drift guard did not guard. It asserted every production regex matches at least
one example, and the sets overlap, so `^\d{1,2}/\d{1,2}/\d{4}$` was already
covered by `15/01/2024`; deleting the distinguishing `1/2/2024` example left it
green. The table is now keyed by regex source and asserts **set equality** against
both statics, so overlap cannot hide anything. Verified against both drift
scenarios rather than assumed:

| simulated drift | result |
| --- | --- |
| added `^\d{4}\d{2}\d{2}$` to `DATE_REGEXES`, table untouched | FAILED |
| deleted the `1/2/2024` row, its pattern still present | FAILED |

## Note on the earlier local-testing caveat

An earlier revision of this description said `cargo test --workspace` could not
complete here, failing `LNK1104` on a different test binary each run. That is now
resolved and the full run passes: the cause was the local target directory, which
had reached 246 GB across 450,907 files. After `cargo clean` the same command
completes with 848 tests passing and no linker errors. Nothing about the change
itself was involved, and Defender — my first guess — was not running at all.
