### PR TITLE
fix(csv): align header-only analysis across engines

### DIFF
--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -354,7 +354,7 @@ pub fn analyze_csv_file_with_dimensions_and_hints(
     let file = std::fs::File::open(file_path).map_err(|error| map_io_error(file_path, error))?;
     let buf_reader = std::io::BufReader::new(file);
 
-    let (column_profiles, column_stats, rows_read, header_names) =
+    let (column_profiles, column_stats, rows_read, _header_names) =
         analyze_csv_from_reader_with_hints(buf_reader, config, semantic_hints)?;
 
     let file_source = DataSource::File {
@@ -365,11 +365,12 @@ pub fn analyze_csv_file_with_dimensions_and_hints(
         parquet_metadata: None,
     };
 
+    // Every header name is pre-registered above, so no profiles means no header
+    // declared a column: the source is empty, not merely rowless.
     if column_profiles.is_empty() && rows_read == 0 {
         return Ok(ReportAssembler::new(
             file_source,
-            ExecutionMetadata::new(0, header_names.len(), start.elapsed().as_millis())
-                .with_engine("csv"),
+            ExecutionMetadata::new(0, 0, start.elapsed().as_millis()).with_engine("csv"),
         )
         .skip_quality()
         .build());
@@ -589,6 +590,10 @@ mod tests {
 
         assert!(report.column_profiles.is_empty());
         assert_eq!(report.execution.rows_processed, 0);
+        assert_eq!(report.execution.columns_detected, 0);
+        // Records this path's behaviour, not a settled contract: the engines
+        // answer the same empty file with a quality block scoring 0.0/Exact
+        // over nothing at all. See #573.
         assert!(report.quality.is_none());
     }
 

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -281,6 +281,8 @@ pub fn analyze_csv_from_reader_with_hints<R: Read>(
     };
 
     let mut column_stats = StreamingColumnCollection::new().with_semantic_hints(semantic_hints);
+    // A header declares the columns even when no data records follow it.
+    column_stats.init_columns(&header_names);
     let mut rows_read = 0;
 
     for result in csv_reader.records() {
@@ -562,13 +564,32 @@ mod tests {
     }
 
     #[test]
-    fn test_analyze_csv_file_empty_file() {
+    fn test_analyze_csv_file_header_only_preserves_declared_columns() {
         let csv = write_csv("name,age\n");
         let config = CsvParserConfig::default();
         let report = analyze_csv_file(csv.path(), &config).unwrap();
 
-        assert_eq!(report.column_profiles.len(), 0);
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| (column.name.as_str(), column.data_type.clone()))
+                .collect::<Vec<_>>(),
+            vec![("name", DataType::String), ("age", DataType::String)]
+        );
         assert_eq!(report.execution.rows_processed, 0);
+        assert!(report.quality.is_some());
+    }
+
+    #[test]
+    fn test_analyze_csv_file_empty_file_has_no_columns() {
+        let csv = write_csv("");
+        let config = CsvParserConfig::default();
+        let report = analyze_csv_file(csv.path(), &config).unwrap();
+
+        assert!(report.column_profiles.is_empty());
+        assert_eq!(report.execution.rows_processed, 0);
+        assert!(report.quality.is_none());
     }
 
     #[test]

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -1139,6 +1139,11 @@ impl AsyncStreamingProfiler {
             });
         }
 
+        // Headers are the declared schema even when the stream contains no
+        // records. Pre-register them so the public async path preserves the
+        // same header-only CSV invariant as the file-based engines.
+        column_stats.init_columns(&headers);
+
         // Estimate total rows for progress (if we know the total size)
         let estimated_total_rows = size_hint.map(|total| {
             (total as usize) / 50 // rough estimate: ~50 bytes per row
@@ -1339,7 +1344,18 @@ mod tests {
         let profiler = AsyncStreamingProfiler::new();
         let report = profiler.analyze_stream(source).await.unwrap();
 
-        assert_eq!(report.column_profiles.len(), 0);
+        let names: Vec<&str> = report
+            .column_profiles
+            .iter()
+            .map(|profile| profile.name.as_str())
+            .collect();
+        assert_eq!(names, vec!["name", "age", "salary"]);
+        assert!(
+            report
+                .column_profiles
+                .iter()
+                .all(|profile| profile.data_type == DataType::String && profile.total_count == 0)
+        );
         assert_eq!(report.execution.rows_processed, 0);
     }
 

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -798,17 +798,14 @@ fn analyze_structure_csv(
         config = config.with_delimiter(delimiter);
     }
 
-    let (profiles, column_stats, rows_sampled, headers) =
+    let (profiles, column_stats, rows_sampled, _) =
         dataprof_csv::analyze_csv_from_reader(file, &config)?;
     let row_count = if rows_sampled < max_rows {
         exact_row_count_from_sample(rows_sampled, start.elapsed().as_millis())
     } else {
         quick_row_count_with_format(path, FileFormat::Csv)?
     };
-    let mut columns = structure_columns_from_profiles(&profiles, &column_stats, "sample");
-    if columns.is_empty() && !headers.is_empty() {
-        columns = empty_structure_columns_from_headers(&headers, "sample");
-    }
+    let columns = structure_columns_from_profiles(&profiles, &column_stats, "sample");
 
     let (source_exhausted, truncated, truncation_reason) =
         sample_status(&row_count, rows_sampled, max_rows);
@@ -952,26 +949,6 @@ fn structure_columns_from_profiles(
         .collect()
 }
 
-fn empty_structure_columns_from_headers(
-    headers: &[String],
-    provenance: &str,
-) -> Vec<StructureColumnSummary> {
-    headers
-        .iter()
-        .map(|name| StructureColumnSummary {
-            name: name.clone(),
-            data_type: dataprof_core::DataType::String,
-            total_count: Some(0),
-            null_count: Some(0),
-            null_ratio: None,
-            unique_count: Some(0),
-            uniqueness_ratio: None,
-            distinct_count_approximate: Some(false),
-            provenance: provenance.to_string(),
-        })
-        .collect()
-}
-
 fn ratio(numerator: usize, denominator: usize) -> Option<f64> {
     if denominator == 0 {
         None
@@ -1039,17 +1016,13 @@ fn schema_from_streaming_stats(
 ) -> SchemaResult {
     let columns = headers
         .iter()
-        .map(|name| {
-            // A header can declare a column before any row creates statistics.
-            // String is the existing type convention when no values were observed.
-            let data_type = column_stats.get_column_stats(name).map_or(
-                dataprof_core::DataType::String,
-                profile_builder::infer_data_type_streaming,
-            );
-            ColumnSchema {
-                name: name.clone(),
-                data_type,
-            }
+        .filter_map(|name| {
+            column_stats
+                .get_column_stats(name)
+                .map(|stats| ColumnSchema {
+                    name: name.clone(),
+                    data_type: profile_builder::infer_data_type_streaming(stats),
+                })
         })
         .collect();
 
@@ -1287,6 +1260,16 @@ mod tests {
                 .map(|column| column.name.as_str())
                 .collect::<Vec<_>>()
         );
+        for column in &structure.columns {
+            assert_eq!(column.data_type, DataType::String);
+            assert_eq!(column.total_count, Some(0));
+            assert_eq!(column.null_count, Some(0));
+            assert_eq!(column.null_ratio, None);
+            assert_eq!(column.unique_count, Some(0));
+            assert_eq!(column.uniqueness_ratio, None);
+            assert_eq!(column.distinct_count_approximate, Some(false));
+            assert_eq!(column.provenance, "sample");
+        }
     }
 
     #[test]

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -21,7 +21,7 @@ use dataprof_core::{
 };
 use dataprof_csv::CsvParserConfig;
 use dataprof_json::JsonParserConfig;
-use dataprof_runtime::{StreamingColumnCollection, profile_builder};
+use dataprof_runtime::StreamingColumnCollection;
 
 /// Schema inference sample size (rows to read for CSV/JSON).
 const SCHEMA_SAMPLE_ROWS: usize = 1000;
@@ -260,15 +260,11 @@ fn infer_schema_from_csv_reader<R: Read>(
     let config = CsvParserConfig::default()
         .has_header(has_header)
         .max_rows(Some(SCHEMA_SAMPLE_ROWS));
-    let (_profiles, column_stats, rows_read, headers) =
+    let (profiles, _column_stats, rows_read, _headers) =
         dataprof_csv::analyze_csv_from_reader(reader, &config)?;
 
-    Ok(schema_from_streaming_stats(
-        &column_stats,
-        &headers,
-        rows_read,
-        0, // caller patches timing
-    ))
+    // Zero elapsed: the caller patches the timing.
+    Ok(schema_from_profiles(&profiles, rows_read, 0))
 }
 
 /// Infer schema from any JSON/JSONL reader. Reads up to `SCHEMA_SAMPLE_ROWS` rows.
@@ -281,19 +277,11 @@ fn infer_schema_from_json_reader<R: BufRead>(
         FileFormat::Json => JsonParserConfig::json_document().with_max_rows(SCHEMA_SAMPLE_ROWS),
         _ => JsonParserConfig::default().with_max_rows(SCHEMA_SAMPLE_ROWS),
     };
-    let (_profiles, column_stats, rows_read, _malformed_lines, _detected_format) =
+    let (profiles, _column_stats, rows_read, _malformed_lines, _detected_format) =
         dataprof_json::analyze_json_from_reader(reader, &config)?;
 
-    // column_names() is already in first-seen source order, which is the
-    // public ordering contract for JSON/JSONL. Do not re-sort it.
-    let names = column_stats.column_names();
-
-    Ok(schema_from_streaming_stats(
-        &column_stats,
-        &names,
-        rows_read,
-        0, // caller patches timing
-    ))
+    // Zero elapsed: the caller patches the timing.
+    Ok(schema_from_profiles(&profiles, rows_read, 0))
 }
 
 /// Infer schema from a generic reader, dispatching by format.
@@ -1008,21 +996,23 @@ fn delimiter_to_string(delimiter: u8) -> String {
     }
 }
 
-fn schema_from_streaming_stats(
-    column_stats: &StreamingColumnCollection,
-    headers: &[String],
+/// Build a schema from the profiles the parser already produced.
+///
+/// Profiles are one per declared column, in first-seen source order: the CSV
+/// header order, or the public ordering contract for JSON/JSONL. Do not re-sort
+/// them. Reading the type off the profile keeps `infer_schema` and `profile`
+/// from ever naming a column's type differently, and leaves no column to drop
+/// or default.
+fn schema_from_profiles(
+    profiles: &[ColumnProfile],
     rows_sampled: usize,
     elapsed_ms: u128,
 ) -> SchemaResult {
-    let columns = headers
+    let columns = profiles
         .iter()
-        .filter_map(|name| {
-            column_stats
-                .get_column_stats(name)
-                .map(|stats| ColumnSchema {
-                    name: name.clone(),
-                    data_type: profile_builder::infer_data_type_streaming(stats),
-                })
+        .map(|profile| ColumnSchema {
+            name: profile.name.clone(),
+            data_type: profile.data_type.clone(),
         })
         .collect();
 

--- a/tests/async_streaming.rs
+++ b/tests/async_streaming.rs
@@ -191,6 +191,28 @@ async fn test_profiler_profile_stream_csv() {
     assert!(report.execution.source_exhausted);
 }
 
+#[tokio::test]
+async fn test_profiler_profile_stream_header_only_csv_preserves_schema() {
+    let csv = b"name,age,salary\n";
+    let source = BytesSource::new(
+        bytes::Bytes::from_static(csv),
+        AsyncSourceInfo::new("header-only-csv", FileFormat::Csv).size_hint(Some(csv.len() as u64)),
+    );
+
+    let report = Profiler::new().profile_stream(source).await.unwrap();
+
+    let names: Vec<&str> = report
+        .column_profiles
+        .iter()
+        .map(|profile| profile.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["name", "age", "salary"]);
+    assert!(report.column_profiles.iter().all(|profile| {
+        profile.data_type == dataprof::DataType::String && profile.total_count == 0
+    }));
+    assert_eq!(report.execution.rows_processed, 0);
+}
+
 /// Verify `Profiler::profile_stream()` works with JSON format.
 #[tokio::test]
 async fn test_profiler_profile_stream_json() {

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -25,6 +25,68 @@ fn create_sorted_30k_csv() -> NamedTempFile {
     f
 }
 
+#[test]
+fn test_header_only_csv_columns_match_across_engines_and_serialization() {
+    let mut csv = NamedTempFile::new().unwrap();
+    writeln!(csv, "name,age").unwrap();
+    csv.flush().unwrap();
+
+    let standard = analyze_csv_file(csv.path(), &CsvParserConfig::default())
+        .expect("standard CSV analysis should succeed");
+    let reports = [
+        ("standard", standard),
+        (
+            "auto",
+            Profiler::new()
+                .engine(EngineType::Auto)
+                .analyze_file(csv.path())
+                .expect("auto analysis should succeed"),
+        ),
+        (
+            "incremental",
+            Profiler::new()
+                .engine(EngineType::Incremental)
+                .analyze_file(csv.path())
+                .expect("incremental analysis should succeed"),
+        ),
+        (
+            "columnar",
+            Profiler::new()
+                .engine(EngineType::Columnar)
+                .analyze_file(csv.path())
+                .expect("columnar analysis should succeed"),
+        ),
+    ];
+
+    for (engine, report) in reports {
+        assert_eq!(report.execution.rows_processed, 0, "{engine}");
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| (column.name.as_str(), column.data_type.clone()))
+                .collect::<Vec<_>>(),
+            vec![("name", DataType::String), ("age", DataType::String)],
+            "{engine}"
+        );
+        assert!(report.quality.is_some(), "{engine}");
+
+        let serialized = serde_json::to_value(&report).expect("report should serialize");
+        let serialized_columns = serialized["column_profiles"]
+            .as_array()
+            .expect("column_profiles should be an array");
+        assert_eq!(
+            serialized_columns
+                .iter()
+                .map(|column| column["name"].as_str().expect("column name"))
+                .collect::<Vec<_>>(),
+            vec!["name", "age"],
+            "{engine}"
+        );
+        assert!(serialized["quality"].is_object(), "{engine}");
+    }
+}
+
 /// Base numeric statistics must be exact — computed over every value, not the
 /// bounded sample — and identical across engines, even when the data is
 /// sorted and larger than the sample capacity (#424).


### PR DESCRIPTION
# Pull Request

## 📝 Summary

Make the CSV profiling paths preserve declared columns for a header-only file, so standard, auto, incremental, columnar, and async-streaming analysis all expose the same schema. This also removes the now-redundant partial-analysis fallbacks added before the parser owned that invariant.

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🚨 Breaking change (would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ⚡ Performance improvement
- [ ] 🎨 Code refactoring (no functional changes)

## 📋 Changes Made

- Pre-register CSV header names in `StreamingColumnCollection` before reading records in both file-based and async-streaming paths.
- Split the former “empty file” regression into genuinely empty and header-only cases.
- Remove duplicate header-only schema/structure fallbacks from `dataprof-partial` and pin the resulting structure fields.
- Add a cross-engine and serialization regression for header-only CSV input.

**Related Issue:** Closes #558

## 🧪 Testing

- [x] Tested locally with `cargo test`
- [x] Added new tests for this feature
- [x] All existing tests pass
- [x] Tested with sample data files
- [x] Tested edge cases (empty files, large files, etc.)

### Test Commands Run

```bash
cargo test --workspace --all-features
cargo test -p dataprof-engines --features async-streaming
cargo test --features async-streaming --test async_streaming
cargo clippy -p dataprof-csv -p dataprof-partial -p dataprof --all-targets --all-features -- -D warnings
cargo clippy --features async-streaming --all-targets -- -D warnings
cargo fmt --all -- --check
uv sync
uv run maturin develop
uv run pytest python/tests/test_python_api.py -q  # 323 passed
uv run ruff check .
uv run ty check
git diff --check
```

The repository-wide `uv run ruff format --check .` also reports eight pre-existing documentation/skill files that current Ruff would reformat; this PR changes only Rust files.

## 📖 Documentation

- [ ] Updated README.md if user-facing changes
- [x] Added/updated inline code comments
- [ ] Updated docs/ folder if architectural changes
- [x] No documentation changes needed

## ⚡ Performance Impact

- [x] No performance impact
- [ ] Performance improved
- [ ] Performance may be affected (explain below)

## 🚨 Breaking Changes

- [x] No breaking changes

## 📌 Additional Notes

The separate zero-row quality aggregation decision remains tracked in #571 and is intentionally unchanged here.

## ✅ Checklist

- [x] Code builds without warnings
- [x] No linting errors (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] All tests pass
- [x] Self-reviewed my code
- [x] Comments added for complex logic
- [x] No hardcoded secrets or sensitive data

