### PR TITLE
fix(async): reject duplicate CSV headers

### DIFF
--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -576,6 +576,7 @@ impl AsyncStreamingProfiler {
             .map_err(|e| Self::csv_error(&e, flexible))?;
 
         let header_fields: Vec<String> = headers.iter().map(|f| f.to_string()).collect();
+        dataprof_core::validate_unique_column_names(&header_fields, "CSV header")?;
         let header_len = header_fields.len();
         // Byte counts come from the parser's own position rather than from the
         // parsed fields: a record's fields exclude delimiters, quotes and line

--- a/tests/async_streaming.rs
+++ b/tests/async_streaming.rs
@@ -213,6 +213,23 @@ async fn test_profiler_profile_stream_header_only_csv_preserves_schema() {
     assert_eq!(report.execution.rows_processed, 0);
 }
 
+#[tokio::test]
+async fn test_profiler_profile_stream_rejects_duplicate_csv_headers() {
+    let csv = b"x,x\n1,2\n";
+    let source = BytesSource::new(
+        bytes::Bytes::from_static(csv),
+        AsyncSourceInfo::new("duplicate-header-csv", FileFormat::Csv),
+    );
+
+    let error = Profiler::new()
+        .profile_stream(source)
+        .await
+        .expect_err("async CSV profiling must reject duplicate headers");
+
+    assert_eq!(error.category(), "duplicate_column_name");
+    assert!(error.to_string().contains("'x'"));
+}
+
 /// Verify `Profiler::profile_stream()` works with JSON format.
 #[tokio::test]
 async fn test_profiler_profile_stream_json() {


### PR DESCRIPTION
## Description

Reject duplicate CSV header names in the async streaming reader before per-column state is initialized. This keeps async CSV behavior aligned with the existing file, incremental, and columnar paths and prevents two source columns from being merged into one profile.

## Related issue

Fixes #574

## Testing

- `cargo test --features async-streaming --test async_streaming test_profiler_profile_stream_rejects_duplicate_csv_headers`
- `cargo fmt --all`

Prepared with AI assistance; maintainer review is requested.