### PR TITLE
fix(metrics): align empty CSV quality parity

### DIFF
--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -397,6 +397,7 @@ impl IncrementalProfiler {
             execution = execution.with_source_exhausted(false);
         }
 
+        let empty_source = column_profiles.is_empty() && analyzed_rows == 0;
         let mut assembler = ReportAssembler::new(
             DataSource::File {
                 path: file_path.display().to_string(),
@@ -409,7 +410,7 @@ impl IncrementalProfiler {
         )
         .columns(column_profiles);
 
-        if MetricPack::include_quality(packs) {
+        if MetricPack::include_quality(packs) && !empty_source {
             assembler = assembler
                 .with_quality_data(sample_columns)
                 .with_row_duplicates(column_stats.row_duplicate_summary())

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -322,6 +322,7 @@ impl ArrowProfiler {
             execution = execution.with_truncation(TruncationReason::MaxRows(max as u64));
         }
 
+        let empty_source = column_profiles.is_empty() && total_rows == 0;
         let mut assembler = ReportAssembler::new(
             DataSource::File {
                 path: file_path.display().to_string(),
@@ -335,7 +336,7 @@ impl ArrowProfiler {
         .columns(column_profiles)
         .with_row_duplicates(row_tracker.summary());
 
-        if MetricPack::include_quality(packs) {
+        if MetricPack::include_quality(packs) && !empty_source {
             assembler = assembler
                 .with_quality_data(sample_columns)
                 .with_exact_value_hint_bindings(hint_bindings.bindings(headers.iter()))

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -87,6 +87,50 @@ fn test_header_only_csv_columns_match_across_engines_and_serialization() {
     }
 }
 
+#[test]
+fn test_empty_csv_quality_presence_matches_across_engines_and_serialization() {
+    let csv = NamedTempFile::new().unwrap();
+    let path = csv.path();
+
+    let reports = [
+        (
+            "standard",
+            analyze_csv_file(path, &CsvParserConfig::default())
+                .expect("standard CSV analysis should succeed"),
+        ),
+        (
+            "auto",
+            Profiler::new()
+                .engine(EngineType::Auto)
+                .analyze_file(path)
+                .expect("auto analysis should succeed"),
+        ),
+        (
+            "incremental",
+            Profiler::new()
+                .engine(EngineType::Incremental)
+                .analyze_file(path)
+                .expect("incremental analysis should succeed"),
+        ),
+        (
+            "columnar",
+            Profiler::new()
+                .engine(EngineType::Columnar)
+                .analyze_file(path)
+                .expect("columnar analysis should succeed"),
+        ),
+    ];
+
+    for (engine, report) in reports {
+        assert!(report.column_profiles.is_empty(), "{engine}");
+        assert_eq!(report.execution.rows_processed, 0, "{engine}");
+        assert!(report.quality.is_none(), "{engine} must not assess no data");
+
+        let serialized = serde_json::to_value(&report).expect("report should serialize");
+        assert!(serialized["quality"].is_null(), "{engine}");
+    }
+}
+
 /// Base numeric statistics must be exact — computed over every value, not the
 /// bounded sample — and identical across engines, even when the data is
 /// sorted and larger than the sample capacity (#424).


### PR DESCRIPTION
## Description

Treat a zero-byte CSV as unassessed across standard, incremental, and columnar analysis paths, matching the parser’s `quality: None` contract. Added raw and serialized cross-engine parity coverage.

## Related issue

Fixes #573

## Testing

- `cargo test --test cross_engine_consistency test_empty_csv_quality_presence_matches_across_engines_and_serialization`
- `cargo fmt --all`

Prepared with AI assistance; maintainer review is requested.