### PR TITLE
fix(patterns): make locale a closed set instead of a silent filter

### DIFF
--- a/.claude/skills/dataprof/reference/interpretation.md
+++ b/.claude/skills/dataprof/reference/interpretation.md
@@ -116,6 +116,11 @@ A detected pattern is a detection, not a guarantee. Locale matters: without a
 pattern result looks surprising, check whether a locale should have been set
 before reporting it as a finding.
 
+The supported locales are `CA`, `DE`, `FR`, `GB`, `IT`, `US`. Case, the alpha-3
+code (`ITA`) and the BCP 47 / POSIX forms (`it-IT`, `it_IT`) all normalise to
+the same locale; any other tag raises `ValueError` instead of returning a report
+with every locale-specific pattern suppressed.
+
 ## Comparisons
 
 `before.compare(after)` returns deltas. Two caveats:

--- a/crates/dataprof-core/src/analysis_options.rs
+++ b/crates/dataprof-core/src/analysis_options.rs
@@ -8,6 +8,7 @@
 //! [`AnalysisOptions`] bundles them so a path either carries the whole selection
 //! or does not compile.
 
+use crate::locale::Locale;
 use crate::quality::{MetricPack, QualityDimension};
 use crate::semantic::SemanticHints;
 
@@ -19,7 +20,7 @@ use crate::semantic::SemanticHints;
 pub struct AnalysisOptions {
     metric_packs: Option<Vec<MetricPack>>,
     quality_dimensions: Option<Vec<QualityDimension>>,
-    locale: Option<String>,
+    locale: Option<Locale>,
     semantic_hints: SemanticHints,
 }
 
@@ -36,8 +37,12 @@ impl AnalysisOptions {
         self
     }
 
-    /// Set the ISO 3166-1 alpha-2 locale used to rank detected patterns.
-    pub fn with_locale(mut self, locale: Option<String>) -> Self {
+    /// Set the locale used to rank detected patterns.
+    ///
+    /// Parse a user-supplied tag with [`Locale::parse_optional`] first, so an
+    /// unrecognised tag is rejected where it is written rather than silently
+    /// suppressing every locale-specific pattern.
+    pub fn with_locale(mut self, locale: Option<Locale>) -> Self {
         self.locale = locale;
         self
     }
@@ -82,8 +87,8 @@ impl AnalysisOptions {
     /// A locale only ranks patterns, so it has no effect of its own when
     /// [`include_patterns`](Self::include_patterns) is false and detection never
     /// runs.
-    pub fn locale(&self) -> Option<&str> {
-        self.locale.as_deref()
+    pub fn locale(&self) -> Option<Locale> {
+        self.locale
     }
 
     /// The requested quality dimensions, if the caller narrowed them.
@@ -147,9 +152,9 @@ mod tests {
     #[test]
     fn a_locale_alone_does_not_re_enable_pattern_detection() {
         let options = AnalysisOptions::default()
-            .with_locale(Some("IT".to_string()))
+            .with_locale(Some(Locale::It))
             .with_metric_packs(Some(vec![MetricPack::Schema]));
-        assert_eq!(options.locale(), Some("IT"));
+        assert_eq!(options.locale(), Some(Locale::It));
         assert!(!options.include_patterns());
     }
 }

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod errors;
 pub mod execution;
 #[doc(hidden)]
 pub mod io;
+pub mod locale;
 pub mod memory_sampler;
 pub mod memory_tracker;
 pub mod output;
@@ -32,6 +33,7 @@ pub use errors::{DataProfilerError, RecoveryAttempt, RecoveryStrategy, RetryConf
 pub use execution::{ExecutionMetadata, TruncationReason};
 #[doc(hidden)]
 pub use io::Utf8BomReader;
+pub use locale::Locale;
 pub use memory_sampler::PeakMemorySampler;
 pub use memory_tracker::{MemoryLeak, MemoryTracker};
 pub use output::OutputFormat;

--- a/crates/dataprof-core/src/locale.rs
+++ b/crates/dataprof-core/src/locale.rs
@@ -1,0 +1,185 @@
+//! The closed set of locales the pattern catalogue carries detectors for.
+//!
+//! A locale is *strict*: setting one suppresses patterns belonging to any other
+//! locale. That strictness is right for a tag the catalogue knows, and wrong for
+//! one it does not — an unrecognised tag used to be accepted and behave as
+//! "suppress every locale-specific pattern", so `locale="it-IT"` returned no
+//! patterns where `locale="IT"` returned a confident match, with nothing in the
+//! report saying the tag was not understood. Parsing a tag into [`Locale`]
+//! before it can be stored keeps that failure out of the type: the common
+//! spellings normalise, and anything left over is an error naming the set.
+
+/// A locale the pattern catalogue carries locale-specific detectors for.
+///
+/// Parse a user-supplied tag with [`str::parse`] or
+/// [`Locale::parse_optional`]; the variants are also usable directly
+/// (`Locale::It`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Locale {
+    /// Canada
+    Ca,
+    /// Germany
+    De,
+    /// France
+    Fr,
+    /// United Kingdom
+    Gb,
+    /// Italy
+    It,
+    /// United States
+    Us,
+}
+
+impl Locale {
+    /// Every supported locale, in the order error messages list them.
+    pub fn all() -> Vec<Self> {
+        vec![Self::Ca, Self::De, Self::Fr, Self::Gb, Self::It, Self::Us]
+    }
+
+    /// The ISO 3166-1 alpha-2 code, as the pattern catalogue spells it.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ca => "CA",
+            Self::De => "DE",
+            Self::Fr => "FR",
+            Self::Gb => "GB",
+            Self::It => "IT",
+            Self::Us => "US",
+        }
+    }
+
+    /// The ISO 3166-1 alpha-3 code, accepted as an alternative spelling.
+    fn alpha3(&self) -> &'static str {
+        match self {
+            Self::Ca => "CAN",
+            Self::De => "DEU",
+            Self::Fr => "FRA",
+            Self::Gb => "GBR",
+            Self::It => "ITA",
+            Self::Us => "USA",
+        }
+    }
+
+    /// Parse an optional tag, where absent and blank both mean "no locale".
+    ///
+    /// This is the boundary helper for callers who receive a tag from a user or
+    /// another language: `None` and `""` are the same request (rank patterns
+    /// without a locale preference), and every other value must resolve.
+    ///
+    /// ```
+    /// use dataprof_core::Locale;
+    ///
+    /// assert_eq!(Locale::parse_optional(None), Ok(None));
+    /// assert_eq!(Locale::parse_optional(Some("  ")), Ok(None));
+    /// assert_eq!(Locale::parse_optional(Some("it-IT")), Ok(Some(Locale::It)));
+    /// assert!(Locale::parse_optional(Some("XX")).is_err());
+    /// ```
+    pub fn parse_optional(tag: Option<&str>) -> Result<Option<Self>, String> {
+        match tag.map(str::trim) {
+            None | Some("") => Ok(None),
+            Some(tag) => tag.parse().map(Some),
+        }
+    }
+
+    /// Resolve a normalised tag, or `None` when it names no supported locale.
+    ///
+    /// A single subtag is read as a region code (`"IT"`, `"it"`, `"ITA"`). With
+    /// more than one, the region is the last subtag, so both the BCP 47 and the
+    /// POSIX spellings resolve (`"it-IT"`, `"it_IT"`, `"en-GB"`). A tag naming a
+    /// region the catalogue has no patterns for (`"de-CH"`) does not fall back
+    /// to its language subtag: it names a locale dataprof does not support, and
+    /// answering with Germany's patterns would be a guess.
+    fn resolve(tag: &str) -> Option<Self> {
+        let region = tag
+            .split(['-', '_'])
+            .rfind(|subtag| !subtag.is_empty())?
+            .to_ascii_uppercase();
+
+        Self::all()
+            .into_iter()
+            .find(|locale| locale.as_str() == region || locale.alpha3() == region)
+    }
+}
+
+impl std::str::FromStr for Locale {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::resolve(s).ok_or_else(|| {
+            let supported = Self::all()
+                .iter()
+                .map(|locale| locale.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "Unknown locale: '{s}'. Supported locales: {supported} (ISO 3166-1 alpha-2). \
+                 'it', 'ITA' and 'it-IT' are accepted spellings of 'IT'."
+            )
+        })
+    }
+}
+
+impl std::fmt::Display for Locale {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spellings_of_the_same_locale_resolve_alike() {
+        for tag in ["IT", "it", "It", " it ", "ITA", "ita", "it-IT", "it_IT"] {
+            assert_eq!(
+                Locale::parse_optional(Some(tag)),
+                Ok(Some(Locale::It)),
+                "tag {tag:?} did not resolve to IT"
+            );
+        }
+    }
+
+    #[test]
+    fn the_region_subtag_decides_not_the_language() {
+        // en-GB and en-US share a language and select different catalogues.
+        assert_eq!(Locale::parse_optional(Some("en-GB")), Ok(Some(Locale::Gb)));
+        assert_eq!(Locale::parse_optional(Some("en-US")), Ok(Some(Locale::Us)));
+        assert_eq!(Locale::parse_optional(Some("fr-CA")), Ok(Some(Locale::Ca)));
+    }
+
+    #[test]
+    fn absent_and_blank_mean_no_locale() {
+        assert_eq!(Locale::parse_optional(None), Ok(None));
+        assert_eq!(Locale::parse_optional(Some("")), Ok(None));
+        assert_eq!(Locale::parse_optional(Some("   ")), Ok(None));
+    }
+
+    #[test]
+    fn an_unsupported_region_is_an_error_not_a_fallback() {
+        // Switzerland has no catalogue; resolving de-CH to Germany would be a
+        // guess, and accepting it silently is the bug this type exists for.
+        for tag in ["XX", "de-CH", "es", "en", "ZZZZ", "it-IT-u-ca-gregory"] {
+            assert!(
+                tag.parse::<Locale>().is_err(),
+                "tag {tag:?} was accepted as a locale"
+            );
+        }
+    }
+
+    #[test]
+    fn the_error_names_the_supported_set() {
+        let error = "it-IT-u-ca-gregory".parse::<Locale>().unwrap_err();
+        assert!(error.contains("it-IT-u-ca-gregory"), "{error}");
+        for locale in Locale::all() {
+            assert!(error.contains(locale.as_str()), "{error}");
+        }
+    }
+
+    #[test]
+    fn display_round_trips_through_parse() {
+        for locale in Locale::all() {
+            assert_eq!(locale.to_string().parse::<Locale>(), Ok(locale));
+        }
+    }
+}

--- a/crates/dataprof-core/src/locale.rs
+++ b/crates/dataprof-core/src/locale.rs
@@ -83,17 +83,28 @@ impl Locale {
 
     /// Resolve a normalised tag, or `None` when it names no supported locale.
     ///
-    /// A single subtag is read as a region code (`"IT"`, `"it"`, `"ITA"`). With
-    /// more than one, the region is the last subtag, so both the BCP 47 and the
-    /// POSIX spellings resolve (`"it-IT"`, `"it_IT"`, `"en-GB"`). A tag naming a
-    /// region the catalogue has no patterns for (`"de-CH"`) does not fall back
-    /// to its language subtag: it names a locale dataprof does not support, and
-    /// answering with Germany's patterns would be a guess.
+    /// Two forms resolve: a bare region code (`"IT"`, `"it"`, `"ITA"`) and a
+    /// language-region pair, in either the BCP 47 or the POSIX spelling
+    /// (`"it-IT"`, `"it_IT"`, `"en-GB"`). A stray separator is tolerated; a
+    /// longer tag is not, because its last subtag is not its region — the
+    /// script, variant, extension and private-use subtags all sit after it, so
+    /// reading `de-CH-x-IT` as Italy would answer a Swiss request with Italy's
+    /// patterns.
+    ///
+    /// A tag naming a region the catalogue has no patterns for (`"de-CH"`) does
+    /// not fall back to its language subtag either: it names a locale dataprof
+    /// does not support, and answering with Germany's patterns would be a guess.
     fn resolve(tag: &str) -> Option<Self> {
-        let region = tag
+        let subtags: Vec<&str> = tag
             .split(['-', '_'])
-            .rfind(|subtag| !subtag.is_empty())?
-            .to_ascii_uppercase();
+            .filter(|subtag| !subtag.is_empty())
+            .collect();
+
+        let region = match subtags.as_slice() {
+            // One subtag is the region itself; two are language and region.
+            [region] | [_, region] => region.to_ascii_uppercase(),
+            _ => return None,
+        };
 
         Self::all()
             .into_iter()
@@ -159,10 +170,42 @@ mod tests {
     fn an_unsupported_region_is_an_error_not_a_fallback() {
         // Switzerland has no catalogue; resolving de-CH to Germany would be a
         // guess, and accepting it silently is the bug this type exists for.
-        for tag in ["XX", "de-CH", "es", "en", "ZZZZ", "it-IT-u-ca-gregory"] {
+        for tag in ["XX", "de-CH", "es", "en", "ZZZZ"] {
             assert!(
                 tag.parse::<Locale>().is_err(),
                 "tag {tag:?} was accepted as a locale"
+            );
+        }
+    }
+
+    #[test]
+    fn a_subtag_past_the_region_is_not_read_as_the_region() {
+        // Script, variant, extension and private-use subtags all sit after the
+        // region, so the last subtag of a longer tag is not it: `de-CH-x-IT`
+        // names Switzerland, and reading it as Italy would be the same silent
+        // wrong answer from the other direction.
+        for tag in [
+            "de-CH-x-IT",
+            "it-IT-u-ca-gregory",
+            "zh-Hans-CN",
+            "sr-Latn-RS-x-US",
+        ] {
+            assert!(
+                tag.parse::<Locale>().is_err(),
+                "tag {tag:?} was accepted as a locale"
+            );
+        }
+    }
+
+    #[test]
+    fn a_stray_separator_is_tolerated() {
+        // A trailing or doubled separator is a typo for the tag, not a longer
+        // tag: the subtags it actually carries still name one region.
+        for tag in ["IT-", "_it_", "it--IT", "-IT"] {
+            assert_eq!(
+                tag.parse::<Locale>(),
+                Ok(Locale::It),
+                "tag {tag:?} should resolve to IT"
             );
         }
     }

--- a/crates/dataprof-engines/src/adaptive.rs
+++ b/crates/dataprof-engines/src/adaptive.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use dataprof_core::{ChunkSize, DataProfilerError, MetricPack, QualityDimension, SemanticHints};
+use dataprof_core::{
+    ChunkSize, DataProfilerError, Locale, MetricPack, QualityDimension, SemanticHints,
+};
 use dataprof_csv::CsvParserConfig;
 use dataprof_runtime::ProfileReport;
 
@@ -24,7 +26,7 @@ pub struct AdaptiveProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     csv_config: Option<CsvParserConfig>,
-    locale: Option<String>,
+    locale: Option<Locale>,
     semantic_hints: SemanticHints,
     memory_limit_mb: Option<usize>,
     chunk_size: Option<ChunkSize>,
@@ -70,7 +72,7 @@ impl AdaptiveProfiler {
         self
     }
 
-    pub fn locale(mut self, locale: String) -> Self {
+    pub fn locale(mut self, locale: Locale) -> Self {
         self.locale = Some(locale);
         self
     }
@@ -245,8 +247,8 @@ impl AdaptiveProfiler {
                 if let Some(ref config) = self.csv_config {
                     profiler = profiler.csv_config(config.clone());
                 }
-                if let Some(ref l) = self.locale {
-                    profiler = profiler.locale(l.clone());
+                if let Some(l) = self.locale {
+                    profiler = profiler.locale(l);
                 }
                 if let Some(mb) = self.memory_limit_mb {
                     profiler = profiler.memory_limit_mb(mb);
@@ -271,8 +273,8 @@ impl AdaptiveProfiler {
                 if let Some(ref config) = self.csv_config {
                     profiler = profiler.csv_config(config.clone());
                 }
-                if let Some(ref l) = self.locale {
-                    profiler = profiler.locale(l.clone());
+                if let Some(l) = self.locale {
+                    profiler = profiler.locale(l);
                 }
                 profiler = profiler.semantic_hints(self.semantic_hints.clone());
                 profiler.analyze_file(file_path)

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use dataprof_core::{
     AnalysisOptions, ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat,
-    JsonErrorPolicy, MetricPack, ProgressSink, QualityDimension, RowSampler, RowView,
+    JsonErrorPolicy, Locale, MetricPack, ProgressSink, QualityDimension, RowSampler, RowView,
     SamplingStrategy, SchemaStabilityTracker, SemanticHints, StopCondition, StopEvaluator,
     StreamSourceSystem, TruncationReason,
 };
@@ -317,7 +317,7 @@ impl AsyncStreamingProfiler {
     }
 
     /// Set the locale used to rank detected patterns.
-    pub fn locale(mut self, locale: String) -> Self {
+    pub fn locale(mut self, locale: Locale) -> Self {
         self.options = std::mem::take(&mut self.options).with_locale(Some(locale));
         self
     }

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use dataprof_core::{
-    ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, MetricPack,
+    ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, Locale, MetricPack,
     PeakMemorySampler, ProgressSink, QualityDimension, RowSampler, RowView, SamplingStrategy,
     SchemaStabilityTracker, SemanticHints, StopCondition, StopEvaluator,
 };
@@ -26,7 +26,7 @@ pub struct IncrementalProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     csv_config: Option<CsvParserConfig>,
-    locale: Option<String>,
+    locale: Option<Locale>,
     semantic_hints: SemanticHints,
 }
 
@@ -88,7 +88,7 @@ impl IncrementalProfiler {
         self
     }
 
-    pub fn locale(mut self, locale: String) -> Self {
+    pub fn locale(mut self, locale: Locale) -> Self {
         self.locale = Some(locale);
         self
     }
@@ -349,7 +349,7 @@ impl IncrementalProfiler {
             &column_stats,
             skip_stats,
             skip_patterns,
-            self.locale.as_deref(),
+            self.locale,
             &self.semantic_hints,
         );
 

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -1,6 +1,6 @@
 use dataprof_core::AnalysisOptions;
 
-use crate::types::{ColumnProfile, ColumnStats, DataType};
+use crate::types::{ColumnProfile, ColumnStats, DataType, Locale};
 
 use crate::analysis::inference::{infer_type, is_null_like_token, parse_strict_boolean_token};
 use crate::analysis::patterns::detect_patterns;
@@ -12,13 +12,13 @@ use crate::stats::{calculate_datetime_stats, calculate_text_stats};
 /// The streaming engines express the same choices through
 /// `profile_builder::build_column_profile`; this is the in-memory equivalent for
 /// callers that hold a whole column as `Vec<String>` (the database connectors).
-struct ColumnAnalysis<'a> {
+struct ColumnAnalysis {
     /// Produce [`ColumnStats::None`] instead of computing statistics.
     skip_statistics: bool,
     /// Produce `patterns: None` instead of running detection.
     skip_patterns: bool,
     /// Locale used to rank detected patterns.
-    locale: Option<&'a str>,
+    locale: Option<Locale>,
     /// Leave `unique_count` absent instead of counting distinct values.
     skip_unique_count: bool,
 }
@@ -86,7 +86,7 @@ pub fn analyze_column_with_analysis_options(
 fn analyze_column_with_options(
     name: &str,
     data: &[String],
-    analysis: &ColumnAnalysis<'_>,
+    analysis: &ColumnAnalysis,
 ) -> ColumnProfile {
     let total_count = data.len();
 

--- a/crates/dataprof-metrics/src/analysis/patterns.rs
+++ b/crates/dataprof-metrics/src/analysis/patterns.rs
@@ -2,7 +2,7 @@ use regex::{Regex, RegexSet};
 use std::sync::LazyLock;
 
 use crate::analysis::validators;
-use crate::types::{Pattern, PatternCategory};
+use crate::types::{Locale, Pattern, PatternCategory};
 
 /// Internal pattern definition with metadata for overlap resolution and confidence scoring.
 struct PatternDef {
@@ -11,8 +11,8 @@ struct PatternDef {
     category: PatternCategory,
     /// 0-255: higher = more structurally specific regex (fewer false positives).
     specificity: u8,
-    /// ISO 3166-1 alpha-2 locale, or None for universal patterns.
-    locale: Option<&'static str>,
+    /// Locale this pattern belongs to, or None for universal patterns.
+    locale: Option<Locale>,
     /// Per-pattern minimum match percentage to report (replaces uniform 5% threshold).
     min_threshold: f64,
     /// Optional semantic validator run on regex-matched values.
@@ -58,7 +58,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for Phone (US)"),
             category: PatternCategory::Contact,
             specificity: 70,
-            locale: Some("US"),
+            locale: Some(Locale::Us),
             min_threshold: 5.0,
             validator: None,
         },
@@ -68,7 +68,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for Phone (IT)"),
             category: PatternCategory::Contact,
             specificity: 70,
-            locale: Some("IT"),
+            locale: Some(Locale::It),
             min_threshold: 5.0,
             validator: None,
         },
@@ -150,7 +150,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for Codice Fiscale"),
             category: PatternCategory::Identifier,
             specificity: 95,
-            locale: Some("IT"),
+            locale: Some(Locale::It),
             min_threshold: 5.0,
             validator: Some(validators::validate_codice_fiscale),
         },
@@ -160,7 +160,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for P.IVA"),
             category: PatternCategory::Identifier,
             specificity: 40,
-            locale: Some("IT"),
+            locale: Some(Locale::It),
             min_threshold: 25.0,
             validator: Some(validators::validate_piva_it),
         },
@@ -170,7 +170,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for CAP"),
             category: PatternCategory::Geographic,
             specificity: 35,
-            locale: Some("IT"),
+            locale: Some(Locale::It),
             min_threshold: 20.0,
             validator: Some(validators::validate_cap_it),
         },
@@ -180,7 +180,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for ZIP Code"),
             category: PatternCategory::Geographic,
             specificity: 35,
-            locale: Some("US"),
+            locale: Some(Locale::Us),
             min_threshold: 15.0,
             validator: None,
         },
@@ -221,7 +221,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for SSN (US)"),
             category: PatternCategory::Identifier,
             specificity: 70,
-            locale: Some("US"),
+            locale: Some(Locale::Us),
             min_threshold: 10.0,
             validator: Some(validators::validate_ssn_us),
         },
@@ -231,7 +231,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for UK Postcode"),
             category: PatternCategory::Geographic,
             specificity: 50,
-            locale: Some("GB"),
+            locale: Some(Locale::Gb),
             min_threshold: 15.0,
             validator: None,
         },
@@ -241,7 +241,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for German PLZ"),
             category: PatternCategory::Geographic,
             specificity: 30,
-            locale: Some("DE"),
+            locale: Some(Locale::De),
             min_threshold: 20.0,
             validator: None,
         },
@@ -251,7 +251,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for Canadian Postal Code"),
             category: PatternCategory::Geographic,
             specificity: 50,
-            locale: Some("CA"),
+            locale: Some(Locale::Ca),
             min_threshold: 15.0,
             validator: None,
         },
@@ -261,7 +261,7 @@ static PATTERN_DEFS: LazyLock<Vec<PatternDef>> = LazyLock::new(|| {
                 .expect("BUG: Invalid regex for French Code Postal"),
             category: PatternCategory::Geographic,
             specificity: 30,
-            locale: Some("FR"),
+            locale: Some(Locale::Fr),
             min_threshold: 20.0,
             validator: None,
         },
@@ -448,13 +448,12 @@ fn compute_confidence(specificity: u8, match_percentage: f64, validator_pass_rat
 /// List supported pattern detectors in detector order.
 ///
 /// Passing a locale returns universal patterns plus patterns specific to that
-/// ISO 3166-1 alpha-2 locale. Locale matching is case-insensitive.
-pub fn list_patterns(locale: Option<&str>) -> Vec<PatternMetadata> {
-    let normalized_locale = locale.map(|l| l.trim().to_ascii_uppercase());
-
+/// locale. Parse a user-supplied tag with [`Locale::parse_optional`] so an
+/// unrecognised one is rejected rather than narrowing the catalogue to nothing.
+pub fn list_patterns(locale: Option<Locale>) -> Vec<PatternMetadata> {
     PATTERN_DEFS
         .iter()
-        .filter(|def| match normalized_locale.as_deref() {
+        .filter(|def| match locale {
             None => true,
             Some(locale) => def.locale.is_none() || def.locale == Some(locale),
         })
@@ -462,7 +461,7 @@ pub fn list_patterns(locale: Option<&str>) -> Vec<PatternMetadata> {
             name: def.name.to_string(),
             regex: def.regex.as_str().to_string(),
             category: def.category.clone(),
-            locale: def.locale.map(str::to_string),
+            locale: def.locale.map(|locale| locale.as_str().to_string()),
             min_threshold: def.min_threshold,
         })
         .collect()
@@ -476,22 +475,16 @@ pub fn list_patterns(locale: Option<&str>) -> Vec<PatternMetadata> {
 ///
 /// # Arguments
 /// * `data` - Slice of string values to analyze
-/// * `locale` - Optional ISO 3166-1 alpha-2 locale (e.g. "IT", "US", "GB").
-///   Matching is case-insensitive. When set, locale-matching patterns receive
-///   a confidence boost and non-matching locale patterns are suppressed.
-///   Without a locale, locale-specific candidates remain available as evidence
-///   but receive a confidence penalty, with a further penalty for ambiguous
-///   matches shared by patterns from different locales.
+/// * `locale` - Optional locale (e.g. [`Locale::It`]). When set, locale-matching
+///   patterns receive a confidence boost and non-matching locale patterns are
+///   suppressed. Without a locale, locale-specific candidates remain available
+///   as evidence but receive a confidence penalty, with a further penalty for
+///   ambiguous matches shared by patterns from different locales.
 ///
 /// # Returns
 /// Vector of detected patterns sorted by confidence descending, after overlap
 /// suppression and locale filtering.
-pub fn detect_patterns(data: &[String], locale: Option<&str>) -> Vec<Pattern> {
-    let normalized_locale = locale
-        .map(str::trim)
-        .filter(|locale| !locale.is_empty())
-        .map(str::to_ascii_uppercase);
-
+pub fn detect_patterns(data: &[String], locale: Option<Locale>) -> Vec<Pattern> {
     // Filter empty and whitespace-only strings for robust analysis
     let non_empty: Vec<&str> = data
         .iter()
@@ -632,11 +625,9 @@ pub fn detect_patterns(data: &[String], locale: Option<&str>) -> Vec<Pattern> {
                 pm.validator_pass_rate,
             );
 
-            if let Some(configured_locale) = normalized_locale.as_deref() {
+            if let Some(configured_locale) = locale {
                 match pm.def.locale {
-                    Some(pattern_locale)
-                        if pattern_locale.eq_ignore_ascii_case(configured_locale) =>
-                    {
+                    Some(pattern_locale) if pattern_locale == configured_locale => {
                         confidence = (confidence * 1.2).min(1.0);
                         if pm.match_percentage >= 80.0 && pm.validator_pass_rate >= 0.8 {
                             confidence = confidence.max(0.5);
@@ -1454,7 +1445,8 @@ mod tests {
 
     #[test]
     fn test_list_patterns_filters_locale_case_insensitive() {
-        let patterns = list_patterns(Some("it"));
+        let locale = Locale::parse_optional(Some("it")).expect("'it' is a supported spelling");
+        let patterns = list_patterns(locale);
 
         assert!(patterns.iter().any(|pattern| pattern.name == "Email"));
         assert!(patterns.iter().any(|pattern| pattern.name == "Phone (IT)"));
@@ -1510,7 +1502,7 @@ mod tests {
     fn test_locale_it_boosts_cap_confidence() {
         let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
         let without_locale = detect_patterns(&data, None);
-        let with_locale = detect_patterns(&data, Some("IT"));
+        let with_locale = detect_patterns(&data, Some(Locale::It));
 
         let cap_no_locale = without_locale.iter().find(|p| p.name == "CAP (IT)");
         let cap_it_locale = with_locale.iter().find(|p| p.name == "CAP (IT)");
@@ -1538,7 +1530,7 @@ mod tests {
         for i in 0..100 {
             data.push(format!("text_{}", i));
         }
-        let with_us = detect_patterns(&data, Some("US"));
+        let with_us = detect_patterns(&data, Some(Locale::Us));
 
         // CAP (IT) has low specificity (35) and locale=IT.
         // With US locale and low match rate, it should be suppressed
@@ -1552,7 +1544,7 @@ mod tests {
     #[test]
     fn test_explicit_locale_suppresses_non_matching_even_at_high_match_rate() {
         let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
-        let with_us = detect_patterns(&data, Some("US"));
+        let with_us = detect_patterns(&data, Some(Locale::Us));
 
         let cap_us = with_us.iter().find(|p| p.name == "CAP (IT)");
         assert!(
@@ -1567,21 +1559,38 @@ mod tests {
     }
 
     #[test]
-    fn test_locale_is_case_insensitive() {
+    fn test_every_spelling_of_a_locale_detects_alike() {
         let data: Vec<String> = (20100..=20200).map(|n| format!("{:05}", n)).collect();
-        let uppercase = detect_patterns(&data, Some("IT"));
-        let lowercase = detect_patterns(&data, Some("it"));
+        let reference = detect_patterns(&data, Some(Locale::It));
+        let reference_cap = reference
+            .iter()
+            .find(|p| p.name == "CAP (IT)")
+            .expect("the IT locale should detect CAP");
 
-        let uppercase_cap = uppercase
-            .iter()
-            .find(|p| p.name == "CAP (IT)")
-            .expect("uppercase locale should detect CAP");
-        let lowercase_cap = lowercase
-            .iter()
-            .find(|p| p.name == "CAP (IT)")
-            .expect("lowercase locale should detect CAP");
-        assert_eq!(uppercase_cap.confidence, lowercase_cap.confidence);
-        assert!(lowercase.iter().all(|p| p.name != "ZIP Code (US)"));
+        for tag in ["IT", "it", "ITA", "it-IT", "it_IT"] {
+            let locale = Locale::parse_optional(Some(tag))
+                .unwrap_or_else(|error| panic!("tag {tag:?} was rejected: {error}"));
+            let detected = detect_patterns(&data, locale);
+            let cap = detected
+                .iter()
+                .find(|p| p.name == "CAP (IT)")
+                .unwrap_or_else(|| panic!("tag {tag:?} should detect CAP"));
+            assert_eq!(cap.confidence, reference_cap.confidence, "tag {tag:?}");
+            assert!(detected.iter().all(|p| p.name != "ZIP Code (US)"));
+        }
+    }
+
+    #[test]
+    fn test_every_supported_locale_has_patterns() {
+        // A locale that selects nothing would reproduce the silent narrowing
+        // that accepting unrecognised tags used to cause.
+        for locale in Locale::all() {
+            let specific = list_patterns(Some(locale))
+                .into_iter()
+                .filter(|pattern| pattern.locale.as_deref() == Some(locale.as_str()))
+                .count();
+            assert!(specific > 0, "{locale} has no patterns in the catalogue");
+        }
     }
 
     #[test]
@@ -1637,7 +1646,7 @@ mod tests {
     #[test]
     fn test_e2e_confidence_never_exceeds_one() {
         let data: Vec<String> = (0..200).map(|i| format!("user{}@example.com", i)).collect();
-        let patterns = detect_patterns(&data, Some("US"));
+        let patterns = detect_patterns(&data, Some(Locale::Us));
 
         for p in &patterns {
             assert!(

--- a/crates/dataprof-metrics/src/types.rs
+++ b/crates/dataprof-metrics/src/types.rs
@@ -1,6 +1,6 @@
 pub use dataprof_core::{
-    BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, FrequencyItem, MetricPack,
-    NumericStats, Pattern, PatternCategory, QualityDimension, Quartiles, TextStats,
+    BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, FrequencyItem, Locale,
+    MetricPack, NumericStats, Pattern, PatternCategory, QualityDimension, Quartiles, TextStats,
 };
 
 pub use crate::quality::{

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -4,7 +4,7 @@ use arrow::csv::ReaderBuilder;
 use arrow::datatypes::*;
 use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
-    ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata, FileFormat,
+    ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata, FileFormat, Locale,
     MetricPack, PeakMemorySampler, QualityDimension, SemanticHints, TruncationReason,
 };
 use dataprof_csv::CsvParserConfig;
@@ -38,7 +38,7 @@ pub struct ArrowProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
     csv_config: Option<CsvParserConfig>,
-    locale: Option<String>,
+    locale: Option<Locale>,
     semantic_hints: SemanticHints,
 }
 
@@ -80,7 +80,7 @@ impl ArrowProfiler {
         self
     }
 
-    pub fn locale(mut self, locale: String) -> Self {
+    pub fn locale(mut self, locale: Locale) -> Self {
         self.locale = Some(locale);
         self
     }
@@ -300,7 +300,7 @@ impl ArrowProfiler {
                     name.clone(),
                     skip_stats,
                     skip_patterns,
-                    self.locale.as_deref(),
+                    self.locale,
                     &self.semantic_hints,
                 );
                 column_profiles.push(profile);
@@ -877,7 +877,7 @@ impl ColumnAnalyzer {
         name: String,
         skip_statistics: bool,
         skip_patterns: bool,
-        locale: Option<&str>,
+        locale: Option<Locale>,
         semantic_hints: &SemanticHints,
     ) -> ColumnProfile {
         let data_type = if semantic_hints.is_identifier_column(&name) {

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -5,7 +5,7 @@ use arrow::array::*;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
-    ColumnProfile, DataType, SemanticHintBinding, SemanticHintKind, SemanticHints,
+    ColumnProfile, DataType, Locale, SemanticHintBinding, SemanticHintKind, SemanticHints,
 };
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
@@ -190,7 +190,7 @@ impl RecordBatchAnalyzer {
         &self,
         skip_statistics: bool,
         skip_patterns: bool,
-        locale: Option<&str>,
+        locale: Option<Locale>,
     ) -> Vec<ColumnProfile> {
         self.to_profiles_with_hints(
             skip_statistics,
@@ -204,7 +204,7 @@ impl RecordBatchAnalyzer {
         &self,
         skip_statistics: bool,
         skip_patterns: bool,
-        locale: Option<&str>,
+        locale: Option<Locale>,
         semantic_hints: &SemanticHints,
     ) -> Vec<ColumnProfile> {
         self.column_order
@@ -1018,7 +1018,7 @@ impl ColumnAnalyzer {
         name: String,
         skip_statistics: bool,
         skip_patterns: bool,
-        locale: Option<&str>,
+        locale: Option<Locale>,
         semantic_hints: &SemanticHints,
     ) -> ColumnProfile {
         let data_type = if semantic_hints.is_identifier_column(&name) {

--- a/crates/dataprof-python/src/analysis.rs
+++ b/crates/dataprof-python/src/analysis.rs
@@ -1,8 +1,9 @@
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::collections::HashMap;
 use std::path::Path;
 
-use dataprof::{Profiler, list_patterns as dataprof_list_patterns};
+use dataprof::{Locale, Profiler, list_patterns as dataprof_list_patterns};
 
 use super::config::PyProfilerConfig;
 use super::errors::analysis_error_to_py;
@@ -82,6 +83,8 @@ pub fn list_patterns(
     py: Python<'_>,
     locale: Option<&str>,
 ) -> PyResult<Vec<HashMap<String, Py<PyAny>>>> {
+    let locale = Locale::parse_optional(locale).map_err(PyValueError::new_err)?;
+
     dataprof_list_patterns(locale)
         .into_iter()
         .map(|pattern| {

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -395,7 +395,7 @@ pub fn profile_dataframe(
         .process_batch(&batch)
         .map_err(crate::errors::analyzer_error_to_py)?;
 
-    let locale = config.and_then(|c| c.locale.as_deref());
+    let locale = config.and_then(|c| c.locale);
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
     let sample_columns = if include_quality {
@@ -511,7 +511,7 @@ pub fn profile_arrow(
         .process_batch(&batch)
         .map_err(crate::errors::analyzer_error_to_py)?;
 
-    let locale = config.and_then(|c| c.locale.as_deref());
+    let locale = config.and_then(|c| c.locale);
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
     let sample_columns = analyzer.create_sample_columns();

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -58,7 +58,7 @@ pub fn profile_columns(
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
     let include_quality = MetricPack::include_quality(packs);
-    let locale = config.and_then(|c| c.locale.as_deref());
+    let locale = config.and_then(|c| c.locale);
     let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
 
     let effective_max_rows =

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dataprof::{
-    AnalysisOptions, ChunkSize, EngineType, FileFormat, JsonErrorPolicy, MetricPack, Profiler,
-    QualityDimension, SemanticHints, StopCondition,
+    AnalysisOptions, ChunkSize, EngineType, FileFormat, JsonErrorPolicy, Locale, MetricPack,
+    Profiler, QualityDimension, SemanticHints, StopCondition,
 };
 
 use super::progress::py_callback_to_sink;
@@ -33,7 +33,7 @@ pub struct PyProfilerConfig {
     pub(crate) progress_interval_ms: Option<u64>,
     pub(crate) quality_dimensions: Option<Vec<QualityDimension>>,
     pub(crate) metric_packs: Option<Vec<MetricPack>>,
-    pub(crate) locale: Option<String>,
+    pub(crate) locale: Option<Locale>,
     pub(crate) positive_columns: Vec<String>,
     pub(crate) identifier_columns: Vec<String>,
     pub(crate) temporal_columns: Vec<String>,
@@ -127,6 +127,11 @@ impl PyProfilerConfig {
             })
             .transpose()?;
 
+        // Parse the locale tag here rather than storing it raw: an unrecognised
+        // tag suppresses every locale-specific pattern, so accepting one would
+        // return a plausible, emptier report with nothing saying why.
+        let locale = Locale::parse_optional(locale.as_deref()).map_err(PyValueError::new_err)?;
+
         // Parse metrics strings into MetricPack enums
         let metric_packs = metrics
             .map(|packs| {
@@ -214,10 +219,10 @@ impl PyProfilerConfig {
         }
     }
 
-    /// Locale for pattern detection
+    /// Locale for pattern detection, normalised to ISO 3166-1 alpha-2
     #[getter]
     fn locale(&self) -> Option<&str> {
-        self.locale.as_deref()
+        self.locale.map(|locale| locale.as_str())
     }
 
     /// Columns expected to contain non-negative numeric values
@@ -300,7 +305,7 @@ impl PyProfilerConfig {
         if let Some(ref packs) = self.metric_packs {
             profiler = profiler.metric_packs(packs.clone());
         }
-        if let Some(ref l) = self.locale {
+        if let Some(l) = self.locale {
             profiler = profiler.locale(l);
         }
         if !self.positive_columns.is_empty() {
@@ -334,7 +339,7 @@ impl PyProfilerConfig {
         AnalysisOptions::default()
             .with_metric_packs(self.metric_packs.clone())
             .with_quality_dimensions(self.quality_dimensions.clone())
-            .with_locale(self.locale.clone())
+            .with_locale(self.locale)
             .with_semantic_hints(self.semantic_hints())
     }
 

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -8,7 +8,8 @@
 use std::collections::HashMap;
 
 use dataprof_core::{
-    BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, SemanticHints, TextStats,
+    BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, Locale, SemanticHints,
+    TextStats,
 };
 use dataprof_metrics::{
     analysis::inference::{is_integer_token, is_null_like_token, parse_strict_boolean_token},
@@ -41,7 +42,7 @@ pub struct ColumnProfileInput<'a> {
     /// When true, skip pattern detection (produce `patterns: None`).
     pub skip_patterns: bool,
     /// Optional locale for pattern detection (e.g. "IT", "US").
-    pub locale: Option<&'a str>,
+    pub locale: Option<Locale>,
     /// Exact aggregates over every numeric value the engine streamed.
     ///
     /// When present, these override the sample-derived `min`, `max`, `mean`,
@@ -219,7 +220,7 @@ pub fn profiles_from_streaming(
     column_stats: &StreamingColumnCollection,
     skip_statistics: bool,
     skip_patterns: bool,
-    locale: Option<&str>,
+    locale: Option<Locale>,
 ) -> Vec<ColumnProfile> {
     profiles_from_streaming_with_hints(
         column_stats,
@@ -235,7 +236,7 @@ pub fn profiles_from_streaming_with_hints(
     column_stats: &StreamingColumnCollection,
     skip_statistics: bool,
     skip_patterns: bool,
-    locale: Option<&str>,
+    locale: Option<Locale>,
     semantic_hints: &SemanticHints,
 ) -> Vec<ColumnProfile> {
     let mut profiles = Vec::new();
@@ -263,7 +264,7 @@ pub fn profile_from_stats(
     stats: &StreamingStatistics,
     skip_statistics: bool,
     skip_patterns: bool,
-    locale: Option<&str>,
+    locale: Option<Locale>,
 ) -> ColumnProfile {
     profile_from_stats_with_hints(
         name,
@@ -281,7 +282,7 @@ pub fn profile_from_stats_with_hints(
     stats: &StreamingStatistics,
     skip_statistics: bool,
     skip_patterns: bool,
-    locale: Option<&str>,
+    locale: Option<Locale>,
     semantic_hints: &SemanticHints,
 ) -> ColumnProfile {
     let data_type = if semantic_hints.is_identifier_column(name) {

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -26,11 +26,12 @@ pub use dataprof_core::{
     AnalysisOptions, BooleanStats, ChunkSize, ColumnProfile, ColumnSchema, ColumnStats,
     CountMethod, DataFrameLibrary, DataProfilerError, DataSource, DataType, DataprofConfig,
     DataprofConfigBuilder, DateTimeStats, ExecutionMetadata, FileFormat, FrequencyItem,
-    InputValidator, IsoQualityConfig, MetricPack, NumericStats, OutputFormat, ParquetMetadata,
-    Pattern, PatternCategory, ProgressEvent, ProgressSink, QualityDimension, QualityScoreWeights,
-    Quartiles, QueryEngine, RowCountEstimate, SamplingStrategy, SchemaResult, SemanticHintBinding,
-    SemanticHintKind, SemanticHints, StopCondition, StopEvaluator, StructureColumnSummary,
-    StructureReport, TextStats, TruncationReason, ValidationError, validate_unique_column_names,
+    InputValidator, IsoQualityConfig, Locale, MetricPack, NumericStats, OutputFormat,
+    ParquetMetadata, Pattern, PatternCategory, ProgressEvent, ProgressSink, QualityDimension,
+    QualityScoreWeights, Quartiles, QueryEngine, RowCountEstimate, SamplingStrategy, SchemaResult,
+    SemanticHintBinding, SemanticHintKind, SemanticHints, StopCondition, StopEvaluator,
+    StructureColumnSummary, StructureReport, TextStats, TruncationReason, ValidationError,
+    validate_unique_column_names,
 };
 pub use dataprof_csv::{
     CsvDiagnostics, CsvParserConfig, analyze_csv_file, analyze_csv_from_reader,

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use dataprof_core::{
-    AnalysisOptions, ChunkSize, DataProfilerError, DataSource, FileFormat, MetricPack,
+    AnalysisOptions, ChunkSize, DataProfilerError, DataSource, FileFormat, Locale, MetricPack,
     ProgressEvent, ProgressSink, QualityDimension, RowCountEstimate, SamplingStrategy,
     SchemaResult, SemanticHints, StopCondition, StructureReport,
 };
@@ -47,7 +47,7 @@ pub struct ProfilerConfig {
     /// Which metric packs to compute. `None` = all (default).
     /// Controls whether statistics, patterns, and quality are included.
     pub metric_packs: Option<Vec<MetricPack>>,
-    /// ISO 3166-1 alpha-2 locale for pattern detection (e.g. "IT", "US", "GB").
+    /// Locale for pattern detection (e.g. [`Locale::It`]).
     /// When set, locale-matching patterns get a confidence boost and non-matching
     /// locale patterns are suppressed (unless they have a very high match rate).
     /// `None` = no locale preference (default).
@@ -56,7 +56,7 @@ pub struct ProfilerConfig {
     /// JSON/JSONL, Parquet), DataFrame and Arrow sources, the async streaming
     /// entry points, and database queries. A locale ranks the same patterns
     /// whichever path read the data.
-    pub locale: Option<String>,
+    pub locale: Option<Locale>,
     /// Columns whose numeric values are expected to be non-negative.
     pub positive_columns: Vec<String>,
     /// Columns that should be treated as semantic identifiers, not measures.
@@ -253,12 +253,25 @@ impl Profiler {
         self
     }
 
-    /// Set the locale for pattern detection (e.g. "IT", "US", "GB").
+    /// Set the locale for pattern detection.
     ///
     /// Locale-matching patterns get a confidence boost; non-matching locale
     /// patterns are suppressed unless they have a very high match rate.
-    pub fn locale(mut self, locale: impl Into<String>) -> Self {
-        self.config.locale = Some(locale.into());
+    ///
+    /// Parse a tag that came from a user or another language with
+    /// [`Locale::parse_optional`], which normalises the common spellings and
+    /// rejects the rest:
+    ///
+    /// ```
+    /// use dataprof::{Locale, Profiler};
+    ///
+    /// let profiler = Profiler::new().locale(Locale::It);
+    /// let from_user = Locale::parse_optional(Some("it-IT")).unwrap();
+    /// assert_eq!(from_user, Some(Locale::It));
+    /// # let _ = profiler;
+    /// ```
+    pub fn locale(mut self, locale: Locale) -> Self {
+        self.config.locale = Some(locale);
         self
     }
 
@@ -503,7 +516,7 @@ impl Profiler {
         AnalysisOptions::default()
             .with_metric_packs(self.config.metric_packs.clone())
             .with_quality_dimensions(self.config.quality_dimensions.clone())
-            .with_locale(self.config.locale.clone())
+            .with_locale(self.config.locale)
             .with_semantic_hints(self.semantic_hints())
     }
 
@@ -677,8 +690,8 @@ impl Profiler {
                     if let Some(p) = self.effective_metric_packs() {
                         profiler = profiler.metric_packs(p);
                     }
-                    if let Some(l) = &self.config.locale {
-                        profiler = profiler.locale(l.clone());
+                    if let Some(l) = self.config.locale {
+                        profiler = profiler.locale(l);
                     }
                     profiler = profiler.semantic_hints(options.semantic_hints().clone());
                     let csv_config = self.csv_config_for_file(file_path);
@@ -744,8 +757,8 @@ impl Profiler {
         if let Some(p) = self.effective_metric_packs() {
             profiler = profiler.metric_packs(p);
         }
-        if let Some(l) = &self.config.locale {
-            profiler = profiler.locale(l.clone());
+        if let Some(l) = self.config.locale {
+            profiler = profiler.locale(l);
         }
         profiler = profiler.semantic_hints(options.semantic_hints().clone());
         let csv_config = self.csv_config_for_file(file_path);
@@ -802,8 +815,8 @@ impl Profiler {
             if let Some(p) = self.effective_metric_packs() {
                 profiler = profiler.metric_packs(p);
             }
-            if let Some(l) = &self.config.locale {
-                profiler = profiler.locale(l.clone());
+            if let Some(l) = self.config.locale {
+                profiler = profiler.locale(l);
             }
             profiler = profiler.semantic_hints(options.semantic_hints().clone());
             // ArrowProfiler reads the row cap off the CSV config; the incremental

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -98,7 +98,7 @@ dp.profile(
     progress_interval_ms=None,       # int -- ms between progress events
     metrics=None,                    # list[str] -- "schema", "statistics", "patterns", "quality"
     quality_dimensions=None,         # list[str] -- subset of dimensions to compute
-    locale=None,                     # str -- pattern locale hint, e.g. "IT"
+    locale=None,                     # str -- "CA"|"DE"|"FR"|"GB"|"IT"|"US"
     positive_columns=None,           # list[str] -- columns expected to be non-negative
     identifier_columns=None,         # list[str] -- semantic IDs, not measures
     temporal_columns=None,           # list[str] -- columns assessed for timeliness

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -642,13 +642,18 @@ def list_patterns(locale: str | None = None) -> list[dict[str, _Any]]:
     """List supported pattern detectors.
 
     Args:
-        locale: Optional ISO 3166-1 alpha-2 locale. When provided, the result
-            includes universal patterns plus locale-specific patterns matching
-            the locale, case-insensitively.
+        locale: Optional locale. When provided, the result includes universal
+            patterns plus the patterns specific to that locale. Supported:
+            "CA", "DE", "FR", "GB", "IT", "US". Case, the ISO 3166-1 alpha-3
+            spelling ("ITA") and the BCP 47 / POSIX forms ("it-IT", "it_IT")
+            all normalise; an empty string means no locale.
 
     Returns:
         A list of dicts with ``name``, ``regex``, ``category``, ``locale``, and
         ``min_threshold`` keys, in detector order.
+
+    Raises:
+        ValueError: If ``locale`` names no supported locale.
     """
     return _list_patterns(locale)
 
@@ -1101,8 +1106,10 @@ def profile_file(
         metrics: List of metric packs to compute. Valid values: "schema"
             (always included), "statistics", "patterns", "quality".
             None = all packs (default).
-        locale: ISO 3166-1 alpha-2 locale for pattern detection (e.g. "IT",
-            "US", "GB").
+        locale: Locale for pattern detection. Supported: "CA", "DE", "FR",
+            "GB", "IT", "US"; "it", "ITA" and "it-IT" all mean "IT", and an
+            unsupported tag raises ValueError rather than silently suppressing
+            every locale-specific pattern.
         positive_columns: Columns whose numeric values are expected to be
             non-negative.
         identifier_columns: Numeric-looking columns to treat as semantic
@@ -1225,9 +1232,12 @@ def profile(
             (always included), "statistics", "patterns", "quality".
             None = all packs (default). Omitting a pack skips that
             category of computation entirely.
-        locale: ISO 3166-1 alpha-2 locale for pattern detection (e.g. "IT",
-            "US", "GB"). Boosts confidence for locale-matching patterns and
-            suppresses non-matching locale patterns. None = no preference.
+        locale: Locale for pattern detection. Boosts confidence for
+            locale-matching patterns and suppresses non-matching locale
+            patterns. None = no preference. Supported: "CA", "DE", "FR", "GB",
+            "IT", "US"; "it", "ITA" and "it-IT" all mean "IT", and an
+            unsupported tag raises ValueError rather than silently suppressing
+            every locale-specific pattern.
         positive_columns: Columns whose numeric values are expected to be
             non-negative.
         identifier_columns: Numeric-looking columns to treat as semantic
@@ -1578,7 +1588,11 @@ class Profiler:
         return self
 
     def locale(self, locale: str) -> Profiler:
-        """Set locale for pattern detection (e.g. "IT", "US", "GB")."""
+        """Set locale for pattern detection (e.g. "IT", "US", "GB").
+
+        Raises ValueError at profiling time if the tag names no supported
+        locale; see :func:`profile` for the accepted spellings.
+        """
         self._kwargs["locale"] = locale
         return self
 

--- a/python/tests/test_locale_tags.py
+++ b/python/tests/test_locale_tags.py
@@ -33,7 +33,7 @@ IT_SPELLINGS = ("IT", "it", "It", " it ", "ITA", "ita", "it-IT", "it_IT")
 # Tags that name no supported locale. "de-CH" is the interesting one: falling
 # back to its language subtag would answer a Swiss request with Germany's
 # patterns, which is a guess.
-UNKNOWN_TAGS = ("XX", "ZZZZ", "de-CH", "en", "italiano", "-", "0")
+UNKNOWN_TAGS = ("XX", "ZZZZ", "de-CH", "de-CH-x-IT", "en", "italiano", "-", "0")
 
 
 def _patterns(locale: str | None) -> list[tuple[str, float]]:

--- a/python/tests/test_locale_tags.py
+++ b/python/tests/test_locale_tags.py
@@ -1,0 +1,130 @@
+"""Locale tags are a closed set, normalised then rejected (#545).
+
+``locale=`` is strict: setting one suppresses every pattern belonging to a
+different locale. Applied to a tag the catalogue does not know, that made a typo
+produce a strictly worse report than passing nothing at all, silently.
+``locale="it-IT"`` — the BCP 47 spelling a user is most likely to reach for, and
+the one an agent passing a locale through from user text is most likely to
+produce — returned zero patterns where ``locale="IT"`` returned a confident
+match, with nothing in the report saying the tag was not understood.
+
+The common spellings now normalise to the same locale, and anything left over
+raises ``ValueError`` naming the supported set. These tests cover every surface a
+tag can enter through: ``profile()``, ``ProfilerConfig``, the ``Profiler``
+builder, and ``list_patterns()``.
+"""
+
+from __future__ import annotations
+
+import io
+
+import dataprof as dp
+import pytest
+
+SUPPORTED = ("CA", "DE", "FR", "GB", "IT", "US")
+
+# Ten Italian CAP values. A five-digit string matches both ``CAP (IT)`` and
+# ``ZIP Code (US)``, so the column shows what a locale did.
+CAP_CSV = b"cap\n20121\n00184\n10121\n50123\n80133\n35100\n40121\n16121\n70121\n90133\n"
+
+# Every spelling of Italy that has to mean the same thing.
+IT_SPELLINGS = ("IT", "it", "It", " it ", "ITA", "ita", "it-IT", "it_IT")
+
+# Tags that name no supported locale. "de-CH" is the interesting one: falling
+# back to its language subtag would answer a Swiss request with Germany's
+# patterns, which is a guess.
+UNKNOWN_TAGS = ("XX", "ZZZZ", "de-CH", "en", "italiano", "-", "0")
+
+
+def _patterns(locale: str | None) -> list[tuple[str, float]]:
+    report = dp.profile(io.BytesIO(CAP_CSV), format="csv", locale=locale)
+    detected = report.column_profiles["cap"].patterns or []
+    return sorted((p.name, round(p.match_percentage, 1)) for p in detected)
+
+
+def test_every_spelling_of_a_locale_profiles_alike():
+    expected = _patterns("IT")
+    assert ("CAP (IT)", 100.0) in expected
+    assert not any(name == "ZIP Code (US)" for name, _ in expected)
+
+    for tag in IT_SPELLINGS:
+        assert _patterns(tag) == expected, f"tag {tag!r} profiled differently from 'IT'"
+
+
+def test_an_unknown_tag_raises_naming_the_supported_set():
+    for tag in UNKNOWN_TAGS:
+        with pytest.raises(ValueError) as excinfo:
+            dp.profile(io.BytesIO(CAP_CSV), format="csv", locale=tag)
+
+        message = str(excinfo.value)
+        assert tag in message, f"the error should quote the rejected tag: {message}"
+        for locale in SUPPORTED:
+            assert locale in message, f"the error should name {locale}: {message}"
+
+
+def test_an_unknown_tag_never_returns_an_emptier_report():
+    """The failure this issue is about: a silent, plausible, emptier answer."""
+    without_locale = _patterns(None)
+    assert without_locale, "the fixture detects patterns with no locale set"
+
+    for tag in UNKNOWN_TAGS:
+        with pytest.raises(ValueError):
+            dp.profile(io.BytesIO(CAP_CSV), format="csv", locale=tag)
+
+
+def test_a_stray_separator_is_tolerated():
+    """A trailing separator is a typo for the tag, not a different one."""
+    assert dp.ProfilerConfig(locale="IT-").locale == "IT"
+    assert dp.ProfilerConfig(locale="_it_").locale == "IT"
+
+
+def test_a_blank_tag_means_no_locale():
+    without_locale = _patterns(None)
+    assert ("CAP (IT)", 100.0) in without_locale
+    assert ("ZIP Code (US)", 100.0) in without_locale
+
+    for tag in ("", "   "):
+        assert _patterns(tag) == without_locale, f"tag {tag!r} should mean no locale"
+
+
+def test_config_rejects_and_normalises_at_construction():
+    with pytest.raises(ValueError, match="Unknown locale"):
+        dp.ProfilerConfig(locale="it-IT-u-ca-gregory")
+
+    assert dp.ProfilerConfig(locale="it-IT").locale == "IT"
+    assert dp.ProfilerConfig(locale="ita").locale == "IT"
+    assert dp.ProfilerConfig(locale="").locale is None
+    assert dp.ProfilerConfig().locale is None
+
+
+def test_builder_rejects_an_unknown_tag():
+    with pytest.raises(ValueError, match="Unknown locale"):
+        dp.Profiler().format("csv").locale("XX").profile(io.BytesIO(CAP_CSV))
+
+    report = dp.Profiler().format("csv").locale("it-IT").profile(io.BytesIO(CAP_CSV))
+    names = {p.name for p in report.column_profiles["cap"].patterns or []}
+    assert "CAP (IT)" in names
+    assert "ZIP Code (US)" not in names
+
+
+def test_list_patterns_normalises_and_rejects():
+    catalogue = dp.list_patterns()
+    assert {p["locale"] for p in catalogue if p["locale"]} == set(SUPPORTED)
+
+    reference = dp.list_patterns("IT")
+    assert all(p["locale"] in {None, "IT"} for p in reference)
+    for tag in IT_SPELLINGS:
+        assert dp.list_patterns(tag) == reference, f"tag {tag!r} listed a different catalogue"
+
+    assert dp.list_patterns("") == catalogue
+    assert dp.list_patterns(None) == catalogue
+
+    for tag in UNKNOWN_TAGS:
+        with pytest.raises(ValueError, match="Unknown locale"):
+            dp.list_patterns(tag)
+
+
+def test_every_supported_locale_selects_its_own_patterns():
+    for locale in SUPPORTED:
+        specific = [p for p in dp.list_patterns(locale) if p["locale"] == locale]
+        assert specific, f"{locale} is accepted but selects no patterns"

--- a/tests/analysis_option_parity.rs
+++ b/tests/analysis_option_parity.rs
@@ -11,7 +11,7 @@
 
 use std::io::Write;
 
-use dataprof::{ColumnStats, MetricPack, ProfileReport, Profiler, QualityDimension};
+use dataprof::{ColumnStats, Locale, MetricPack, ProfileReport, Profiler, QualityDimension};
 use tempfile::NamedTempFile;
 
 /// Five records with an Italian postal code column. `cap` is what makes locale
@@ -212,7 +212,7 @@ fn locale_reaches_pattern_detection_on_every_format() {
             .analyze_file(file.path())
             .unwrap_or_else(|e| panic!("[{label}] profiling failed: {e}"));
         let localized = Profiler::new()
-            .locale("IT")
+            .locale(Locale::It)
             .analyze_file(file.path())
             .unwrap_or_else(|e| panic!("[{label}] localized profiling failed: {e}"));
 
@@ -309,10 +309,10 @@ mod async_transport {
     fn async_paths_honour_the_locale_and_match_the_sync_result() {
         for (label, file) in fixtures() {
             let sync = Profiler::new()
-                .locale("IT")
+                .locale(Locale::It)
                 .analyze_file(file.path())
                 .unwrap_or_else(|e| panic!("[{label}] sync profiling failed: {e}"));
-            let async_ = profile_async(Profiler::new().locale("IT"), file.path());
+            let async_ = profile_async(Profiler::new().locale(Locale::It), file.path());
 
             assert_eq!(
                 pattern_names(&sync, "cap"),

--- a/tests/database_option_parity.rs
+++ b/tests/database_option_parity.rs
@@ -14,7 +14,7 @@
 use std::io::Write;
 
 use dataprof::{
-    ColumnStats, DatabaseConfig, MetricPack, ProfileReport, Profiler, QualityDimension,
+    ColumnStats, DatabaseConfig, Locale, MetricPack, ProfileReport, Profiler, QualityDimension,
     SemanticHints,
 };
 use tempfile::NamedTempFile;
@@ -187,7 +187,7 @@ async fn locale_reaches_pattern_detection_and_matches_csv() {
         .await
         .expect("query profiling should succeed");
     let localized = sqlite_profiler(&db_path)
-        .locale("IT")
+        .locale(Locale::It)
         .analyze_query(QUERY)
         .await
         .expect("localized query profiling should succeed");
@@ -210,7 +210,7 @@ async fn locale_reaches_pattern_detection_and_matches_csv() {
     // The product contract: the same rows profile the same way whether they
     // came out of a query or off disk.
     let csv_localized = Profiler::new()
-        .locale("IT")
+        .locale(Locale::It)
         .analyze_file(csv.path())
         .expect("csv profiling should succeed");
     assert_eq!(
@@ -228,7 +228,7 @@ async fn no_quality_entry_point_keeps_statistics_and_patterns() {
     let (_dir, db_path) = sqlite_fixture().await;
 
     let report = sqlite_profiler(&db_path)
-        .locale("IT")
+        .locale(Locale::It)
         .analyze_query_no_quality(QUERY)
         .await
         .expect("query profiling should succeed");

--- a/tests/locale_tags.rs
+++ b/tests/locale_tags.rs
@@ -82,7 +82,7 @@ fn every_spelling_of_a_locale_profiles_alike() {
 
 #[test]
 fn an_unrecognised_tag_is_rejected_naming_the_supported_set() {
-    for tag in ["XX", "ZZZZ", "de-CH", "en", "italiano"] {
+    for tag in ["XX", "ZZZZ", "de-CH", "de-CH-x-IT", "en", "italiano"] {
         let error = Locale::parse_optional(Some(tag))
             .expect_err(&format!("tag {tag:?} should not be accepted"));
 

--- a/tests/locale_tags.rs
+++ b/tests/locale_tags.rs
@@ -1,0 +1,125 @@
+//! Locale tags are a closed set (#545).
+//!
+//! `locale=` is strict: setting one suppresses every pattern belonging to a
+//! different locale. Applied to a tag the catalogue does not know, that made a
+//! typo produce a strictly worse report than passing nothing at all, silently —
+//! `"it-IT"`, the BCP 47 spelling a user is most likely to reach for, returned
+//! no patterns where `"IT"` returned a confident match.
+//!
+//! These tests hold the two halves of the fix at the public API: the common
+//! spellings all mean the same locale, and anything left over is an error that
+//! names the supported set.
+
+use std::io::Write;
+
+use dataprof::{Locale, ProfileReport, Profiler};
+use tempfile::NamedTempFile;
+
+/// Italian postal codes. A five-digit string matches both `CAP (IT)` and
+/// `ZIP Code (US)`, so the column shows what a locale did: `IT` keeps CAP and
+/// suppresses ZIP, and a tag that resolves to nothing keeps neither.
+const CAPS: [&str; 5] = ["20121", "00184", "10121", "80132", "50122"];
+
+fn csv_fixture() -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".csv").unwrap();
+    writeln!(file, "cap").unwrap();
+    for cap in CAPS {
+        writeln!(file, "{cap}").unwrap();
+    }
+    file.flush().unwrap();
+    file
+}
+
+fn pattern_names(report: &ProfileReport) -> Vec<String> {
+    let mut names: Vec<String> = report
+        .column_profiles
+        .iter()
+        .find(|profile| profile.name == "cap")
+        .expect("the fixture has a cap column")
+        .patterns
+        .as_ref()
+        .expect("pattern detection runs by default")
+        .iter()
+        .map(|pattern| pattern.name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+#[test]
+fn every_spelling_of_a_locale_profiles_alike() {
+    let file = csv_fixture();
+    let reference = Profiler::new()
+        .locale(Locale::It)
+        .analyze_file(file.path())
+        .expect("profiling with a locale should succeed");
+    let expected = pattern_names(&reference);
+    assert!(
+        expected.iter().any(|name| name == "CAP (IT)"),
+        "the fixture should detect CAP under the IT locale, got {expected:?}"
+    );
+    assert!(
+        !expected.iter().any(|name| name == "ZIP Code (US)"),
+        "the IT locale should suppress the US pattern, got {expected:?}"
+    );
+
+    for tag in ["IT", "it", "It", " it ", "ITA", "ita", "it-IT", "it_IT"] {
+        let locale = Locale::parse_optional(Some(tag))
+            .unwrap_or_else(|error| panic!("tag {tag:?} was rejected: {error}"))
+            .unwrap_or_else(|| panic!("tag {tag:?} resolved to no locale"));
+        let report = Profiler::new()
+            .locale(locale)
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{tag}] profiling failed: {e}"));
+
+        assert_eq!(
+            pattern_names(&report),
+            expected,
+            "tag {tag:?} profiled differently from Locale::It"
+        );
+    }
+}
+
+#[test]
+fn an_unrecognised_tag_is_rejected_naming_the_supported_set() {
+    for tag in ["XX", "ZZZZ", "de-CH", "en", "italiano"] {
+        let error = Locale::parse_optional(Some(tag))
+            .expect_err(&format!("tag {tag:?} should not be accepted"));
+
+        assert!(
+            error.contains(tag),
+            "the error should quote the rejected tag, got {error:?}"
+        );
+        for locale in Locale::all() {
+            assert!(
+                error.contains(locale.as_str()),
+                "the error should name {locale}, got {error:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_blank_tag_means_no_locale_rather_than_an_unmatched_one() {
+    let file = csv_fixture();
+    let unset = Profiler::new()
+        .analyze_file(file.path())
+        .expect("profiling without a locale should succeed");
+    let unset_patterns = pattern_names(&unset);
+
+    // Both locale-specific candidates survive without a locale preference; the
+    // old behaviour for a blank tag was to leave the column with none.
+    assert!(
+        unset_patterns.iter().any(|name| name == "CAP (IT)")
+            && unset_patterns.iter().any(|name| name == "ZIP Code (US)"),
+        "without a locale both candidates should remain as evidence, got {unset_patterns:?}"
+    );
+
+    for tag in [Some(""), Some("   "), None] {
+        assert_eq!(
+            Locale::parse_optional(tag),
+            Ok(None),
+            "tag {tag:?} should mean no locale"
+        );
+    }
+}

--- a/tests/public_api_facade.rs
+++ b/tests/public_api_facade.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use dataprof::{
     ChunkSize, CsvParserConfig, DataSource, DataType, EngineType, FileFormat, JsonFormat,
-    JsonParserConfig, MetricPack, OutputFormat, Profiler, ProfilerConfig, ProgressSink,
+    JsonParserConfig, Locale, MetricPack, OutputFormat, Profiler, ProfilerConfig, ProgressSink,
     QualityDimension, SamplingStrategy, StopCondition, analyze_column_fast, analyze_structure,
     calculate_numeric_stats, calculate_text_stats, detect_patterns, infer_type,
 };
@@ -20,7 +20,7 @@ fn stable_facade_builder_surface_compiles() {
         .csv_flexible(true)
         .quality_dimensions(vec![QualityDimension::Completeness])
         .metric_packs(vec![MetricPack::Schema, MetricPack::Quality])
-        .locale("IT")
+        .locale(Locale::It)
         .progress_interval(Duration::from_millis(25))
         .progress_sink(ProgressSink::None);
 
@@ -49,7 +49,7 @@ fn parser_and_metrics_reexports_compile() {
     assert_eq!(analyze_column_fast("n", &numeric_values).name, "n");
     let _numeric_stats = calculate_numeric_stats(&numeric_values);
     let _text_stats = calculate_text_stats(&text_values);
-    let _patterns = detect_patterns(&text_values, Some("US"));
+    let _patterns = detect_patterns(&text_values, Some(Locale::Us));
 
     let csv_config = CsvParserConfig::strict()
         .with_delimiter(b';')


### PR DESCRIPTION
Closes #545.

## The bug

An unrecognised `locale=` tag was accepted and behaved as "suppress every
locale-specific pattern". `locale="it-IT"` — the BCP 47 spelling a user is most
likely to reach for, and the one an agent passing a locale through from user
text is most likely to produce — returned zero patterns on a column where
`locale="IT"` returned a confident match, and nothing in the report said the tag
was not understood. A typo produced a strictly worse report than passing nothing
at all, silently.

## The fix

The tag names a closed set, so it is parsed into one. `Locale` in
`dataprof-core` carries the six locales the catalogue has detectors for, and:

- normalises case, ISO 3166-1 alpha-3 (`ITA`), BCP 47 (`it-IT`), POSIX
  (`it_IT`), and a stray separator (`IT-`);
- treats `None`, `""` and whitespace as "no locale preference";
- rejects everything else with an error naming the supported values.

A tag naming an unsupported region does not fall back to its language subtag:
`de-CH` errors rather than answering a Swiss request with Germany's patterns,
which would be a guess.

The type replaces the raw string on every path a locale travels — analysis
options, the pattern catalogue, `detect_patterns` / `list_patterns`, the
Arrow/incremental/async engine builders, the Parquet analyzers, `ProfilerConfig`
— so no path can carry an unvalidated tag. `PatternDef.locale` is now
`Option<Locale>`, which makes the catalogue and the accepted set agree at
compile time rather than by convention.

## Breaking changes (release-note callout for 0.11.0)

| Surface | Before | After |
| --- | --- | --- |
| `Profiler::locale` | `impl Into<String>` | `Locale` (`Profiler::new().locale(Locale::It)`) |
| `detect_patterns`, `list_patterns` | `Option<&str>` | `Option<Locale>` |
| `AnalysisOptions::with_locale` / `locale()` | `Option<String>` / `Option<&str>` | `Option<Locale>` |
| Python `locale=` | unrecognised tag accepted, report silently emptier | raises `ValueError` naming the supported set |
| Python `ProfilerConfig.locale` | echoes the tag as given | reads back normalised (`"it-IT"` -> `"IT"`) |

Rust callers with a tag from a user or another language parse it first with
`Locale::parse_optional`. The Python signature is unchanged.

## Tests

- `tests/locale_tags.rs` — spellings profile alike through `Profiler`; an
  unrecognised tag is rejected naming the set; a blank tag means no locale.
- `python/tests/test_locale_tags.py` — the same contract across every surface a
  tag can enter through: `profile()`, `ProfilerConfig`, the `Profiler` builder,
  and `list_patterns()`.
- `dataprof-core` unit tests for the parser; `dataprof-metrics` gains a check
  that every accepted locale selects at least one pattern.

The Python file was run against the unfixed code (changes stashed, extension
rebuilt): 7 of 9 tests fail, including
`test_every_spelling_of_a_locale_profiles_alike` at `'ITA'`. The two that pass
on master are the blank-tag and per-locale-catalogue cases — master already
filtered an empty tag on the detection path, so those pin behaviour rather than
catch the bug. The Rust integration test cannot be run against unfixed code; it
does not compile there, which is the point of the type.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace
cargo test --test public_api_facade --no-default-features
cargo test --test public_api_facade --no-default-features --features async-streaming
cargo test --test public_api_facade --all-features
cargo test -p dataprof-engines --all-features
uv run maturin develop
uv run pytest python/tests -q          # 836 passed, 110 skipped
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```

## Docs

Python docstrings for `profile`, `analyze`, `list_patterns` and
`Profiler.locale`; `docs/python/README.md`; the dataprof skill's interpretation
reference now names the supported locales and the accepted spellings.
