### PR TITLE
feat(profile): flag a column that has no dominant type

### DIFF
--- a/.claude/skills/dataprof/SKILL.md
+++ b/.claude/skills/dataprof/SKILL.md
@@ -150,9 +150,22 @@ re-read and eyeball two files by hand.
   A perfect score therefore means the column holds one kind of value — for a
   `string` column, ordinary text — not that the text is fit for your purpose. And
   the score is symmetric around a 50/50 mix: 20% junk and 80% junk both report
-  80. If a column is typed `string` but its name or data suggests it should hold
-  numbers, dates, or identifiers, say so; read `sample_values` rather than the
-  score alone.
+  80.
+- **`data_type` alone does not tell you whether a column is uniform.** A column
+  of names and a column that is 60% numbers are both `string`. The per-column
+  evidence is `type_homogeneity` — counts of non-null values by lexical class —
+  and `to_llm_context()` renders it as a `mixed types` flag once at least 5% of
+  the values fall outside the dominant class:
+
+  ```
+  flags (1):
+  - amount_eur: mixed types (60% numeric, 40% text)
+  ```
+
+  Report that mixture rather than the type. The counts come from the values the
+  profiler retained, so on a large source they describe the 10k reservoir
+  sample; the flag says `sampled N of M values` when that is the case, and
+  summing the counts against `total_count - null_count` tells you directly.
 
 Before interpreting a specific dimension, an approximate count, a detected
 pattern, or a comparison, read [reference/interpretation.md](reference/interpretation.md).

--- a/.claude/skills/dataprof/evals/README.md
+++ b/.claude/skills/dataprof/evals/README.md
@@ -51,9 +51,9 @@ score improvement has missed the row loss.
 the column `string`. Consistency now scores that column on its dominant lexical
 class, so it contributes 6 of 10 values and the file scores **97.9/100** rather
 than the 100.0/100 it reported before #544 was fixed. That is still high enough
-to read as clean, and `to_llm_context()` still shows no per-column flag (#561), so
-a money column carrying text remains a finding the score alone will not make for
-you.
+to read as clean, which is the point of the scenario: the finding is in
+`to_llm_context()`'s per-column flag —
+`amount_eur: mixed types (60% numeric, 40% text)` — not in the score.
 
 ## When these change
 

--- a/.claude/skills/dataprof/evals/scenarios.json
+++ b/.claude/skills/dataprof/evals/scenarios.json
@@ -59,6 +59,7 @@
     "expected_behavior": [
       "Profiles the file rather than eyeballing ten rows",
       "Notices that amount_eur is typed string, not float, and that a money column typed as text is the finding",
+      "Surfaces the mixed types flag on amount_eur (60% numeric, 40% text) rather than reading the schema line alone",
       "Names the four unparseable values (pending, n/a, see invoice, awaiting PO) as the reason no numeric statistics exist for that column",
       "Explains that the 97.9/100 score does not contradict this: the column is scored on its dominant lexical class, so 6 numeric values out of 10 leave the file looking mostly fine",
       "Answers the actual question with a no, or a qualified no, for a finance load"

--- a/.claude/skills/dataprof/reference/interpretation.md
+++ b/.claude/skills/dataprof/reference/interpretation.md
@@ -8,6 +8,7 @@ means and — more importantly — what it does not.
 
 - The absence rule
 - Quality dimensions, one by one
+- Type homogeneity
 - Approximation provenance
 - Patterns and sensitive data
 - Comparisons
@@ -61,9 +62,11 @@ perfect score means one kind — which for a `string` column is ordinary text, n
 a guarantee the text is useful.
 
 The score is symmetric around a 50/50 mix: 20% junk and 80% junk both report 80,
-because the minority is what costs the column its consistency in each case. Read
-it with the column's `data_type` and its `sample_values`, not alone. A column
-that is 80% junk is typed `string` because that is what it mostly is.
+because the minority is what costs the column its consistency in each case. A
+column that is 80% junk is typed `string` because that is what it mostly is.
+
+The dataset-level score cannot tell you *which* column is mixed; the per-column
+evidence is `type_homogeneity` (see below). Read the two together.
 
 Two kinds of column keep the plain type check rather than the dominant-class
 rule, so a low score there means something different: columns declared through
@@ -94,6 +97,34 @@ evidence of rounding errors.
 
 The overall score is a weighted combination (`score_weights()`). Report what
 drove it, not just the number.
+
+## Type homogeneity
+
+`report["col"].type_homogeneity` counts the column's non-null values by lexical
+class: `{"numeric": 600, "date": 0, "boolean": 0, "text": 400}`. It answers the
+question `data_type` cannot — a column of names and a column that is 60% numbers
+are both `string` — and it is the only per-column evidence that a column defeated
+type inference, because `invalid_count` is absent on string columns by contract.
+
+The absence rule applies with a twist worth stating twice:
+
+- `None` — the classification did not run (a report reloaded from a document
+  written before the field existed, or a hand-edited one).
+- all four counts `0` — classified, and there was nothing to classify: the
+  column is all-null or has no rows.
+
+Never read the second as the first, or either as "one uniform class".
+
+The counts cover the values the profiler retained, which on a source larger than
+the 10k per-column reservoir is a sample. Sum them and compare against
+`total_count - null_count`: short means the shares are sampled, and you should
+say so. `to_llm_context()` does this for you and appends `sampled N of M values`
+to the flag.
+
+A `mixed types` flag appears in `to_llm_context()` once at least 5% of a
+column's classified values fall outside its dominant class. That threshold is
+display only — it changes no score — and `identifier` columns are exempt,
+because an ID scheme mixing `A1` and `123` is intended rather than a defect.
 
 ## Approximation provenance
 

--- a/.claude/skills/dataprof/scripts/dp_context.py
+++ b/.claude/skills/dataprof/scripts/dp_context.py
@@ -165,6 +165,10 @@ def _describe_column(report: Any, name: str) -> int:
         "unique_count": column.unique_count,
         "uniqueness_ratio": column.uniqueness_ratio,
         "approximate": bool(column.is_approximate or column.unique_count_is_approximate),
+        # Counts by lexical class, which is what says whether a `string` column
+        # is text or a column that defeated type inference. Counts, not values:
+        # nothing here echoes a cell.
+        "type_homogeneity": column.type_homogeneity,
         "patterns": patterns,
     }
     # Pattern names only. Values are withheld unconditionally: this script has

--- a/crates/dataprof-core/src/classification.rs
+++ b/crates/dataprof-core/src/classification.rs
@@ -17,6 +17,148 @@ pub enum DataType {
     Boolean,
 }
 
+/// Mutually exclusive lexical form of a single non-null value.
+///
+/// The variants partition non-null values — every value belongs to exactly one —
+/// which is what lets the share held by the largest class describe a column
+/// whose inferred [`DataType`] says nothing about the mixture inside it. A
+/// `String` column of names and a `String` column that is 60% numbers are the
+/// same type; they are not the same class distribution.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum LexicalClass {
+    /// Whole numbers and fractions alike: `["1.5", "2"]` is one numeric column,
+    /// not a two-class mixture.
+    Numeric,
+    /// Any date or datetime form the profiler recognizes.
+    Date,
+    /// Strict boolean tokens.
+    Boolean,
+    /// Everything else.
+    Text,
+}
+
+impl std::fmt::Display for LexicalClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Numeric => write!(f, "numeric"),
+            Self::Date => write!(f, "date"),
+            Self::Boolean => write!(f, "boolean"),
+            Self::Text => write!(f, "text"),
+        }
+    }
+}
+
+/// How a column's non-null values distribute across [`LexicalClass`]es.
+///
+/// Raw counts rather than a share, so that a reader can state the mixture it
+/// actually found ("60% numeric, 40% text") instead of the dominant class and
+/// an unnamed remainder, and so a serialized report carries no rounded
+/// derivative of a number it does not also carry exactly.
+///
+/// All four counts are always present. Every field zero means the column was
+/// classified and had no non-null values to classify — "analyzed, found
+/// nothing", which is not the same as an absent `type_homogeneity`.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    schemars::JsonSchema,
+)]
+pub struct TypeHomogeneity {
+    pub numeric: usize,
+    pub date: usize,
+    pub boolean: usize,
+    pub text: usize,
+}
+
+impl TypeHomogeneity {
+    /// Counts in declaration order, which is also the order ties resolve in.
+    fn counts(&self) -> [(LexicalClass, usize); 4] {
+        [
+            (LexicalClass::Numeric, self.numeric),
+            (LexicalClass::Date, self.date),
+            (LexicalClass::Boolean, self.boolean),
+            (LexicalClass::Text, self.text),
+        ]
+    }
+
+    /// Add one value of `class`.
+    pub fn record(&mut self, class: LexicalClass) {
+        match class {
+            LexicalClass::Numeric => self.numeric += 1,
+            LexicalClass::Date => self.date += 1,
+            LexicalClass::Boolean => self.boolean += 1,
+            LexicalClass::Text => self.text += 1,
+        }
+    }
+
+    /// Non-null values classified — the denominator of every share below.
+    pub fn classified_count(&self) -> usize {
+        self.numeric + self.date + self.boolean + self.text
+    }
+
+    /// The class holding the most values and its count, or `None` when nothing
+    /// was classified.
+    ///
+    /// A tie is held by the earliest-declared class. Which class wins does not
+    /// change the reported share — both hold the same count — it only keeps the
+    /// answer stable across runs.
+    pub fn dominant(&self) -> Option<(LexicalClass, usize)> {
+        self.counts()
+            .into_iter()
+            .filter(|(_, count)| *count > 0)
+            .fold(None, |best, candidate| match best {
+                Some((_, best_count)) if best_count >= candidate.1 => best,
+                _ => Some(candidate),
+            })
+    }
+
+    /// Share of classified values held by [`Self::dominant`], in `0.0..=1.0`.
+    /// `None` when nothing was classified, where the ratio is undefined.
+    pub fn dominant_share(&self) -> Option<f64> {
+        let (_, count) = self.dominant()?;
+        Some(count as f64 / self.classified_count() as f64)
+    }
+
+    /// Every class that holds at least one value, largest first, with its share
+    /// of the classified values. Empty when nothing was classified.
+    ///
+    /// Ties keep declaration order, so the sequence is stable across runs.
+    pub fn mixture(&self) -> Vec<(LexicalClass, usize, f64)> {
+        let total = self.classified_count();
+        if total == 0 {
+            return Vec::new();
+        }
+        let mut present: Vec<(LexicalClass, usize)> = self
+            .counts()
+            .into_iter()
+            .filter(|(_, count)| *count > 0)
+            .collect();
+        // Stable sort on the descending count keeps declaration order for ties.
+        present.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+        present
+            .into_iter()
+            .map(|(class, count)| (class, count, count as f64 / total as f64))
+            .collect()
+    }
+}
+
 /// Semantic category for a detected pattern.
 #[derive(
     Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
@@ -49,6 +191,107 @@ impl std::fmt::Display for PatternCategory {
             Self::Financial => write!(f, "financial"),
             Self::FilePath => write!(f, "file_path"),
             Self::Other => write!(f, "other"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod type_homogeneity_tests {
+    use super::*;
+
+    fn homogeneity(numeric: usize, date: usize, boolean: usize, text: usize) -> TypeHomogeneity {
+        TypeHomogeneity {
+            numeric,
+            date,
+            boolean,
+            text,
+        }
+    }
+
+    #[test]
+    fn recording_values_counts_them_by_class() {
+        let mut counts = TypeHomogeneity::default();
+        counts.record(LexicalClass::Numeric);
+        counts.record(LexicalClass::Text);
+        counts.record(LexicalClass::Numeric);
+
+        assert_eq!(counts, homogeneity(2, 0, 0, 1));
+        assert_eq!(counts.classified_count(), 3);
+        assert_eq!(counts.dominant(), Some((LexicalClass::Numeric, 2)));
+    }
+
+    #[test]
+    fn nothing_classified_has_no_dominant_class_and_no_share() {
+        // The all-zero value is "classified, nothing to classify" — every
+        // derived answer is absent rather than a number invented from a zero
+        // denominator.
+        let empty = TypeHomogeneity::default();
+
+        assert_eq!(empty.classified_count(), 0);
+        assert_eq!(empty.dominant(), None);
+        assert_eq!(empty.dominant_share(), None);
+        assert!(empty.mixture().is_empty());
+    }
+
+    #[test]
+    fn a_tie_is_held_by_the_earliest_declared_class() {
+        // Which class wins a tie does not change the share — both hold the same
+        // count — but it must be the same class on every run, and the same one
+        // the consistency dimension scores against.
+        let tied = homogeneity(50, 50, 0, 0);
+
+        assert_eq!(tied.dominant(), Some((LexicalClass::Numeric, 50)));
+        assert_eq!(tied.dominant_share(), Some(0.5));
+        assert_eq!(
+            tied.mixture(),
+            vec![
+                (LexicalClass::Numeric, 50, 0.5),
+                (LexicalClass::Date, 50, 0.5)
+            ]
+        );
+    }
+
+    #[test]
+    fn mixture_reports_every_present_class_largest_first() {
+        let mixed = homogeneity(60, 10, 0, 30);
+
+        assert_eq!(mixed.dominant_share(), Some(0.6));
+        assert_eq!(
+            mixed.mixture(),
+            vec![
+                (LexicalClass::Numeric, 60, 0.6),
+                (LexicalClass::Text, 30, 0.3),
+                (LexicalClass::Date, 10, 0.1),
+            ],
+            "an absent class must not appear with a 0% share"
+        );
+    }
+
+    #[test]
+    fn counts_survive_a_json_round_trip() {
+        let counts = homogeneity(600, 0, 0, 400);
+        let json = serde_json::to_string(&counts).expect("counts should serialize");
+
+        assert_eq!(json, r#"{"numeric":600,"date":0,"boolean":0,"text":400}"#);
+        assert_eq!(
+            serde_json::from_str::<TypeHomogeneity>(&json).expect("counts should deserialize"),
+            counts
+        );
+    }
+
+    #[test]
+    fn lexical_classes_serialize_as_the_names_reports_use() {
+        for (class, name) in [
+            (LexicalClass::Numeric, "numeric"),
+            (LexicalClass::Date, "date"),
+            (LexicalClass::Boolean, "boolean"),
+            (LexicalClass::Text, "text"),
+        ] {
+            assert_eq!(class.to_string(), name);
+            assert_eq!(
+                serde_json::to_string(&class).expect("class should serialize"),
+                format!("\"{name}\"")
+            );
         }
     }
 }

--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -22,7 +22,7 @@ pub mod stop_condition;
 pub mod validation;
 
 pub use analysis_options::AnalysisOptions;
-pub use classification::{DataType, PatternCategory};
+pub use classification::{DataType, LexicalClass, PatternCategory, TypeHomogeneity};
 #[cfg(feature = "database")]
 pub use config::{DatabaseSamplingConfig, DatabaseSettings};
 pub use config::{

--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::classification::DataType;
+use crate::classification::{DataType, TypeHomogeneity};
 use crate::pattern::Pattern;
 
 /// Profiling statistics for a single column.
@@ -37,6 +37,25 @@ pub struct ColumnProfile {
     /// never "no invalid values", which is `Some(0)`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub invalid_count: Option<usize>,
+    /// How the column's non-null values distribute across lexical classes.
+    ///
+    /// `data_type` cannot answer "did this column have a dominant form?": a
+    /// column of names and a column that is 60% numbers are both `String`, and
+    /// `invalid_count` is absent on string columns by contract. This carries the
+    /// evidence, so a consumer can tell a textual column from one that defeated
+    /// type inference.
+    ///
+    /// Counted over the values the profiler retained — the engine's bounded
+    /// reservoir sample on a large source, the whole column on a small or
+    /// in-memory one. `classified_count()` against `total_count - null_count`
+    /// is what says which happened; treat the shares as sampled whenever it is
+    /// short.
+    ///
+    /// `None` means the classification did not run, never "one uniform class":
+    /// a column that was classified and had nothing to classify (all-null, or
+    /// zero rows) is `Some` with every count zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_homogeneity: Option<TypeHomogeneity>,
     pub stats: ColumnStats,
     /// Detected patterns, or `None` when pattern detection did not run.
     ///
@@ -245,6 +264,7 @@ mod tests {
             unique_count: Some(8),
             unique_count_is_approximate: Some(false),
             invalid_count: Some(0),
+            type_homogeneity: None,
             stats: ColumnStats::Numeric(NumericStats {
                 min: 1.0,
                 max: 100.0,
@@ -298,6 +318,7 @@ mod tests {
             unique_count: Some(3),
             unique_count_is_approximate: Some(false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::Text(TextStats {
                 min_length: 3,
                 max_length: 7,

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -2,7 +2,9 @@ use dataprof_core::AnalysisOptions;
 
 use crate::types::{ColumnProfile, ColumnStats, DataType, Locale};
 
-use crate::analysis::inference::{infer_type, is_null_like_token, parse_strict_boolean_token};
+use crate::analysis::inference::{
+    classify_lexical_forms, infer_type, is_null_like_token, parse_strict_boolean_token,
+};
 use crate::analysis::patterns::detect_patterns;
 use crate::stats::numeric::compute_numeric_stats_with_parsed_count;
 use crate::stats::{calculate_datetime_stats, calculate_text_stats};
@@ -187,6 +189,11 @@ fn analyze_column_with_options(
         // exact whenever it was computed at all.
         unique_count_is_approximate: unique_count.map(|_| false),
         invalid_count,
+        // Classified over `data`, which on this path is the whole column, so the
+        // counts are exact rather than sampled. Not gated by the analysis
+        // selection: which forms a column holds is schema-level evidence like
+        // the inferred type itself, not a statistic derived from a pack.
+        type_homogeneity: Some(classify_lexical_forms(data)),
         stats,
         patterns,
     }
@@ -246,6 +253,62 @@ mod tests {
 
         assert_eq!(profile.null_count, 0); // Trimmed values are not null
         assert!(matches!(profile.data_type, DataType::Integer));
+    }
+
+    #[test]
+    fn type_homogeneity_covers_the_whole_column_on_this_path() {
+        // The in-memory path holds every value, so the counts are exact rather
+        // than sampled: they must add up to the non-null total.
+        let data: Vec<String> = (0..80)
+            .map(|i| i.to_string())
+            .chain((0..20).map(|i| format!("junk{i}")))
+            .chain(std::iter::once(String::new()))
+            .collect();
+
+        let profile = analyze_column("v", &data);
+        let counts = profile
+            .type_homogeneity
+            .expect("classification runs on every column");
+
+        assert_eq!(counts.numeric, 80);
+        assert_eq!(counts.text, 20);
+        assert_eq!(
+            counts.classified_count(),
+            profile.total_count - profile.null_count
+        );
+    }
+
+    #[test]
+    fn type_homogeneity_is_recorded_even_when_the_column_is_ordinary() {
+        // Absence has to mean "not classified". A clean numeric column reports
+        // one class holding everything, not a missing field.
+        let data = ["1", "2", "3"].map(String::from).to_vec();
+
+        let counts = analyze_column("v", &data)
+            .type_homogeneity
+            .expect("present");
+
+        assert_eq!(counts.dominant_share(), Some(1.0));
+    }
+
+    #[test]
+    fn a_narrowed_metric_selection_still_classifies_the_column() {
+        // Which forms a column holds is schema-level evidence like the inferred
+        // type, not a statistic a narrowed pack selection can take away.
+        let data = ["1", "2", "junk"].map(String::from).to_vec();
+        let options = AnalysisOptions::default().with_metric_packs(Some(vec![]));
+        assert!(!options.include_statistics());
+
+        let profile = analyze_column_with_analysis_options("v", &data, &options);
+
+        assert!(matches!(profile.stats, ColumnStats::None));
+        assert_eq!(
+            profile
+                .type_homogeneity
+                .expect("present")
+                .classified_count(),
+            3
+        );
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
+use dataprof_core::{LexicalClass, TypeHomogeneity};
+
 use crate::types::DataType;
 
 // Pre-compile regex patterns for better performance
@@ -148,10 +150,106 @@ pub fn parse_strict_boolean_token(value: &str) -> Option<bool> {
     }
 }
 
+/// Classify one trimmed, non-null value into its [`LexicalClass`].
+///
+/// The precedence matches the order [`infer_type`] tries types on whole columns,
+/// so a column that just missed a type threshold reports the same share of
+/// matching values that it reported while it still had that type. Integers and
+/// fractions share [`LexicalClass::Numeric`] deliberately: `["1.5", "2", "3"]`
+/// is one numeric column, not a two-class mixture.
+///
+/// Dates use [`is_date_token`], the union of the forms inference and validation
+/// each recognize. Using only the validation set would drop ISO datetimes and
+/// dotted dates into `Text` alongside genuine junk.
+pub fn lexical_class(value: &str) -> LexicalClass {
+    if is_integer_token(value) || value.parse::<f64>().is_ok() {
+        LexicalClass::Numeric
+    } else if is_date_token(value) {
+        LexicalClass::Date
+    } else if parse_strict_boolean_token(value).is_some() {
+        LexicalClass::Boolean
+    } else {
+        LexicalClass::Text
+    }
+}
+
+/// Distribute `values` across the lexical classes, skipping null-like tokens.
+///
+/// This is the single classifier behind both the consistency score of a column
+/// with no inferred type and the `type_homogeneity` a profile reports, so the
+/// two can never disagree about what a column holds.
+pub fn classify_lexical_forms<S: AsRef<str>>(values: &[S]) -> TypeHomogeneity {
+    let mut homogeneity = TypeHomogeneity::default();
+    for value in values {
+        let trimmed = value.as_ref().trim();
+        if !is_null_like_token(trimmed) {
+            homogeneity.record(lexical_class(trimmed));
+        }
+    }
+    homogeneity
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn each_value_lands_in_exactly_one_class() {
+        for (value, expected) in [
+            ("42", LexicalClass::Numeric),
+            ("-1.5", LexicalClass::Numeric),
+            (u64::MAX.to_string().as_str(), LexicalClass::Numeric),
+            ("2024-01-15", LexicalClass::Date),
+            ("2024-01-15T10:30:00", LexicalClass::Date),
+            ("15.01.2024", LexicalClass::Date),
+            ("true", LexicalClass::Boolean),
+            ("FALSE", LexicalClass::Boolean),
+            ("junk0", LexicalClass::Text),
+            ("N/A", LexicalClass::Text),
+        ] {
+            assert_eq!(lexical_class(value), expected, "{value}");
+        }
+    }
+
+    #[test]
+    fn classification_counts_only_non_null_values() {
+        // Null-like tokens are absence, not a lexical form: counting them would
+        // make a sparse numeric column look mixed.
+        let values = ["1", "2", "", "null", "NaN", "junk", "2024-01-15"].map(String::from);
+
+        let counts = classify_lexical_forms(&values);
+
+        assert_eq!(counts.numeric, 2);
+        assert_eq!(counts.date, 1);
+        assert_eq!(counts.text, 1);
+        assert_eq!(counts.classified_count(), 4);
+    }
+
+    #[test]
+    fn classification_matches_the_consistency_score_it_shares_a_classifier_with() {
+        // 800 integers and 200 junk values: the shape from #544. The dominant
+        // share and the consistency score of the same column are one number,
+        // computed once, so the flag and the score can never disagree.
+        let values: Vec<String> = (0..800)
+            .map(|i| (1000 + i).to_string())
+            .chain((0..200).map(|i| format!("junk{i}")))
+            .collect();
+
+        let counts = classify_lexical_forms(&values);
+
+        assert_eq!(counts.dominant(), Some((LexicalClass::Numeric, 800)));
+        assert_eq!(counts.dominant_share(), Some(0.8));
+    }
+
+    #[test]
+    fn a_column_of_only_nulls_is_classified_and_holds_nothing() {
+        let values = ["", "   ", "NULL"].map(String::from);
+
+        // Not the same as "never classified": the caller can tell the two apart
+        // because one is `Some` and the other is absent from the profile.
+        assert_eq!(classify_lexical_forms(&values), TypeHomogeneity::default());
+    }
 
     #[test]
     fn test_infer_integer() {

--- a/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
@@ -240,6 +240,7 @@ mod tests {
             unique_count: None,
             unique_count_is_approximate: None,
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/consistency.rs
@@ -5,7 +5,8 @@
 
 use super::utils::{DATE_FORMAT_REGEXES, is_likely_date_column};
 use crate::analysis::inference::{
-    is_date_token, is_integer_token, is_null_like_token, parse_strict_boolean_token,
+    classify_lexical_forms, is_date_token, is_integer_token, is_null_like_token, lexical_class,
+    parse_strict_boolean_token,
 };
 use crate::core::errors::DataProfilerError;
 use crate::types::{ColumnProfile, DataType};
@@ -18,77 +19,6 @@ pub(crate) struct ConsistencyMetrics {
     pub format_violations: usize,
     pub encoding_issues: usize,
     pub values_checked: usize,
-}
-
-/// Mutually exclusive lexical form of a single non-null value.
-///
-/// The variants partition non-null values — every value belongs to exactly one —
-/// which is what lets the share held by the largest class stand in for
-/// consistency on a column that has no inferred type of its own.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LexicalClass {
-    Numeric,
-    Date,
-    Boolean,
-    Text,
-}
-
-/// [`LexicalClass`] indexed by discriminant, used to count without a `HashMap`
-/// so that a tie between two classes resolves the same way on every run.
-/// `lexical_class_order_matches_discriminants` pins the two together.
-const LEXICAL_CLASS_ORDER: [LexicalClass; 4] = [
-    LexicalClass::Numeric,
-    LexicalClass::Date,
-    LexicalClass::Boolean,
-    LexicalClass::Text,
-];
-
-/// Classify one trimmed, non-null value.
-///
-/// The precedence matches the order `infer_type` tries types on whole columns,
-/// so a column that just missed a type threshold reports the same share of
-/// matching values that it reported while it still had that type. Integers and
-/// fractions share `Numeric` deliberately: `["1.5", "2", "3"]` is one numeric
-/// column, not a two-class mixture.
-///
-/// Dates use [`is_date_token`], the union of the forms inference and validation
-/// each recognize. Using only the validation set would drop ISO datetimes and
-/// dotted dates into `Text` alongside genuine junk, and a column of 70%
-/// datetimes and 30% junk would report a perfect score again.
-fn lexical_class(value: &str) -> LexicalClass {
-    if is_integer_token(value) || value.parse::<f64>().is_ok() {
-        LexicalClass::Numeric
-    } else if is_date_token(value) {
-        LexicalClass::Date
-    } else if parse_strict_boolean_token(value).is_some() {
-        LexicalClass::Boolean
-    } else {
-        LexicalClass::Text
-    }
-}
-
-/// The class holding the most non-null values, or `None` when the column has no
-/// non-null values to classify.
-fn dominant_lexical_class(values: &[String]) -> Option<LexicalClass> {
-    let mut counts = [0usize; LEXICAL_CLASS_ORDER.len()];
-    for value in values {
-        let trimmed = value.trim();
-        if !is_null_like_token(trimmed) {
-            counts[lexical_class(trimmed) as usize] += 1;
-        }
-    }
-
-    // Strict `>` leaves the earliest-declared class holding a tie. Which class
-    // wins does not change the reported share — both hold the same count — it
-    // only keeps the answer stable across runs.
-    let mut best: Option<(usize, usize)> = None;
-    for (index, count) in counts.into_iter().enumerate() {
-        if count > 0 && best.is_none_or(|(_, best_count)| count > best_count) {
-            best = Some((index, count));
-        }
-    }
-
-    best.map(|(index, _)| LEXICAL_CLASS_ORDER[index])
 }
 
 /// Calculator for consistency dimension metrics
@@ -141,7 +71,9 @@ impl ConsistencyCalculator {
                 let dominant_class = if profile.data_type == DataType::String
                     && !is_likely_date_column(&profile.name)
                 {
-                    dominant_lexical_class(column_data)
+                    classify_lexical_forms(column_data)
+                        .dominant()
+                        .map(|(class, _)| class)
                 } else {
                     None
                 };
@@ -329,6 +261,7 @@ mod tests {
             unique_count: None,
             unique_count_is_approximate: None,
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }
@@ -359,16 +292,6 @@ mod tests {
             .map(|i| (1000 + i).to_string())
             .chain((0..junk).map(|i| format!("junk{i}")))
             .collect()
-    }
-
-    #[test]
-    fn lexical_class_order_matches_discriminants() {
-        for (index, class) in LEXICAL_CLASS_ORDER.into_iter().enumerate() {
-            assert_eq!(
-                class as usize, index,
-                "LEXICAL_CLASS_ORDER must be indexed by discriminant: {class:?}"
-            );
-        }
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -789,6 +789,7 @@ mod tests {
             unique_count: Some(100),
             unique_count_is_approximate: Some(false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -841,6 +842,7 @@ mod tests {
             unique_count: Some(1),
             unique_count_is_approximate: Some(false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];
@@ -882,6 +884,7 @@ mod tests {
             unique_count: Some(10),
             unique_count_is_approximate: Some(false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }];

--- a/crates/dataprof-metrics/src/analysis/metrics/precision.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/precision.rs
@@ -101,6 +101,7 @@ mod tests {
             unique_count: Some(4),
             unique_count_is_approximate: Some(false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/testing.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/testing.rs
@@ -34,6 +34,7 @@ pub(super) fn string_profile(name: &str, total: usize, nulls: usize) -> ColumnPr
         unique_count: Some(unique_count),
         unique_count_is_approximate: Some(false),
         invalid_count: None,
+        type_homogeneity: None,
         stats: ColumnStats::Text(TextStats::from_lengths(1, 10, 5.0)),
         patterns: Some(vec![]),
     }

--- a/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/uniqueness.rs
@@ -207,6 +207,7 @@ mod tests {
             unique_count: unique,
             unique_count_is_approximate: unique.map(|_| false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns: Some(vec![]),
         }

--- a/crates/dataprof-metrics/src/analysis/metrics/validity.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/validity.rs
@@ -85,6 +85,7 @@ mod tests {
             unique_count: Some(4),
             unique_count_is_approximate: Some(false),
             invalid_count: None,
+            type_homogeneity: None,
             stats: ColumnStats::None,
             patterns,
         }

--- a/crates/dataprof-metrics/src/analysis/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/mod.rs
@@ -5,6 +5,6 @@ pub mod patterns;
 pub(crate) mod validators;
 
 pub use column::{analyze_column, analyze_column_fast, analyze_column_with_analysis_options};
-pub use inference::{infer_type, is_null_like_token};
+pub use inference::{classify_lexical_forms, infer_type, is_null_like_token, lexical_class};
 pub use metrics::{MetricsCalculator, compute_value_hint_bindings, value_matches_hint};
 pub use patterns::{PatternMetadata, detect_patterns, list_patterns};

--- a/crates/dataprof-metrics/src/lib.rs
+++ b/crates/dataprof-metrics/src/lib.rs
@@ -8,8 +8,9 @@ pub mod types;
 
 pub use analysis::{
     MetricsCalculator, PatternMetadata, analyze_column, analyze_column_fast,
-    analyze_column_with_analysis_options, compute_value_hint_bindings, detect_patterns, infer_type,
-    is_null_like_token, list_patterns, value_matches_hint,
+    analyze_column_with_analysis_options, classify_lexical_forms, compute_value_hint_bindings,
+    detect_patterns, infer_type, is_null_like_token, lexical_class, list_patterns,
+    value_matches_hint,
 };
 pub use quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, PrecisionMetrics,

--- a/crates/dataprof-metrics/src/types.rs
+++ b/crates/dataprof-metrics/src/types.rs
@@ -1,6 +1,7 @@
 pub use dataprof_core::{
-    BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, FrequencyItem, Locale,
-    MetricPack, NumericStats, Pattern, PatternCategory, QualityDimension, Quartiles, TextStats,
+    BooleanStats, ColumnProfile, ColumnStats, DataType, DateTimeStats, FrequencyItem, LexicalClass,
+    Locale, MetricPack, NumericStats, Pattern, PatternCategory, QualityDimension, Quartiles,
+    TextStats, TypeHomogeneity,
 };
 
 pub use crate::quality::{

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -65,6 +65,19 @@ pub struct PyColumnProfile {
     /// statistics skipped); `Some(0)` = every non-null value was valid.
     #[pyo3(get)]
     pub invalid_count: Option<usize>,
+    /// Count of non-null values per lexical class — `numeric`, `date`,
+    /// `boolean`, `text` — over the values the profiler retained.
+    ///
+    /// Answers what `data_type` cannot: whether a `string` column is ordinary
+    /// text or a column that defeated type inference. All four keys are always
+    /// present; every count zero means the column was classified and had
+    /// nothing to classify (all-null, or zero rows). `None` = the
+    /// classification did not run, never "one uniform class".
+    ///
+    /// Sum the counts and compare against `total_count - null_count` to tell a
+    /// full-column count from one bounded by the engine's reservoir sample.
+    #[pyo3(get)]
+    pub type_homogeneity: Option<std::collections::BTreeMap<String, usize>>,
     /// Percentage of null values, or `None` for a zero-row column where the
     /// ratio (`null_count / total_count`) is undefined — absent means "not
     /// measured", never "0% nulls".
@@ -213,6 +226,18 @@ impl From<&ColumnProfile> for PyColumnProfile {
             .as_ref()
             .map(|ps| ps.iter().map(PyPattern::from).collect());
 
+        // A BTreeMap, not a HashMap: the Python dict keeps insertion order, so
+        // an unordered map would hand the same profile a different key order
+        // from run to run and make serialized reports differ for no reason.
+        let type_homogeneity = profile.type_homogeneity.as_ref().map(|h| {
+            std::collections::BTreeMap::from([
+                ("numeric".to_string(), h.numeric),
+                ("date".to_string(), h.date),
+                ("boolean".to_string(), h.boolean),
+                ("text".to_string(), h.text),
+            ])
+        });
+
         Self {
             name: profile.name.clone(),
             data_type: match profile.data_type {
@@ -228,6 +253,7 @@ impl From<&ColumnProfile> for PyColumnProfile {
             unique_count: profile.unique_count,
             unique_count_is_approximate: profile.unique_count_is_approximate,
             invalid_count: profile.invalid_count,
+            type_homogeneity,
             null_percentage,
             uniqueness_ratio,
             min,

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -12,7 +12,9 @@ use dataprof_core::{
     TextStats,
 };
 use dataprof_metrics::{
-    analysis::inference::{is_integer_token, is_null_like_token, parse_strict_boolean_token},
+    analysis::inference::{
+        classify_lexical_forms, is_integer_token, is_null_like_token, parse_strict_boolean_token,
+    },
     analysis::patterns::looks_like_date,
     calculate_datetime_stats, calculate_text_stats, detect_patterns,
     stats::numeric::{calculate_coefficient_of_variation, compute_numeric_stats_with_parsed_count},
@@ -210,6 +212,12 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
         unique_count: input.unique_count,
         unique_count_is_approximate: input.unique_count_is_approximate,
         invalid_count,
+        // Classified over the retained sample, so the counts are bounded by the
+        // engine's reservoir on a large source. `classified_count()` against
+        // `total_count - null_count` is what tells a reader which happened.
+        // Not gated by `skip_statistics`: which forms a column holds is
+        // schema-level evidence like the inferred type, not a statistic.
+        type_homogeneity: Some(classify_lexical_forms(input.sample_values)),
         stats,
         patterns,
     }
@@ -418,6 +426,43 @@ mod tests {
         assert_eq!(value.data_type, DataType::Float);
         assert_eq!(value.invalid_count, Some(2));
         assert!(matches!(value.stats, ColumnStats::Numeric(_)));
+    }
+
+    #[test]
+    fn type_homogeneity_is_classified_from_the_retained_sample() {
+        // The streaming path only holds its reservoir, so the counts describe
+        // the sample. `classified_count()` short of the non-null total is the
+        // signal that the shares are sampled — nothing else discloses it.
+        let samples = ["1", "2", "junk", ""].map(String::from).to_vec();
+        let profile = build_column_profile(ColumnProfileInput {
+            name: "v".to_string(),
+            data_type: DataType::String,
+            total_count: 4_000,
+            null_count: 1_000,
+            unique_count: Some(3),
+            unique_count_is_approximate: Some(false),
+            sample_values: &samples,
+            text_lengths: None,
+            boolean_counts: None,
+            // Not gated by the analysis selection: a column's lexical makeup is
+            // schema-level evidence, like its inferred type.
+            skip_statistics: true,
+            skip_patterns: true,
+            exact_numeric: None,
+            exact_date_matches: None,
+            locale: None,
+        });
+
+        let counts = profile
+            .type_homogeneity
+            .expect("classification runs on every column");
+        assert_eq!(counts.numeric, 2);
+        assert_eq!(counts.text, 1);
+        assert_eq!(counts.classified_count(), 3, "null-like values are skipped");
+        assert!(
+            counts.classified_count() < profile.total_count - profile.null_count,
+            "a sample-derived count must read as short of the column"
+        );
     }
 
     #[test]

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -135,6 +135,11 @@ struct PythonColumnDocument {
     uniqueness_ratio: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     invalid_count: Option<usize>,
+    /// Counts per lexical class, keyed `numeric` / `date` / `boolean` / `text`.
+    /// The Python dialect writes the counts as a map rather than the Rust
+    /// struct, but the keys and their meaning are the same.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    type_homogeneity: Option<std::collections::BTreeMap<String, usize>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stats: Option<PythonColumnStatsDocument>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -135,11 +135,13 @@ struct PythonColumnDocument {
     uniqueness_ratio: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     invalid_count: Option<usize>,
-    /// Counts per lexical class, keyed `numeric` / `date` / `boolean` / `text`.
-    /// The Python dialect writes the counts as a map rather than the Rust
-    /// struct, but the keys and their meaning are the same.
+    /// Counts per lexical class. The Python dialect writes them as a plain
+    /// mapping, but it is the same four-key object the Rust dialect writes, so
+    /// it is described by the same definition: a reader that accepted a partial
+    /// mapping here would validate a document the Python loader then discards
+    /// as incomplete rather than inventing the missing counts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    type_homogeneity: Option<std::collections::BTreeMap<String, usize>>,
+    type_homogeneity: Option<dataprof_core::TypeHomogeneity>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stats: Option<PythonColumnStatsDocument>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/dataprof/src/lib.rs
+++ b/crates/dataprof/src/lib.rs
@@ -26,12 +26,12 @@ pub use dataprof_core::{
     AnalysisOptions, BooleanStats, ChunkSize, ColumnProfile, ColumnSchema, ColumnStats,
     CountMethod, DataFrameLibrary, DataProfilerError, DataSource, DataType, DataprofConfig,
     DataprofConfigBuilder, DateTimeStats, ExecutionMetadata, FileFormat, FrequencyItem,
-    InputValidator, IsoQualityConfig, Locale, MetricPack, NumericStats, OutputFormat,
+    InputValidator, IsoQualityConfig, LexicalClass, Locale, MetricPack, NumericStats, OutputFormat,
     ParquetMetadata, Pattern, PatternCategory, ProgressEvent, ProgressSink, QualityDimension,
     QualityScoreWeights, Quartiles, QueryEngine, RowCountEstimate, SamplingStrategy, SchemaResult,
     SemanticHintBinding, SemanticHintKind, SemanticHints, StopCondition, StopEvaluator,
-    StructureColumnSummary, StructureReport, TextStats, TruncationReason, ValidationError,
-    validate_unique_column_names,
+    StructureColumnSummary, StructureReport, TextStats, TruncationReason, TypeHomogeneity,
+    ValidationError, validate_unique_column_names,
 };
 pub use dataprof_csv::{
     CsvDiagnostics, CsvParserConfig, analyze_csv_file, analyze_csv_from_reader,
@@ -45,7 +45,8 @@ pub use dataprof_metrics::{
     PatternMetadata, PrecisionMetrics, QualityAssessment, QualityMetrics, TimelinessMetrics,
     UniquenessMetrics, ValidityMetrics, analyze_column, analyze_column_fast,
     analyze_column_with_analysis_options, calculate_datetime_stats, calculate_numeric_stats,
-    calculate_text_stats, detect_patterns, infer_type, is_null_like_token, list_patterns,
+    calculate_text_stats, classify_lexical_forms, detect_patterns, infer_type, is_null_like_token,
+    lexical_class, list_patterns,
 };
 #[cfg(feature = "parquet-async")]
 pub use dataprof_parquet::{HttpParquetReader, analyze_parquet_async_http};

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -125,6 +125,20 @@ reports 100. Two exceptions keep the plain type check: columns you declared via
 `identifier_columns`, whose schemes mix forms on purpose, and columns whose name
 announces dates, which stay held to dates.
 
+`data_type_consistency` is a dataset-level number and cannot say *which* column
+is mixed. Each column carries its own evidence in `type_homogeneity`, a count of
+non-null values per lexical class:
+
+```python
+report["amount_eur"].type_homogeneity
+# {"numeric": 6, "date": 0, "boolean": 0, "text": 4}
+```
+
+`None` there means the classification did not run; four zero counts mean it ran
+and the column had nothing to classify. The counts cover the values the profiler
+retained, so compare their sum against `total_count - null_count` to see whether
+they describe the whole column or the engine's reservoir sample.
+
 ### Uniqueness
 
 Measures duplication in the data.

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -277,6 +277,7 @@ Per-column profiling statistics.
 | `null_count` | `int` | Number of null/missing values |
 | `unique_count` | `int \| None` | Distinct value count |
 | `invalid_count` | `int \| None` | Non-null values that did not parse as a finite number (parse failures and non-finite tokens like `inf`/`NaN`) and are excluded from the statistics. `None` = check did not run (non-numeric column, or statistics skipped); `0` = every non-null value parsed |
+| `type_homogeneity` | `dict[str, int] \| None` | Non-null values counted by lexical class: `{"numeric", "date", "boolean", "text"}`. Tells a `string` column of ordinary text from one that defeated type inference, which `data_type` cannot. All four keys are always present; all-zero = classified with nothing to classify (all-null or no rows); `None` = the classification did not run. Counted over the values the profiler retained, so sum them against `total_count - null_count` to tell an exact count from one bounded by the 10k reservoir sample |
 | `null_percentage` | `float` | Null ratio (0.0--100.0) |
 | `uniqueness_ratio` | `float` | Unique values / total values |
 | `min` | `float \| None` | Minimum (numeric columns) |
@@ -477,7 +478,8 @@ table = report.to_arrow()
 ```
 
 Columns included: `name`, `data_type`, `total_count`, `null_count`, `null_percentage`,
-`unique_count`, `uniqueness_ratio`, `min`, `max`, `mean`, `std_dev`, `variance`,
+`unique_count`, `uniqueness_ratio`, `dominant_type`, `dominant_type_share`,
+`min`, `max`, `mean`, `std_dev`, `variance`,
 `median`, `mode`, `skewness`, `kurtosis`, `coefficient_of_variation`, `q1`, `q2`,
 `q3`, `iqr`, `is_approximate`, `min_length`, `max_length`, `avg_length`,
 `top_pattern`, `top_pattern_pct`.

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -99,6 +99,17 @@
           "minimum": 0,
           "type": "integer"
         },
+        "type_homogeneity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeHomogeneity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How the column's non-null values distribute across lexical classes.\n\n`data_type` cannot answer \"did this column have a dominant form?\": a\ncolumn of names and a column that is 60% numbers are both `String`, and\n`invalid_count` is absent on string columns by contract. This carries the\nevidence, so a consumer can tell a textual column from one that defeated\ntype inference.\n\nCounted over the values the profiler retained — the engine's bounded\nreservoir sample on a large source, the whole column on a small or\nin-memory one. `classified_count()` against `total_count - null_count`\nis what says which happened; treat the shares as sampled whenever it is\nshort.\n\n`None` means the classification did not run, never \"one uniform class\":\na column that was classified and had nothing to classify (all-null, or\nzero rows) is `Some` with every count zero."
+        },
         "unique_count": {
           "format": "uint",
           "minimum": 0,
@@ -1147,6 +1158,18 @@
           "minimum": 0,
           "type": "integer"
         },
+        "type_homogeneity": {
+          "additionalProperties": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "description": "Counts per lexical class, keyed `numeric` / `date` / `boolean` / `text`.\nThe Python dialect writes the counts as a map rather than the Rust\nstruct, but the keys and their meaning are the same.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "unique_count": {
           "format": "uint",
           "minimum": 0,
@@ -2146,6 +2169,38 @@
           "type": "string"
         }
       ]
+    },
+    "TypeHomogeneity": {
+      "description": "How a column's non-null values distribute across [`LexicalClass`]es.\n\nRaw counts rather than a share, so that a reader can state the mixture it\nactually found (\"60% numeric, 40% text\") instead of the dominant class and\nan unnamed remainder, and so a serialized report carries no rounded\nderivative of a number it does not also carry exactly.\n\nAll four counts are always present. Every field zero means the column was\nclassified and had no non-null values to classify — \"analyzed, found\nnothing\", which is not the same as an absent `type_homogeneity`.",
+      "properties": {
+        "boolean": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "date": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "numeric": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "numeric",
+        "date",
+        "boolean",
+        "text"
+      ],
+      "type": "object"
     },
     "UniquenessMetrics": {
       "description": "Uniqueness metrics (ISO 8000-110).",

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -1159,16 +1159,15 @@
           "type": "integer"
         },
         "type_homogeneity": {
-          "additionalProperties": {
-            "format": "uint",
-            "minimum": 0,
-            "type": "integer"
-          },
-          "description": "Counts per lexical class, keyed `numeric` / `date` / `boolean` / `text`.\nThe Python dialect writes the counts as a map rather than the Rust\nstruct, but the keys and their meaning are the same.",
-          "type": [
-            "object",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TypeHomogeneity"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Counts per lexical class. The Python dialect writes them as a plain\nmapping, but it is the same four-key object the Rust dialect writes, so\nit is described by the same definition: a reader that accepted a partial\nmapping here would validate a document the Python loader then discards\nas incomplete rather than inventing the missing counts."
         },
         "unique_count": {
           "format": "uint",

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -663,6 +663,56 @@ def list_patterns(locale: str | None = None) -> list[dict[str, _Any]]:
 # ---------------------------------------------------------------------------
 
 
+#: The lexical classes ``type_homogeneity`` counts, in the order ties resolve
+#: in. Mirrors the declaration order the Rust classifier uses to pick a dominant
+#: class, so both layers name the same winner when two classes hold equal counts.
+#: Serialization keys are sorted instead — see :func:`_homogeneity_counts`.
+_LEXICAL_CLASS_ORDER = ("numeric", "date", "boolean", "text")
+
+
+def _homogeneity_counts(value: _Any) -> dict[str, int] | None:
+    """Normalize a ``type_homogeneity`` mapping, or ``None`` when there is none.
+
+    Absence is preserved rather than filled in: ``None`` means the
+    classification did not run, and must never read back as four zero counts,
+    which mean "classified, and there was nothing to classify". A malformed or
+    incomplete mapping is treated as absence for the same reason -- an invented
+    count is worse than a gap.
+
+    Keys come back sorted, matching the order the native extension builds them
+    in, so the two report backings serialize byte-identical documents.
+    """
+    if not isinstance(value, dict):
+        return None
+    counts: dict[str, int] = {}
+    for name in sorted(_LEXICAL_CLASS_ORDER):
+        count = value.get(name)
+        # bool before int: bool is an int subclass, and True == 1.
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            return None
+        counts[name] = count
+    return counts
+
+
+def _type_mixture(col: ColumnProfile) -> list[tuple[str, int, float]]:
+    """Lexical classes holding at least one value, largest first.
+
+    Each entry is ``(class, count, share)`` with ``share`` in ``0..1``. Empty
+    when the column was not classified, or was classified and held no non-null
+    values -- the caller cannot tell those apart from here, and must read
+    ``type_homogeneity`` itself if the difference matters.
+    """
+    counts = _homogeneity_counts(col.type_homogeneity)
+    if counts is None:
+        return []
+    total = sum(counts.values())
+    if total == 0:
+        return []
+    present = [(name, n) for name, n in counts.items() if n]
+    present.sort(key=lambda item: (-item[1], _LEXICAL_CLASS_ORDER.index(item[0])))
+    return [(name, n, n / total) for name, n in present]
+
+
 def column_to_dict(col: ColumnProfile) -> dict[str, _Any]:
     """Convert a single ColumnProfile to the nested dict layout used by
     :meth:`ProfileReport.to_dict`.
@@ -702,6 +752,11 @@ def column_to_dict(col: ColumnProfile) -> dict[str, _Any]:
     # serialization; a clean checked column serializes 0.
     if col.invalid_count is not None:
         col_data["invalid_count"] = col.invalid_count
+    # Same omit-when-absent rule: the key is missing when the classification did
+    # not run, so a reloaded report cannot mistake absence for four zero counts.
+    homogeneity = _homogeneity_counts(col.type_homogeneity)
+    if homogeneity is not None:
+        col_data["type_homogeneity"] = homogeneity
     if col.min is not None:
         col_data["stats"] = {
             k: v
@@ -777,6 +832,13 @@ def _column_record(col: ColumnProfile) -> dict[str, _Any]:
         top_pattern_category = best.category
         top_pattern_confidence = round(best.confidence, 4)
 
+    # These exports are flat -- a CSV column cannot hold the four-way count map
+    # -- so the record carries the two scalars derived from it. Both are None
+    # when the column was not classified, or held nothing to classify.
+    mixture = _type_mixture(col)
+    dominant_type = mixture[0][0] if mixture else None
+    dominant_type_share = _r4(mixture[0][2]) if mixture else None
+
     return {
         "name": col.name,
         "data_type": col.data_type,
@@ -788,6 +850,8 @@ def _column_record(col: ColumnProfile) -> dict[str, _Any]:
         # 4dp for the same reason as in column_to_dict() — see the note there.
         "uniqueness_ratio": _r4(col.uniqueness_ratio),
         "invalid_count": col.invalid_count,
+        "dominant_type": dominant_type,
+        "dominant_type_share": dominant_type_share,
         "min": _r4(col.min),
         "max": _r4(col.max),
         "mean": _r4(col.mean),
@@ -879,6 +943,12 @@ _CHARS_PER_TOKEN = 4
 #: A column is flagged ``null-heavy`` at or above this null percentage.
 _NULL_HEAVY_PCT = 20.0
 
+#: A column is flagged ``mixed types`` once at least this percentage of its
+#: classified values falls outside its dominant lexical class. Display only: it
+#: changes no score, and exists so that one stray ``N/A`` in a clean numeric
+#: column does not spend budget competing with the findings an agent asked for.
+_MIXED_TYPE_PCT = 5.0
+
 #: Pattern categories whose concrete values should stay out of agent-facing
 #: output even when ``include_samples=True`` asks for numeric extrema.
 _SENSITIVE_PATTERN_CATEGORIES = {
@@ -937,6 +1007,52 @@ def _may_expose_values(col: ColumnProfile) -> bool:
     )
 
 
+def _share_pct(share: float) -> str:
+    """Render a ``0..1`` share as a percentage that never rounds down to zero.
+
+    A class holding one value in ten thousand is 0.01%, and printing that as
+    "0% date" beside a real mixture states something untrue about the data.
+    """
+    pct = round(share * 100, 1)
+    if pct == 0.0 and share > 0.0:
+        return "<0.1"
+    return f"{pct:g}"
+
+
+def _mixed_type_flag(col: ColumnProfile) -> tuple[float, str] | None:
+    """Flag a column whose values do not agree on one lexical class.
+
+    This is the signal ``data_type`` cannot carry: below the inference
+    thresholds a half-numeric column is typed ``string``, identical in the
+    schema listing to a column of names. The flag states the mixture actually
+    found rather than restating the type.
+
+    Suppressed for ``identifier`` columns, where mixing forms ("A1", "123") is
+    what an ID scheme does rather than a defect -- the same exemption the
+    consistency dimension makes.
+    """
+    if col.data_type == "identifier":
+        return None
+    mixture = _type_mixture(col)
+    if len(mixture) < 2:
+        return None
+    outside_pct = 100.0 * (1.0 - mixture[0][2])
+    if outside_pct < _MIXED_TYPE_PCT:
+        return None
+
+    name = _one_line(col.name)
+    shares = ", ".join(f"{_share_pct(share)}% {cls}" for cls, _, share in mixture)
+
+    # The counts cover what the profiler retained, which on a large source is a
+    # bounded sample of the column. Disclose that where it is true, rather than
+    # letting a share taken over 10k values read as a fact about 10M.
+    classified = sum(count for _, count, _ in mixture)
+    non_null = (col.total_count or 0) - (col.null_count or 0)
+    scope = f"; sampled {classified:,} of {non_null:,} values" if classified < non_null else ""
+
+    return (outside_pct, f"{name}: mixed types ({shares}{scope})")
+
+
 def _column_flags(col: ColumnProfile) -> list[tuple[float, str]]:
     """Derive ``(severity, text)`` quality flags for one column.
 
@@ -968,6 +1084,10 @@ def _column_flags(col: ColumnProfile) -> list[tuple[float, str]]:
     if outliers > 0 and total > 0:
         pct = 100.0 * outliers / total
         flags.append((min(50.0, pct), f"{name}: {outliers} outliers ({pct:.1f}%)"))
+
+    mixed = _mixed_type_flag(col)
+    if mixed is not None:
+        flags.append(mixed)
 
     return flags
 
@@ -1701,6 +1821,9 @@ class _DictColumn:
         self.unique_count_is_approximate = d.get("unique_count_is_approximate")
         self.uniqueness_ratio = d.get("uniqueness_ratio")
         self.invalid_count = d.get("invalid_count")
+        # Normalized on the way in, so a hand-edited or truncated mapping reads
+        # back as "not classified" rather than as counts that were never taken.
+        self.type_homogeneity = _homogeneity_counts(d.get("type_homogeneity"))
         # Overlay only known stat attributes — never setattr arbitrary keys from
         # (possibly malformed) input, which could inject unexpected/dunder names.
         stats = d.get("stats")

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -155,6 +155,15 @@ class ColumnProfile:
     unique_count: int | None
     unique_count_is_approximate: bool | None
     invalid_count: int | None
+    #: Non-null values per lexical class -- ``numeric``, ``date``, ``boolean``,
+    #: ``text`` -- over the values the profiler retained. Answers what
+    #: ``data_type`` cannot: whether a ``string`` column is ordinary text or one
+    #: that defeated type inference. All four keys are always present; all-zero
+    #: means "classified, nothing to classify" (all-null or zero rows), while
+    #: ``None`` means the classification did not run. Sum the counts and compare
+    #: against ``total_count - null_count`` to tell an exact count from one
+    #: bounded by the engine's reservoir sample.
+    type_homogeneity: dict[str, int] | None
     null_percentage: float | None
     uniqueness_ratio: float | None
     min: float | None

--- a/python/tests/test_agent_docs_sync.py
+++ b/python/tests/test_agent_docs_sync.py
@@ -442,6 +442,16 @@ def test_eval_rubrics_cite_current_fixture_values() -> None:
         if pattern not in quoted:
             stale.append(f"README/scenarios no longer name the {pattern} pattern")
 
+    # The high-score-is-not-clean rubric now grades against a per-column flag
+    # rather than the score alone, and quotes its wording. A flag that changed
+    # shape would leave the rubric grading against a line dataprof no longer
+    # emits — the same way the score went stale under #544.
+    payments_flag = "amount_eur: mixed types (60% numeric, 40% text)"
+    if payments_flag not in payments.to_llm_context():
+        stale.append(f"to_llm_context no longer emits the quoted flag {payments_flag!r}")
+    if payments_flag not in quoted:
+        stale.append("README/scenarios no longer quote the amount_eur mixed-types flag")
+
     assert not stale, (
         "eval rubrics are out of date with what dataprof produces: "
         + "; ".join(stale)

--- a/python/tests/test_report_roundtrip_parity.py
+++ b/python/tests/test_report_roundtrip_parity.py
@@ -350,11 +350,13 @@ def test_all_null_flag_requires_exact_counts():
     """A rounded 100.0% null percentage is not proof that every value is null."""
     almost_all_null = SimpleNamespace(
         name="almost",
+        data_type="string",
         null_percentage=99.996,
         null_count=24_999,
         total_count=25_000,
         unique_count=1,
         outlier_count=0,
+        type_homogeneity=None,
     )
     flags = _column_flags(almost_all_null)
     texts = [text for _, text in flags]
@@ -363,11 +365,14 @@ def test_all_null_flag_requires_exact_counts():
 
     genuinely_all_null = SimpleNamespace(
         name="empty",
+        data_type="string",
         null_percentage=100.0,
         null_count=25_000,
         total_count=25_000,
         unique_count=0,
         outlier_count=0,
+        # Classified, and there was nothing to classify.
+        type_homogeneity={"numeric": 0, "date": 0, "boolean": 0, "text": 0},
     )
     assert [text for _, text in _column_flags(genuinely_all_null)] == ["empty: all-null"]
 

--- a/python/tests/test_type_homogeneity.py
+++ b/python/tests/test_type_homogeneity.py
@@ -10,8 +10,10 @@ acceptance criterion 4 of #544, the half an agent actually reads.
 from __future__ import annotations
 
 import json
+import pathlib
 
 import pytest
+from jsonschema import Draft202012Validator
 
 try:
     import dataprof as dp
@@ -106,6 +108,60 @@ class TestTypeHomogeneity:
 
         assert restored["v"].type_homogeneity is None
         assert "type_homogeneity" not in restored.to_dict()["columns"][0]
+
+    def test_the_published_schema_rejects_what_the_loader_discards(self):
+        # A partial mapping validating against the schema while the loader
+        # treats it as absence would let a document be "valid" and still lose
+        # the field on reload. The Python dialect is described by the same
+        # four-key definition the Rust dialect is.
+        schema_path = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "docs"
+            / "schema"
+            / "profile-report.v1.schema.json"
+        )
+        validator = Draft202012Validator(json.loads(schema_path.read_text(encoding="utf-8")))
+
+        document = {
+            "schema_version": dp.REPORT_SCHEMA_VERSION,
+            "source": "hand-edited.csv",
+            "source_type": "file",
+            "execution": {
+                "engine": None,
+                "rows_processed": 1,
+                "columns_detected": 1,
+                "scan_time_ms": 0,
+                "source_exhausted": True,
+                "truncation_reason": None,
+                "bytes_consumed": None,
+                "throughput_rows_sec": None,
+                "memory_peak_mb": None,
+                "error_count": 0,
+                "ragged_row_count": 0,
+                "sampling_applied": False,
+                "sampling_ratio": None,
+            },
+            "columns": [
+                {
+                    "name": "v",
+                    "data_type": "string",
+                    "total_count": 1,
+                    "null_count": 0,
+                    "null_percentage": 0.0,
+                    "unique_count": 1,
+                    "unique_count_is_approximate": False,
+                    "uniqueness_ratio": 1.0,
+                    "type_homogeneity": {"numeric": 0, "date": 0, "boolean": 0, "text": 1},
+                }
+            ],
+            "quality": None,
+        }
+        validator.validate(document)
+
+        document["columns"][0]["type_homogeneity"] = {"numeric": 3}
+        assert list(validator.iter_errors(document)), (
+            "a partial count map must not validate, because the loader drops it"
+        )
 
     def test_a_malformed_mapping_reads_as_absence(self):
         # An invented count is worse than a gap: a partial mapping cannot be

--- a/python/tests/test_type_homogeneity.py
+++ b/python/tests/test_type_homogeneity.py
@@ -1,0 +1,220 @@
+"""Per-column evidence that a column defeated type inference (#561).
+
+`data_type` cannot carry this: below the inference thresholds a half-numeric
+column is typed `string`, identical in a schema listing to a column of names,
+and `invalid_count` is absent on string columns by contract. `type_homogeneity`
+carries the counts, and `to_llm_context()` turns them into a flag — which is
+acceptance criterion 4 of #544, the half an agent actually reads.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+try:
+    import dataprof as dp
+except ImportError:
+    pytest.skip(
+        "dataprof native extension not built. Run: maturin develop",
+        allow_module_level=True,
+    )
+
+
+def _profile_column(tmp_path, values: list[str], name: str = "v", **kwargs):
+    path = tmp_path / "column.csv"
+    path.write_text(f"{name}\n" + "\n".join(values) + "\n", encoding="utf-8")
+    return dp.profile(str(path), **kwargs)
+
+
+def _numeric_with_junk(junk: int, total: int = 1000) -> list[str]:
+    """The shape reported in #544: `junk` non-numeric values padded with integers."""
+    return [str(1000 + i) for i in range(total - junk)] + [f"junk{i}" for i in range(junk)]
+
+
+def _flags(report) -> list[str]:
+    """The flag lines of a report's LLM context, without the bullet."""
+    context = report.to_llm_context()
+    if "\nflags (" not in context:
+        return []
+    section = context.split("\nflags (", 1)[1]
+    body = section.split("\n\n", 1)[0]
+    return [line[2:] for line in body.splitlines() if line.startswith("- ")]
+
+
+class TestTypeHomogeneity:
+    """The field itself."""
+
+    def test_counts_every_non_null_value_by_class(self, tmp_path):
+        report = _profile_column(tmp_path, ["1", "2.5", "2024-01-15", "true", "junk", ""])
+
+        assert report["v"].type_homogeneity == {
+            "boolean": 1,
+            "date": 1,
+            "numeric": 2,
+            "text": 1,
+        }
+
+    def test_a_clean_column_reports_one_class_rather_than_absence(self, tmp_path):
+        # Absence has to keep meaning "not classified". A clean column is
+        # `Some` with everything in one class, never a missing field.
+        report = _profile_column(tmp_path, [str(i) for i in range(10)])
+
+        assert report["v"].type_homogeneity == {
+            "boolean": 0,
+            "date": 0,
+            "numeric": 10,
+            "text": 0,
+        }
+
+    def test_an_all_null_column_is_classified_and_holds_nothing(self, tmp_path):
+        # "Analyzed, found nothing" is four zero counts — not None, which would
+        # claim the classification never ran.
+        report = _profile_column(tmp_path, ["", "", ""])
+
+        assert report["v"].type_homogeneity == {
+            "boolean": 0,
+            "date": 0,
+            "numeric": 0,
+            "text": 0,
+        }
+
+    def test_counts_survive_the_document_round_trip(self, tmp_path):
+        report = _profile_column(tmp_path, _numeric_with_junk(200))
+        native = report["v"].type_homogeneity
+        assert native == {"boolean": 0, "date": 0, "numeric": 800, "text": 200}
+
+        restored = dp.ProfileReport.from_json(report.to_json())
+
+        assert restored["v"].type_homogeneity == native
+        assert json.loads(report.to_json())["columns"][0]["type_homogeneity"] == native
+
+    def test_absence_does_not_read_back_as_zero_counts(self):
+        # A document written before this field existed must reload as "not
+        # classified", not as a column whose values were all classified away.
+        document = {
+            "schema_version": dp.REPORT_SCHEMA_VERSION,
+            "source": "legacy.csv",
+            "source_type": "file",
+            "execution": {"rows_processed": 1, "columns_detected": 1},
+            "columns": [{"name": "v", "data_type": "string", "total_count": 1, "null_count": 0}],
+            "quality": None,
+        }
+
+        restored = dp.ProfileReport.from_dict(document)
+
+        assert restored["v"].type_homogeneity is None
+        assert "type_homogeneity" not in restored.to_dict()["columns"][0]
+
+    def test_a_malformed_mapping_reads_as_absence(self):
+        # An invented count is worse than a gap: a partial mapping cannot be
+        # completed with zeros, because zero is a claim about the data.
+        document = {
+            "schema_version": dp.REPORT_SCHEMA_VERSION,
+            "source": "hand-edited.csv",
+            "source_type": "file",
+            "execution": {"rows_processed": 1, "columns_detected": 1},
+            "columns": [
+                {
+                    "name": "v",
+                    "data_type": "string",
+                    "total_count": 1,
+                    "null_count": 0,
+                    "type_homogeneity": {"numeric": 3},
+                }
+            ],
+            "quality": None,
+        }
+
+        assert dp.ProfileReport.from_dict(document)["v"].type_homogeneity is None
+
+    def test_the_flat_exports_carry_the_derived_scalars(self, tmp_path):
+        # to_dataframe()/save(".csv") are flat and cannot hold the count map, so
+        # they carry the dominant class and its share instead.
+        report = _profile_column(tmp_path, _numeric_with_junk(200))
+
+        record = report._records()[0]
+
+        assert record["dominant_type"] == "numeric"
+        assert record["dominant_type_share"] == 0.8
+
+
+class TestMixedTypeFlag:
+    """What `to_llm_context()` does with it."""
+
+    def test_a_column_that_defeated_inference_is_flagged(self, tmp_path):
+        # The acceptance criterion: 20% junk types the column `string` and used
+        # to render exactly like a column of names.
+        report = _profile_column(tmp_path, _numeric_with_junk(200))
+
+        assert report["v"].data_type == "string"
+        assert _flags(report) == ["v: mixed types (80% numeric, 20% text)"]
+
+    def test_a_textual_column_is_not_flagged(self, tmp_path):
+        # The control the flag exists to be distinguishable from. This column is
+        # also `string`, and it is fine.
+        report = _profile_column(tmp_path, [f"person{i}" for i in range(100)], name="name")
+
+        assert report["name"].data_type == "string"
+        assert _flags(report) == []
+
+    def test_the_flag_states_the_mixture_rather_than_the_type(self, tmp_path):
+        report = _profile_column(
+            tmp_path,
+            ["1"] * 60 + ["2024-01-15"] * 10 + ["junk"] * 30,
+        )
+
+        assert _flags(report) == ["v: mixed types (60% numeric, 30% text, 10% date)"]
+
+    def test_a_stray_value_does_not_earn_a_flag(self, tmp_path):
+        # Display threshold: below 5% outside the dominant class the column is
+        # not "mixed", and a flag there would spend budget an agent asked for.
+        assert _flags(_profile_column(tmp_path, _numeric_with_junk(3))) == []
+
+    def test_the_threshold_fires_where_it_is_documented(self, tmp_path):
+        report = _profile_column(tmp_path, _numeric_with_junk(50))
+
+        assert _flags(report) == ["v: mixed types (95% numeric, 5% text)"]
+
+    def test_a_share_too_small_to_round_is_not_printed_as_zero(self, tmp_path):
+        # 1 date in 1000 is 0.1%; a third class rounding to "0%" would state
+        # something untrue beside a real mixture.
+        values = _numeric_with_junk(100, total=999) + ["2024-01-15"]
+        report = _profile_column(tmp_path, values)
+
+        assert _flags(report) == ["v: mixed types (89.9% numeric, 10% text, 0.1% date)"]
+
+    def test_a_sampled_count_discloses_its_scope(self, tmp_path):
+        # The counts come from the engine's 10k reservoir. A share taken over
+        # 10k values must not read as a fact about 50k.
+        report = _profile_column(tmp_path, _numeric_with_junk(12_500, total=50_000))
+        flags = _flags(report)
+
+        assert len(flags) == 1
+        assert flags[0].startswith("v: mixed types (")
+        assert "; sampled 10,000 of 50,000 values)" in flags[0]
+
+    def test_an_unsampled_count_claims_no_scope(self, tmp_path):
+        report = _profile_column(tmp_path, _numeric_with_junk(200))
+
+        assert "sampled" not in _flags(report)[0]
+
+    def test_identifier_columns_may_mix_forms_without_a_flag(self, tmp_path):
+        # An ID scheme mixing "A1" and "123" is intended, not a defect — the
+        # same exemption the consistency dimension makes.
+        values = [f"A{i}" for i in range(50)] + [str(i) for i in range(50)]
+        report = _profile_column(
+            tmp_path, values, name="customer_id", identifier_columns=["customer_id"]
+        )
+
+        assert report["customer_id"].data_type == "identifier"
+        assert _flags(report) == []
+
+    def test_the_flag_survives_the_document_round_trip(self, tmp_path):
+        report = _profile_column(tmp_path, _numeric_with_junk(200))
+
+        restored = dp.ProfileReport.from_json(report.to_json())
+
+        assert restored.to_llm_context() == report.to_llm_context()
+        assert _flags(restored) == ["v: mixed types (80% numeric, 20% text)"]

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -10,6 +10,7 @@ use dataprof::{
     ColumnStats, CsvParserConfig, DataType, MetricConfidence, QualityDimension, analyze_csv_file,
 };
 use dataprof::{EngineType, Profiler};
+use serde_json::json;
 use tempfile::NamedTempFile;
 
 /// 30k rows of *sorted* values — larger than the 10k per-column sample
@@ -1023,6 +1024,100 @@ fn surplus_fields_do_not_leak_into_duplicate_detection() {
         assert_eq!(
             uniqueness.duplicate_rows, 1,
             "{engine:?} must see the truncated row as a duplicate"
+        );
+    }
+}
+
+/// A column that defeated type inference is `String`, the same type a column of
+/// names gets, and `invalid_count` is absent on string columns by contract. The
+/// evidence that tells the two apart is `type_homogeneity`, and every engine has
+/// to report the same counts for the same input or an agent's reading of a
+/// column depends on which engine happened to profile it (#561).
+#[test]
+fn type_homogeneity_agrees_across_engines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "amount,name,when").unwrap();
+    for i in 0..200 {
+        // amount: 150 numbers and 50 placeholders — under the 80% threshold, so
+        // inference gives up and the column is typed `string`.
+        let amount = if i % 4 == 0 {
+            "pending".to_string()
+        } else {
+            format!("{}.50", 100 + i)
+        };
+        writeln!(f, "{amount},person{i},2024-01-15").unwrap();
+    }
+    f.flush().unwrap();
+
+    let standard = analyze_csv_file(f.path(), &CsvParserConfig::default())
+        .expect("standard CSV analysis should succeed");
+    let reports = [
+        ("standard", standard),
+        (
+            "auto",
+            Profiler::new()
+                .engine(EngineType::Auto)
+                .analyze_file(f.path())
+                .expect("auto analysis should succeed"),
+        ),
+        (
+            "incremental",
+            Profiler::new()
+                .engine(EngineType::Incremental)
+                .analyze_file(f.path())
+                .expect("incremental analysis should succeed"),
+        ),
+        (
+            "columnar",
+            Profiler::new()
+                .engine(EngineType::Columnar)
+                .analyze_file(f.path())
+                .expect("columnar analysis should succeed"),
+        ),
+    ];
+
+    for (engine, report) in reports {
+        let counts = |name: &str| {
+            let column = report
+                .column_profiles
+                .iter()
+                .find(|column| column.name == name)
+                .unwrap_or_else(|| panic!("[{engine}] {name} column"));
+            (
+                column.data_type.clone(),
+                column
+                    .type_homogeneity
+                    .unwrap_or_else(|| panic!("[{engine}] {name} must be classified")),
+            )
+        };
+
+        let (amount_type, amount) = counts("amount");
+        assert_eq!(
+            amount_type,
+            DataType::String,
+            "[{engine}] the fixture must reproduce the inference fallback"
+        );
+        assert_eq!(amount.numeric, 150, "[{engine}] amount numeric");
+        assert_eq!(amount.text, 50, "[{engine}] amount text");
+        assert_eq!(amount.dominant_share(), Some(0.75), "[{engine}] amount");
+
+        // A genuinely textual column is the control: same `String` type, one
+        // class, no mixture to report.
+        let (name_type, name) = counts("name");
+        assert_eq!(name_type, DataType::String, "[{engine}] name");
+        assert_eq!(name.text, 200, "[{engine}] name text");
+        assert_eq!(name.dominant_share(), Some(1.0), "[{engine}] name");
+
+        // Dates are their own class, not text that happens to look structured.
+        let (_, when) = counts("when");
+        assert_eq!(when.date, 200, "[{engine}] when date");
+
+        // And it survives serialization with the counts intact.
+        let serialized = serde_json::to_value(&report).expect("report should serialize");
+        assert_eq!(
+            serialized["column_profiles"][0]["type_homogeneity"],
+            json!({"numeric": 150, "date": 0, "boolean": 0, "text": 50}),
+            "[{engine}] serialized amount counts"
         );
     }
 }

--- a/tests/public_api_facade.rs
+++ b/tests/public_api_facade.rs
@@ -2,9 +2,10 @@ use std::time::Duration;
 
 use dataprof::{
     ChunkSize, CsvParserConfig, DataSource, DataType, EngineType, FileFormat, JsonFormat,
-    JsonParserConfig, Locale, MetricPack, OutputFormat, Profiler, ProfilerConfig, ProgressSink,
-    QualityDimension, SamplingStrategy, StopCondition, analyze_column_fast, analyze_structure,
-    calculate_numeric_stats, calculate_text_stats, detect_patterns, infer_type,
+    JsonParserConfig, LexicalClass, Locale, MetricPack, OutputFormat, Profiler, ProfilerConfig,
+    ProgressSink, QualityDimension, SamplingStrategy, StopCondition, TypeHomogeneity,
+    analyze_column, analyze_column_fast, analyze_structure, calculate_numeric_stats,
+    calculate_text_stats, classify_lexical_forms, detect_patterns, infer_type, lexical_class,
 };
 
 #[test]
@@ -47,6 +48,16 @@ fn parser_and_metrics_reexports_compile() {
 
     assert_eq!(infer_type(&numeric_values), DataType::Integer);
     assert_eq!(analyze_column_fast("n", &numeric_values).name, "n");
+
+    // A `ColumnProfile` field a consumer cannot name is a field they cannot
+    // match on or construct, so the classification types travel with it.
+    assert_eq!(lexical_class("42"), LexicalClass::Numeric);
+    let homogeneity: TypeHomogeneity = classify_lexical_forms(&numeric_values);
+    assert_eq!(homogeneity.dominant(), Some((LexicalClass::Numeric, 3)));
+    assert_eq!(
+        analyze_column("n", &numeric_values).type_homogeneity,
+        Some(homogeneity)
+    );
     let _numeric_stats = calculate_numeric_stats(&numeric_values);
     let _text_stats = calculate_text_stats(&text_values);
     let _patterns = detect_patterns(&text_values, Some(Locale::Us));


### PR DESCRIPTION
## Summary

`to_llm_context()` gave an agent the dataset quality score and each column's
type, and nothing that said a column had no dominant form. After #560 a
half-numeric column scores 86.7 rather than 100, but the column still rendered
as `- v: string` — indistinguishable from a column of names.

`data_type` cannot carry that difference, and `invalid_count` is `None` on
string columns by contract, so the dominant lexical class the consistency
calculator already computed was folded into a dataset average and discarded.
This surfaces it per column and flags it.

## Before / after

`.claude/skills/dataprof/evals/fixtures/payments_mixed_amount.csv` — a money
column where 4 of 10 values are placeholders:

```
 rows: 10 | columns: 4 | quality: 97.9/100
                                                 flags (1):
                                               + - amount_eur: mixed types (60% numeric, 40% text)

 schema (4):
 - amount_eur: string
```

## What changed

- **`ColumnProfile.type_homogeneity`** — non-null values counted by lexical
  class, `{"numeric": 6, "date": 0, "boolean": 0, "text": 4}`. Additive and
  optional: `None` keeps meaning "not analyzed", while a column that *was*
  classified and had nothing to classify is `Some` with four zero counts. Counts
  rather than a share, so the flag can state the mixture it actually found
  instead of a dominant class and an unnamed remainder.
- **One classifier.** `lexical_class` / `classify_lexical_forms` move out of the
  consistency calculator into `dataprof-metrics::analysis::inference`, so a
  column's flag and its consistency score are the same measurement rather than
  two that agree by inspection.
- **Every engine.** Both profile construction paths populate the field — the
  streaming builder from its retained sample, the in-memory path (database
  connectors) from the whole column. Not gated by the metric packs: which forms
  a column holds is schema-level evidence like the inferred type, not a
  statistic.
- **The flag.** Emitted once at least 5% of classified values fall outside the
  dominant class. Display only — it changes no score — and `identifier` columns
  are exempt, matching the exemption consistency already makes for ID schemes
  that mix forms on purpose.
- **Sample scope.** The counts cover what the profiler retained, so the flag
  appends `sampled 10,000 of 50,000 values` when it was short of the column, and
  summing the counts against `total_count - null_count` says so directly.
- **Flat exports** (`to_dataframe`, `save(".csv")`, `to_arrow`) cannot hold the
  count map, so they carry `dominant_type` and `dominant_type_share`.

Two open questions from the issue, settled: the flag threshold (5% outside the
dominant class, display only) and the field shape (per-class counts rather than
dominant + share).

## Acceptance criteria

- [x] A column with no dominant type is visibly distinct from a textual column
      in `to_llm_context()`.
- [x] The field round-trips through `to_json()` / report reload, and `None`
      still means "not analyzed" — covered by the generic round-trip parity
      sweep plus explicit absence-vs-zero tests.
- [x] Cross-engine parity: `type_homogeneity_agrees_across_engines` profiles one
      mixed CSV through standard / auto / incremental / columnar and asserts
      identical counts, including through serialization. Verified by hand across
      JSON, JSONL, Parquet and pandas too.
- [x] The `dataprof` skill's #544 warning is updated: SKILL.md and
      `reference/interpretation.md` now teach the field and the flag, and the
      `high-score-is-not-clean` eval no longer says the flag is missing.

## Tests

Each part was reverted separately and the guards confirmed failing:

| Reverted | Fails |
| --- | --- |
| runtime classification (`build_column_profile`) | `type_homogeneity_agrees_across_engines`, 12 of 17 Python tests |
| in-memory classification (`analyze_column`) | 3 `analysis::column` tests |
| the flag in `_column_flags` | 7 Python flag tests |
| threshold 5% → 20% | 5 Python flag tests |
| `column_to_dict` emission | 11 round-trip tests |
| read-back normalization | the malformed-mapping test |

`test_eval_rubrics_cite_current_fixture_values` now also profiles the fixture
and checks the flag wording the rubric quotes, so that rubric cannot go stale
the way the score did under #544.

## Commands run

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace
cargo run --example generate_profile_schema     # committed schema regenerated
uv run maturin develop
uv run pytest python/tests/ -q                  # 853 passed
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```

Closes #561. Closes #544 — this was its remaining acceptance criterion.
