### PR TITLE
feat(schema): add bytes source_type for byte-buffer inputs

### DIFF
--- a/crates/dataprof-core/src/source.rs
+++ b/crates/dataprof-core/src/source.rs
@@ -192,6 +192,17 @@ pub enum DataSource {
         #[serde(skip_serializing_if = "Option::is_none")]
         memory_bytes: Option<u64>,
     },
+    /// In-memory byte buffer that was parsed as text (CSV/JSON/JSONL/Parquet).
+    /// Distinguished from [`DataSource::DataFrame`]: the caller handed over
+    /// bytes, not a schema-bearing dataframe, so provenance must say so.
+    Bytes {
+        /// Human-readable name for identification
+        name: String,
+        /// Format the buffer was parsed as
+        format: FileFormat,
+        /// Size of the buffer in bytes
+        size_bytes: u64,
+    },
     /// Streaming data source
     Stream {
         /// Stream identifier (e.g., Kafka topic, Kinesis stream name)
@@ -240,6 +251,7 @@ impl DataSource {
                 source_library,
                 ..
             } => format!("{}[{}]", source_library, name),
+            Self::Bytes { name, .. } => format!("python[{name}]"),
             Self::Stream {
                 source_system,
                 topic,
@@ -254,6 +266,7 @@ impl DataSource {
         match self {
             Self::File { size_bytes, .. } => Some(*size_bytes as f64 / 1_048_576.0),
             Self::DataFrame { memory_bytes, .. } => memory_bytes.map(|b| b as f64 / 1_048_576.0),
+            Self::Bytes { size_bytes, .. } => Some(*size_bytes as f64 / 1_048_576.0),
             Self::Query { .. } | Self::Stream { .. } => None,
         }
     }
@@ -276,6 +289,11 @@ impl DataSource {
     /// Check if this is a Stream-based source.
     pub fn is_stream(&self) -> bool {
         matches!(self, Self::Stream { .. })
+    }
+
+    /// Check if this is an in-memory byte-buffer source.
+    pub fn is_bytes(&self) -> bool {
+        matches!(self, Self::Bytes { .. })
     }
 
     /// Get the file path if this is a file-based source.
@@ -322,6 +340,22 @@ mod tests {
         assert!(!ds.is_query());
         assert!(!ds.is_dataframe());
         assert!(!ds.is_stream());
+    }
+
+    #[test]
+    fn test_data_source_bytes_identifier_and_helpers() {
+        let ds = DataSource::Bytes {
+            name: "csv_bytes".to_string(),
+            format: FileFormat::Csv,
+            size_bytes: 42,
+        };
+
+        assert_eq!(ds.identifier(), "python[csv_bytes]");
+        assert!(ds.is_bytes());
+        assert!(!ds.is_file());
+        assert!(!ds.is_dataframe());
+        assert!(!ds.is_stream());
+        assert_eq!(ds.size_mb(), Some(42.0 / 1_048_576.0));
     }
 
     #[test]

--- a/crates/dataprof-core/src/source.rs
+++ b/crates/dataprof-core/src/source.rs
@@ -192,7 +192,8 @@ pub enum DataSource {
         #[serde(skip_serializing_if = "Option::is_none")]
         memory_bytes: Option<u64>,
     },
-    /// In-memory byte buffer that was parsed as text (CSV/JSON/JSONL/Parquet).
+    /// In-memory byte buffer profiled without a path behind it. The buffer may
+    /// be text (CSV/JSON/JSONL) or binary (Parquet); `format` says which.
     /// Distinguished from [`DataSource::DataFrame`]: the caller handed over
     /// bytes, not a schema-bearing dataframe, so provenance must say so.
     Bytes {
@@ -200,7 +201,7 @@ pub enum DataSource {
         name: String,
         /// Format the buffer was parsed as
         format: FileFormat,
-        /// Size of the buffer in bytes
+        /// Length of the buffer handed over, not of the values decoded from it
         size_bytes: u64,
     },
     /// Streaming data source
@@ -251,7 +252,7 @@ impl DataSource {
                 source_library,
                 ..
             } => format!("{}[{}]", source_library, name),
-            Self::Bytes { name, .. } => format!("python[{name}]"),
+            Self::Bytes { name, .. } => format!("bytes[{name}]"),
             Self::Stream {
                 source_system,
                 topic,
@@ -350,7 +351,7 @@ mod tests {
             size_bytes: 42,
         };
 
-        assert_eq!(ds.identifier(), "python[csv_bytes]");
+        assert_eq!(ds.identifier(), "bytes[csv_bytes]");
         assert!(ds.is_bytes());
         assert!(!ds.is_file());
         assert!(!ds.is_dataframe());

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 use crate::record_batch_analyzer::RecordBatchAnalyzer;
 use dataprof_core::{
-    AnalysisOptions, DataFrameLibrary, DataProfilerError, DataSource, ExecutionMetadata,
-    FileFormat, ParquetMetadata, QualityDimension, SemanticHints, TruncationReason,
+    AnalysisOptions, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, ParquetMetadata,
+    QualityDimension, SemanticHints, TruncationReason,
 };
 use dataprof_runtime::{ProfileReport, ReportAssembler};
 
@@ -449,6 +449,32 @@ mod tests {
 
         assert_eq!(report.execution.rows_processed, 2);
         assert!(report.execution.truncation_reason.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_parquet_bytes_report_the_buffer_length_they_were_given() -> Result<()> {
+        let encoded = to_parquet_bytes(&mixed_batch()?)?;
+        let byte_len = encoded.len() as u64;
+        let report = analyze_parquet_bytes(
+            Bytes::from(encoded),
+            "buffer",
+            &ParquetConfig::default(),
+            None,
+            &SemanticHints::default(),
+        )?;
+
+        // `size_bytes` describes the buffer handed over. Decoded values are a
+        // different size entirely -- for Parquet, off by the compression ratio.
+        match &report.data_source {
+            DataSource::Bytes {
+                format, size_bytes, ..
+            } => {
+                assert_eq!(*size_bytes, byte_len);
+                assert_eq!(*format, FileFormat::Parquet);
+            }
+            other => panic!("expected a byte-buffer source, got {other:?}"),
+        }
         Ok(())
     }
 

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -325,14 +325,12 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
             parquet_metadata,
         },
         // A buffer has no path, and `DataSource::File` is where Parquet metadata
-        // lives, so the in-memory case reports the same shape every other
-        // byte-buffer input reports and drops the file-level metadata.
-        ParquetOrigin::Memory { name, byte_len } => DataSource::DataFrame {
+        // lives, so the in-memory case reports the byte-buffer shape and drops
+        // the file-level metadata.
+        ParquetOrigin::Memory { name, byte_len } => DataSource::Bytes {
             name,
-            source_library: DataFrameLibrary::Custom("dataprof".to_string()),
-            row_count: total_rows,
-            column_count: num_columns,
-            memory_bytes: Some(byte_len),
+            format: FileFormat::Parquet,
+            size_bytes: byte_len,
         },
     };
 

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -39,9 +39,17 @@ pub type PyColumn = (String, Vec<Option<String>>);
 /// columns are present their cell count already carries the row count, and a
 /// `row_count` that disagrees with it is rejected rather than silently ignored.
 ///
+/// `source_bytes` is the length of the original buffer, required when
+/// `source_type` is `"bytes"`: the decoded cells are a different size from the
+/// bytes they came out of, so the caller is the only one who knows it.
+///
 /// Raises `ValueError` when the columns do not all have the same length.
+// One flat parameter per Python keyword argument: the pyo3 signature is the
+// call surface, so grouping them into a struct would only move the list into
+// `#[derive(FromPyObject)]`. Same reasoning as `PyProfilerConfig::new`.
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0, row_count = None, source_type = "dataframe".to_string(), source_format = None))]
+#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0, row_count = None, source_type = "dataframe".to_string(), source_format = None, source_bytes = None))]
 pub fn profile_columns(
     py: Python<'_>,
     columns: Vec<PyColumn>,
@@ -52,6 +60,7 @@ pub fn profile_columns(
     row_count: Option<usize>,
     source_type: String,
     source_format: Option<String>,
+    source_bytes: Option<u64>,
 ) -> PyResult<PyProfileReport> {
     let start = std::time::Instant::now();
 
@@ -197,10 +206,19 @@ pub fn profile_columns(
             Some("parquet") => FileFormat::Parquet,
             other => FileFormat::Unknown(other.unwrap_or_default().to_string()),
         };
+        // `memory_bytes` is the decoded cells added up, which is not the size of
+        // the buffer they were parsed from -- delimiters, quoting and encoding
+        // all move it, and for Parquet it is off by the compression ratio.
+        // Reporting it as the buffer size would be a plausible wrong number.
+        let size_bytes = source_bytes.ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(
+                "source_type='bytes' requires source_bytes, the length of the original buffer",
+            )
+        })?;
         DataSource::Bytes {
             name,
             format,
-            size_bytes: memory_bytes,
+            size_bytes,
         }
     } else {
         DataSource::DataFrame {

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -11,8 +11,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use dataprof::{
-    DataFrameLibrary, DataSource, ExecutionMetadata, MetricPack, TruncationReason, infer_type,
-    is_null_like_token,
+    DataFrameLibrary, DataSource, ExecutionMetadata, FileFormat, MetricPack, TruncationReason,
+    infer_type, is_null_like_token,
 };
 use dataprof_runtime::{
     ColumnProfileInput, ReportAssembler, RowUniquenessTracker, build_column_profile,
@@ -41,7 +41,7 @@ pub type PyColumn = (String, Vec<Option<String>>);
 ///
 /// Raises `ValueError` when the columns do not all have the same length.
 #[pyfunction]
-#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0, row_count = None))]
+#[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0, row_count = None, source_type = "dataframe".to_string(), source_format = None))]
 pub fn profile_columns(
     py: Python<'_>,
     columns: Vec<PyColumn>,
@@ -50,6 +50,8 @@ pub fn profile_columns(
     config: Option<&PyProfilerConfig>,
     error_count: usize,
     row_count: Option<usize>,
+    source_type: String,
+    source_format: Option<String>,
 ) -> PyResult<PyProfileReport> {
     let start = std::time::Instant::now();
 
@@ -187,18 +189,32 @@ pub fn profile_columns(
         .map(|v| v.len() as u64)
         .sum();
 
-    let mut assembler = ReportAssembler::new(
+    let data_source = if source_type == "bytes" {
+        let format = match source_format.as_deref() {
+            Some("csv") => FileFormat::Csv,
+            Some("json") => FileFormat::Json,
+            Some("jsonl") => FileFormat::Jsonl,
+            Some("parquet") => FileFormat::Parquet,
+            other => FileFormat::Unknown(other.unwrap_or_default().to_string()),
+        };
+        DataSource::Bytes {
+            name,
+            format,
+            size_bytes: memory_bytes,
+        }
+    } else {
         DataSource::DataFrame {
             name,
             source_library: DataFrameLibrary::Custom("python".to_string()),
             row_count: num_rows,
             column_count: num_cols,
             memory_bytes: Some(memory_bytes),
-        },
-        exec,
-    )
-    .columns(column_profiles)
-    .with_row_duplicates(row_duplicates);
+        }
+    };
+
+    let mut assembler = ReportAssembler::new(data_source, exec)
+        .columns(column_profiles)
+        .with_row_duplicates(row_duplicates);
 
     if include_quality {
         assembler = assembler

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -832,7 +832,7 @@ impl PyProfileReport {
         self.inner.data_source.identifier()
     }
 
-    /// Source type: "file", "dataframe", "stream", "query"
+    /// Source type: "file", "dataframe", "stream", "query", "bytes"
     #[getter]
     fn source_type(&self) -> &str {
         match &self.inner.data_source {
@@ -840,6 +840,7 @@ impl PyProfileReport {
             DataSource::DataFrame { .. } => "dataframe",
             DataSource::Stream { .. } => "stream",
             DataSource::Query { .. } => "query",
+            DataSource::Bytes { .. } => "bytes",
         }
     }
 

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -102,6 +102,7 @@ enum PythonSourceType {
     Query,
     Dataframe,
     Stream,
+    Bytes,
 }
 
 #[allow(dead_code)]

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -179,3 +179,10 @@ jobs:
           print(f"validated {len(report_paths)} report(s)")
           PY
 ```
+
+## v1 additive change: `bytes` source type
+
+Version 1.1 (additive) introduced the `"bytes"` value in `PythonSourceType` for
+byte-buffer inputs (CSV/JSON/JSONL/Parquet bytes). Previously they were labeled
+`"dataframe"`. Consumers matching on `"dataframe"` must also accept `"bytes"`
+for byte inputs; stored v1 reports are unchanged.

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -65,7 +65,7 @@
           "$ref": "#/$defs/DataType"
         },
         "invalid_count": {
-          "description": "Non-null values that failed the column type's raw validity predicate:\nnon-finite or malformed numbers on numeric columns, and values that do\nnot parse directly as calendar dates on date columns. The date predicate\nintentionally does not trim surrounding whitespace; descriptive date\nstatistics may normalize whitespace independently.\n\nFor numeric columns, `mean`/`std_dev` cover\n`total_count - null_count - invalid_count` values. For date columns,\nthis count audits the strict raw-value quality predicate. `None` means\nthe check did not run (another column type, or statistics skipped) —\nnever \"no invalid values\", which is `Some(0)`.",
+          "description": "Non-null values that failed the column type's raw validity predicate:\nnon-finite or malformed numbers on numeric columns, and values that do\nnot parse directly as calendar dates on date columns. The date predicate\nintentionally does not trim surrounding whitespace; descriptive date\nstatistics may normalize whitespace independently.\n\nFor numeric columns, `mean`/`std_dev` cover\n`total_count - null_count - invalid_count` values. For date columns,\nthis count audits the strict raw-value quality predicate. `None` means\nthe check did not run (another column type, or statistics skipped) \u2014\nnever \"no invalid values\", which is `Some(0)`.",
           "format": "uint",
           "minimum": 0,
           "type": [
@@ -108,7 +108,7 @@
               "type": "null"
             }
           ],
-          "description": "How the column's non-null values distribute across lexical classes.\n\n`data_type` cannot answer \"did this column have a dominant form?\": a\ncolumn of names and a column that is 60% numbers are both `String`, and\n`invalid_count` is absent on string columns by contract. This carries the\nevidence, so a consumer can tell a textual column from one that defeated\ntype inference.\n\nCounted over the values the profiler retained — the engine's bounded\nreservoir sample on a large source, the whole column on a small or\nin-memory one. `classified_count()` against `total_count - null_count`\nis what says which happened; treat the shares as sampled whenever it is\nshort.\n\n`None` means the classification did not run, never \"one uniform class\":\na column that was classified and had nothing to classify (all-null, or\nzero rows) is `Some` with every count zero."
+          "description": "How the column's non-null values distribute across lexical classes.\n\n`data_type` cannot answer \"did this column have a dominant form?\": a\ncolumn of names and a column that is 60% numbers are both `String`, and\n`invalid_count` is absent on string columns by contract. This carries the\nevidence, so a consumer can tell a textual column from one that defeated\ntype inference.\n\nCounted over the values the profiler retained \u2014 the engine's bounded\nreservoir sample on a large source, the whole column on a small or\nin-memory one. `classified_count()` against `total_count - null_count`\nis what says which happened; treat the shares as sampled whenever it is\nshort.\n\n`None` means the classification did not run, never \"one uniform class\":\na column that was classified and had nothing to classify (all-null, or\nzero rows) is `Some` with every count zero."
         },
         "unique_count": {
           "format": "uint",
@@ -211,7 +211,7 @@
         },
         "total_cells": {
           "default": 0,
-          "description": "Total cells examined (rows × columns). 0 means the dimension had\nnothing to assess and it is excluded from the overall score.",
+          "description": "Total cells examined (rows \u00d7 columns). 0 means the dimension had\nnothing to assess and it is excluded from the overall score.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
@@ -616,7 +616,7 @@
         },
         "ragged_row_count": {
           "default": 0,
-          "description": "Number of data rows whose field count differed from the header's.\n\nThese rows were recovered — extra trailing fields dropped, missing\ntrailing fields padded to null — so profiling continued, but each one\nis a structural violation in the source. A nonzero value means the file\ndid not parse cleanly even though a report was produced. Additive field:\nlegacy documents without it deserialize as `0`.",
+          "description": "Number of data rows whose field count differed from the header's.\n\nThese rows were recovered \u2014 extra trailing fields dropped, missing\ntrailing fields padded to null \u2014 so profiling continued, but each one\nis a structural violation in the source. A nonzero value means the file\ndid not parse cleanly even though a report was produced. Additive field:\nlegacy documents without it deserialize as `0`.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
@@ -845,7 +845,7 @@
           ]
         },
         "outlier_count": {
-          "description": "Number of values flagged as IQR-based outliers in this column.\n\nUses the same Tukey-style detection (Q1 − k·IQR, Q3 + k·IQR with\nk = 1.5 by default) that feeds the global `accuracy.outlier_ratio`.\n`None` when outlier detection didn't run (sample below the configured\nminimum or non-numeric column).",
+          "description": "Number of values flagged as IQR-based outliers in this column.\n\nUses the same Tukey-style detection (Q1 \u2212 k\u00b7IQR, Q3 + k\u00b7IQR with\nk = 1.5 by default) that feeds the global `accuracy.outlier_ratio`.\n`None` when outlier detection didn't run (sample below the configured\nminimum or non-numeric column).",
           "format": "uint",
           "minimum": 0,
           "type": [
@@ -1076,7 +1076,7 @@
               "type": "null"
             }
           ],
-          "description": "Data quality assessment (optional — partial analysis may skip quality)"
+          "description": "Data quality assessment (optional \u2014 partial analysis may skip quality)"
         },
         "schema_version": {
           "const": 1,
@@ -1085,7 +1085,7 @@
           "type": "integer"
         },
         "semantic_hint_bindings": {
-          "description": "Per-column evidence of how each semantic hint bound to the data.\n\nEmpty when no hints were supplied. Recorded for provenance: a hint proven\ninert over the full data is rejected before a report is returned, so a\nsuccessful report only carries bindings that matched something or whose\nevidence was sampled. Additive field — older readers ignore it.",
+          "description": "Per-column evidence of how each semantic hint bound to the data.\n\nEmpty when no hints were supplied. Recorded for provenance: a hint proven\ninert over the full data is rejected before a report is returned, so a\nsuccessful report only carries bindings that matched something or whose\nevidence was sampled. Additive field \u2014 older readers ignore it.",
           "items": {
             "$ref": "#/$defs/SemanticHintBinding"
           },
@@ -1700,7 +1700,8 @@
         "file",
         "query",
         "dataframe",
-        "stream"
+        "stream",
+        "bytes"
       ],
       "type": "string"
     },
@@ -2088,7 +2089,7 @@
         },
         "temporal_pairs_checked": {
           "default": 0,
-          "description": "Start/end value pairs actually compared for temporal ordering.\n`temporal_violations` is bounded by this, not by\n`date_values_checked` — the pair scan may cover columns the date\nscan does not.",
+          "description": "Start/end value pairs actually compared for temporal ordering.\n`temporal_violations` is bounded by this, not by\n`date_values_checked` \u2014 the pair scan may cover columns the date\nscan does not.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
@@ -2170,7 +2171,7 @@
       ]
     },
     "TypeHomogeneity": {
-      "description": "How a column's non-null values distribute across [`LexicalClass`]es.\n\nRaw counts rather than a share, so that a reader can state the mixture it\nactually found (\"60% numeric, 40% text\") instead of the dominant class and\nan unnamed remainder, and so a serialized report carries no rounded\nderivative of a number it does not also carry exactly.\n\nAll four counts are always present. Every field zero means the column was\nclassified and had no non-null values to classify — \"analyzed, found\nnothing\", which is not the same as an absent `type_homogeneity`.",
+      "description": "How a column's non-null values distribute across [`LexicalClass`]es.\n\nRaw counts rather than a share, so that a reader can state the mixture it\nactually found (\"60% numeric, 40% text\") instead of the dominant class and\nan unnamed remainder, and so a serialized report carries no rounded\nderivative of a number it does not also carry exactly.\n\nAll four counts are always present. Every field zero means the column was\nclassified and had no non-null values to classify \u2014 \"analyzed, found\nnothing\", which is not the same as an absent `type_homogeneity`.",
       "properties": {
         "boolean": {
           "format": "uint",

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -65,7 +65,7 @@
           "$ref": "#/$defs/DataType"
         },
         "invalid_count": {
-          "description": "Non-null values that failed the column type's raw validity predicate:\nnon-finite or malformed numbers on numeric columns, and values that do\nnot parse directly as calendar dates on date columns. The date predicate\nintentionally does not trim surrounding whitespace; descriptive date\nstatistics may normalize whitespace independently.\n\nFor numeric columns, `mean`/`std_dev` cover\n`total_count - null_count - invalid_count` values. For date columns,\nthis count audits the strict raw-value quality predicate. `None` means\nthe check did not run (another column type, or statistics skipped) \u2014\nnever \"no invalid values\", which is `Some(0)`.",
+          "description": "Non-null values that failed the column type's raw validity predicate:\nnon-finite or malformed numbers on numeric columns, and values that do\nnot parse directly as calendar dates on date columns. The date predicate\nintentionally does not trim surrounding whitespace; descriptive date\nstatistics may normalize whitespace independently.\n\nFor numeric columns, `mean`/`std_dev` cover\n`total_count - null_count - invalid_count` values. For date columns,\nthis count audits the strict raw-value quality predicate. `None` means\nthe check did not run (another column type, or statistics skipped) —\nnever \"no invalid values\", which is `Some(0)`.",
           "format": "uint",
           "minimum": 0,
           "type": [
@@ -108,7 +108,7 @@
               "type": "null"
             }
           ],
-          "description": "How the column's non-null values distribute across lexical classes.\n\n`data_type` cannot answer \"did this column have a dominant form?\": a\ncolumn of names and a column that is 60% numbers are both `String`, and\n`invalid_count` is absent on string columns by contract. This carries the\nevidence, so a consumer can tell a textual column from one that defeated\ntype inference.\n\nCounted over the values the profiler retained \u2014 the engine's bounded\nreservoir sample on a large source, the whole column on a small or\nin-memory one. `classified_count()` against `total_count - null_count`\nis what says which happened; treat the shares as sampled whenever it is\nshort.\n\n`None` means the classification did not run, never \"one uniform class\":\na column that was classified and had nothing to classify (all-null, or\nzero rows) is `Some` with every count zero."
+          "description": "How the column's non-null values distribute across lexical classes.\n\n`data_type` cannot answer \"did this column have a dominant form?\": a\ncolumn of names and a column that is 60% numbers are both `String`, and\n`invalid_count` is absent on string columns by contract. This carries the\nevidence, so a consumer can tell a textual column from one that defeated\ntype inference.\n\nCounted over the values the profiler retained — the engine's bounded\nreservoir sample on a large source, the whole column on a small or\nin-memory one. `classified_count()` against `total_count - null_count`\nis what says which happened; treat the shares as sampled whenever it is\nshort.\n\n`None` means the classification did not run, never \"one uniform class\":\na column that was classified and had nothing to classify (all-null, or\nzero rows) is `Some` with every count zero."
         },
         "unique_count": {
           "format": "uint",
@@ -211,7 +211,7 @@
         },
         "total_cells": {
           "default": 0,
-          "description": "Total cells examined (rows \u00d7 columns). 0 means the dimension had\nnothing to assess and it is excluded from the overall score.",
+          "description": "Total cells examined (rows × columns). 0 means the dimension had\nnothing to assess and it is excluded from the overall score.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
@@ -405,6 +405,36 @@
             "source_library",
             "row_count",
             "column_count"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "In-memory byte buffer profiled without a path behind it. The buffer may\nbe text (CSV/JSON/JSONL) or binary (Parquet); `format` says which.\nDistinguished from [`DataSource::DataFrame`]: the caller handed over\nbytes, not a schema-bearing dataframe, so provenance must say so.",
+          "properties": {
+            "format": {
+              "$ref": "#/$defs/FileFormat",
+              "description": "Format the buffer was parsed as"
+            },
+            "name": {
+              "description": "Human-readable name for identification",
+              "type": "string"
+            },
+            "size_bytes": {
+              "description": "Length of the buffer handed over, not of the values decoded from it",
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": {
+              "const": "bytes",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name",
+            "format",
+            "size_bytes"
           ],
           "type": "object"
         },
@@ -616,7 +646,7 @@
         },
         "ragged_row_count": {
           "default": 0,
-          "description": "Number of data rows whose field count differed from the header's.\n\nThese rows were recovered \u2014 extra trailing fields dropped, missing\ntrailing fields padded to null \u2014 so profiling continued, but each one\nis a structural violation in the source. A nonzero value means the file\ndid not parse cleanly even though a report was produced. Additive field:\nlegacy documents without it deserialize as `0`.",
+          "description": "Number of data rows whose field count differed from the header's.\n\nThese rows were recovered — extra trailing fields dropped, missing\ntrailing fields padded to null — so profiling continued, but each one\nis a structural violation in the source. A nonzero value means the file\ndid not parse cleanly even though a report was produced. Additive field:\nlegacy documents without it deserialize as `0`.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
@@ -845,7 +875,7 @@
           ]
         },
         "outlier_count": {
-          "description": "Number of values flagged as IQR-based outliers in this column.\n\nUses the same Tukey-style detection (Q1 \u2212 k\u00b7IQR, Q3 + k\u00b7IQR with\nk = 1.5 by default) that feeds the global `accuracy.outlier_ratio`.\n`None` when outlier detection didn't run (sample below the configured\nminimum or non-numeric column).",
+          "description": "Number of values flagged as IQR-based outliers in this column.\n\nUses the same Tukey-style detection (Q1 − k·IQR, Q3 + k·IQR with\nk = 1.5 by default) that feeds the global `accuracy.outlier_ratio`.\n`None` when outlier detection didn't run (sample below the configured\nminimum or non-numeric column).",
           "format": "uint",
           "minimum": 0,
           "type": [
@@ -1076,7 +1106,7 @@
               "type": "null"
             }
           ],
-          "description": "Data quality assessment (optional \u2014 partial analysis may skip quality)"
+          "description": "Data quality assessment (optional — partial analysis may skip quality)"
         },
         "schema_version": {
           "const": 1,
@@ -1085,7 +1115,7 @@
           "type": "integer"
         },
         "semantic_hint_bindings": {
-          "description": "Per-column evidence of how each semantic hint bound to the data.\n\nEmpty when no hints were supplied. Recorded for provenance: a hint proven\ninert over the full data is rejected before a report is returned, so a\nsuccessful report only carries bindings that matched something or whose\nevidence was sampled. Additive field \u2014 older readers ignore it.",
+          "description": "Per-column evidence of how each semantic hint bound to the data.\n\nEmpty when no hints were supplied. Recorded for provenance: a hint proven\ninert over the full data is rejected before a report is returned, so a\nsuccessful report only carries bindings that matched something or whose\nevidence was sampled. Additive field — older readers ignore it.",
           "items": {
             "$ref": "#/$defs/SemanticHintBinding"
           },
@@ -2089,7 +2119,7 @@
         },
         "temporal_pairs_checked": {
           "default": 0,
-          "description": "Start/end value pairs actually compared for temporal ordering.\n`temporal_violations` is bounded by this, not by\n`date_values_checked` \u2014 the pair scan may cover columns the date\nscan does not.",
+          "description": "Start/end value pairs actually compared for temporal ordering.\n`temporal_violations` is bounded by this, not by\n`date_values_checked` — the pair scan may cover columns the date\nscan does not.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
@@ -2171,7 +2201,7 @@
       ]
     },
     "TypeHomogeneity": {
-      "description": "How a column's non-null values distribute across [`LexicalClass`]es.\n\nRaw counts rather than a share, so that a reader can state the mixture it\nactually found (\"60% numeric, 40% text\") instead of the dominant class and\nan unnamed remainder, and so a serialized report carries no rounded\nderivative of a number it does not also carry exactly.\n\nAll four counts are always present. Every field zero means the column was\nclassified and had no non-null values to classify \u2014 \"analyzed, found\nnothing\", which is not the same as an absent `type_homogeneity`.",
+      "description": "How a column's non-null values distribute across [`LexicalClass`]es.\n\nRaw counts rather than a share, so that a reader can state the mixture it\nactually found (\"60% numeric, 40% text\") instead of the dominant class and\nan unnamed remainder, and so a serialized report carries no rounded\nderivative of a number it does not also carry exactly.\n\nAll four counts are always present. Every field zero means the column was\nclassified and had no non-null values to classify — \"analyzed, found\nnothing\", which is not the same as an absent `type_homogeneity`.",
       "properties": {
         "boolean": {
           "format": "uint",

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1455,6 +1455,7 @@ def profile(
         row_count: int | None = None,
         source_type: str = "dataframe",
         source_format: str | None = None,
+        source_bytes: int | None = None,
     ) -> ProfileReport:
         rust_report = _profile_columns(
             columns,
@@ -1465,6 +1466,7 @@ def profile(
             row_count,
             source_type,
             source_format,
+            source_bytes,
         )
         return ProfileReport(rust_report)
 
@@ -1578,8 +1580,16 @@ def profile(
         else:
             raise ValueError("Unsupported bytes format. Use 'csv', 'json', 'jsonl', or 'parquet'.")
 
+        # The buffer's own length, not the decoded cells: `size_bytes` on the
+        # report is a statement about the input the caller handed over.
         return _profile_python_columns(
-            columns, f"{fmt}_bytes", skipped, row_count, "bytes", fmt
+            columns,
+            f"{fmt}_bytes",
+            skipped,
+            row_count,
+            "bytes",
+            fmt,
+            len(buffer.getvalue()),
         )
 
     # DataFrame detection via module name

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1453,9 +1453,18 @@ def profile(
         default_name: str,
         error_count: int = 0,
         row_count: int | None = None,
+        source_type: str = "dataframe",
+        source_format: str | None = None,
     ) -> ProfileReport:
         rust_report = _profile_columns(
-            columns, name or default_name, max_rows, _df_config(), error_count, row_count
+            columns,
+            name or default_name,
+            max_rows,
+            _df_config(),
+            error_count,
+            row_count,
+            source_type,
+            source_format,
         )
         return ProfileReport(rust_report)
 
@@ -1569,7 +1578,9 @@ def profile(
         else:
             raise ValueError("Unsupported bytes format. Use 'csv', 'json', 'jsonl', or 'parquet'.")
 
-        return _profile_python_columns(columns, f"{fmt}_bytes", skipped, row_count)
+        return _profile_python_columns(
+            columns, f"{fmt}_bytes", skipped, row_count, "bytes", fmt
+        )
 
     # DataFrame detection via module name
     source_module = type(source).__module__ or ""

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -394,6 +394,8 @@ def profile_columns(
     config: ProfilerConfig | None,
     error_count: int = 0,
     row_count: int | None = None,
+    source_type: str = "dataframe",
+    source_format: str | None = None,
 ) -> ProfileReport: ...
 def profile_parquet_bytes(
     data: bytes,

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -396,6 +396,7 @@ def profile_columns(
     row_count: int | None = None,
     source_type: str = "dataframe",
     source_format: str | None = None,
+    source_bytes: int | None = None,
 ) -> ProfileReport: ...
 def profile_parquet_bytes(
     data: bytes,

--- a/python/tests/test_parquet_bytes_parity.py
+++ b/python/tests/test_parquet_bytes_parity.py
@@ -186,6 +186,54 @@ def test_bytes_report_is_labelled_as_an_in_memory_source(tmp_path):
     assert "pandas" not in report.source
 
 
+@pytest.mark.parametrize(
+    ("payload", "fmt"),
+    [
+        (b"id,name\n1,alice\n2,bob\n", "csv"),
+        (b'{"id": [1, 2], "name": ["alice", "bob"]}', "json"),
+        (b'{"id": 1}\n{"id": 2}\n', "jsonl"),
+    ],
+)
+def test_every_bytes_format_reports_the_bytes_source_type(payload, fmt):
+    """`source_type` changed for all four byte inputs, not just Parquet, and
+    each takes a different route into the report — the text formats decode in
+    Python and go through `profile_columns`, Parquet goes through the Rust
+    reader. Cover the three that share the first route."""
+    report = dp.profile(payload, format=fmt)
+
+    assert report.source_type == "bytes"
+    assert f"{fmt}_bytes" in report.source
+
+
+def test_a_real_dataframe_still_reports_dataframe():
+    """The control for the case above: `bytes` must not have swallowed the
+    dataframe label on the path that shares the same entry point."""
+    report = dp.profile({"id": ["1", "2"], "name": ["alice", "bob"]})
+
+    assert report.source_type == "dataframe"
+
+
+def test_a_bytes_source_cannot_be_built_without_the_buffer_length():
+    """`size_bytes` is a statement about the input handed over, and the decoded
+    cells are not it — quoting, delimiters and encoding all move the number, and
+    Parquet is off by the compression ratio. The entry point refuses to guess
+    rather than record a plausible wrong size."""
+    from dataprof._dataprof import profile_columns
+
+    with pytest.raises(ValueError, match="source_bytes"):
+        profile_columns(
+            [("id", ["1", "2"])],
+            "csv_bytes",
+            None,
+            None,
+            0,
+            None,
+            "bytes",
+            "csv",
+            None,
+        )
+
+
 def test_name_overrides_the_default_label(tmp_path):
     data = _write(tmp_path, pa.table({"id": [1, 2]})).read_bytes()
     assert "orders" in dp.profile(data, format="parquet", name="orders").source

--- a/python/tests/test_parquet_bytes_parity.py
+++ b/python/tests/test_parquet_bytes_parity.py
@@ -178,10 +178,10 @@ def test_a_buffer_that_is_not_parquet_fails_like_the_file_path(tmp_path):
 
 
 def test_bytes_report_is_labelled_as_an_in_memory_source(tmp_path):
-    """A buffer has no path, so it reports the in-memory shape, not a fake one."""
+    """A buffer has no path, so it reports the byte-buffer shape, not a fake one."""
     data = _write(tmp_path, pa.table({"id": [1, 2]})).read_bytes()
     report = dp.profile(data, format="parquet")
-    assert report.source_type == "dataframe"
+    assert report.source_type == "bytes"
     assert "parquet_bytes" in report.source
     assert "pandas" not in report.source
 


### PR DESCRIPTION
## Summary

Byte-buffer inputs (CSV/JSON/JSONL/Parquet) reported `source_type = "dataframe"`, misleading consumers that branch on the typed field — the buffers were never dataframes. This adds a `"bytes"` source type so provenance is honest (gh #548, option 1).

## Changes

- `DataSource` gains a `Bytes { name, format, size_bytes }` variant with serde tag `"bytes"`, `identifier()` as `python[{name}]`, `size_mb()`, and `is_bytes()`.
- The Python `source_type` getter returns `"bytes"` for that variant; `PythonSourceType` (runtime schema doc) gains `Bytes`.
- The Parquet in-memory origin and `profile_columns`' byte-buffer path now build `DataSource::Bytes`; real pandas/polars/pyarrow dataframes stay `"dataframe"`.
- `profile_columns` gains optional `source_type`/`source_format` parameters (defaults preserve the dataframe path); the Python `dp.profile` bytes dispatch passes them.
- `docs/schema/profile-report.v1.schema.json` includes `"bytes"` in `PythonSourceType`; the README records the additive v1 change.
- `to_llm_context()` now reads `python[csv_bytes] (bytes)` for byte inputs.

## Validation

- `cargo test -p dataprof-core` — 141 passed (incl. new Bytes identifier/size tests)
- `cargo test -p dataprof-parquet` / `-p dataprof-engines` / `-p dataprof-runtime` — all green
- `cargo check -p dataprof-python` — clean
- Updated `test_parquet_bytes_parity.py` to assert `source_type == "bytes"` (runs in the hosted matrix, which builds the wheel)
- `cargo fmt --all -- --check` and `git diff --check` — clean


Closes #548
