### PR TITLE
fix(schema): serialize report mapping fields in deterministic order

### DIFF
--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -109,7 +109,7 @@ pub struct PyColumnProfile {
     #[pyo3(get)]
     pub coefficient_of_variation: Option<f64>,
     #[pyo3(get)]
-    pub quartiles: Option<std::collections::HashMap<String, f64>>,
+    pub quartiles: Option<std::collections::BTreeMap<String, f64>>,
     #[pyo3(get)]
     pub is_approximate: Option<bool>,
     #[pyo3(get)]
@@ -168,7 +168,7 @@ impl From<&ColumnProfile> for PyColumnProfile {
         ) = match &profile.stats {
             ColumnStats::Numeric(n) => {
                 let q_map = n.quartiles.as_ref().map(|q| {
-                    let mut m = std::collections::HashMap::new();
+                    let mut m = std::collections::BTreeMap::new();
                     m.insert("q1".to_string(), q.q1);
                     m.insert("q2".to_string(), q.q2);
                     m.insert("q3".to_string(), q.q3);
@@ -432,9 +432,9 @@ impl PyDataQualityMetrics {
 
     /// Relative weights used by the aggregate quality score.
     #[getter]
-    fn score_weights(&self) -> std::collections::HashMap<String, f64> {
+    fn score_weights(&self) -> std::collections::BTreeMap<String, f64> {
         let weights = self.inner.score_weights;
-        std::collections::HashMap::from([
+        std::collections::BTreeMap::from([
             ("completeness".to_string(), weights.completeness),
             ("consistency".to_string(), weights.consistency),
             ("uniqueness".to_string(), weights.uniqueness),
@@ -452,12 +452,12 @@ impl PyDataQualityMetrics {
     fn completeness(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .completeness
             .as_ref()
             .map(|c| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "missing_values_ratio".into(),
                     c.missing_values_ratio
@@ -494,12 +494,12 @@ impl PyDataQualityMetrics {
     fn consistency(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .consistency
             .as_ref()
             .map(|c| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "data_type_consistency".into(),
                     c.data_type_consistency
@@ -529,12 +529,12 @@ impl PyDataQualityMetrics {
     fn uniqueness(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .uniqueness
             .as_ref()
             .map(|u| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "duplicate_rows".into(),
                     u.duplicate_rows.into_pyobject(py)?.unbind().into_any(),
@@ -581,12 +581,12 @@ impl PyDataQualityMetrics {
     fn accuracy(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .accuracy
             .as_ref()
             .map(|a| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "outlier_ratio".into(),
                     a.outlier_ratio.into_pyobject(py)?.unbind().into_any(),
@@ -619,12 +619,12 @@ impl PyDataQualityMetrics {
     fn timeliness(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .timeliness
             .as_ref()
             .map(|t| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "future_dates_count".into(),
                     t.future_dates_count.into_pyobject(py)?.unbind().into_any(),
@@ -662,12 +662,12 @@ impl PyDataQualityMetrics {
     fn validity(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .validity
             .as_ref()
             .map(|v| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "valid_values_ratio".into(),
                     v.valid_values_ratio.into_pyobject(py)?.unbind().into_any(),
@@ -690,12 +690,12 @@ impl PyDataQualityMetrics {
     fn precision(
         &self,
         py: Python<'_>,
-    ) -> PyResult<Option<std::collections::HashMap<String, Py<PyAny>>>> {
+    ) -> PyResult<Option<std::collections::BTreeMap<String, Py<PyAny>>>> {
         self.inner
             .precision
             .as_ref()
             .map(|p| -> PyResult<_> {
-                let mut m = std::collections::HashMap::new();
+                let mut m = std::collections::BTreeMap::new();
                 m.insert(
                     "decimal_places_consistency".into(),
                     p.decimal_places_consistency
@@ -742,8 +742,8 @@ impl PyDataQualityMetrics {
 
     /// Per-dimension scores (0-100). A dimension maps to None when it was
     /// not computed or had nothing to assess.
-    fn dimension_scores(&self) -> std::collections::HashMap<String, Option<f64>> {
-        std::collections::HashMap::from([
+    fn dimension_scores(&self) -> std::collections::BTreeMap<String, Option<f64>> {
+        std::collections::BTreeMap::from([
             ("completeness".to_string(), self.inner.completeness_score()),
             ("consistency".to_string(), self.inner.consistency_score()),
             ("uniqueness".to_string(), self.inner.uniqueness_score()),

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -219,7 +219,7 @@ struct PythonPatternDocument {
 struct PythonQualityDocument {
     overall_score: f64,
     assessed_dimensions: Vec<PythonQualityDimension>,
-    dimension_scores: std::collections::HashMap<PythonQualityDimension, Option<f64>>,
+    dimension_scores: std::collections::BTreeMap<PythonQualityDimension, Option<f64>>,
     low_sample_warning: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     completeness: Option<CompletenessMetrics>,
@@ -238,7 +238,9 @@ struct PythonQualityDocument {
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 enum PythonQualityDimension {
     Completeness,

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -14,6 +14,7 @@ import importlib.util
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -2963,24 +2964,30 @@ class TestSemanticHintValidation:
 
 
 def test_to_json_is_byte_stable_for_unchanged_input(tmp_path):
-    """Two profiles of the same file serialize identically once execution
-    timings are masked — mapping fields must not reorder between runs (gh #546)."""
-    import json
-    import re
+    """Profiling one unchanged file twice must produce identical JSON bytes
+    once the three timing-dependent execution fields are masked (gh #546).
 
+    The comparison is deliberately on the raw strings. Parsing to dicts first,
+    or sorting keys while comparing, erases the very thing at issue: mapping
+    fields backed by a Rust ``HashMap`` came out in a different order on every
+    run, and a dict comparison cannot see that.
+    """
     p = tmp_path / "stable.csv"
     p.write_text("name,age,salary\nAlice,30,50000\nBob,25,60000\nCarol,35,70000\n")
 
-    a = json.loads(dataprof.profile(str(p)).to_json())
-    b = json.loads(dataprof.profile(str(p)).to_json())
+    # Only the measured-duration fields may differ between two runs of the same
+    # input. Everything else, values included, is expected to be reproducible.
+    volatile = re.compile(r'"(scan_time_ms|throughput_rows_sec|memory_peak_mb)": [^,\n}]+')
 
-    def mask(obj):
-        if isinstance(obj, dict):
-            return {k: mask(v) for k, v in sorted(obj.items())}
-        if isinstance(obj, list):
-            return [mask(v) for v in obj]
-        if isinstance(obj, (int, float)):
-            return "<num>"
-        return obj
+    assert volatile.search(dataprof.profile(str(p)).to_json()), (
+        "the mask matched nothing; the execution field names changed and this "
+        "test would compare unmasked timings"
+    )
 
-    assert mask(a) == mask(b)
+    # Five runs, not two: HashMap ordering is randomized per instance, so a
+    # single pair can coincide by luck.
+    rendered = {
+        volatile.sub(r'"\1": <masked>', dataprof.profile(str(p)).to_json()) for _ in range(5)
+    }
+
+    assert len(rendered) == 1, f"to_json() rendered {len(rendered)} different documents"

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -2960,3 +2960,27 @@ class TestSemanticHintValidation:
         report = dataprof.profile({"pressure": ["1", "2", "3"]})
         assert report.semantic_hint_bindings == []
         assert "semantic_hint_bindings" not in report.to_dict()
+
+
+def test_to_json_is_byte_stable_for_unchanged_input(tmp_path):
+    """Two profiles of the same file serialize identically once execution
+    timings are masked — mapping fields must not reorder between runs (gh #546)."""
+    import json
+    import re
+
+    p = tmp_path / "stable.csv"
+    p.write_text("name,age,salary\nAlice,30,50000\nBob,25,60000\nCarol,35,70000\n")
+
+    a = json.loads(dataprof.profile(str(p)).to_json())
+    b = json.loads(dataprof.profile(str(p)).to_json())
+
+    def mask(obj):
+        if isinstance(obj, dict):
+            return {k: mask(v) for k, v in sorted(obj.items())}
+        if isinstance(obj, list):
+            return [mask(v) for v in obj]
+        if isinstance(obj, (int, float)):
+            return "<num>"
+        return obj
+
+    assert mask(a) == mask(b)


### PR DESCRIPTION
## Summary

Profiling the same file twice produced two different JSON documents: only execution timings differ in values, but mapping fields (`quartiles`, `dimension_scores`, `score_weights`, and the per-dimension sub-mappings) reordered on every call because they were `HashMap`s with per-instance seed randomization (gh #546).

## Changes

- `crates/dataprof-python/src/types.rs`: all report-facing map types and their local builders are now `BTreeMap` (22 sites). The file already had this exact rationale for `type_homogeneity`; this extends it to the remaining churn sites.
- `crates/dataprof-runtime/src/profile_report.rs`: `PythonQualityDocument.dimension_scores` is now `BTreeMap<PythonQualityDimension, Option<f64>>`, with `PartialOrd + Ord` added to the dimension enum.

`BTreeMap` keeps the change dependency-free and pins the emitted order into the published schema (alphabetical by key); the existing `BTreeMap` precedent made this the consistent choice over adding `indexmap`.

## Validation

- `cargo test -p dataprof-core -p dataprof-runtime` — 191 passed
- `cargo check -p dataprof-python` — clean (local dylib link stays blocked by the pre-existing macOS toolchain mismatch)
- New Python test `test_to_json_is_byte_stable_for_unchanged_input` asserts two profiles of one fixture serialize identically after masking execution numbers (runs in the hosted matrix, which builds the wheel)
- `cargo fmt --all -- --check` and `git diff --check` — clean


Closes #546
