### PR TITLE
feat(python): ship async and HTTP profiling in the default wheel

### DIFF
--- a/.github/scripts/wheel_smoke.py
+++ b/.github/scripts/wheel_smoke.py
@@ -2,8 +2,12 @@
 
 This runs against an *installed wheel*, not an editable build, and asserts the
 base-wheel contract: everything here must work with zero Python dependencies
-and no source build. Anything that needs pandas, a compiled async extension, or
-a database connector belongs in the regular pytest suite, not here.
+and no source build. Anything that needs pandas or a database connector belongs
+in the regular pytest suite, not here.
+
+The async/HTTP surface IS part of that contract as of the feature set shipped by
+`[tool.maturin] features` in pyproject.toml, so it is asserted here rather than
+left to a build that enables it explicitly.
 
 Run it from a directory outside the repository, so that `import dataprof`
 resolves to the installed package rather than the `python/dataprof` sources::
@@ -168,6 +172,46 @@ def acceptance_agent_output_is_redacted(workdir: Path) -> None:
     )
 
 
+def acceptance_async_is_in_the_base_wheel(workdir: Path) -> None:
+    """Async, URL and remote-Parquet support ship in the wheel; database does not.
+
+    Asserted against the installed artifact because `capabilities()` reads
+    compile-time cfg flags: a feature-list drift between pyproject.toml and the
+    release workflow, or a cfg-gating mistake, would otherwise ship a wheel
+    missing these exports with nothing failing.
+    """
+    print("acceptance: async is in the base wheel")
+    caps = dp.capabilities()
+    check(caps.async_streaming, "capabilities() reports async_streaming")
+    check(caps.url_profiling, "capabilities() reports url_profiling")
+    check(caps.remote_parquet, "capabilities() reports remote_parquet")
+
+    # The deliberate other half of the contract (#588): database connectors are
+    # NOT shipped while their decode path still records DECIMAL/temporal/UUID/
+    # BLOB columns as null (#365) and returns no quality block (#554).
+    check(not caps.database, "capabilities() reports database is absent")
+    check(caps.database_connectors == (), "no database connectors are compiled in")
+
+    # The compiled export, not just the flag: profile_url_async is what
+    # parquet-async/async-streaming actually add to the extension module.
+    from dataprof._dataprof import profile_url_async  # noqa: F401
+
+    check(True, "profile_url_async is exported by the extension")
+
+    # Importing dataprof.asyncio proves nothing: the module and its function
+    # objects import fine on a wheel with no async support, and the ImportError
+    # is deferred to call time. So call it.
+    import asyncio
+
+    from dataprof.asyncio import profile_file
+
+    src = workdir / "async.csv"
+    src.write_text("a,b\n1,2\n3,4\n", encoding="utf-8")
+    report = asyncio.run(profile_file(str(src)))
+    check(report.rows == 2, "async profile_file() reads 2 rows")
+    check(report.columns == 2, "async profile_file() reads 2 columns")
+
+
 def main() -> int:
     print(f"dataprof {dp.__version__} from {Path(dp.__file__).parent}")
     if Path(dp.__file__).resolve().parents[1].name == "python":
@@ -182,6 +226,7 @@ def main() -> int:
         acceptance_parquet_needs_no_dependencies(workdir)
         acceptance_export_reload_compare(workdir)
         acceptance_agent_output_is_redacted(workdir)
+        acceptance_async_is_in_the_base_wheel(workdir)
 
     print("\nwheel smoke passed")
     return 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,6 +365,11 @@ jobs:
             target: aarch64
             cpu_profile: baseline
             rustflags: "-C target-cpu=generic -C opt-level=2"
+            # manylinux2014's aarch64 cross image ships GCC 4.8.5, which does
+            # not define __ARM_ARCH; ring's assembly refuses to build without
+            # it and upstream closed that WONTFIX (briansmith/ring#1728).
+            # 2_28 ships GCC 7.5. Raises this arch's glibc floor 2.17 -> 2.28.
+            manylinux: '2_28'
           - os: windows-latest
             target: x64
             cpu_profile: baseline
@@ -376,7 +381,11 @@ jobs:
           - os: macos-latest
             target: aarch64
             cpu_profile: baseline
-            rustflags: "-C target-cpu=generic -C opt-level=2"
+            # No -C target-cpu: `generic` strips neon/aes/sha2/pmull, which
+            # ring asserts are statically present on aarch64-apple-darwin
+            # (src/cpu/arm/darwin.rs). Every arm64 Mac has them, so `generic`
+            # bought no compatibility and cost performance.
+            rustflags: "-C opt-level=2"
 
           # Optimized builds (performance optimized)
           - os: ubuntu-latest
@@ -406,9 +415,9 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        args: --release --out dist --find-interpreter --features python
+        args: --release --out dist --find-interpreter --features python,python-async,async-streaming,parquet-async
         sccache: 'true'
-        manylinux: auto
+        manylinux: ${{ matrix.manylinux || 'auto' }}
         # Ensure compatibility flags are properly set
         rust-toolchain: stable
       env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,11 @@ dev = [
 ]
 
 [tool.maturin]
-features = ["python"]
+# Kept in sync with the --features list in .github/workflows/release.yml.
+# The duplication is tracked by #589; until it is removed, changing one
+# without the other makes `pip install dataprof` and
+# `pip install --no-binary dataprof` differ in capability, silently.
+features = ["python", "python-async", "async-streaming", "parquet-async"]
 manifest-path = "crates/dataprof-python/Cargo.toml"
 module-name = "dataprof._dataprof"
 python-source = "python"


### PR DESCRIPTION
Closes #587

These features are now deemed 'good enough' for straight pypi availability. `dataprof.asyncio`, `profile_url_async` and remote Parquet are documented in `docs/python/README.md`

## Changes

**`pyproject.toml`** and **`release.yml`**: shipped feature set becomes `python,python-async,async-streaming,parquet-async`.

**`release.yml`, Linux aarch64 baseline leg**: `manylinux: 2_28`.

**`release.yml`, macOS aarch64 baseline leg**: drop `-C target-cpu=generic`.

The last two are pre-existing defects, dormant until `rustls` enters the dependency graph. They are fixed here because enabling async is what triggers them, and shipping the feature without them breaks two wheels on the next release. Both were reproduced and verified fixed in #586.

## ⚠️ aarch64 glibc floor moves 2.17 → 2.28

`manylinux2014`'s aarch64 cross image ships GCC 4.8.5, which does not define `__ARM_ARCH`. ring's assembly hard-errors without it, and upstream closed that WONTFIX ([briansmith/ring#1728](https://github.com/briansmith/ring/issues/1728)), so a newer image is the fix rather than a workaround.

This drops CentOS/RHEL 7 and Ubuntu before 18.10 **on aarch64 only**; x86_64 stays on manylinux2014. All dropped platforms are EOL (RHEL 7 ended June 2024). Linux aarch64 skews modern in practice: Graviton, Docker on Apple Silicon, recent Pi OS.

**This needs to be called out in 0.11.0's release notes.** I did not edit `docs/release-notes.md`, which describes 0.10.0 and is rewritten per release.

## Size

3.72 → 5.25 MiB on Linux x86_64, cp310, against the published 0.10.0 wheel. 1.41x. Still zero Python dependencies; the growth is statically linked Rust.

Database is deliberately excluded (#588): #365 silently records `DECIMAL`/temporal/`UUID`/`BLOB` columns as null and #554 leaves `quality = None`. It is also the expensive half, +1.79 MiB marginal.

## Validation

Built locally with **no** explicit `--features`, confirming `pyproject.toml` drives it:

```
{"async_streaming": true, "url_profiling": true, "remote_parquet": true,
 "database": false, "database_connectors": []}
async profile OK: 2 rows, 2 cols
```

- `uv run pytest python/tests/` → **964 passed, 9 skipped** (all 9 database-gated, expected)
- `uv run pytest python/tests/test_async_url_api.py` → **10 passed** against the default build, which previously required a source build

The matrix changes themselves were validated in #586 across all five release targets with the full feature set. This PR ships a strict subset of that set, so the build is covered; what is not independently re-run is async-only on aarch64 and macOS specifically.

No Rust or Python source changed, so `cargo fmt`/`clippy`/`ruff`/`ty` are unaffected.

## Not in scope

`pyproject.toml` and `release.yml` now state the feature list twice and must agree. That duplication is #589; I added a comment at both sites rather than fixing it here.
