### PR TITLE
ci: stop building the Rust extension in the Python lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,16 +179,26 @@ jobs:
             pyproject.toml
             uv.lock
 
+      # Plain `uv run` syncs the project first, which compiles the Rust
+      # extension through the PEP 517 backend. Nothing here needs it: ruff
+      # reads source, and ty resolves the native module from the checked-in
+      # .pyi stubs. It is not free either — when #595 added async-streaming
+      # and parquet-async to [tool.maturin] features, rustls/tokio/reqwest
+      # entered the graph and the build alone took 5m06s, overrunning this
+      # job's 5-minute timeout (which GitHub reports as "cancelled").
+      - name: Install dev tools
+        run: uv sync --no-install-project
+
       - name: Check formatting
-        run: uv run ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/
+        run: uv run --no-sync ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/
 
       - name: Lint
-        run: uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
+        run: uv run --no-sync ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
 
       # ty is pre-1.0 (Astral's type checker) but the codebase passes it, so
       # keep it blocking to prevent regressions.
       - name: Type check (ty)
-        run: uv run ty check python/
+        run: uv run --no-sync ty check python/
 
   python-tests:
     name: Python Tests


### PR DESCRIPTION
## Problem

`Python Lint & Format` has been failing as `cancelled` since #595 merged. It is not a lint error — it is the 5-minute job timeout, which GitHub surfaces as a cancelled job rather than a timeout.

`uv run` syncs the project before running, which compiles the Rust extension through the PEP 517 backend. #595 added `async-streaming` and `parquet-async` to `[tool.maturin] features`, pulling rustls/tokio/reqwest into the graph, and the build alone now costs ~5 minutes:

```
11:39:33  Downloaded pandas
11:44:39  Built dataprof @ file:///home/runner/work/dataprof/dataprof   <- 5m06s
11:44:39  43 files already formatted
11:44:39  ##[error]The operation was canceled.
```

The job sits on the boundary rather than being deterministically broken, so it fails intermittently depending on runner speed:

| run | duration | result |
| --- | --- | --- |
| #570 (same feature list) | 4m44s | success, 16s of margin |
| master push of #595 | 5m13s | killed at the timeout |

## Fix

The job never needed the extension: ruff reads source, and `ty` resolves the native module from the checked-in `python/dataprof/*.pyi` stubs. Sync with `--no-install-project` and run the three checks with `--no-sync`, matching the pattern already used by `python-wheel-smoke`.

## Verification

Uninstalled the project from `.venv` (`uv sync --no-install-project`), then ran each check against a venv with no compiled extension present:

```
uv run --no-sync ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/   # 43 files already formatted
uv run --no-sync ruff check  python/ .github/scripts/ .claude/skills/dataprof/scripts/           # All checks passed!
uv run --no-sync ty check python/                                                                # All checks passed! (3.4s)
```

All three pass, confirming the build step was pure overhead rather than a dependency of the checks.
