### PR TITLE
ci: give feature-checks room to survive a cold cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,14 @@ jobs:
   feature-checks:
     name: Feature Checks (${{ matrix.scope }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Same cold-cache trap as python-wheel-smoke below. A dependency bump
+    # changes Cargo.lock and so the rust-cache key, and the all-features-crates
+    # scope builds four feature graphs back to back: warm it is ~3m, cold it
+    # needed ~21m on the #566 parquet bump. At 20 the tests all passed and the
+    # job was killed 87s later during the post-job cache save, so nothing was
+    # written — leaving the next run on that same lockfile cold too. The
+    # timeout has to clear the build *and* the save, or the job cannot recover.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

The CI run on `d8f0405` (the #566 parquet merge) came back `cancelled`. The cancelled job is `Feature Checks (all-features-crates)`, and it is a timeout, not a test failure.

All four cargo commands passed:

```
Finished `test` profile in 9m 16s   -> 17 passed
Finished `test` profile in 4m 56s   -> 39 passed
Finished `test` profile in 3m 54s   -> 34 passed
Finished `test` profile in 15.01s   -> 45 passed, 4 passed
14:13:32  last test result: ok
14:14:59  ##[error]The operation was canceled.
```

The work finished at 18m34s. The job was killed 87 seconds later, during the post-job cache save, against `timeout-minutes: 20`.

## Why now

The job log opens with `No cache found.` — a dependency bump changes `Cargo.lock` and therefore the rust-cache key, so every dependency PR gets one cold run of ~400 crates. The same job took **3m16s on `850e012`** with a warm cache.

The part that makes this worth fixing rather than re-running: rust-cache only writes on success. A timeout means nothing is stored, so the next run on that same lockfile is cold too, and the job does not recover on its own. This is the identical trap already documented for `python-wheel-smoke`, which was raised to 35 for it.

## Fix

Raise the cap to 35, matching `python-wheel-smoke`. The budget has to clear the build *and* the cache save, not just the build.

Cold cost measured at ~21m, so this leaves roughly 14 minutes of headroom for a slower runner. Warm runs are unaffected at ~3m.

## Verification

`ci.yml` parses and job timeouts are as intended:

```
test-suite: 30          python-quality: 5        examples-smoke: 20
quality-checks: 10      python-tests: 15         python-async-url-tests: 15
feature-checks: 35      python-wheel-smoke: 35   db-integration-tests: 20
                                                 python-db-tests: 20
```

Note this PR's own `feature-checks` run does not exercise the cold path — it does not touch `Cargo.lock`, so it restores the warm cache and finishes in ~3m. The cold path gets exercised by the next dependency bump, which is what #567 will do.
