### PR TITLE
fix(python): assess quality by default on database queries

### DIFF
--- a/crates/dataprof-python/src/database_async.rs
+++ b/crates/dataprof-python/src/database_async.rs
@@ -23,7 +23,8 @@ use dataprof::{
 /// * `connection_string` - Database connection string (postgres://, mysql://, sqlite://)
 /// * `query` - SQL query to analyze
 /// * `batch_size` - Optional batch size for streaming (default: 10000)
-/// * `calculate_quality` - Whether to calculate quality metrics (default: false)
+/// * `calculate_quality` - Legacy coarse toggle. Left unset, quality is computed,
+///   which is what every file path does; `False` drops the quality pack
 /// * `config` - Optional profiler config carrying `metrics`, `quality_dimensions`,
 ///   and `locale`, honoured the same way every file path honours them
 ///
@@ -41,7 +42,6 @@ use dataprof::{
 ///         "postgresql://user:pass@localhost/db",
 ///         "SELECT * FROM users LIMIT 1000",
 ///         batch_size=1000,
-///         calculate_quality=True,
 ///         config=ProfilerConfig(locale="IT"),
 ///     )
 ///     print(result)
@@ -49,13 +49,13 @@ use dataprof::{
 /// asyncio.run(analyze_db())
 /// ```
 #[pyfunction]
-#[pyo3(signature = (connection_string, query, batch_size=10000, calculate_quality=false, config=None))]
+#[pyo3(signature = (connection_string, query, batch_size=10000, calculate_quality=None, config=None))]
 pub fn analyze_database_async<'py>(
     py: Python<'py>,
     connection_string: String,
     query: String,
     batch_size: usize,
-    calculate_quality: bool,
+    calculate_quality: Option<bool>,
     config: Option<&PyProfilerConfig>,
 ) -> PyResult<Bound<'py, PyAny>> {
     if batch_size == 0 {
@@ -70,12 +70,13 @@ pub fn analyze_database_async<'py>(
         let selected = config
             .map(PyProfilerConfig::analysis_options)
             .unwrap_or_default();
-        if calculate_quality {
-            selected
-        } else {
-            // `calculate_quality=False` is the older, coarser way to say "no
-            // quality pack"; express it as a pack so one value carries the
-            // whole selection from here on.
+        // Unset means "whatever the selection says", and an unnarrowed selection
+        // includes quality — the same default every file path applies. Only an
+        // explicit `False` drops the pack, and it is the older, coarser way to
+        // say so; express it as a pack so one value carries the whole selection
+        // from here on. `True` adds nothing back: `metrics=["schema"]` stays a
+        // schema-only profile.
+        if calculate_quality == Some(false) {
             let packs = selected
                 .effective_metric_packs()
                 .unwrap_or_else(MetricPack::all)
@@ -83,6 +84,8 @@ pub fn analyze_database_async<'py>(
                 .filter(|pack| *pack != MetricPack::Quality)
                 .collect();
             selected.with_metric_packs(Some(packs))
+        } else {
+            selected
         }
     };
     #[cfg(not(all(feature = "database", feature = "python-async")))]

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -57,7 +57,6 @@ async def main():
         "postgres://user:pass@localhost/mydb",
         "SELECT * FROM users",
         batch_size=10000,
-        calculate_quality=True,
     )
     print(f"{report.rows} rows, quality: {report.quality_score}")
 

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -304,7 +304,6 @@ async def main():
         "postgres://user:pass@localhost/mydb",
         "SELECT * FROM users WHERE active = true",
         batch_size=5000,
-        calculate_quality=True,
     )
     print(f"{report.rows} rows, quality: {report.quality_score}")
 
@@ -543,7 +542,6 @@ async def main():
     db_report = await dp.analyze_database_async(
         "postgres://ro:pass@prod/app",
         "SELECT * FROM users",
-        calculate_quality=True,
     )
 
     print(f"File: {file_report.rows} rows, quality={file_report.quality_score:.2f}")

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -344,7 +344,6 @@ Build the Python extension from source with `python-async,database` and the conn
 report = await dp.analyze_database_async(
     "postgres://user:pass@localhost/mydb",
     "SELECT * FROM users",
-    calculate_quality=True,
 )
 ```
 

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -699,7 +699,6 @@ async def main():
         "postgres://user:pass@localhost/mydb",
         "SELECT * FROM users",
         batch_size=10000,
-        calculate_quality=True,
     )
     print(f"{report.rows} rows, quality: {report.quality_score}")
 

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -69,15 +69,16 @@ try:
         connection_string: str,
         query: str,
         batch_size: int = 10000,
-        calculate_quality: bool = False,
+        calculate_quality: bool | None = None,
         config: _Any | None = None,
     ) -> ProfileReport:
         """Profile the rows returned by ``query``.
 
         ``config`` takes a :class:`ProfilerConfig` carrying ``metrics``,
         ``quality_dimensions``, and ``locale``; they apply here exactly as they
-        do on every file path. ``calculate_quality=False`` remains the coarse
-        way to drop the quality pack.
+        do on every file path. Quality is assessed by default, as it is on
+        every file path; ``calculate_quality=False`` remains the coarse way to
+        drop the quality pack.
 
         The native call yields a raw core report; wrap it so the result carries
         the same surface as every other ``ProfileReport`` in this package.

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -280,7 +280,7 @@ async def analyze_database_async(
     connection_string: str,
     query: str,
     batch_size: int = 10000,
-    calculate_quality: bool = False,
+    calculate_quality: bool | None = None,
     config: ProfilerConfig | None = None,
 ) -> ProfileReport: ...
 async def count_table_rows_async(connection_string: str, table_name: str) -> int: ...

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -423,7 +423,7 @@ async def analyze_database_async(
     connection_string: str,
     query: str,
     batch_size: int = 10000,
-    calculate_quality: bool = False,
+    calculate_quality: bool | None = None,
     config: ProfilerConfig | None = None,
 ) -> ProfileReport: ...
 async def count_table_rows_async(connection_string: str, table_name: str) -> int: ...

--- a/python/tests/test_database_api.py
+++ b/python/tests/test_database_api.py
@@ -92,6 +92,13 @@ class TestDatabaseAnalysis:
         assert len(report.column_profiles) == 5  # id, name, email, age, salary
         assert report.source_type == "query"
 
+    def test_analyze_assesses_quality_by_default(self, sqlite_db):
+        # #554: a query used to come back with quality = None unless the caller
+        # knew about the flag, while every file path assessed quality by default.
+        report = _run(analyze_database_async, sqlite_db, "SELECT * FROM test_users")
+        assert report.quality is not None, "a database profile must assess quality by default"
+        assert report.quality_score is not None
+
     def test_analyze_with_quality(self, sqlite_db):
         report = _run(
             analyze_database_async,

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -91,19 +91,26 @@ def _run(async_fn, *args, **kwargs):
     return asyncio.run(_inner())
 
 
-def _profile_query(db_path, query: str = QUERY, **config_kwargs):
+def _profile_query(db_path, **config_kwargs):
     """Profile the fixture query, leaving the quality toggle unset by default."""
     calculate_quality = config_kwargs.pop("calculate_quality", None)
     config = ProfilerConfig(**config_kwargs) if config_kwargs else None
     report = _run(
         analyze_database_async,
         str(db_path),
-        query,
+        QUERY,
         10000,
         calculate_quality,
         config,
     )
     return dp.ProfileReport(report)
+
+
+def _profile_rich_query(db_path):
+    """Profile the quality-parity fixture, with every option left at its default."""
+    return dp.ProfileReport(
+        _run(analyze_database_async, str(db_path), RICH_QUERY, 10000, None, None)
+    )
 
 
 @pytest.fixture()
@@ -225,9 +232,11 @@ def test_quality_is_assessed_by_default(sqlite_db) -> None:
 def test_default_quality_matches_the_same_rows_on_disk(rich_sqlite_db, rich_csv_file) -> None:
     # The output contract: the numbers do not depend on which path produced
     # them. Compares every dimension score plus the overall, not just presence.
-    db_report = _profile_query(rich_sqlite_db, query=RICH_QUERY)
+    db_report = _profile_rich_query(rich_sqlite_db)
     csv_report = dp.profile(rich_csv_file)
 
+    assert db_report.quality is not None, "a query must assess quality by default"
+    assert csv_report.quality is not None
     assert set(db_report.quality.assessed_dimensions()) == QUALITY_DIMENSIONS
     assert set(csv_report.quality.assessed_dimensions()) == QUALITY_DIMENSIONS
 

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -58,8 +58,8 @@ def _run(async_fn, *args, **kwargs):
 
 
 def _profile_query(db_path, **config_kwargs):
-    """Profile the fixture query, with quality on unless a test says otherwise."""
-    calculate_quality = config_kwargs.pop("calculate_quality", True)
+    """Profile the fixture query, leaving the quality toggle unset by default."""
+    calculate_quality = config_kwargs.pop("calculate_quality", None)
     config = ProfilerConfig(**config_kwargs) if config_kwargs else None
     report = _run(
         analyze_database_async,
@@ -141,6 +141,51 @@ def test_locale_reaches_pattern_detection_and_matches_csv(sqlite_db, csv_file) -
     assert localized == _pattern_names(dp.profile(csv_file, locale="IT"), "cap"), (
         "a query and a CSV holding the same rows disagree on locale-ranked patterns"
     )
+
+
+def _quality_row(report) -> dict:
+    """The quality half of ``quality_summary``, without the source-specific keys."""
+    row = report.quality_summary()
+    for key in ("source", "execution_time_ms"):
+        row.pop(key, None)
+    return row
+
+
+def test_quality_is_assessed_by_default(sqlite_db) -> None:
+    # #554: the entry point defaulted `calculate_quality` to False, so a query
+    # profile came back with quality = None while a CSV of the same rows scored.
+    # The toggle now defaults to unset, which means "whatever the selection
+    # says", and an unnarrowed selection includes quality.
+    report = _profile_query(sqlite_db)
+
+    assert report.quality is not None, "a query must assess quality by default"
+    assert report.quality_score is not None
+    assert report.quality.assessed_dimensions(), "an assessment names what it assessed"
+
+
+def test_default_quality_matches_the_same_rows_on_disk(sqlite_db, csv_file) -> None:
+    # The output contract: the numbers do not depend on which path produced
+    # them. Compares every dimension score plus the overall, not just presence.
+    assert _quality_row(_profile_query(sqlite_db)) == _quality_row(dp.profile(csv_file))
+
+
+def test_explicit_quality_selection_survives_the_unset_flag(sqlite_db) -> None:
+    # The legacy flag defaulted to False and filtered the quality pack out of
+    # whatever the config had selected, so asking for quality and not mentioning
+    # the flag silently got no quality (#554).
+    for config_kwargs in ({"metrics": ["quality"]}, {"quality_dimensions": ["completeness"]}):
+        report = _profile_query(sqlite_db, **config_kwargs)
+        assert report.quality is not None, (
+            f"an explicit {config_kwargs} selection must not be overridden by the unset flag"
+        )
+
+
+def test_calculate_quality_true_does_not_widen_a_narrowed_selection(sqlite_db) -> None:
+    # The flag drops the pack; it never adds it back. `metrics=["schema"]` is a
+    # schema-only profile no matter what the coarse toggle says.
+    report = _profile_query(sqlite_db, metrics=["schema"], calculate_quality=True)
+
+    assert report.quality is None, "calculate_quality=True must not override metrics=['schema']"
 
 
 def test_calculate_quality_false_still_honours_the_rest(sqlite_db) -> None:

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -6,8 +6,8 @@ pattern detection with no locale, so a query and a CSV holding the same rows
 disagreed about what had been analyzed. The Python database entry point could
 not express the selection at all.
 
-These tests profile the same five records out of SQLite and off disk, and
-require the two to agree.
+These tests profile the same records out of SQLite and off disk, and require the
+two to agree — on what was analyzed, and on the quality numbers themselves.
 
 Requires building with database feature flags::
 
@@ -43,6 +43,40 @@ RECORDS = [
 
 QUERY = "SELECT * FROM parity"
 
+# A second fixture, for quality parity rather than option plumbing. ``RECORDS``
+# is five complete, unique, one-decimal rows with no date column, so it scores a
+# flat 100 on four dimensions and leaves timeliness and validity unassessed —
+# comparing two of those proves nothing. These records are deliberately
+# imperfect in a different way per dimension: nulls for completeness, a repeated
+# row for uniqueness, one malformed address for validity, mixed decimal places
+# for precision, and dates so timeliness has something to read.
+RICH_COLUMNS = ["id", "email", "signup_date", "amount", "notes"]
+RICH_RECORDS = [
+    (1, "anna@example.com", "2024-01-15", 10.5, "alpha"),
+    (2, "bruno@example.com", "2024-02-20", 21.25, None),
+    (3, "not-an-email", "2024-03-05", 33.0, "gamma"),
+    (4, "dario@example.com", "2024-04-11", 42.125, None),
+    (5, "elena@example.com", "2024-05-30", 55.5, "epsilon"),
+    (6, "fabio@example.com", "2024-06-18", 60.0, "zeta"),
+    (7, None, "2024-07-22", 71.75, "eta"),
+    (8, "hugo@example.com", "2024-08-09", 80.5, "theta"),
+    (9, "irene@example.com", "2024-09-14", 91.25, "iota"),
+    (10, "jacopo@example.com", "2024-10-01", 100.0, "kappa"),
+    (10, "jacopo@example.com", "2024-10-01", 100.0, "kappa"),
+]
+
+RICH_QUERY = "SELECT * FROM rich"
+
+QUALITY_DIMENSIONS = {
+    "completeness",
+    "consistency",
+    "uniqueness",
+    "accuracy",
+    "timeliness",
+    "validity",
+    "precision",
+}
+
 
 def _run(async_fn, *args, **kwargs):
     """Call a pyo3-async-runtimes function and block until completion.
@@ -57,14 +91,14 @@ def _run(async_fn, *args, **kwargs):
     return asyncio.run(_inner())
 
 
-def _profile_query(db_path, **config_kwargs):
+def _profile_query(db_path, query: str = QUERY, **config_kwargs):
     """Profile the fixture query, leaving the quality toggle unset by default."""
     calculate_quality = config_kwargs.pop("calculate_quality", None)
     config = ProfilerConfig(**config_kwargs) if config_kwargs else None
     report = _run(
         analyze_database_async,
         str(db_path),
-        QUERY,
+        query,
         10000,
         calculate_quality,
         config,
@@ -89,6 +123,31 @@ def csv_file(tmp_path):
     path = tmp_path / "parity.csv"
     lines = ["id,cap,amount"]
     lines += [f"{id_},{cap},{amount}" for id_, cap, amount in RECORDS]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def rich_sqlite_db(tmp_path):
+    db_path = tmp_path / "rich.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE rich (id INTEGER, email TEXT, signup_date TEXT, amount REAL, notes TEXT)"
+    )
+    conn.executemany("INSERT INTO rich VALUES (?, ?, ?, ?, ?)", RICH_RECORDS)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+@pytest.fixture()
+def rich_csv_file(tmp_path):
+    """``RICH_RECORDS`` on disk. A SQL NULL is an empty CSV field."""
+    path = tmp_path / "rich.csv"
+    lines = [",".join(RICH_COLUMNS)]
+    lines += [
+        ",".join("" if value is None else str(value) for value in record) for record in RICH_RECORDS
+    ]
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return path
 
@@ -163,10 +222,25 @@ def test_quality_is_assessed_by_default(sqlite_db) -> None:
     assert report.quality.assessed_dimensions(), "an assessment names what it assessed"
 
 
-def test_default_quality_matches_the_same_rows_on_disk(sqlite_db, csv_file) -> None:
+def test_default_quality_matches_the_same_rows_on_disk(rich_sqlite_db, rich_csv_file) -> None:
     # The output contract: the numbers do not depend on which path produced
     # them. Compares every dimension score plus the overall, not just presence.
-    assert _quality_row(_profile_query(sqlite_db)) == _quality_row(dp.profile(csv_file))
+    db_report = _profile_query(rich_sqlite_db, query=RICH_QUERY)
+    csv_report = dp.profile(rich_csv_file)
+
+    assert set(db_report.quality.assessed_dimensions()) == QUALITY_DIMENSIONS
+    assert set(csv_report.quality.assessed_dimensions()) == QUALITY_DIMENSIONS
+
+    db_row = _quality_row(db_report)
+    # Guard the fixture, not the code: an equality over flat 100s holds however
+    # far the two paths drift, so fail loudly if the records stop exercising a
+    # dimension. Consistency and accuracy are clean by construction here.
+    for dimension in ("completeness", "uniqueness", "validity", "precision"):
+        assert db_row[dimension] < 100.0, (
+            f"{dimension} is a vacuous 100; the fixture stopped biting"
+        )
+
+    assert db_row == _quality_row(csv_report)
 
 
 def test_explicit_quality_selection_survives_the_unset_flag(sqlite_db) -> None:


### PR DESCRIPTION
Closes #554.

## What was actually wrong

Nothing is missing from the metrics layer. `analyze_database_with_options`
already assembles quality (`with_quality_data(columns.into_map())`), and
`AnalysisOptions::default().include_quality()` is `true`. The Python entry point
was discarding it: `calculate_quality` defaulted to `false` and filtered
`MetricPack::Quality` out of the selection before the call.

Measured on 200 rows loaded into SQLite and written to CSV, profiled both ways:

| call | `quality` |
| --- | --- |
| default | **None** |
| `metrics=["quality"]`, flag unset | **None** — the explicit selection was overridden |
| `quality_dimensions=["completeness"]`, flag unset | **None** — same |
| `calculate_quality=True` | present |
| `metrics=["schema"]`, flag on | None (correct) |

The second and third rows are the sharper defect: an unspecified legacy flag
silently beat a specified config.

## Parity already holds

With the flag on, the database report and a CSV of the same rows agree exactly —
all seven dimensions and the overall score:

```
db  : completeness 59.8  consistency 100.0  uniqueness 99.75  accuracy 100.0
      timeliness 100.0  validity 100.0  precision 50.0  ->  87.41
csv : completeness 59.8  consistency 100.0  uniqueness 99.75  accuracy 100.0
      timeliness 100.0  validity 100.0  precision 50.0  ->  87.41
```

The fixture carries nulls, a duplicate id, empty strings, dates, and a mix of
decimal precisions, so every dimension has something to bite on. That parity is
now a test rather than a one-off measurement.

## The change

`calculate_quality` becomes tri-state:

- **unset** (new default) — honour the selection. An unnarrowed selection
  includes quality, which is what every file path does.
- **`False`** — drop the quality pack. Unchanged, still the coarse toggle.
- **`True`** — no filtering. It never adds the pack back, so
  `metrics=["schema"]` stays a schema-only profile.

## Scope questions from the issue

- **Which dimensions are computable?** All seven, with no second pass and no
  hint plumbing. Timeliness works because `effective_temporal_columns` folds in
  columns the profiler inferred as dates, so it does not depend on the semantic
  hints the database path rejects.
- **Full result set or a sample?** The full result set. The path materializes
  what it fetched, so `quality_data` covers every row. When
  `sampling_config` narrows the query, `execution.sampling_applied` is set and
  the assembler switches to bifurcated confidence, which discloses it.
- **Should `quality` ever be `None`?** Left as-is, deliberately. `None` means
  "not analyzed" everywhere — `metrics=["schema"]` and
  `quality_dimensions=[]` produce it on file paths too, and existing tests pin
  that meaning. One shape across paths now holds in the sense that matters:
  the database path defaults the same way every file path does. Changing `None`
  to an all-`None` object would be a cross-cutting API decision, not a database
  fix, and it would lose the distinction the repo maintains.

## Unblocks

#588 lists #554 as one of its two blockers for shipping database support in the
wheel. #365 (typed-value decoding) remains the other.

## Verification

The four new behaviour assertions were run against the unfixed semantics — same
signature, old branch condition — and all four fail with `AssertionError`, along
with the pre-existing `test_narrowed_quality_dimensions_still_analyze` now that
its helper leaves the flag unset. `test_calculate_quality_true_does_not_widen_a_narrowed_selection`
passes in both states; it is a preservation test and does not discriminate the fix.

```
cargo fmt --all
cargo clippy -p dataprof-python --features "python,python-async,database,sqlite" --all-targets -- -D warnings
cargo test --features sqlite --test database_integration      # 18 passed
uv run pytest python/tests/ -q                                # 996 passed, 4 skipped
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```

Exercised against SQLite only; the change is in the binding, above any
connector.
