### PR TITLE
docs: record the database decision and describe what the wheel ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uv pip install dataprof
 
 Requires Python 3.10 or newer.
 
-The pre-built PyPI wheels have **no Python dependencies**. Everything below runs on a bare `pip install dataprof`: local files, dicts, row dicts, bytes buffers, and every export in this section. Install the `pandas` extra only for the pandas-typed exports (`to_dataframe()`, `describe()` as a DataFrame) and for Parquet *byte buffers*. Async URL profiling and database helpers are opt-in source builds.
+The pre-built PyPI wheels have **no Python dependencies**. Everything below runs on a bare `pip install dataprof`: local files, dicts, row dicts, bytes buffers, and every export in this section. Install the `pandas` extra only for the pandas-typed exports (`to_dataframe()`, `describe()` as a DataFrame) and for Parquet *byte buffers*. Async profiling, including HTTP URLs and remote Parquet, is in the wheel too; database connectors are the one documented feature that still needs a source build.
 
 #### 1. Profile
 
@@ -153,7 +153,7 @@ for col in &report.column_profiles {
 - **True streaming** -- bounded-memory profiling with online algorithms for files bigger than RAM
 - **Multi-format by default** -- move from CSV and JSON to Parquet, live databases, DataFrames, and Arrow batches without changing tools
 - **Two polished entry points** -- a compact Rust facade and a Python package that feels natural in notebooks
-- **Async-ready** -- Rust async APIs and opt-in Python extension builds cover stream pipelines, services, and remote Parquet sources
+- **Async-ready** -- Rust async APIs and a Python async module that ships in the wheel cover stream pipelines, services, and remote Parquet sources
 - **Explainable quality assessment** -- seven selectively requestable dimensions, including validity and decimal-scale precision, with inspectable facts behind every score
 
 ## Feature Flags

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -39,7 +39,11 @@ uv run maturin develop --features "python,python-async,database,sqlite"
 
 ### Python
 
-Python database functions are async and are not included in the default PyPI wheel. Build the extension from source with `python-async`, `database`, and the connector feature you need first:
+Python database functions are async and are not included in the PyPI wheel. That
+is a deliberate, standing decision (#588), not a gap waiting on the next
+release: connectors are compile-time features, so no `pip` extra can turn them
+on. Build the extension from a checkout with `python-async`, `database`, and the
+connector feature you need first:
 
 ```bash
 uv run maturin develop --features "python,python-async,database,sqlite"

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -276,9 +276,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### Async URL profiling (source build)
-
-Build the Python extension with `python-async,async-streaming` before using this recipe.
+### Async URL profiling
 
 ```python
 import asyncio
@@ -293,7 +291,7 @@ asyncio.run(main())
 
 ### Database profiling from Python (source build)
 
-Build the Python extension with `python-async,database` and the connector feature you need before using this recipe.
+Not in the published wheels. Build the Python extension from a checkout with `python-async,database` and the connector feature you need before using this recipe.
 
 ```python
 import asyncio
@@ -530,7 +528,7 @@ async def profile_upload(file: UploadFile):
 
 ### Compare database vs file quality (source build)
 
-Build the Python extension with `python-async,database` and the connector feature you need before using this recipe.
+Not in the published wheels. Build the Python extension from a checkout with `python-async,database` and the connector feature you need before using this recipe.
 
 ```python
 import asyncio

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -306,7 +306,7 @@ When embedding dataprof in a web service or processing live streams, use the asy
 
 ### Python
 
-Build the Python extension from source with `python-async,async-streaming` before using these helpers.
+These helpers ship in the published wheels; `pip install dataprof` is enough.
 
 ```python
 from dataprof.asyncio import profile_file, profile_url
@@ -338,7 +338,9 @@ Profile data directly from PostgreSQL, MySQL, or SQLite without exporting to fil
 
 ### Python
 
-Build the Python extension from source with `python-async,database` and the connector feature you need before using this API.
+Database support is not in the published wheels. Build the Python extension from
+a checkout with `python-async,database` and the connector feature you need
+before using this API.
 
 ```python
 report = await dp.analyze_database_async(

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -18,15 +18,14 @@ pip install dataprof
 
 Requires Python 3.10+. The package ships pre-built wheels for Linux, macOS, and Windows, and declares **no Python dependencies**. The base API needs nothing else: local file profiling, DataFrame and Arrow inputs, ad-hoc dict/bytes inputs, and report exports. Install the `pandas` extra only for pandas-typed exports (`to_dataframe()`, `describe()` as a DataFrame).
 
-Async URL profiling and database helpers are not part of the default wheel contract for this release. Use a source build when you need those optional features:
+The wheel also carries the async API: `dataprof.asyncio`, HTTP URL profiling,
+and remote Parquet all work on a bare `pip install dataprof`.
+
+Database profiling is the one documented feature the wheel does not contain.
+Connectors are a compile-time feature rather than a Python dependency, so no
+extra can install them; they need a build from a checkout of this repository:
 
 ```bash
-uv run maturin develop --features "python,python-async,async-streaming"
-
-# Add parquet-async for remote Parquet support
-uv run maturin develop --features "python,python-async,async-streaming,parquet-async"
-
-# Add database plus a connector when needed
 uv run maturin develop --features "python,python-async,database,sqlite"
 ```
 
@@ -645,9 +644,9 @@ print(f"{result.count} rows ({'exact' if result.exact else 'estimated'})")
 print(f"Method: {result.method}, took {result.count_time_ms}ms")
 ```
 
-## Optional Async API (Source Build)
+## Async API
 
-The `dataprof.asyncio` module provides async variants for use in web frameworks, stream processors, and other async contexts. These helpers require a source build with `python-async` and `async-streaming` enabled.
+The `dataprof.asyncio` module provides async variants for use in web frameworks, stream processors, and other async contexts. These helpers ship in the published wheels.
 
 ```python
 from dataprof.asyncio import profile_file, profile_bytes, profile_url
@@ -676,9 +675,13 @@ schema = await infer_schema_stream(csv_bytes, format="csv")
 count = await quick_row_count_stream(csv_bytes, format="csv")
 ```
 
-## Optional Database Profiling (Source Build)
+## Database Profiling (Source Build Only)
 
-Async database functions for PostgreSQL, MySQL, and SQLite require a source build with `python-async`, `database`, and the relevant connector features enabled:
+Async database functions for PostgreSQL, MySQL, and SQLite are **not** in the
+published wheels, and there is no extra that installs them. On a wheel install
+they exist as stubs that raise `ImportError` when called, and
+`dp.capabilities().database` is `False`. Build the extension from a checkout
+with `python-async`, `database`, and the connector features you need:
 
 ```bash
 uv run maturin develop --features "python,python-async,database,sqlite"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ Issues = "https://github.com/AndreaBozzo/dataprof/issues"
 pandas = ["pandas>=2.0.0"]
 jupyter = ["pandas>=2.0.0", "ipython>=8.0.0"]
 all = ["pandas>=2.0.0", "ipython>=8.0.0", "numpy>=1.23.0"]
-database = []  # No Python deps; compile the extension with python-async,database,<connector>
+# There is deliberately no `database` extra: database support is a compile-time
+# feature of the extension, not a Python dependency, and the published wheels do
+# not carry it (#588). An extra cannot install it, so offering one only promises
+# an install path that does not exist.
 
 [dependency-groups]
 dev = [
@@ -57,10 +60,9 @@ dev = [
 ]
 
 [tool.maturin]
-# Kept in sync with the --features list in .github/workflows/release.yml.
-# The duplication is tracked by #589; until it is removed, changing one
-# without the other makes `pip install dataprof` and
-# `pip install --no-binary dataprof` differ in capability, silently.
+# The single declaration of the shipped feature set: the release workflow
+# passes no --features, so this list drives both the wheel and the sdist.
+# python/tests/test_wheel_feature_single_source.py fails if that changes.
 features = ["python", "python-async", "async-streaming", "parquet-async"]
 manifest-path = "crates/dataprof-python/Cargo.toml"
 module-name = "dataprof._dataprof"

--- a/python/dataprof/asyncio.py
+++ b/python/dataprof/asyncio.py
@@ -1,7 +1,8 @@
 """Async API for dataprof.
 
-Provides async/await versions of profiling operations. Requires the
-``python-async`` and ``async-streaming`` features to be compiled.
+Provides async/await versions of profiling operations. The features behind it
+(``python-async``, ``async-streaming``, ``parquet-async``) are compiled into the
+published wheels.
 
 Example::
 

--- a/python/tests/test_async_url_api.py
+++ b/python/tests/test_async_url_api.py
@@ -1,10 +1,8 @@
 """Async URL profiling regression tests.
 
-These tests require building with async URL features:
-    uv run maturin develop --features "python,python-async,async-streaming"
-
-For remote Parquet coverage:
-    uv run maturin develop --features "python,python-async,parquet-async"
+The async URL and remote Parquet features these cover ship in the wheel, so the
+default development build is enough:
+    uv run maturin develop
 """
 
 from __future__ import annotations

--- a/python/tests/test_wheel_feature_single_source.py
+++ b/python/tests/test_wheel_feature_single_source.py
@@ -40,6 +40,36 @@ def test_pyproject_declares_a_nonempty_wheel_feature_set():
     assert _tool_maturin_features(), "the shipped feature set must be declared in pyproject.toml"
 
 
+def _optional_dependency_extras() -> dict[str, str]:
+    """Every `name = [...]` entry under `[project.optional-dependencies]`."""
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    section = re.search(
+        r"^\[project\.optional-dependencies\]\s*$(.*?)(?=^\[|\Z)", text, re.M | re.S
+    )
+    assert section, "pyproject.toml has no [project.optional-dependencies] section"
+    return {
+        name: body
+        for name, body in re.findall(r"^(\S+)\s*=\s*\[(.*?)\]", section.group(1), re.M | re.S)
+    }
+
+
+def test_no_extra_resolves_to_nothing():
+    """An extra may only exist if installing it installs something.
+
+    `database = []` shipped for several releases as a placeholder for a
+    compile-time feature (#588). `pip install dataprof[database]` succeeded and
+    produced a package with no database support, which is a worse answer than
+    no extra at all. Compile-time features belong in build instructions.
+    """
+    extras = _optional_dependency_extras()
+    assert extras, "expected at least one optional-dependency extra"
+    empty = sorted(name for name, body in extras.items() if not body.strip())
+    assert not empty, (
+        f"extras resolve to no requirements: {empty}. An extra that installs nothing "
+        "promises an install path that does not exist; document the build instead."
+    )
+
+
 def _maturin_args_lines(workflow: str) -> list[str]:
     """The `args:` values of every maturin-action step (wheels + sdist).
 

--- a/uv.lock
+++ b/uv.lock
@@ -85,7 +85,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'jupyter'", specifier = ">=2.0.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["all", "database", "jupyter", "pandas"]
+provides-extras = ["all", "jupyter", "pandas"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #591. Implements the decision recorded on #588, which stays open to
track the revisit once #365 closes.

## What

Two things that had drifted apart from what `pip install dataprof` delivers:

**#588 — the database decision.** Option 3 from the issue: database stays a
source build. `pyproject.toml` declared `database = []`, an extra that resolved
to no requirements, so `pip install dataprof[database]` succeeded and installed
a package with no database support. Connectors are a compile-time feature of the
extension, so no extra can ever deliver them. The extra is removed and the docs
say the source build is the install path.

**#591 — the source-build instructions.** Async shipped in the default wheel
with #587, which made six "build from source for async" sites wrong in the
direction that costs a reader the most: a toolchain install they do not need.
Each site now describes the installed wheel.

## Verification

A default-feature build (uv, through the same PEP 517 backend the sdist uses)
reports exactly what the docs now claim:

```
async_streaming=True, url_profiling=True, remote_parquet=True,
database=False, database_connectors=()
```

- `uv run pytest python/tests -q` — 974 passed, 9 skipped.
- `uv run ruff format --check`, `uv run ruff check`, `uv run ty check python/` — clean.
- New `test_no_extra_resolves_to_nothing` fails with `database = []` restored
  (`extras resolve to no requirements: ['database']`) and passes without it.

No Rust change, so the cargo gates were not run.

## Notes

- `uv.lock` carries the one line the change implies (`provides-extras`); the
  unrelated marker churn a fresh `uv lock` wanted is left out.
- Removing an extra is not a hard break: pip warns "does not provide the extra"
  and continues, and the extra never installed anything.
- The `[tool.maturin]` comment still pointed at #589 as open; #594 closed it.

