### PR TITLE
fix(metrics): count complete records on rows, not null cells

### DIFF
--- a/.claude/skills/dataprof/evals/README.md
+++ b/.claude/skills/dataprof/evals/README.md
@@ -42,7 +42,7 @@ around that with `to_dict()` or a raw read.
 
 `fixtures/inventory_before.csv` / `inventory_after.csv` — a cleaning step that
 genuinely improves quality (duplicate rows 1 to 0, missing values 22.2% to 0%,
-score 80.9 to 97.9) while dropping half the rows. An agent that reports only the
+score 83.5 to 97.9) while dropping half the rows. An agent that reports only the
 score improvement has missed the row loss.
 
 `fixtures/payments_mixed_amount.csv` — 10 payment rows where 4 of the

--- a/.claude/skills/dataprof/evals/scenarios.json
+++ b/.claude/skills/dataprof/evals/scenarios.json
@@ -41,7 +41,7 @@
     "tests": "Step 6 of the skill: compare() is reached for rather than two hand-read profiles.",
     "expected_behavior": [
       "Profiles both files and calls before.compare(after) instead of describing each profile separately",
-      "Cites the specific improvements: duplicate rows 1 to 0, missing values 22.2% to 0%, quality score 80.9 to 97.9",
+      "Cites the specific improvements: duplicate rows 1 to 0, missing values 22.2% to 0%, quality score 83.5 to 97.9",
       "Notes that 3 of 6 rows were removed, so the comparison reflects both cleaning and row loss",
       "Does not recommend further transformations as though dataprof had suggested them"
     ],

--- a/.claude/skills/dataprof/reference/interpretation.md
+++ b/.claude/skills/dataprof/reference/interpretation.md
@@ -35,8 +35,9 @@ Each dimension is a dict of its own evidence — `report.quality.completeness`,
 `report.quality.uniqueness`, and so on. The keys named below live inside it.
 
 **Completeness** — presence of values. `missing_values_ratio` is per-value;
-`complete_records_ratio` is per-row and drops sharply when any single optional
-column is sparse. Check both before describing a dataset as incomplete.
+`complete_records_ratio` is per-row and treats every column as required, so it
+drops sharply when any single optional column is sparse. Check both, and name
+the columns in `null_columns`, before describing a dataset as incomplete.
 
 **Consistency** — whether values in a column agree on type and format.
 `data_type_consistency` and `format_violations` are the evidence.

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -394,6 +394,7 @@ pub fn analyze_csv_file_with_dimensions_and_hints(
     .columns(column_profiles)
     .with_quality_data(sample_columns)
     .with_row_duplicates(column_stats.row_duplicate_summary())
+    .with_row_completeness(column_stats.row_completeness_summary())
     .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
     .with_semantic_hints(semantic_hints.clone());
     if let Some(dimensions) = quality_dimensions {

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -9,7 +9,7 @@ use dataprof_core::{
     AnalysisOptions, DataSource, ExecutionMetadata, MetricPack, QualityDimension, QueryEngine,
 };
 use dataprof_metrics::analyze_column_with_analysis_options;
-use dataprof_runtime::{ProfileReport, ReportAssembler};
+use dataprof_runtime::{ProfileReport, ReportAssembler, RowCompletenessTracker};
 
 pub mod connection;
 pub mod connectors;
@@ -300,6 +300,13 @@ pub async fn analyze_database_with_options(
         .map(|(name, data)| analyze_column_with_analysis_options(name, data, options))
         .collect();
 
+    // The query result is row-aligned and holds every value, so complete
+    // records can be counted directly rather than bounded from null totals.
+    let mut completeness = RowCompletenessTracker::default();
+    let aligned: Vec<&[String]> = columns.values().map(|data| data.as_slice()).collect();
+    completeness.observe_aligned_columns(&aligned, actual_rows_processed);
+    let row_completeness = completeness.summary();
+
     let scan_time_ms = start.elapsed().as_millis();
     let sampling_ratio = sample_info.map(|s| s.sampling_ratio).unwrap_or(1.0);
     let num_columns = column_profiles.len();
@@ -325,6 +332,7 @@ pub async fn analyze_database_with_options(
     // Quality metrics look every column up by name and never iterate for
     // presentation, so dropping the order here costs nothing.
     .with_quality_data(columns.into_map())
+    .with_row_completeness(row_completeness)
     .with_analysis_options(options)
     .build())
 }

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -512,6 +512,7 @@ impl AsyncStreamingProfiler {
             .columns(column_profiles)
             .with_quality_data(sample_columns)
             .with_row_duplicates(column_stats.row_duplicate_summary())
+            .with_row_completeness(column_stats.row_completeness_summary())
             .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
             .with_analysis_options(&self.options)
             .build())

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -414,6 +414,7 @@ impl IncrementalProfiler {
             assembler = assembler
                 .with_quality_data(sample_columns)
                 .with_row_duplicates(column_stats.row_duplicate_summary())
+                .with_row_completeness(column_stats.row_completeness_summary())
                 .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
                 .with_semantic_hints(self.semantic_hints.clone());
             if let Some(ref dims) = self.quality_dimensions {

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -923,6 +923,7 @@ pub fn analyze_json_file_with_options(
         .columns(column_profiles)
         .with_quality_data(sample_columns)
         .with_row_duplicates(column_stats.row_duplicate_summary())
+        .with_row_completeness(column_stats.row_completeness_summary())
         .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
         .with_analysis_options(options)
         .build())

--- a/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/completeness.rs
@@ -5,7 +5,7 @@
 
 use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
-use crate::types::ColumnProfile;
+use crate::types::{ColumnProfile, RowCompletenessSummary};
 use std::collections::HashMap;
 
 /// Completeness metrics container
@@ -20,11 +20,45 @@ pub(crate) struct CompletenessMetrics {
 /// Calculator for completeness dimension metrics
 pub(crate) struct CompletenessCalculator<'a> {
     thresholds: &'a IsoQualityConfig,
+    row_completeness: Option<RowCompletenessSummary>,
 }
 
 impl<'a> CompletenessCalculator<'a> {
     pub fn new(thresholds: &'a IsoQualityConfig) -> Self {
-        Self { thresholds }
+        Self {
+            thresholds,
+            row_completeness: None,
+        }
+    }
+
+    /// Supply an engine's exact full-stream complete-record count.
+    pub fn with_row_completeness(mut self, summary: Option<RowCompletenessSummary>) -> Self {
+        self.row_completeness = summary;
+        self
+    }
+
+    /// Percentage of records in which every field is present.
+    ///
+    /// Prefers the engine's row-level count, which is exact. Without one,
+    /// falls back to a lower bound derived from per-column null totals: it
+    /// assumes no two nulls share a record, so it understates completeness
+    /// whenever they do, and collapses to 0 once the null cells outnumber
+    /// the rows. See [`RowCompletenessSummary`] for why the bound is all the
+    /// column counters can support.
+    fn complete_records_ratio(&self, column_profiles: &[ColumnProfile]) -> f64 {
+        if let Some(summary) = self.row_completeness {
+            if summary.rows_checked > 0 {
+                return summary.complete_rows as f64 / summary.rows_checked as f64 * 100.0;
+            }
+            return 100.0;
+        }
+
+        let total_rows = column_profiles.first().map(|p| p.total_count).unwrap_or(0);
+        if total_rows == 0 {
+            return 100.0;
+        }
+        let null_cells: usize = column_profiles.iter().map(|p| p.null_count).sum();
+        (total_rows.saturating_sub(null_cells) as f64 / total_rows as f64 * 100.0).max(0.0)
     }
 
     /// Calculate completeness dimension metrics
@@ -52,14 +86,7 @@ impl<'a> CompletenessCalculator<'a> {
             Self::calculate_missing_values_ratio(data)?
         };
         let complete_records_ratio = if !column_profiles.is_empty() {
-            // Use profile-based lower bound (same as calculate_from_profiles)
-            let total = column_profiles.first().map(|p| p.total_count).unwrap_or(0);
-            let null_cells: usize = column_profiles.iter().map(|p| p.null_count).sum();
-            if total == 0 {
-                100.0
-            } else {
-                (total.saturating_sub(null_cells) as f64 / total as f64 * 100.0).max(0.0)
-            }
+            self.complete_records_ratio(column_profiles)
         } else {
             Self::calculate_complete_records_ratio(data, total_rows)?
         };
@@ -114,10 +141,10 @@ impl<'a> CompletenessCalculator<'a> {
 
     /// Compute completeness from global [`ColumnProfile`] counters (exact for streaming).
     ///
-    /// `missing_values_ratio` and `null_columns` are exact.
-    /// `complete_records_ratio` uses a pessimistic lower bound: it assumes nulls
-    /// are maximally spread across different rows. The bound is tight when nulls
-    /// are sparse and exact when no column has nulls.
+    /// `missing_values_ratio` and `null_columns` are exact. So is
+    /// `complete_records_ratio` when the engine supplied a row-level count
+    /// via [`Self::with_row_completeness`]; otherwise it degrades to the
+    /// lower bound documented on [`Self::complete_records_ratio`].
     pub fn calculate_from_profiles(
         &self,
         column_profiles: &[ColumnProfile],
@@ -131,12 +158,7 @@ impl<'a> CompletenessCalculator<'a> {
             (null_cells as f64 / total_cells as f64) * 100.0
         };
 
-        let total_rows = column_profiles.first().map(|p| p.total_count).unwrap_or(0);
-        let complete_records_ratio = if total_rows == 0 {
-            100.0
-        } else {
-            (total_rows.saturating_sub(null_cells) as f64 / total_rows as f64 * 100.0).max(0.0)
-        };
+        let complete_records_ratio = self.complete_records_ratio(column_profiles);
 
         let null_columns = self.identify_null_columns(column_profiles);
 
@@ -174,6 +196,7 @@ mod tests {
         expected_completeness, null_threshold, string_profile,
     };
     use super::*;
+    use crate::types::RowCompletenessSummary;
 
     #[test]
     fn completeness_scenarios_cover_boundaries() {
@@ -182,6 +205,7 @@ mod tests {
                 name: "empty input is computed but neutral",
                 input: CompletenessInput::Profiles(vec![]),
                 config: IsoQualityConfig::default(),
+                row_completeness: None,
                 expected: expected_completeness(0.0, 100.0, &[], 0),
             },
             CompletenessScenario {
@@ -191,27 +215,56 @@ mod tests {
                     total_rows: 2,
                 },
                 config: IsoQualityConfig::default(),
+                row_completeness: None,
                 expected: expected_completeness(0.0, 100.0, &[], 4),
             },
             CompletenessScenario {
                 name: "exact null threshold is not a null column",
                 input: CompletenessInput::Profiles(vec![string_profile("boundary", 100, 25)]),
                 config: null_threshold(25.0),
+                row_completeness: None,
                 expected: expected_completeness(25.0, 75.0, &[], 100),
             },
             CompletenessScenario {
-                name: "degraded profiles expose exact counters",
+                name: "row count wins over the null-cell bound",
                 input: CompletenessInput::Profiles(vec![
                     string_profile("partial", 100, 10),
                     string_profile("mostly_null", 100, 60),
                 ]),
                 config: IsoQualityConfig::default(),
+                // Every `partial` null shares a row with a `mostly_null` one,
+                // so 40 rows are complete where the bound would say 30.
+                row_completeness: Some(RowCompletenessSummary {
+                    complete_rows: 40,
+                    rows_checked: 100,
+                }),
+                expected: expected_completeness(35.0, 40.0, &["mostly_null"], 200),
+            },
+            CompletenessScenario {
+                name: "without a row count the bound is all that is available",
+                input: CompletenessInput::Profiles(vec![
+                    string_profile("partial", 100, 10),
+                    string_profile("mostly_null", 100, 60),
+                ]),
+                config: IsoQualityConfig::default(),
+                row_completeness: None,
                 expected: expected_completeness(35.0, 30.0, &["mostly_null"], 200),
+            },
+            CompletenessScenario {
+                name: "more null cells than rows bottoms the bound out at zero",
+                input: CompletenessInput::Profiles(vec![
+                    string_profile("a", 10, 7),
+                    string_profile("b", 10, 7),
+                ]),
+                config: IsoQualityConfig::default(),
+                row_completeness: None,
+                expected: expected_completeness(70.0, 0.0, &["a", "b"], 20),
             },
         ];
 
         for scenario in scenarios {
-            let calculator = CompletenessCalculator::new(&scenario.config);
+            let calculator = CompletenessCalculator::new(&scenario.config)
+                .with_row_completeness(scenario.row_completeness);
             let actual = match &scenario.input {
                 CompletenessInput::Rows { data, total_rows } => {
                     calculator.calculate(data, &[], *total_rows)

--- a/crates/dataprof-metrics/src/analysis/metrics/mod.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/mod.rs
@@ -76,8 +76,8 @@ use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
 use crate::types::{
     AccuracyMetrics, ColumnProfile, CompletenessMetrics, ConsistencyMetrics, DataType,
-    PrecisionMetrics, QualityDimension, QualityMetrics, RowDuplicateSummary, TimelinessMetrics,
-    UniquenessMetrics, ValidityMetrics,
+    PrecisionMetrics, QualityDimension, QualityMetrics, RowCompletenessSummary,
+    RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics, ValidityMetrics,
 };
 use dataprof_core::SemanticHints;
 use std::collections::HashMap;
@@ -86,6 +86,8 @@ use std::collections::HashMap;
 pub struct MetricsCalculator {
     /// Configurable quality thresholds and score weights.
     pub thresholds: IsoQualityConfig,
+    /// Exact full-stream complete-record count, when the engine tracked one.
+    row_completeness: Option<RowCompletenessSummary>,
 }
 
 impl Default for MetricsCalculator {
@@ -97,28 +99,35 @@ impl Default for MetricsCalculator {
 impl MetricsCalculator {
     /// Create a new calculator with default quality settings.
     pub fn new() -> Self {
-        Self {
-            thresholds: IsoQualityConfig::default(),
-        }
+        Self::with_thresholds(IsoQualityConfig::default())
     }
 
     /// Create a calculator with custom thresholds
     pub fn with_thresholds(thresholds: IsoQualityConfig) -> Self {
-        Self { thresholds }
+        Self {
+            thresholds,
+            row_completeness: None,
+        }
     }
 
     /// Create a calculator with strict thresholds (finance, healthcare)
     pub fn strict() -> Self {
-        Self {
-            thresholds: IsoQualityConfig::strict(),
-        }
+        Self::with_thresholds(IsoQualityConfig::strict())
     }
 
     /// Create a calculator with lenient thresholds (exploratory, marketing)
     pub fn lenient() -> Self {
-        Self {
-            thresholds: IsoQualityConfig::lenient(),
-        }
+        Self::with_thresholds(IsoQualityConfig::lenient())
+    }
+
+    /// Supply the engine's exact complete-record count over the full stream.
+    ///
+    /// Without it the completeness dimension can only report a lower bound
+    /// for `complete_records_ratio`, because per-column null totals do not
+    /// say whether two nulls shared a record.
+    pub fn with_row_completeness(mut self, summary: Option<RowCompletenessSummary>) -> Self {
+        self.row_completeness = summary;
+        self
     }
 
     /// Validate statistical requirements for metric calculation
@@ -245,11 +254,9 @@ impl MetricsCalculator {
 
         // Completeness dimension
         let completeness = if Self::is_requested(requested, QualityDimension::Completeness) {
-            let c = CompletenessCalculator::new(&self.thresholds).calculate(
-                data,
-                column_profiles,
-                sample_size,
-            )?;
+            let c = CompletenessCalculator::new(&self.thresholds)
+                .with_row_completeness(self.row_completeness)
+                .calculate(data, column_profiles, sample_size)?;
             Some(CompletenessMetrics {
                 missing_values_ratio: c.missing_values_ratio,
                 complete_records_ratio: c.complete_records_ratio,
@@ -560,6 +567,7 @@ impl MetricsCalculator {
         // Phase A: Completeness from exact global counters
         let completeness = if Self::is_requested(requested, QualityDimension::Completeness) {
             let c = CompletenessCalculator::new(&self.thresholds)
+                .with_row_completeness(self.row_completeness)
                 .calculate_from_profiles(column_profiles)?;
             exact_dimensions.push("completeness".to_string());
             Some(CompletenessMetrics {

--- a/crates/dataprof-metrics/src/analysis/metrics/testing.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/testing.rs
@@ -6,7 +6,7 @@
 
 use super::completeness::CompletenessMetrics;
 use crate::core::config::IsoQualityConfig;
-use crate::types::{ColumnProfile, ColumnStats, DataType, TextStats};
+use crate::types::{ColumnProfile, ColumnStats, DataType, RowCompletenessSummary, TextStats};
 use std::collections::HashMap;
 
 pub(super) fn column_data(columns: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
@@ -59,6 +59,8 @@ pub(super) struct CompletenessScenario {
     pub name: &'static str,
     pub input: CompletenessInput,
     pub config: IsoQualityConfig,
+    /// The engine's exact complete-record count, when it tracked one.
+    pub row_completeness: Option<RowCompletenessSummary>,
     pub expected: CompletenessMetrics,
 }
 

--- a/crates/dataprof-metrics/src/lib.rs
+++ b/crates/dataprof-metrics/src/lib.rs
@@ -14,8 +14,8 @@ pub use analysis::{
 };
 pub use quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, PrecisionMetrics,
-    QualityAssessment, QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
-    ValidityMetrics,
+    QualityAssessment, QualityMetrics, RowCompletenessSummary, RowDuplicateSummary,
+    TimelinessMetrics, UniquenessMetrics, ValidityMetrics,
 };
 pub use stats::{
     CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog, calculate_datetime_stats,

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -10,6 +10,10 @@ use crate::core::errors::DataProfilerError;
 pub struct CompletenessMetrics {
     #[serde(serialize_with = "crate::serde_helpers::round_2")]
     pub missing_values_ratio: f64,
+    /// Percentage of records in which every field is present, counted over
+    /// every row the engine read. Strict by design: a record missing one
+    /// optional field is not complete, so read it beside `null_columns`,
+    /// which names the columns responsible.
     #[serde(serialize_with = "crate::serde_helpers::round_2")]
     pub complete_records_ratio: f64,
     pub null_columns: Vec<String>,
@@ -67,6 +71,20 @@ pub struct RowDuplicateSummary {
     pub duplicate_rows: usize,
     pub rows_checked: usize,
     pub approximate: bool,
+}
+
+/// Full-stream complete-record counts produced by an engine's row tracker.
+///
+/// A "complete" record is one whose every field is present. That is a
+/// property of a row, so it can only be counted while whole rows are in
+/// hand; per-column null totals cannot recover it, because they do not say
+/// whether two nulls landed in the same record. Engines that see whole
+/// records accumulate this exactly over the full stream with one counter,
+/// independent of sampling.
+#[derive(Debug, Clone, Copy)]
+pub struct RowCompletenessSummary {
+    pub complete_rows: usize,
+    pub rows_checked: usize,
 }
 
 /// Accuracy metrics (ISO 25012).

--- a/crates/dataprof-metrics/src/types.rs
+++ b/crates/dataprof-metrics/src/types.rs
@@ -6,6 +6,6 @@ pub use dataprof_core::{
 
 pub use crate::quality::{
     AccuracyMetrics, CompletenessMetrics, ConsistencyMetrics, MetricConfidence, PrecisionMetrics,
-    QualityAssessment, QualityMetrics, RowDuplicateSummary, TimelinessMetrics, UniquenessMetrics,
-    ValidityMetrics,
+    QualityAssessment, QualityMetrics, RowCompletenessSummary, RowDuplicateSummary,
+    TimelinessMetrics, UniquenessMetrics, ValidityMetrics,
 };

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -334,7 +334,8 @@ impl ArrowProfiler {
             execution,
         )
         .columns(column_profiles)
-        .with_row_duplicates(row_tracker.summary());
+        .with_row_duplicates(row_tracker.summary())
+        .with_row_completeness(row_tracker.completeness_summary());
 
         if MetricPack::include_quality(packs) && !empty_source {
             assembler = assembler

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -329,6 +329,7 @@ pub async fn analyze_parquet_async_http_with_options(
     )
     .columns(column_profiles)
     .with_row_duplicates(analyzer.row_duplicate_summary())
+    .with_row_completeness(analyzer.row_completeness_summary())
     .with_quality_data(sample_columns)
     .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
     .with_analysis_options(options)

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -337,6 +337,7 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
     Ok(ReportAssembler::new(data_source, execution)
         .columns(column_profiles)
         .with_row_duplicates(analyzer.row_duplicate_summary())
+        .with_row_completeness(analyzer.row_completeness_summary())
         .with_quality_data(sample_columns)
         .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
         .with_analysis_options(options)

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -9,10 +9,10 @@ use dataprof_core::{
 };
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
-use dataprof_metrics::{RowDuplicateSummary, infer_type};
+use dataprof_metrics::{RowCompletenessSummary, RowDuplicateSummary, infer_type};
 use dataprof_runtime::{
-    ColumnProfileInput, ExactNumericAggregates, RowUniquenessTracker, StreamReservoirSampler,
-    TextLengths, build_column_profile,
+    ColumnProfileInput, ExactNumericAggregates, RowCompletenessTracker, RowUniquenessTracker,
+    StreamReservoirSampler, TextLengths, build_column_profile,
 };
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -37,6 +37,7 @@ const NUMERIC_SAMPLE_CAP: usize = 10_000;
 #[derive(Default)]
 pub(crate) struct BatchRowTracker {
     tracker: RowUniquenessTracker,
+    completeness: RowCompletenessTracker,
     disabled: bool,
 }
 
@@ -45,7 +46,7 @@ impl BatchRowTracker {
         if self.disabled {
             return;
         }
-        if observe_batch_rows(&mut self.tracker, batch).is_err() {
+        if observe_batch_rows(&mut self.tracker, &mut self.completeness, batch).is_err() {
             self.disabled = true;
         }
     }
@@ -58,11 +59,25 @@ impl BatchRowTracker {
         }
         self.tracker.summary()
     }
+
+    /// Full-stream complete-record counts; `None` under the same conditions
+    /// as [`Self::summary`] — a batch that could not be rendered leaves the
+    /// count short, and a short count is worse than an absent one.
+    pub(crate) fn completeness_summary(&self) -> Option<RowCompletenessSummary> {
+        if self.disabled {
+            return None;
+        }
+        self.completeness.summary()
+    }
 }
 
 /// Fold every row of a batch into the tracker as a canonical signature.
 /// See [`BatchRowTracker`] for the encoding and failure contract.
-fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -> Result<()> {
+fn observe_batch_rows(
+    tracker: &mut RowUniquenessTracker,
+    completeness: &mut RowCompletenessTracker,
+    batch: &RecordBatch,
+) -> Result<()> {
     use arrow::datatypes::DataType as ArrowDataType;
     use arrow::util::display::{ArrayFormatter, FormatOptions};
 
@@ -83,6 +98,7 @@ fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -
     let mut value_buffer = String::new();
     for row_index in 0..batch.num_rows() {
         let mut row_signature = String::new();
+        let mut row_has_null = false;
         for (column, formatter) in batch.columns().iter().zip(&formatters) {
             value_buffer.clear();
             if let Some(formatter) = formatter
@@ -93,8 +109,13 @@ fn observe_batch_rows(tracker: &mut RowUniquenessTracker, batch: &RecordBatch) -
             }
             let _ = write!(row_signature, "{}:", value_buffer.len());
             row_signature.push_str(&value_buffer);
+            // Arrow nulls already render empty here, and the null-like tokens
+            // are the same ones the column analyzers count, so the record
+            // count and the cell counts describe one definition of null.
+            row_has_null |= is_null_like_token(&value_buffer);
         }
         tracker.observe(row_signature);
+        completeness.observe(row_has_null);
     }
 
     Ok(())
@@ -184,6 +205,11 @@ impl RecordBatchAnalyzer {
     /// the batches could not be signed (see the internal `BatchRowTracker`).
     pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
         self.row_tracker.summary()
+    }
+
+    /// Full-stream complete-record counts across every observed batch.
+    pub fn row_completeness_summary(&self) -> Option<RowCompletenessSummary> {
+        self.row_tracker.completeness_summary()
     }
 
     pub fn to_profiles(

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -430,7 +430,8 @@ pub fn profile_dataframe(
         exec,
     )
     .columns(column_profiles)
-    .with_row_duplicates(analyzer.row_duplicate_summary());
+    .with_row_duplicates(analyzer.row_duplicate_summary())
+    .with_row_completeness(analyzer.row_completeness_summary());
 
     if include_quality {
         assembler = assembler
@@ -538,7 +539,8 @@ pub fn profile_arrow(
         exec,
     )
     .columns(column_profiles)
-    .with_row_duplicates(analyzer.row_duplicate_summary());
+    .with_row_duplicates(analyzer.row_duplicate_summary())
+    .with_row_completeness(analyzer.row_completeness_summary());
 
     if include_quality {
         assembler = assembler

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -15,7 +15,8 @@ use dataprof::{
     infer_type, is_null_like_token,
 };
 use dataprof_runtime::{
-    ColumnProfileInput, ReportAssembler, RowUniquenessTracker, build_column_profile,
+    ColumnProfileInput, ReportAssembler, RowCompletenessTracker, RowUniquenessTracker,
+    build_column_profile,
 };
 
 use super::config::PyProfilerConfig;
@@ -113,7 +114,7 @@ pub fn profile_columns(
     let num_cols = columns.len();
 
     // Analysis is pure Rust over owned data, so the GIL buys us nothing here.
-    let (column_profiles, sample_columns, row_duplicates) = py.detach(|| {
+    let (column_profiles, sample_columns, row_duplicates, row_completeness) = py.detach(|| {
         let mut profiles = Vec::with_capacity(num_cols);
         let mut samples = std::collections::HashMap::new();
 
@@ -122,16 +123,23 @@ pub fn profile_columns(
         // engines. Null cells contribute an empty value, so files and
         // ad-hoc inputs holding the same data agree on duplicate counts.
         let mut row_tracker = RowUniquenessTracker::default();
+        let mut completeness_tracker = RowCompletenessTracker::default();
         if num_cols > 0 {
             use std::fmt::Write as _;
             for row_index in 0..num_rows {
                 let mut row_signature = String::new();
+                let mut row_has_null = false;
                 for (_, cells) in &columns {
                     let value = cells[row_index].as_deref().unwrap_or("");
                     let _ = write!(row_signature, "{}:", value.len());
                     row_signature.push_str(value);
+                    // A missing cell renders empty, which `is_null_like_token`
+                    // already treats as null — the same rule that produces
+                    // `null_count` below.
+                    row_has_null |= is_null_like_token(value);
                 }
                 row_tracker.observe(row_signature);
+                completeness_tracker.observe(row_has_null);
             }
         }
 
@@ -176,7 +184,12 @@ pub fn profile_columns(
             }
         }
 
-        (profiles, samples, row_tracker.summary())
+        (
+            profiles,
+            samples,
+            row_tracker.summary(),
+            completeness_tracker.summary(),
+        )
     });
 
     let mut exec = ExecutionMetadata::new(num_rows, num_cols, start.elapsed().as_millis())
@@ -232,7 +245,8 @@ pub fn profile_columns(
 
     let mut assembler = ReportAssembler::new(data_source, exec)
         .columns(column_profiles)
-        .with_row_duplicates(row_duplicates);
+        .with_row_duplicates(row_duplicates)
+        .with_row_completeness(row_completeness);
 
     if include_quality {
         assembler = assembler

--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -24,6 +24,6 @@ pub use profile_report::profile_report_schema_document;
 pub use profile_report::{ProfileReport, REPORT_SCHEMA_VERSION};
 pub use report_assembler::ReportAssembler;
 pub use streaming_stats::{
-    RowUniquenessTracker, StreamReservoirSampler, StreamingColumnCollection, StreamingStatistics,
-    TextLengthStats, WelfordAccumulator,
+    RowCompletenessTracker, RowUniquenessTracker, StreamReservoirSampler,
+    StreamingColumnCollection, StreamingStatistics, TextLengthStats, WelfordAccumulator,
 };

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -12,8 +12,8 @@ use dataprof_core::{
     SemanticHintBinding, SemanticHintKind, SemanticHints,
 };
 use dataprof_metrics::{
-    MetricConfidence, MetricsCalculator, QualityAssessment, RowDuplicateSummary,
-    analysis::metrics::BifurcatedResult, compute_value_hint_bindings,
+    MetricConfidence, MetricsCalculator, QualityAssessment, RowCompletenessSummary,
+    RowDuplicateSummary, analysis::metrics::BifurcatedResult, compute_value_hint_bindings,
 };
 
 use crate::ProfileReport;
@@ -30,6 +30,7 @@ pub struct ReportAssembler {
     semantic_hints: SemanticHints,
     exact_value_hint_bindings: Option<Vec<SemanticHintBinding>>,
     row_duplicates: Option<RowDuplicateSummary>,
+    row_completeness: Option<RowCompletenessSummary>,
 }
 
 impl ReportAssembler {
@@ -46,6 +47,7 @@ impl ReportAssembler {
             semantic_hints: SemanticHints::default(),
             exact_value_hint_bindings: None,
             row_duplicates: None,
+            row_completeness: None,
         }
     }
 
@@ -113,6 +115,15 @@ impl ReportAssembler {
     /// tracker; they supersede the sample-based duplicate scan.
     pub fn with_row_duplicates(mut self, summary: Option<RowDuplicateSummary>) -> Self {
         self.row_duplicates = summary;
+        self
+    }
+
+    /// Provide full-stream complete-record counts from an engine's row
+    /// tracker. Without them `complete_records_ratio` can only be bounded
+    /// from below, since per-column null totals cannot tell whether two
+    /// nulls fell in the same record.
+    pub fn with_row_completeness(mut self, summary: Option<RowCompletenessSummary>) -> Self {
+        self.row_completeness = summary;
         self
     }
 
@@ -205,7 +216,7 @@ impl ReportAssembler {
         &self,
         data: &HashMap<String, Vec<String>>,
     ) -> Option<QualityAssessment> {
-        let calculator = MetricsCalculator::new();
+        let calculator = MetricsCalculator::new().with_row_completeness(self.row_completeness);
         match calculator.calculate_bifurcated_metrics_with_all_semantic_hints(
             data,
             &self.columns,
@@ -234,7 +245,7 @@ impl ReportAssembler {
         &self,
         data: &HashMap<String, Vec<String>>,
     ) -> Option<QualityAssessment> {
-        let calculator = MetricsCalculator::new();
+        let calculator = MetricsCalculator::new().with_row_completeness(self.row_completeness);
         match calculator.calculate_comprehensive_metrics_with_all_semantic_hints(
             data,
             &self.columns,

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -7,7 +7,8 @@ use crate::{ValueHintBindingAccumulator, profile_builder::infer_data_type_stream
 use dataprof_core::{SemanticHintBinding, SemanticHintKind, SemanticHints};
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{
-    CardinalityEstimator, HyperLogLog, RowDuplicateSummary, value_matches_hint,
+    CardinalityEstimator, HyperLogLog, RowCompletenessSummary, RowDuplicateSummary,
+    value_matches_hint,
 };
 
 /// Incremental statistics computation for streaming data processing.
@@ -481,11 +482,76 @@ impl RowUniquenessTracker {
     }
 }
 
+/// Full-stream count of records in which every field is present.
+///
+/// Completeness of a *record* is not recoverable from per-column null
+/// totals: those say how many nulls exist, not whether two of them shared a
+/// row. One counter fed whole rows answers it exactly, at any scale and
+/// regardless of sampling.
+#[derive(Debug, Clone, Default)]
+pub struct RowCompletenessTracker {
+    rows_seen: usize,
+    complete_rows: usize,
+}
+
+impl RowCompletenessTracker {
+    /// Record one row. `had_null` is true when any of its fields was absent.
+    pub fn observe(&mut self, had_null: bool) {
+        self.rows_seen += 1;
+        if !had_null {
+            self.complete_rows += 1;
+        }
+    }
+
+    /// A column appeared after rows had already been counted, so every row
+    /// counted so far is missing it and none of them was complete after all.
+    pub fn invalidate_completed_rows(&mut self) {
+        self.complete_rows = 0;
+    }
+
+    /// Count complete records across columns that are already row-aligned
+    /// and hold every value, as the database and ad-hoc input paths do.
+    ///
+    /// A row shorter than `total_rows` in some column is missing that field,
+    /// which is the same as holding a null there — the reading
+    /// [`StreamingColumnCollection::process_record`] gives ragged records.
+    pub fn observe_aligned_columns(&mut self, columns: &[&[String]], total_rows: usize) {
+        if columns.is_empty() {
+            return;
+        }
+        for row_index in 0..total_rows {
+            let had_null = columns.iter().any(|cells| {
+                cells
+                    .get(row_index)
+                    .is_none_or(|value| is_null_like_token(value))
+            });
+            self.observe(had_null);
+        }
+    }
+
+    pub fn merge(&mut self, other: &RowCompletenessTracker) {
+        self.rows_seen += other.rows_seen;
+        self.complete_rows += other.complete_rows;
+    }
+
+    /// Exact complete-record counts, or `None` when no rows were observed.
+    pub fn summary(&self) -> Option<RowCompletenessSummary> {
+        if self.rows_seen == 0 {
+            return None;
+        }
+        Some(RowCompletenessSummary {
+            complete_rows: self.complete_rows,
+            rows_checked: self.rows_seen,
+        })
+    }
+}
+
 pub struct StreamingColumnCollection {
     columns: HashMap<String, StreamingStatistics>,
     ordered_names: Vec<String>,
     memory_limit_bytes: usize,
     row_tracker: RowUniquenessTracker,
+    completeness_tracker: RowCompletenessTracker,
     hint_bindings: ValueHintBindingAccumulator,
 }
 
@@ -496,6 +562,7 @@ impl StreamingColumnCollection {
             ordered_names: Vec::new(),
             memory_limit_bytes: 100 * 1024 * 1024,
             row_tracker: RowUniquenessTracker::default(),
+            completeness_tracker: RowCompletenessTracker::default(),
             hint_bindings: ValueHintBindingAccumulator::default(),
         }
     }
@@ -506,6 +573,7 @@ impl StreamingColumnCollection {
             ordered_names: Vec::new(),
             memory_limit_bytes: limit_mb * 1024 * 1024,
             row_tracker: RowUniquenessTracker::default(),
+            completeness_tracker: RowCompletenessTracker::default(),
             hint_bindings: ValueHintBindingAccumulator::default(),
         }
     }
@@ -544,6 +612,9 @@ impl StreamingColumnCollection {
         };
         self.columns.insert(header.to_string(), stats);
         self.ordered_names.push(header.to_string());
+        if prior_rows > 0 {
+            self.completeness_tracker.invalidate_completed_rows();
+        }
     }
 
     pub fn process_record<I>(&mut self, headers: &[String], values: I)
@@ -553,6 +624,7 @@ impl StreamingColumnCollection {
         // Length-prefixed so field boundaries are unambiguous:
         // ["ab", "c"] and ["a", "bc"] must produce different signatures.
         let mut row_signature = String::new();
+        let mut row_has_null = false;
         let mut values = values.into_iter();
 
         // Headers define the row schema. Normalize a missing trailing field to
@@ -568,17 +640,26 @@ impl StreamingColumnCollection {
             }
             let stats = self.columns.entry(header.to_string()).or_default();
             stats.update(&value);
+            // Same null definition the column counters use, so the record
+            // count and the cell counts always describe the same nulls.
+            row_has_null |= is_null_like_token(&value);
             self.hint_bindings.observe(header, &value);
         }
 
         if !headers.is_empty() {
             self.row_tracker.observe(row_signature);
+            self.completeness_tracker.observe(row_has_null);
         }
     }
 
     /// Full-stream row-duplicate counts, or `None` when no rows were seen.
     pub fn row_duplicate_summary(&self) -> Option<RowDuplicateSummary> {
         self.row_tracker.summary()
+    }
+
+    /// Full-stream complete-record counts, or `None` when no rows were seen.
+    pub fn row_completeness_summary(&self) -> Option<RowCompletenessSummary> {
+        self.completeness_tracker.summary()
     }
 
     /// Exact value-driven semantic-hint evidence over every processed record.
@@ -659,6 +740,97 @@ mod row_tracker_tests {
 
     fn record(collection: &mut StreamingColumnCollection, headers: &[String], values: &[&str]) {
         collection.process_record(headers, values.iter().map(|v| v.to_string()));
+    }
+
+    fn completeness(collection: &StreamingColumnCollection) -> (usize, usize) {
+        let summary = collection
+            .row_completeness_summary()
+            .expect("rows were observed");
+        (summary.complete_rows, summary.rows_checked)
+    }
+
+    #[test]
+    fn test_complete_rows_count_rows_not_null_cells() {
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        // Both nulls land in the same row, so 3 of 4 rows are complete. Per
+        // column the nulls total 2, which the cell-based lower bound would
+        // read as only 2 complete rows.
+        record(&mut collection, &headers, &["", ""]);
+        record(&mut collection, &headers, &["x", "1"]);
+        record(&mut collection, &headers, &["y", "2"]);
+        record(&mut collection, &headers, &["z", "3"]);
+
+        assert_eq!(completeness(&collection), (3, 4));
+    }
+
+    #[test]
+    fn test_null_like_tokens_make_a_row_incomplete() {
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        // The column counters treat these as nulls, so the record count must
+        // too, or the two halves of the dimension describe different data.
+        record(&mut collection, &headers, &["x", "NULL"]);
+        record(&mut collection, &headers, &["y", "NaN"]);
+        record(&mut collection, &headers, &["z", "  "]);
+        record(&mut collection, &headers, &["w", "3"]);
+
+        assert_eq!(completeness(&collection), (1, 4));
+    }
+
+    #[test]
+    fn test_ragged_rows_are_incomplete() {
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        record(&mut collection, &headers, &["x"]);
+        record(&mut collection, &headers, &["y", "1"]);
+
+        assert_eq!(completeness(&collection), (1, 2));
+    }
+
+    #[test]
+    fn test_a_late_column_makes_earlier_rows_incomplete() {
+        let mut collection = StreamingColumnCollection::new();
+        let first = vec!["a".to_string()];
+        record(&mut collection, &first, &["x"]);
+        record(&mut collection, &first, &["y"]);
+        assert_eq!(completeness(&collection), (2, 2));
+
+        // A JSON object introduces `b` on the third record. The first two
+        // records never carried it, so neither of them was complete.
+        collection.init_column_with_missing("b", 2);
+        let both = vec!["a".to_string(), "b".to_string()];
+        record(&mut collection, &both, &["z", "1"]);
+
+        assert_eq!(completeness(&collection), (1, 3));
+    }
+
+    #[test]
+    fn test_no_rows_means_no_completeness_summary() {
+        let collection = StreamingColumnCollection::new();
+        assert!(collection.row_completeness_summary().is_none());
+    }
+
+    #[test]
+    fn test_aligned_columns_count_the_same_complete_rows() {
+        let a: Vec<String> = ["", "x", "y"].iter().map(|v| v.to_string()).collect();
+        let b: Vec<String> = ["", "1", "2"].iter().map(|v| v.to_string()).collect();
+        let mut tracker = RowCompletenessTracker::default();
+        tracker.observe_aligned_columns(&[a.as_slice(), b.as_slice()], 3);
+
+        let summary = tracker.summary().expect("rows were observed");
+        assert_eq!((summary.complete_rows, summary.rows_checked), (2, 3));
+    }
+
+    #[test]
+    fn test_aligned_columns_treat_a_short_column_as_missing() {
+        let a: Vec<String> = ["x", "y"].iter().map(|v| v.to_string()).collect();
+        let b: Vec<String> = ["1"].iter().map(|v| v.to_string()).collect();
+        let mut tracker = RowCompletenessTracker::default();
+        tracker.observe_aligned_columns(&[a.as_slice(), b.as_slice()], 2);
+
+        let summary = tracker.summary().expect("rows were observed");
+        assert_eq!((summary.complete_rows, summary.rows_checked), (1, 2));
     }
 
     #[test]

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -96,16 +96,17 @@ a configurable weighted average of the dimensions that were actually assessed.
 Measures how much data is present vs. missing.
 
 - `missing_values_ratio` -- fraction of null/empty values across all columns
-- `complete_records_ratio` -- fraction of rows with zero nulls
+- `complete_records_ratio` -- percentage of rows with zero nulls, counted over
+  every row read
 - `null_columns` -- columns past the configured null threshold (50% by default)
 
 The completeness score is on the same 0–100 scale as the other dimensions. It
 combines cell completeness (`100 - missing_values_ratio`) and row completeness
 (`complete_records_ratio`), so inspect both underlying values when setting a
 quality gate. `complete_records_ratio` is deliberately strict: every column is
-treated as required, so one sparse optional field can drive it to zero. Inspect
-`missing_values_ratio` and `null_columns` beside it; a richer optional-column
-policy is tracked in [#436](https://github.com/AndreaBozzo/dataprof/issues/436).
+treated as required, so a dataset with one sparse optional field reports a low
+figure by design. `null_columns` names the columns responsible — read it beside
+the ratio rather than reading the ratio alone.
 
 ### Consistency
 

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -196,6 +196,7 @@
       "description": "Completeness metrics (ISO 8000-8).",
       "properties": {
         "complete_records_ratio": {
+          "description": "Percentage of records in which every field is present, counted over\nevery row the engine read. Strict by design: a record missing one\noptional field is not complete, so read it beside `null_columns`,\nwhich names the columns responsible.",
           "format": "double",
           "type": "number"
         },

--- a/python/tests/test_agent_docs_sync.py
+++ b/python/tests/test_agent_docs_sync.py
@@ -413,7 +413,7 @@ def test_eval_rubrics_cite_current_fixture_values() -> None:
 
     # Scores are quoted to one decimal; compare at that precision.
     for label, actual, expected in (
-        ("before quality score", before.quality_score, 80.9),
+        ("before quality score", before.quality_score, 83.5),
         ("after quality score", after.quality_score, 97.9),
         # The high-score-is-not-clean rubric grades against this one. It went
         # stale unnoticed when #544 changed string-column consistency, because

--- a/python/tests/test_complete_records_ratio.py
+++ b/python/tests/test_complete_records_ratio.py
@@ -1,0 +1,68 @@
+"""`complete_records_ratio` counts records, not null cells.
+
+Every input path reaches rows differently — a dict of columns, a list of
+records, a pandas frame handed over as Arrow batches — and each has to arrive
+at the same figure for the same data. Deriving it from per-column null totals
+does not: that assumes no two nulls share a record, which understates
+completeness on exactly the datasets it describes, and reports 0% once the
+null cells outnumber the rows.
+"""
+
+from __future__ import annotations
+
+import dataprof
+import pytest
+
+# Four records, two of them missing both optional fields. Two records are
+# complete, so the answer is 50.0. The null cells number 4 across 4 rows,
+# which a cell-based bound reads as 0%.
+COLUMNS: dict[str, list] = {
+    "id": [1, 2, 3, 4],
+    "notes": [None, None, "ok", "ok"],
+    "city": [None, None, "Rome", "Rome"],
+}
+EXPECTED_RATIO = 50.0
+
+
+def completeness(report) -> dict:
+    return report.quality.completeness
+
+
+def test_dict_of_columns_counts_complete_records() -> None:
+    report = dataprof.profile(COLUMNS)
+    assert completeness(report)["complete_records_ratio"] == pytest.approx(EXPECTED_RATIO)
+
+
+def test_list_of_records_counts_complete_records() -> None:
+    records = [
+        {name: values[row] for name, values in COLUMNS.items()} for row in range(len(COLUMNS["id"]))
+    ]
+    report = dataprof.profile(records)
+    assert completeness(report)["complete_records_ratio"] == pytest.approx(EXPECTED_RATIO)
+
+
+def test_null_like_strings_count_as_missing_fields() -> None:
+    # The column counters read these as nulls, so the record count must too.
+    report = dataprof.profile({"a": ["x", "y"], "b": ["NULL", "1"]})
+    assert completeness(report)["complete_records_ratio"] == pytest.approx(50.0)
+
+
+def test_dataframe_agrees_with_the_dict_it_came_from() -> None:
+    pandas = pytest.importorskip("pandas")
+
+    frame = pandas.DataFrame(COLUMNS)
+    report = dataprof.profile(frame)
+    assert completeness(report)["complete_records_ratio"] == pytest.approx(EXPECTED_RATIO)
+
+
+def test_csv_file_agrees_with_the_same_data_in_memory(tmp_path) -> None:
+    path = tmp_path / "records.csv"
+    rows = ["id,notes,city", "1,,", "2,,", "3,ok,Rome", "4,ok,Rome"]
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+    from_file = dataprof.profile(str(path))
+    from_memory = dataprof.profile(COLUMNS)
+    assert completeness(from_file)["complete_records_ratio"] == pytest.approx(
+        completeness(from_memory)["complete_records_ratio"]
+    )
+    assert completeness(from_file)["complete_records_ratio"] == pytest.approx(EXPECTED_RATIO)

--- a/tests/complete_records_ratio.rs
+++ b/tests/complete_records_ratio.rs
@@ -1,0 +1,143 @@
+//! `complete_records_ratio` must count rows that have no nulls.
+//!
+//! The metric is published as a percentage of complete records, so it has to
+//! be measured on rows. Deriving it from per-column null totals assumes nulls
+//! never share a row, which understates it — without bound — on exactly the
+//! datasets it is meant to describe: a few optional columns that are empty
+//! together.
+
+use std::io::Write;
+
+use dataprof::{
+    CsvParserConfig, EngineType, JsonParserConfig, ProfileReport, Profiler, analyze_csv_file,
+    analyze_json_file,
+};
+use tempfile::NamedTempFile;
+
+fn completeness_ratio(report: &ProfileReport) -> f64 {
+    report
+        .quality
+        .as_ref()
+        .expect("quality assessed")
+        .metrics
+        .completeness
+        .as_ref()
+        .expect("completeness assessed")
+        .complete_records_ratio
+}
+
+/// 10 rows; `notes` empty in 7, `city` empty in 3, and every `city` null
+/// falls on a row that is already missing `notes`. Rows 8-10 are complete,
+/// so the honest answer is 30%.
+fn co_occurring_nulls_csv() -> NamedTempFile {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "id,notes,city").unwrap();
+    for id in 1..=3 {
+        writeln!(f, "{id},,").unwrap();
+    }
+    for id in 4..=7 {
+        writeln!(f, "{id},,Rome").unwrap();
+    }
+    for id in 8..=10 {
+        writeln!(f, "{id},ok,Rome").unwrap();
+    }
+    f.flush().unwrap();
+    f
+}
+
+#[test]
+fn complete_records_ratio_counts_rows_not_null_cells() {
+    let csv = co_occurring_nulls_csv();
+    let report = analyze_csv_file(csv.path(), &CsvParserConfig::default())
+        .expect("CSV analysis should succeed");
+
+    let ratio = completeness_ratio(&report);
+    assert!(
+        (ratio - 30.0).abs() < 0.01,
+        "3 of 10 rows have no nulls, so complete_records_ratio should be 30.0, got {ratio}"
+    );
+}
+
+/// The output contract: the same data must profile to the same numbers on
+/// every engine. The count is row-level, and each engine reaches rows its
+/// own way — record by record, or batch by batch through Arrow.
+#[test]
+fn complete_records_ratio_agrees_across_engines() {
+    let csv = co_occurring_nulls_csv();
+    let engines = [
+        EngineType::Auto,
+        EngineType::Incremental,
+        EngineType::Columnar,
+    ];
+
+    for engine in engines {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(csv.path())
+            .unwrap_or_else(|error| panic!("{engine:?} analysis should succeed: {error}"));
+        let ratio = completeness_ratio(&report);
+        assert!(
+            (ratio - 30.0).abs() < 0.01,
+            "{engine:?} reported complete_records_ratio {ratio}, expected 30.0"
+        );
+    }
+}
+
+/// A record missing a field that only later records introduce is incomplete,
+/// even though it was counted before the field was known to exist.
+#[test]
+fn complete_records_ratio_accounts_for_late_json_fields() {
+    let mut json = NamedTempFile::with_suffix(".jsonl").unwrap();
+    writeln!(json, r#"{{"id": 1}}"#).unwrap();
+    writeln!(json, r#"{{"id": 2, "city": "Rome"}}"#).unwrap();
+    json.flush().unwrap();
+
+    let report = analyze_json_file(json.path(), &JsonParserConfig::default())
+        .expect("JSON analysis should succeed");
+    let ratio = completeness_ratio(&report);
+    assert!(
+        (ratio - 50.0).abs() < 0.01,
+        "the first record has no `city`, so 1 of 2 records is complete, got {ratio}"
+    );
+}
+
+/// Sampling shrinks the retained sample, never the counters: the ratio is
+/// accumulated over every row the engine read.
+#[test]
+fn complete_records_ratio_survives_sampling() {
+    let mut csv = NamedTempFile::new().unwrap();
+    writeln!(csv, "id,notes,city").unwrap();
+    // 40k rows, well past the per-column sample reservoirs. Every fourth row
+    // is missing both optional fields, so exactly 75% of records are
+    // complete while the null cells number half the rows.
+    for id in 0..40_000 {
+        if id % 4 == 0 {
+            writeln!(csv, "{id},,").unwrap();
+        } else {
+            writeln!(csv, "{id},ok,Rome").unwrap();
+        }
+    }
+    csv.flush().unwrap();
+
+    let report = analyze_csv_file(csv.path(), &CsvParserConfig::default())
+        .expect("CSV analysis should succeed");
+    let ratio = completeness_ratio(&report);
+    assert!(
+        (ratio - 75.0).abs() < 0.01,
+        "3 of every 4 rows are complete, so the ratio should be 75.0, got {ratio}"
+    );
+}
+
+#[test]
+fn complete_records_ratio_is_exact_when_every_row_is_complete() {
+    let mut csv = NamedTempFile::new().unwrap();
+    writeln!(csv, "id,city").unwrap();
+    for id in 1..=5 {
+        writeln!(csv, "{id},Rome").unwrap();
+    }
+    csv.flush().unwrap();
+
+    let report = analyze_csv_file(csv.path(), &CsvParserConfig::default())
+        .expect("CSV analysis should succeed");
+    assert!((completeness_ratio(&report) - 100.0).abs() < 0.01);
+}


### PR DESCRIPTION
Closes #436.

## The problem

`complete_records_ratio` is published as the percentage of records with no
missing fields. It was computed from per-column null totals:

```
(total_rows - sum_of_null_cells_across_all_columns) / total_rows, clamped at 0
```

That assumes no two nulls ever share a record. It is a lower bound, not a
measurement, and it was reported as one — feeding the completeness dimension
score and the overall quality number.

The gap is unbounded. On a 10-row table with `notes` empty in 7 rows and
`city` empty in 3 of those same rows, three records are complete and the
metric reported **0%**. The honest row-scanning implementation existed but was
dead code: it only ran when no column profiles were present, which never
happens on a real path. It also could not have worked there, because the data
it scans is the per-column reservoir sample, which drops nulls and is not
row-aligned.

## The fix

Record completeness is a property of a row, so count it on rows. Engines
accumulate it over the full stream with one counter, next to the row-duplicate
tracking they already do:

- `RowCompletenessTracker` in `dataprof-runtime`, fed whole records by
  `StreamingColumnCollection::process_record` (CSV, JSON, incremental, async).
- The same count from Arrow batches in `dataprof-parquet`, using the render the
  duplicate signature already produces.
- Row-aligned column inputs (database results, Python dicts/frames/records)
  count directly.
- `MetricsCalculator::with_row_completeness` carries it into the dimension.

The count uses each path's own definition of null — the one its column
counters use — so the record figure and the cell figures always describe the
same nulls. A JSON key that first appears mid-stream retroactively marks the
earlier records incomplete, matching how their column counters are backfilled.

O(1) memory, exact under sampling, and identical across every input path.

The old bound survives only where no engine supplied a row count, and its
documentation now says it is a bound.

## What this does not change

Semantics. Every column is still treated as required, and `null_columns` still
names the sparse ones — the metric is strict by design, it was just also
wrong. The optional-column policy question is a separate decision.

## Reported numbers move

Upward, wherever nulls co-occur. An eval fixture's quality score goes 80.9 to
83.5. Score-based gates on datasets with co-occurring nulls will read higher.

## Verification

New regression tests, each confirmed to fail against the unfixed code:

| test | fails without |
| --- | --- |
| `complete_records_ratio_counts_rows_not_null_cells` | the row-count preference |
| `complete_records_ratio_agrees_across_engines` | the Arrow wiring (Columnar leg reports 0) |
| `complete_records_ratio_accounts_for_late_json_fields` | the late-column invalidation (reports 100) |
| `complete_records_ratio_survives_sampling` | the row-count preference (reports 50, not 75) |

`complete_records_ratio_is_exact_when_every_row_is_complete` passes with and
without the fix — it is a preservation guard, not a discriminating one, since
the old bound was exact when no column had nulls. The JSON test discriminates
the late-column part but not the core one, where the bound happens to agree at
this fixture size.

Also: unit scenarios for the tracker (co-occurring nulls, null-like tokens,
ragged rows, late columns, aligned columns) and the completeness matrix
(row count wins over the bound; the bound alone; the bound bottoming out),
plus Python tests covering dict, records, pandas, and file-vs-memory parity.

Commands run:

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace                     # 41 suites, all ok
cargo test -p dataprof-db --features sqlite
uv run maturin develop
uv run pytest python/tests/ -q             # 979 passed, 9 skipped
uv run ruff format / ruff check / ty check
cargo run --example generate_profile_schema
```
