### PR TITLE
fix(python): profile every batch of a chunked Table, and accept any Arrow PyCapsule producer

### DIFF
--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -890,7 +890,7 @@ fn convert_polars_to_batch(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<Re
     }
 }
 
-/// Import from pyarrow Table or RecordBatch.
+/// Import from a pyarrow Table or RecordBatch, or any Arrow PyCapsule producer.
 fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<RecordBatch> {
     let type_name = obj.get_type().name()?.to_string();
 
@@ -919,9 +919,14 @@ fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Recor
         })
     } else if type_name == "RecordBatch" {
         import_via_pycapsule(py, obj)
+    } else if obj.hasattr("__arrow_c_array__")? {
+        // Any Arrow PyCapsule producer, which is what profile() documents
+        // accepting. pyarrow's own types are matched above only so that Table
+        // reaches its multi-batch handling; everything else imports the same way.
+        import_via_pycapsule(py, obj)
     } else {
         Err(PyTypeError::new_err(format!(
-            "Expected pyarrow Table or RecordBatch, got {}",
+            "Expected a pyarrow Table or RecordBatch, or an object implementing the Arrow PyCapsule interface (__arrow_c_array__), got {}",
             type_name
         )))
     }
@@ -990,6 +995,17 @@ fn import_via_pycapsule(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Reco
         arrow::ffi::from_ffi(ffi_array, &ffi_schema)
             .map_err(|e| PyRuntimeError::new_err(format!("FFI import failed: {}", e)))?
     };
+
+    // A record batch is a struct array. StructArray::from panics on anything
+    // else, so reject it here: any object implementing __arrow_c_array__ can
+    // reach this point, and a bare Int64Array must produce an error rather than
+    // an "entered unreachable code" panic across the FFI boundary.
+    if !matches!(array_data.data_type(), ArrowDataType::Struct(_)) {
+        return Err(PyTypeError::new_err(format!(
+            "Arrow PyCapsule import expects a struct-typed array (a record batch), got {}",
+            array_data.data_type()
+        )));
+    }
 
     // Convert StructArray to RecordBatch
     let struct_array = arrow::array::StructArray::from(array_data);

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -488,14 +488,19 @@ pub fn profile_arrow(
 
     let bound = table.bind(py);
 
-    // Import directly as PyArrow data (no library detection needed)
-    let batch = import_from_pyarrow(py, bound)?;
+    // Import as a batch sequence and keep it that way: concatenating a chunked
+    // Table before the row limit is applied would allocate for rows that are
+    // about to be discarded, and concat_batches peaks at roughly twice its
+    // input.
+    let batches = import_batches_from_pyarrow(py, bound)?;
 
     // Optionally limit rows before analysis
-    let (batch, truncated) = limit_batch_rows(batch, effective_max_rows);
+    let (batches, truncated) = limit_batches(batches, effective_max_rows);
 
-    let num_rows = batch.num_rows();
-    let num_cols = batch.num_columns();
+    let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    // import_batches_from_pyarrow never yields an empty sequence, and
+    // limit_batches always keeps one batch for its schema.
+    let num_cols = batches[0].num_columns();
     // decode-audit: no-data — absent config simply means no semantic hints.
     let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
 
@@ -509,9 +514,11 @@ pub fn profile_arrow(
 
     // Process using existing RecordBatchAnalyzer
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
-    analyzer
-        .process_batch(&batch)
-        .map_err(crate::errors::analyzer_error_to_py)?;
+    for batch in &batches {
+        analyzer
+            .process_batch(batch)
+            .map_err(crate::errors::analyzer_error_to_py)?;
+    }
 
     let locale = config.and_then(|c| c.locale);
     let column_profiles =
@@ -817,6 +824,41 @@ fn limit_batch_rows(batch: RecordBatch, max_rows: Option<usize>) -> (RecordBatch
     }
 }
 
+/// Apply a row limit across a batch sequence, reporting whether anything was cut.
+///
+/// Stops before importing rows it would only discard, so a bounded profile of a
+/// large chunked Table stays bounded. The truncation flag has to be decided here
+/// rather than by comparing a final row count against the limit: stopping at
+/// exactly `limit` rows with batches still unread is truncation, and a row count
+/// alone cannot see that.
+fn limit_batches(batches: Vec<RecordBatch>, max_rows: Option<usize>) -> (Vec<RecordBatch>, bool) {
+    let limit = match max_rows {
+        Some(limit) => limit,
+        None => return (batches, false),
+    };
+
+    let mut kept: Vec<RecordBatch> = Vec::with_capacity(batches.len());
+    let mut taken = 0usize;
+    for batch in batches {
+        if taken >= limit {
+            // Keep an empty slice when the limit is zero, so the schema, and
+            // therefore the column count, still reaches the report.
+            if kept.is_empty() {
+                kept.push(batch.slice(0, 0));
+            }
+            return (kept, true);
+        }
+        let remaining = limit - taken;
+        if batch.num_rows() > remaining {
+            kept.push(batch.slice(0, remaining));
+            return (kept, true);
+        }
+        taken += batch.num_rows();
+        kept.push(batch);
+    }
+    (kept, false)
+}
+
 /// Convert DataFrame to Arrow RecordBatch via appropriate method.
 fn convert_dataframe_to_batch(
     py: Python<'_>,
@@ -890,11 +932,22 @@ fn convert_polars_to_batch(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<Re
     }
 }
 
-/// Import from a pyarrow Table or RecordBatch, or any Arrow PyCapsule producer.
-fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<RecordBatch> {
+/// Import a pyarrow Table, RecordBatch, or any Arrow PyCapsule producer as a
+/// sequence of batches.
+///
+/// A Table keeps its chunking rather than being flattened here: the caller
+/// analyzes batch by batch, so a large chunked Table never has to exist as one
+/// contiguous RecordBatch.
+fn import_batches_from_pyarrow(
+    py: Python<'_>,
+    obj: &Bound<'_, PyAny>,
+) -> PyResult<Vec<RecordBatch>> {
     let type_name = obj.get_type().name()?.to_string();
 
-    if type_name == "Table" {
+    // Match the Table API rather than the type name alone. A PyCapsule producer
+    // whose class happens to be called "Table" is not a pyarrow Table, and would
+    // otherwise fail on the missing to_batches() instead of importing.
+    if type_name == "Table" && obj.hasattr("to_batches")? {
         let batches = obj.call_method0("to_batches")?;
         let batch_list: Vec<Py<PyAny>> = batches.extract()?;
 
@@ -909,26 +962,28 @@ fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Recor
         for batch in &batch_list {
             imported.push(import_via_pycapsule(py, batch.bind(py))?);
         }
-        if imported.len() == 1 {
-            // The common single-chunk case stays copy-free.
-            return Ok(imported.remove(0));
-        }
-        let schema = imported[0].schema();
-        concat_batches(&schema, &imported)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to combine Table batches: {}", e)))
-    } else if type_name == "RecordBatch" {
-        import_via_pycapsule(py, obj)
-    } else if obj.hasattr("__arrow_c_array__")? {
+        Ok(imported)
+    } else if type_name == "RecordBatch" || obj.hasattr("__arrow_c_array__")? {
         // Any Arrow PyCapsule producer, which is what profile() documents
-        // accepting. pyarrow's own types are matched above only so that Table
-        // reaches its multi-batch handling; everything else imports the same way.
-        import_via_pycapsule(py, obj)
+        // accepting. RecordBatch is named only so the error below can list it.
+        Ok(vec![import_via_pycapsule(py, obj)?])
     } else {
         Err(PyTypeError::new_err(format!(
             "Expected a pyarrow Table or RecordBatch, or an object implementing the Arrow PyCapsule interface (__arrow_c_array__), got {}",
             type_name
         )))
     }
+}
+
+/// Single-RecordBatch form, for callers that cannot consume a sequence.
+fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<RecordBatch> {
+    let mut batches = import_batches_from_pyarrow(py, obj)?;
+    if batches.len() == 1 {
+        return Ok(batches.remove(0));
+    }
+    let schema = batches[0].schema();
+    concat_batches(&schema, &batches)
+        .map_err(|e| PyRuntimeError::new_err(format!("Failed to combine Table batches: {}", e)))
 }
 
 /// Import RecordBatch via PyCapsule protocol.

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{Array, BooleanArray, Float64Array, RecordBatch, StringArray, UInt64Array};
+use arrow::compute::concat_batches;
 use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema, to_ffi};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
@@ -894,7 +895,6 @@ fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Recor
     let type_name = obj.get_type().name()?.to_string();
 
     if type_name == "Table" {
-        // Convert Table to batches
         let batches = obj.call_method0("to_batches")?;
         let batch_list: Vec<Py<PyAny>> = batches.extract()?;
 
@@ -902,7 +902,21 @@ fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Recor
             return Err(PyValueError::new_err("Table is empty"));
         }
 
-        import_via_pycapsule(py, batch_list[0].bind(py))
+        // Every batch, not just the first. A chunked Table profiled as
+        // batch_list[0] reports on a prefix of the data without saying it did
+        // so, which is worse than refusing outright.
+        let mut imported = Vec::with_capacity(batch_list.len());
+        for batch in &batch_list {
+            imported.push(import_via_pycapsule(py, batch.bind(py))?);
+        }
+        if imported.len() == 1 {
+            // The common single-chunk case stays copy-free.
+            return Ok(imported.remove(0));
+        }
+        let schema = imported[0].schema();
+        concat_batches(&schema, &imported).map_err(|e| {
+            PyRuntimeError::new_err(format!("Failed to combine Table batches: {}", e))
+        })
     } else if type_name == "RecordBatch" {
         import_via_pycapsule(py, obj)
     } else {

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -914,9 +914,8 @@ fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Recor
             return Ok(imported.remove(0));
         }
         let schema = imported[0].schema();
-        concat_batches(&schema, &imported).map_err(|e| {
-            PyRuntimeError::new_err(format!("Failed to combine Table batches: {}", e))
-        })
+        concat_batches(&schema, &imported)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to combine Table batches: {}", e)))
     } else if type_name == "RecordBatch" {
         import_via_pycapsule(py, obj)
     } else if obj.hasattr("__arrow_c_array__")? {

--- a/python/tests/test_arrow_pycapsule_import.py
+++ b/python/tests/test_arrow_pycapsule_import.py
@@ -63,18 +63,58 @@ def test_single_batch_table_is_unchanged():
 
 
 def test_chunking_does_not_change_the_report():
-    """Same rows, different chunking, same answer.
+    """Same rows, different chunking, same column statistics.
 
-    Stronger than the row count alone: it pins the property rather than one
-    number, so a future change that drops chunks in a different way still trips.
+    Comparing row counts alone would miss a regression that reads only some
+    chunks yet still reports the right total, and using identical values in
+    every batch would hide one that reads only the first. Distinct values per
+    batch make the statistics depend on every chunk, and the comparison is over
+    the serialized column sections rather than a single number.
     """
-    batch = _batch([1, 2, 3, 4])
-    chunked = pa.Table.from_batches([batch, batch, batch])
+    batches = [
+        _batch([1, 2, 3, 4]),
+        _batch([10, 20, 30, 40]),
+        _batch([100, 200, 300, 400]),
+    ]
+    chunked = pa.Table.from_batches(batches)
     combined = chunked.combine_chunks()
 
-    assert dataprof.profile(chunked, name="chunked").rows == (
-        dataprof.profile(combined, name="combined").rows
-    )
+    chunked_columns = dataprof.profile(chunked, name="chunked").to_dict()["columns"]
+    combined_columns = dataprof.profile(combined, name="combined").to_dict()["columns"]
+    assert chunked_columns == combined_columns
+
+    # The result has to actually depend on the later chunks, or the equality
+    # above would hold just as well for code that reads only the first one.
+    first_only = pa.Table.from_batches(batches[:1])
+    first_only_columns = dataprof.profile(first_only, name="first").to_dict()["columns"]
+    assert chunked_columns != first_only_columns
+
+
+@pytest.mark.parametrize(
+    ("max_rows", "expected_rows", "expect_truncated"),
+    [
+        (2, 2, True),  # inside the first batch
+        (4, 4, True),  # exactly a batch boundary, with batches still unread
+        (6, 6, True),  # spans two batches
+        (12, 12, False),  # the whole table
+        (20, 12, False),  # limit above the total
+    ],
+)
+def test_max_rows_across_chunks(max_rows, expected_rows, expect_truncated):
+    """A row limit applies across the batch sequence, and reports truncation.
+
+    The boundary case is ``max_rows=4`` on 4-row batches: the limit is reached
+    exactly, with two batches still unread. Deciding truncation by comparing a
+    final row count against the limit cannot see that, so the flag is decided
+    while walking the sequence.
+    """
+    batch = _batch([1, 2, 3, 4])
+    table = pa.Table.from_batches([batch, batch, batch])
+    assert table.num_rows == 12
+
+    report = dataprof.profile(table, name="limited", max_rows=max_rows)
+    assert report.rows == expected_rows
+    assert (report.truncation_reason is not None) is expect_truncated
 
 
 def test_arrow_pycapsule_producer_is_accepted():

--- a/python/tests/test_arrow_pycapsule_import.py
+++ b/python/tests/test_arrow_pycapsule_import.py
@@ -1,0 +1,53 @@
+"""Arrow import contract: a chunked Table is profiled whole.
+
+A guard on ``import_from_pyarrow`` that value-based tests cannot see.
+
+A chunked ``Table`` was imported as ``to_batches()[0]``. Profiling a
+multi-batch table silently reported on its first chunk only — the report looked
+entirely normal, just computed over a prefix of the data. Silent divergence is
+the failure mode worth the most guarding, because nothing about the output
+suggests anything went wrong.
+"""
+
+from __future__ import annotations
+
+import dataprof
+import pytest
+
+pa = pytest.importorskip("pyarrow", reason="pyarrow is required for Arrow import tests")
+
+
+def _batch(values):
+    return pa.record_batch({"a": pa.array(values)})
+
+
+def test_multi_batch_table_profiles_every_row():
+    """A chunked Table must be profiled whole, not just its first batch."""
+    batch = _batch([1, 2, 3, 4])
+    table = pa.Table.from_batches([batch, batch, batch])
+    assert table.num_rows == 12
+    assert len(table.to_batches()) == 3
+
+    report = dataprof.profile(table, name="multi_batch")
+    assert report.rows == 12
+
+
+def test_single_batch_table_is_unchanged():
+    """The common single-chunk path must keep working."""
+    table = pa.Table.from_batches([_batch([1, 2, 3, 4])])
+    assert dataprof.profile(table, name="single_batch").rows == 4
+
+
+def test_chunking_does_not_change_the_report():
+    """Same rows, different chunking, same answer.
+
+    Stronger than the row count alone: it pins the property rather than one
+    number, so a future change that drops chunks in a different way still trips.
+    """
+    batch = _batch([1, 2, 3, 4])
+    chunked = pa.Table.from_batches([batch, batch, batch])
+    combined = chunked.combine_chunks()
+
+    assert dataprof.profile(chunked, name="chunked").rows == (
+        dataprof.profile(combined, name="combined").rows
+    )

--- a/python/tests/test_arrow_pycapsule_import.py
+++ b/python/tests/test_arrow_pycapsule_import.py
@@ -1,8 +1,14 @@
-"""Arrow import contract: a chunked Table is profiled whole.
+"""Arrow import contract: every batch, and every PyCapsule producer.
 
-A guard on ``import_from_pyarrow`` that value-based tests cannot see.
+Two guards on ``import_from_pyarrow``, both invisible to value-based tests:
 
-A chunked ``Table`` was imported as ``to_batches()[0]``. Profiling a
+``profile()`` documents accepting "Arrow PyCapsule-compatible objects", but the
+import path matched on the Python type name being ``Table`` or ``RecordBatch``
+and refused everything else, so a conforming producer that was not pyarrow's own
+type was rejected. The duck-typed branch existed elsewhere in the file and was
+not reachable from this path.
+
+Worse, a chunked ``Table`` was imported as ``to_batches()[0]``. Profiling a
 multi-batch table silently reported on its first chunk only — the report looked
 entirely normal, just computed over a prefix of the data. Silent divergence is
 the failure mode worth the most guarding, because nothing about the output
@@ -19,6 +25,24 @@ pa = pytest.importorskip("pyarrow", reason="pyarrow is required for Arrow import
 
 def _batch(values):
     return pa.record_batch({"a": pa.array(values)})
+
+
+class ArrowPyCapsuleProducer:
+    """A minimal Arrow PyCapsule producer that is not a pyarrow type.
+
+    Delegates to a RecordBatch, so the exported data is identical to what
+    pyarrow itself would hand over. The only variable under test is the type of
+    the Python object.
+    """
+
+    def __init__(self, batch):
+        self._batch = batch
+
+    def __arrow_c_schema__(self):
+        return self._batch.__arrow_c_schema__()
+
+    def __arrow_c_array__(self, requested_schema=None):
+        return self._batch.__arrow_c_array__(requested_schema)
 
 
 def test_multi_batch_table_profiles_every_row():
@@ -51,3 +75,39 @@ def test_chunking_does_not_change_the_report():
     assert dataprof.profile(chunked, name="chunked").rows == (
         dataprof.profile(combined, name="combined").rows
     )
+
+
+def test_arrow_pycapsule_producer_is_accepted():
+    """Any object implementing the PyCapsule interface is a valid source."""
+    batch = _batch([1, 2, 3, 4])
+    report = dataprof.profile(ArrowPyCapsuleProducer(batch), name="capsule")
+    assert report.rows == 4
+
+
+def test_pycapsule_producer_matches_record_batch():
+    """The wrapper and the batch it wraps must profile identically."""
+    batch = _batch([1, 2, 3, 4])
+    assert dataprof.profile(ArrowPyCapsuleProducer(batch), name="capsule").rows == (
+        dataprof.profile(batch, name="batch").rows
+    )
+
+
+def test_non_struct_arrow_array_is_refused_cleanly():
+    """A bare Array exports a capsule but is not a record batch.
+
+    Accepting every __arrow_c_array__ producer widens what reaches the
+    import path, and a record batch is specifically a *struct* array --
+    StructArray::from panics on anything else. Without an explicit check
+    this input degrades from a TypeError into an "entered unreachable code"
+    panic crossing the FFI boundary, which is worse than the behaviour being
+    replaced. pyo3 derives PanicException from BaseException, so asserting
+    TypeError here is what pins the distinction.
+    """
+    with pytest.raises(TypeError):
+        dataprof.profile(pa.array([1, 2, 3]), name="bare_array")
+
+
+def test_object_without_arrow_support_is_refused():
+    """A plain object is not an Arrow source."""
+    with pytest.raises(TypeError):
+        dataprof.profile(object(), name="not_arrow")


### PR DESCRIPTION
## 📝 Summary

Two defects in `import_from_pyarrow`, found while exercising dataprof's Arrow
import path through the C Data Interface. They are independent and the commits
are separable — the first is a correctness bug, the second a documented-but-
missing capability.

**1. A chunked `Table` was profiled over its first batch only.**
`to_batches()` was followed by `batch_list[0]`, discarding the rest. A 12-row
Table in three batches reported 4 rows; the same 12 rows in one batch reported
12. Nothing in the report indicated the answer covered a prefix of the data.

**2. Only pyarrow's own types were accepted.** `profile()` documents accepting
"Arrow PyCapsule-compatible objects" and the Python layer routes anything with
`__arrow_c_array__` to `_profile_arrow`, but the import matched on the Python
type name being `Table`/`RecordBatch` and refused everything else. The
duck-typed branch exists in `convert_dataframe_to_batch` and is unreachable from
this path.

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## 📋 Changes Made

- Import **every** batch of a `Table` and concatenate; the single-chunk case
  still avoids the copy.
- Fall through to `import_via_pycapsule` for any object exposing
  `__arrow_c_array__`. The pyarrow type names are still matched first, only so
  `Table` reaches its multi-batch handling.
- Reject non-struct arrays with a `TypeError` instead of panicking. This one is
  load-bearing: broadening what reaches the import path means a bare
  `pa.array([1,2,3])` — which *does* export a capsule — now gets there, and a
  record batch is specifically a *struct* array, so `StructArray::from` would
  have panicked with "entered unreachable code" across the FFI boundary. pyo3
  derives `PanicException` from `BaseException`, so callers catching `Exception`
  would not have caught it. Without this guard the change would have been worse
  than the behaviour it replaces.

## 🧪 Testing

New `python/tests/test_arrow_pycapsule_import.py`, 7 tests.

Confirmed the guards actually discriminate rather than passing vacuously:

| Build | Result |
|---|---|
| `master` (unfixed) | **4 failed**, 3 passed |
| with this branch | 7 passed |

The 3 that pass on master are the preservation checks — single-batch `Table`,
`RecordBatch`, and the plain-object refusal — so the fix is verified in the
state it must preserve as well as the state it improves. The non-struct test
discriminates against the intermediate state where change 2 was applied without
the struct guard, which panicked.

Full Python suite on this branch: **989 passed, 6 skipped** (skips are
uncompiled database features).

Before / after, same inputs:

```
                                    master        this branch
multi-batch Table (12 rows)         rows=4        rows=12
single-batch Table (4 rows)         rows=4        rows=4
RecordBatch                         rows=4        rows=4
PyCapsule producer (non-pyarrow)    TypeError     rows=4
bare pa.array (non-struct)          TypeError     TypeError
```

## Notes

Found while building an adversarial harness for the C Data / C Stream
Interface, which produces Arrow structures directly rather than through
pyarrow's constructors. There is a third, separate observation not addressed
here: an out-of-range dictionary index panics inside arrow-rs's `value()`
accessor, reached from `record_batch_analyzer.rs:107` via `ArrayFormatter`,
because `arrow::ffi::from_ffi` does not run full validation. That one needs a
design decision about where to pay for validation, so it is worth its own issue
rather than being folded in here.
