### PR TITLE
fix(python): validate Arrow data imported over the C Data Interface

### DIFF
--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -392,9 +392,7 @@ pub fn profile_dataframe(
 
     // Process using existing RecordBatchAnalyzer
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
-    analyzer
-        .process_batch(&batch)
-        .map_err(crate::errors::analyzer_error_to_py)?;
+    analyze_imported_batch(&mut analyzer, &batch)?;
 
     let locale = config.and_then(|c| c.locale);
     let column_profiles =
@@ -515,9 +513,7 @@ pub fn profile_arrow(
     // Process using existing RecordBatchAnalyzer
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
     for batch in &batches {
-        analyzer
-            .process_batch(batch)
-            .map_err(crate::errors::analyzer_error_to_py)?;
+        analyze_imported_batch(&mut analyzer, batch)?;
     }
 
     let locale = config.and_then(|c| c.locale);
@@ -1061,8 +1057,6 @@ fn import_via_pycapsule(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Reco
         )));
     }
 
-    validate_imported_array(&array_data)?;
-
     // Convert StructArray to RecordBatch
     let struct_array = arrow::array::StructArray::from(array_data);
     let schema = Arc::new(Schema::new(
@@ -1077,24 +1071,47 @@ fn import_via_pycapsule(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Reco
         .map_err(|e| PyRuntimeError::new_err(format!("RecordBatch creation failed: {}", e)))
 }
 
-/// Check that FFI-imported data actually satisfies the Arrow columnar spec.
+/// Validate an FFI-imported batch, then fold it into the analyzer.
 ///
 /// `arrow::ffi::from_ffi` builds its `ArrayData` with `ArrayData::new_unchecked`
-/// and only realigns buffers — nothing on the import path checks buffer
-/// lengths, offsets, UTF-8, or dictionary keys. Invalid data therefore reaches
+/// and only realigns buffers, so nothing on the import path checks buffer
+/// lengths, offsets, UTF-8 or dictionary keys. Invalid data therefore reaches
 /// the analyzers, where the first accessor to touch it panics: a
 /// `dictionary<int8, utf8>` carrying key 99 against a two-element dictionary
 /// aborts inside arrow's `ArrayFormatter::value()`. pyo3 derives
 /// `PanicException` from `BaseException` precisely so it is *not* caught by
 /// accident, so `except Exception` around `profile()` does not catch it.
 ///
-/// `validate_full()` is the check arrow-rs already implements — recursive, and
-/// covering the dictionary-key bounds that the FFI import skips. It is run on
-/// every import rather than behind a flag: on a 200k-row batch with two wide
-/// string columns it costs about 0.6% of the profiling pass that follows
-/// (1.8ms against 317ms), which is not a price worth a configuration knob.
+/// `validate_full()` is the check arrow-rs already implements: recursive, and
+/// covering the dictionary-key bounds the FFI import skips. It runs on every
+/// analyzed batch rather than behind a flag, because it is cheap next to the
+/// work it guards. On a 200k-row batch with two wide string columns it costs
+/// about 0.6% of the profiling pass that follows (1.8ms against 317ms), which
+/// is not a price worth a configuration knob.
 ///
-/// The input is invalid, so this is a `ValueError` — the same class the CSV and
+/// Validating here, rather than at import, is what keeps `max_rows` bounded.
+/// Import is zero-copy and O(1) per batch, but validation is O(n): running it
+/// on import would scan every value of every batch of a chunked Table even
+/// when a two-row profile was asked for. Sitting immediately before
+/// `process_batch` means exactly the rows that get analyzed get validated, and
+/// no analyzer can be fed unvalidated data. `check_bounds` and the offset
+/// checks honour `ArrayData::offset`, so a batch sliced by the row limit
+/// validates only its slice.
+///
+/// The corollary is deliberate: corruption in rows beyond `max_rows` is not
+/// reported, because those rows are never read.
+fn analyze_imported_batch(analyzer: &mut RecordBatchAnalyzer, batch: &RecordBatch) -> PyResult<()> {
+    for column in batch.columns() {
+        validate_imported_array(&column.to_data())?;
+    }
+    analyzer
+        .process_batch(batch)
+        .map_err(crate::errors::analyzer_error_to_py)
+}
+
+/// Reject data that does not satisfy the Arrow columnar spec.
+///
+/// The input is invalid, so this is a `ValueError`, the same class the CSV and
 /// JSON paths raise for malformed data.
 fn validate_imported_array(array_data: &arrow::array::ArrayData) -> PyResult<()> {
     array_data.validate_full().map_err(|e| {

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -1061,6 +1061,8 @@ fn import_via_pycapsule(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Reco
         )));
     }
 
+    validate_imported_array(&array_data)?;
+
     // Convert StructArray to RecordBatch
     let struct_array = arrow::array::StructArray::from(array_data);
     let schema = Arc::new(Schema::new(
@@ -1073,4 +1075,32 @@ fn import_via_pycapsule(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Reco
 
     RecordBatch::try_new(schema, struct_array.columns().to_vec())
         .map_err(|e| PyRuntimeError::new_err(format!("RecordBatch creation failed: {}", e)))
+}
+
+/// Check that FFI-imported data actually satisfies the Arrow columnar spec.
+///
+/// `arrow::ffi::from_ffi` builds its `ArrayData` with `ArrayData::new_unchecked`
+/// and only realigns buffers — nothing on the import path checks buffer
+/// lengths, offsets, UTF-8, or dictionary keys. Invalid data therefore reaches
+/// the analyzers, where the first accessor to touch it panics: a
+/// `dictionary<int8, utf8>` carrying key 99 against a two-element dictionary
+/// aborts inside arrow's `ArrayFormatter::value()`. pyo3 derives
+/// `PanicException` from `BaseException` precisely so it is *not* caught by
+/// accident, so `except Exception` around `profile()` does not catch it.
+///
+/// `validate_full()` is the check arrow-rs already implements — recursive, and
+/// covering the dictionary-key bounds that the FFI import skips. It is run on
+/// every import rather than behind a flag: on a 200k-row batch with two wide
+/// string columns it costs about 0.6% of the profiling pass that follows
+/// (1.8ms against 317ms), which is not a price worth a configuration knob.
+///
+/// The input is invalid, so this is a `ValueError` — the same class the CSV and
+/// JSON paths raise for malformed data.
+fn validate_imported_array(array_data: &arrow::array::ArrayData) -> PyResult<()> {
+    array_data.validate_full().map_err(|e| {
+        PyValueError::new_err(format!(
+            "Arrow data received over the C Data Interface violates the Arrow \
+             columnar spec and cannot be profiled: {e}"
+        ))
+    })
 }

--- a/python/tests/test_arrow_pycapsule_import.py
+++ b/python/tests/test_arrow_pycapsule_import.py
@@ -156,19 +156,28 @@ def test_object_without_arrow_support_is_refused():
         dataprof.profile(object(), name="not_arrow")
 
 
+def _dictionary_column(indices, safe=True):
+    """An int8-keyed dictionary column over the two-element dictionary [a, b].
+
+    Every caller uses the same key width and dictionary, so batches built from
+    this compose into one Table.
+    """
+    return pa.DictionaryArray.from_arrays(
+        pa.array(indices, type=pa.int8()),
+        pa.array(["a", "b"]),
+        safe=safe,
+    )
+
+
 def _out_of_range_dictionary_column():
-    """A dictionary array whose index 99 addresses a two-element dictionary.
+    """A dictionary column whose index 99 addresses a two-element dictionary.
 
     ``safe=False`` is what makes this constructible: the checked constructor
     refuses the array outright, which is why the input is only reachable from a
     producer that skips validation -- pyarrow's own escape hatch, or any other
     C Data Interface producer.
     """
-    return pa.DictionaryArray.from_arrays(
-        pa.array([0, 99], type=pa.int8()),
-        pa.array(["a", "b"]),
-        safe=False,
-    )
+    return _dictionary_column([0, 99], safe=False)
 
 
 def test_out_of_range_dictionary_index_raises_valueerror():
@@ -207,13 +216,32 @@ def test_valid_dictionary_column_still_profiles():
     Without this, a fix that refused every dictionary column would pass the
     guard above.
     """
-    table = pa.table(
-        {
-            "c": pa.DictionaryArray.from_arrays(
-                pa.array([0, 1, 1, 0], type=pa.int8()), pa.array(["a", "b"])
-            )
-        }
-    )
+    table = pa.table({"c": _dictionary_column([0, 1, 1, 0])})
 
     report = dataprof.profile(table, name="good_dictionary")
     assert report.rows == 4
+
+
+def test_max_rows_does_not_validate_rows_it_discards():
+    """Validation is bounded by the row limit, like the rest of the work.
+
+    Validation is O(n) where the import it follows is O(1) per batch, so running
+    it at import time would scan every value of every batch of a chunked Table
+    to answer a two-row request. Sitting immediately before ``process_batch``
+    instead means only analyzed rows are validated.
+
+    The corollary, pinned here, is that corruption past ``max_rows`` goes
+    unreported: those rows are never read, and reading them to complain about
+    them is the cost the limit exists to avoid.
+    """
+    good = pa.record_batch({"c": _dictionary_column([0, 1])})
+    bad = pa.record_batch({"c": _out_of_range_dictionary_column()})
+    table = pa.Table.from_batches([good, bad])
+
+    report = dataprof.profile(table, name="bounded", max_rows=2)
+    assert report.rows == 2
+
+    # Without the limit the same table is refused, so the pass above is the
+    # limit doing its job, not the corrupt batch having gone missing.
+    with pytest.raises(ValueError, match="Arrow columnar spec"):
+        dataprof.profile(table, name="unbounded")

--- a/python/tests/test_arrow_pycapsule_import.py
+++ b/python/tests/test_arrow_pycapsule_import.py
@@ -1,6 +1,6 @@
-"""Arrow import contract: every batch, and every PyCapsule producer.
+"""Arrow import contract: every batch, every PyCapsule producer, valid data only.
 
-Two guards on ``import_from_pyarrow``, both invisible to value-based tests:
+Guards on ``import_from_pyarrow`` that value-based tests cannot see:
 
 ``profile()`` documents accepting "Arrow PyCapsule-compatible objects", but the
 import path matched on the Python type name being ``Table`` or ``RecordBatch``
@@ -13,6 +13,9 @@ multi-batch table silently reported on its first chunk only — the report looke
 entirely normal, just computed over a prefix of the data. Silent divergence is
 the failure mode worth the most guarding, because nothing about the output
 suggests anything went wrong.
+
+Finally, the C Data Interface import is unchecked in arrow-rs, so malformed
+Arrow data reached the analyzers and panicked there rather than erroring.
 """
 
 from __future__ import annotations
@@ -151,3 +154,66 @@ def test_object_without_arrow_support_is_refused():
     """A plain object is not an Arrow source."""
     with pytest.raises(TypeError):
         dataprof.profile(object(), name="not_arrow")
+
+
+def _out_of_range_dictionary_column():
+    """A dictionary array whose index 99 addresses a two-element dictionary.
+
+    ``safe=False`` is what makes this constructible: the checked constructor
+    refuses the array outright, which is why the input is only reachable from a
+    producer that skips validation -- pyarrow's own escape hatch, or any other
+    C Data Interface producer.
+    """
+    return pa.DictionaryArray.from_arrays(
+        pa.array([0, 99], type=pa.int8()),
+        pa.array(["a", "b"]),
+        safe=False,
+    )
+
+
+def test_out_of_range_dictionary_index_raises_valueerror():
+    """Invalid Arrow data must error, not panic across the FFI boundary.
+
+    ``arrow::ffi::from_ffi`` builds its ArrayData unchecked, so an out-of-range
+    dictionary key survives import and detonates later inside arrow's
+    ArrayFormatter, where the accessor asserts. That panic crosses into Python
+    as ``pyo3_runtime.PanicException``, which derives from ``BaseException`` --
+    ``except Exception`` does not catch it, so a caller cannot handle a bad
+    input at all.
+
+    Asserting ``ValueError`` pins both halves: that the input is refused, and
+    that the refusal is an ordinary catchable exception. ``pytest.raises`` would
+    accept the panic if this asserted ``BaseException``.
+    """
+    table = pa.table({"c": _out_of_range_dictionary_column()})
+
+    with pytest.raises(ValueError, match="Arrow columnar spec"):
+        dataprof.profile(table, name="bad_dictionary")
+
+
+def test_out_of_range_dictionary_index_is_refused_on_every_entry_point():
+    """The check sits at the shared import, so no Arrow entry point skips it."""
+    column = _out_of_range_dictionary_column()
+    batch = pa.record_batch({"c": column})
+
+    for source in (batch, pa.Table.from_batches([batch]), ArrowPyCapsuleProducer(batch)):
+        with pytest.raises(ValueError, match="Arrow columnar spec"):
+            dataprof.profile(source, name="bad_dictionary")
+
+
+def test_valid_dictionary_column_still_profiles():
+    """Validation must not reject the dictionary-encoded data that is fine.
+
+    Without this, a fix that refused every dictionary column would pass the
+    guard above.
+    """
+    table = pa.table(
+        {
+            "c": pa.DictionaryArray.from_arrays(
+                pa.array([0, 1, 1, 0], type=pa.int8()), pa.array(["a", "b"])
+            )
+        }
+    )
+
+    report = dataprof.profile(table, name="good_dictionary")
+    assert report.rows == 4


### PR DESCRIPTION
Closes #609.

## The gap

Reading `arrow::ffi` made the problem wider than the issue described. `from_ffi`
builds its `ArrayData` with `ArrayData::new_unchecked` and then only calls
`align_buffers`. Not even the cheap `validate()` buffer-length pass runs, so the
unchecked surface is buffer lengths, offsets, UTF-8 and dictionary keys, not
dictionary keys alone. `StringArray::value` reads through `from_utf8_unchecked`,
so the consequences are not all confined to clean panics either.

That rules out the "validate only the cheap subset" option: it would have fixed
the reported panic and left the rest.

## The choice

Option 1, always validate, with no config flag. The cost is measured rather than
assumed: on a 200k-row batch with two wide string columns, `validate_full()` over
all four columns takes 1.8ms against a 317ms profiling pass, 0.57%. The profiler
already formats, type-infers and hashes every value, so one validation pass
disappears into that. A knob that saves 0.6% is more API surface than it buys.

Invalid input now raises `ValueError`, matching what the CSV and JSON paths
already raise for malformed data.

## The issue's reproducer note is wrong

It says there is no pyarrow-only reproducer because `DictionaryArray.from_arrays`
bounds-checks. It does, unless you pass `safe=False`:

```python
pa.DictionaryArray.from_arrays(pa.array([0, 99], type=pa.int8()), pa.array(["a", "b"]), safe=False)
```

That builds the array, and profiling it panicked on the installed 0.10.0 wheel.
So the regression test needs no C producer, and the input is more reachable from
ordinary Python than the issue assumed.

## Verification

Three tests in `python/tests/test_arrow_pycapsule_import.py`. The fix was
reverted and the extension rebuilt to check they discriminate it:

* both refusal guards fail with `PanicException` on unfixed code, pass with the fix
* `test_valid_dictionary_column_still_profiles` passes either way. It is the
  counterweight, so a fix that rejected every dictionary column cannot hide
  behind the other two.

Commands run:

```
cargo fmt --all
cargo clippy -p dataprof-python --all-targets -- -D warnings
uv run maturin develop --release
uv run pytest python/tests/          # 994 passed, 9 skipped (unchanged skips)
uv run ruff format python/
uv run ruff check python/
uv run ty check python/
```
