### PR TITLE
ci: pin the Rust toolchain and fix the clippy lint 1.98 added

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,9 +17,13 @@ inputs:
 runs:
   using: composite
   steps:
+    # This ref pins a Rust version. Under `@stable`, every open PR went red the
+    # day a Rust release landed, because a new clippy lint fires on code that
+    # was already merged (1.98 did this with `clippy::drain_collect`). Bump it
+    # deliberately, in step with the versions in `release.yml` and AGENTS.md.
     - name: Install Rust toolchain
       id: rust-install
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.98
       with:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
@@ -32,7 +36,8 @@ runs:
       shell: bash
       run: |
         echo "Primary Rust installation failed, trying manual installation..."
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+          sh -s -- -y --default-toolchain 1.98
         source ~/.cargo/env
         if [ -n "${{ inputs.components }}" ]; then
           rustup component add $(echo "${{ inputs.components }}" | tr ',' ' ')

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,10 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
+    ignore:
+      # The ref on dtolnay/rust-toolchain names a Rust version rather than an
+      # action release. That repo pre-creates a branch for every upcoming
+      # version, so dependabot reads unreleased ones as available upgrades: it
+      # bumped the pin to 1.100 (#521), which rustup cannot install. Rust
+      # version bumps here are deliberate; make them by hand.
+      - dependency-name: "dtolnay/rust-toolchain"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,14 @@ jobs:
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Tag: $TAG, Version: $VERSION"
 
+    # 1.96 is the workspace MSRV (`rust-version` in Cargo.toml); validating
+    # release metadata on it also smoke-tests that the manifests still parse on
+    # the oldest supported toolchain. Dependabot bumped this to 1.100 (#521),
+    # a Rust that does not exist yet: dtolnay/rust-toolchain pre-creates version
+    # branches, so a resolvable ref is no proof of a released toolchain. That
+    # action is now on dependabot's ignore list.
     - name: Install Rust 1.96 for release metadata validation
-      uses: dtolnay/rust-toolchain@1.100
+      uses: dtolnay/rust-toolchain@1.96
 
     - name: Validate tag and release metadata
       env:
@@ -422,7 +428,7 @@ jobs:
         sccache: 'true'
         manylinux: ${{ matrix.manylinux || 'auto' }}
         # Ensure compatibility flags are properly set
-        rust-toolchain: stable
+        rust-toolchain: '1.98'
       env:
         RUSTFLAGS: ${{ matrix.rustflags }}
         # Additional environment variables to ensure compatibility for all targets
@@ -525,7 +531,7 @@ jobs:
         command: sdist
         args: --out dist
         manylinux: auto
-        rust-toolchain: stable
+        rust-toolchain: '1.98'
 
     - name: Upload sdist as artifact
       uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ Keep changes within that identity.
 
 Prerequisites: Rust 1.96+, Python 3.10+, [uv](https://docs.astral.sh/uv/).
 
+1.96 is the MSRV (`rust-version` in `Cargo.toml`). CI lints and tests on a
+**pinned Rust 1.98**; see `.github/actions/setup-rust`. Clippy gates the build
+with `-D warnings` and every Rust release adds lints, so a local toolchain that
+differs from 1.98 can pass here and still fail CI, or the reverse. When clippy
+disagrees with CI, check `rustc --version` first and reproduce with
+`cargo +1.98 clippy`.
+
 ```bash
 uv sync                     # install the Python dev environment
 uv run maturin develop      # build + install the local Python extension

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -181,7 +181,7 @@ impl StreamReservoirSampler {
             return;
         }
 
-        let mut combined: Vec<String> = self.reservoir.drain(..).collect();
+        let mut combined: Vec<String> = std::mem::take(&mut self.reservoir);
         combined.extend(other.reservoir.iter().cloned());
 
         let total = combined.len();

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,9 @@ Thank you for considering contributing to dataprof! We welcome contributions fro
 
 ### Prerequisites
 
-- **Rust 1.96** or later ([install](https://rustup.rs/))
+- **Rust 1.96** or later ([install](https://rustup.rs/)). This is the MSRV; CI
+  lints and tests on a pinned 1.98, so reproduce clippy failures with
+  `cargo +1.98 clippy` instead of your default toolchain
 - **Cargo** (comes with Rust)
 - **Python 3.10** or later
 - **uv** for Python dependency and test commands ([install](https://docs.astral.sh/uv/))


### PR DESCRIPTION
## Why

Every open PR, dependabot's included, is failing the **Code Quality** job. The
cause is not in those PRs: `.github/actions/setup-rust` used
`dtolnay/rust-toolchain@stable`, so CI moved to Rust 1.98 the day it landed, and
1.98's `clippy::drain_collect` fires on code that was already on master. With
`-D warnings` that is a build failure.

## What changed

**The lint.** `StreamReservoirSampler::merge` used `self.reservoir.drain(..).collect()`.
It is now `std::mem::take(&mut self.reservoir)`, which moves the buffer instead
of re-collecting the elements into a fresh allocation. `self.reservoir` is
reassigned from `combined` on both branches below, so the merge result is
identical. This was the only occurrence in the workspace.

**The pins.** CI, the release metadata check, and both maturin wheel builds now
name an explicit Rust version, so picking up a new Rust release is a deliberate
bump rather than an outage on the day it ships. The manual-install fallback in
the action is pinned too, since it would otherwise have re-introduced the drift.

**A latent release failure, found on the way.** The release metadata step read
`dtolnay/rust-toolchain@1.100` while its own step name said 1.96. Dependabot
bumped it in #521. Rust 1.100 does not exist:

```
$ rustup toolchain install 1.100
error: could not download nonexistent rust version `1.100-x86_64-pc-windows-msvc` [...] 404
```

That repo pre-creates a branch for every upcoming version, so the ref resolved
even though the toolchain did not exist. The release workflow has not run since
2026-07-24, so this had not surfaced yet; the next release tag would have failed
on it. Restored to 1.96 (the workspace MSRV) and added the action to
dependabot's ignore list, so the pins hold.

**Docs.** AGENTS.md and CONTRIBUTING now record that 1.96 is the MSRV while CI
lints on a pinned 1.98, and point at `cargo +1.98 clippy` for reproducing a CI
clippy failure. That gap is why the lint looked clean locally.

## Verification

- `cargo +1.98 clippy --lib --tests --all-features -- -D warnings` (CI's exact command) — passes
- `cargo +1.98 clippy --all --all-targets --all-features -- -D warnings` — passes, so 1.98 brought no other lint in tests, examples, or benches
- `cargo fmt --all -- --check` — clean
- `cargo test -p dataprof-runtime` — 58 passed, including `test_streaming_statistics_merge` and `test_reservoir_uniformity`
- All edited YAML re-parsed

To be exact about coverage: the merge tests pass with and without the
`mem::take` change, since it is a refactor with no behavior delta. They confirm
`merge()` still works; the clippy run is what verifies the fix.
