### PR TITLE
feat(errors): retain originating errors as a walkable source chain

### DIFF
--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -99,10 +99,32 @@ pub enum RecoveryStrategy {
 }
 
 /// Enhanced error types with more descriptive messages for DataProfiler
-#[derive(Error, Debug, Clone)]
+/// Boxed originating error retained by the variants that can carry a cause.
+///
+/// `Box` rather than `Arc` is deliberate. `thiserror` renders a boxed source
+/// through `&**b`, so [`std::error::Error::source`] hands back the *concrete*
+/// error and `downcast_ref::<std::io::Error>()` succeeds. Behind an `Arc` the
+/// chain instead yields the `Arc`: the message still reads correctly while
+/// every downcast returns `None`, which is the exact capability this type
+/// exists to provide.
+pub type ErrorSource = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Enhanced error types with more descriptive messages for DataProfiler
+///
+/// Not `Clone`: a retained [`ErrorSource`] is a boxed trait object, and the
+/// originating errors (`std::io::Error`, `csv::Error`, ...) are not cloneable
+/// themselves. Cloning an error was only ever used by the recovery manager,
+/// which now takes ownership instead.
+#[derive(Error, Debug)]
 pub enum DataProfilerError {
     #[error("CSV parsing failed: {message}\nSuggestion: {suggestion}")]
-    CsvParsingError { message: String, suggestion: String },
+    #[non_exhaustive]
+    CsvParsingError {
+        message: String,
+        suggestion: String,
+        #[source]
+        source: Option<ErrorSource>,
+    },
 
     #[error(
         "File not found: {path}\nPlease check that the file exists and you have permission to read it"
@@ -121,7 +143,13 @@ pub enum DataProfilerError {
     MemoryLimitExceeded,
 
     #[error("Invalid configuration: {message}\n{suggestion}")]
-    InvalidConfiguration { message: String, suggestion: String },
+    #[non_exhaustive]
+    InvalidConfiguration {
+        message: String,
+        suggestion: String,
+        #[source]
+        source: Option<ErrorSource>,
+    },
 
     #[error("Invalid semantic hint: {message}\n{suggestion}")]
     InvalidSemanticHint { message: String, suggestion: String },
@@ -145,7 +173,12 @@ pub enum DataProfilerError {
     SamplingError { message: String, suggestion: String },
 
     #[error("I/O error: {message}\nCheck file permissions and disk space")]
-    IoError { message: String },
+    #[non_exhaustive]
+    IoError {
+        message: String,
+        #[source]
+        source: Option<ErrorSource>,
+    },
 
     #[error(
         "Non-UTF-8 input in {path}: {detail}\nRe-encode the file as UTF-8 (e.g. `iconv -f {guess} -t UTF-8 '{path}'`) and profile the result"
@@ -157,7 +190,12 @@ pub enum DataProfilerError {
     },
 
     #[error("JSON parsing failed: {message}\nVerify JSON format and encoding")]
-    JsonParsingError { message: String },
+    #[non_exhaustive]
+    JsonParsingError {
+        message: String,
+        #[source]
+        source: Option<ErrorSource>,
+    },
 
     #[error("Column analysis failed for '{column}': {reason}\n{suggestion}")]
     ColumnAnalysisError {
@@ -188,10 +226,20 @@ pub enum DataProfilerError {
     },
 
     #[error("Parquet processing failed: {message}")]
-    ParquetError { message: String },
+    #[non_exhaustive]
+    ParquetError {
+        message: String,
+        #[source]
+        source: Option<ErrorSource>,
+    },
 
     #[error("Arrow processing failed: {message}")]
-    ArrowError { message: String },
+    #[non_exhaustive]
+    ArrowError {
+        message: String,
+        #[source]
+        source: Option<ErrorSource>,
+    },
 
     #[error("Unsupported data source: {message}")]
     UnsupportedDataSource { message: String },
@@ -351,7 +399,24 @@ impl DataProfilerError {
         DataProfilerError::CsvParsingError {
             message: original_error.to_string(),
             suggestion,
+            source: None,
         }
+    }
+
+    /// Create a CSV parsing error that retains `original` as its source.
+    ///
+    /// The suggestion is derived from the same message text as
+    /// [`DataProfilerError::csv_parsing`], so the two forms render identically;
+    /// only the cause chain differs.
+    pub fn csv_parsing_from<E>(original: E, file_path: Option<&str>) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let mut err = Self::csv_parsing(&original.to_string(), file_path);
+        if let DataProfilerError::CsvParsingError { source, .. } = &mut err {
+            *source = Some(Box::new(original));
+        }
+        err
     }
 
     /// Create a file not found error with path context
@@ -373,6 +438,26 @@ impl DataProfilerError {
         DataProfilerError::InvalidConfiguration {
             message: message.to_string(),
             suggestion: suggestion.to_string(),
+            source: None,
+        }
+    }
+
+    /// Create a configuration error that retains `original` as its source.
+    ///
+    /// Used by the TOML and glob conversions, where the underlying parser
+    /// reports a position worth reaching programmatically.
+    pub fn invalid_config_with_source<E>(
+        message: impl Into<String>,
+        suggestion: impl Into<String>,
+        original: E,
+    ) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::InvalidConfiguration {
+            message: message.into(),
+            suggestion: suggestion.into(),
+            source: Some(Box::new(original)),
         }
     }
 
@@ -416,17 +501,155 @@ impl DataProfilerError {
         }
     }
 
-    /// Create I/O error with context
-    pub fn io_error(original: &std::io::Error) -> Self {
+    /// Create an I/O error that retains `original` as its source.
+    ///
+    /// Takes the error by value: `std::io::Error` is not cloneable, so a
+    /// borrowed one could only ever be stringified, which is what this issue
+    /// set out to stop. Use `map_err(DataProfilerError::io_error)` at call
+    /// sites.
+    pub fn io_error(original: std::io::Error) -> Self {
         DataProfilerError::IoError {
             message: original.to_string(),
+            source: Some(Box::new(original)),
         }
     }
 
-    /// Create JSON parsing error
+    /// Create an I/O error from a message, for callers with no originating
+    /// error to retain (a condition detected by dataprof itself rather than
+    /// reported by the OS).
+    pub fn io_message(message: &str) -> Self {
+        DataProfilerError::IoError {
+            message: message.to_string(),
+            source: None,
+        }
+    }
+
+    /// Create a JSON parsing error with no retained source.
     pub fn json_parsing_error(original: &str) -> Self {
         DataProfilerError::JsonParsingError {
             message: original.to_string(),
+            source: None,
+        }
+    }
+
+    /// Create a JSON parsing error that retains `original` as its source.
+    pub fn json_parsing_from<E>(original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::JsonParsingError {
+            message: original.to_string(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create a CSV parsing error with a caller-supplied message and
+    /// suggestion that still retains `original` as its source.
+    ///
+    /// For callers whose suggestion is specific to their own context and so
+    /// cannot come from [`DataProfilerError::csv_parsing`]'s message analysis.
+    pub fn csv_parsing_with_source<E>(
+        message: impl Into<String>,
+        suggestion: impl Into<String>,
+        original: E,
+    ) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::CsvParsingError {
+            message: message.into(),
+            suggestion: suggestion.into(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create a JSON parsing error with a caller-supplied message that still
+    /// retains `original` as its source.
+    ///
+    /// Used where the message adds context the decoder does not have (a record
+    /// position, a physical line number) and the decoder error is still worth
+    /// keeping underneath it.
+    pub fn json_parsing_with_source<E>(message: impl Into<String>, original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::JsonParsingError {
+            message: message.into(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create an Arrow error with a caller-supplied message that still retains
+    /// `original` as its source.
+    pub fn arrow_with_source<E>(message: impl Into<String>, original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::ArrowError {
+            message: message.into(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create a Parquet error with a caller-supplied message that still retains
+    /// `original` as its source.
+    pub fn parquet_with_source<E>(message: impl Into<String>, original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::ParquetError {
+            message: message.into(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create an I/O error with a caller-supplied message that still retains
+    /// `original` as its source.
+    pub fn io_with_source<E>(message: impl Into<String>, original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::IoError {
+            message: message.into(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create an Arrow error with no retained source.
+    pub fn arrow_error(message: &str) -> Self {
+        DataProfilerError::ArrowError {
+            message: message.to_string(),
+            source: None,
+        }
+    }
+
+    /// Create an Arrow error that retains `original` as its source.
+    pub fn arrow_error_from<E>(original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::ArrowError {
+            message: original.to_string(),
+            source: Some(Box::new(original)),
+        }
+    }
+
+    /// Create a Parquet error with no retained source.
+    pub fn parquet_error(message: &str) -> Self {
+        DataProfilerError::ParquetError {
+            message: message.to_string(),
+            source: None,
+        }
+    }
+
+    /// Create a Parquet error that retains `original` as its source.
+    pub fn parquet_error_from<E>(original: E) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        DataProfilerError::ParquetError {
+            message: original.to_string(),
+            source: Some(Box::new(original)),
         }
     }
 
@@ -624,18 +847,30 @@ impl From<anyhow::Error> for DataProfilerError {
     fn from(err: anyhow::Error) -> Self {
         let error_str = err.to_string();
 
+        // The anyhow error is retained as the source in every branch, so a
+        // caller can still reach the concrete error underneath it via
+        // `source()` even though categorisation here is message-based.
+        let source: Option<ErrorSource> = Some(err.into());
+
         // Categorize by message only; do not invent a path we do not have.
         if error_str.contains("CSV") {
             DataProfilerError::CsvParsingError {
                 message: error_str,
                 suggestion: "Try using robust CSV parsing mode".to_string(),
+                source,
             }
         } else if error_str.contains("JSON") {
-            DataProfilerError::JsonParsingError { message: error_str }
+            DataProfilerError::JsonParsingError {
+                message: error_str,
+                source,
+            }
         } else {
             // Generic I/O error — the original message carries the detail
             // (including "file not found" wording) without a fabricated path.
-            DataProfilerError::IoError { message: error_str }
+            DataProfilerError::IoError {
+                message: error_str,
+                source,
+            }
         }
     }
 }
@@ -647,13 +882,19 @@ impl From<anyhow::Error> for DataProfilerError {
 /// message (which already names the condition) rather than guessing a path.
 impl From<std::io::Error> for DataProfilerError {
     fn from(err: std::io::Error) -> Self {
-        match err.kind() {
-            std::io::ErrorKind::PermissionDenied => DataProfilerError::IoError {
-                message: "Permission denied - check file access rights".to_string(),
-            },
-            _ => DataProfilerError::IoError {
-                message: err.to_string(),
-            },
+        // The message is still rewritten for PermissionDenied, but the original
+        // error is retained either way: `err.source()` now yields the
+        // `std::io::Error`, so a caller can match on `kind()` instead of
+        // pattern-matching the human-readable text.
+        let message = match err.kind() {
+            std::io::ErrorKind::PermissionDenied => {
+                "Permission denied - check file access rights".to_string()
+            }
+            _ => err.to_string(),
+        };
+        DataProfilerError::IoError {
+            message,
+            source: Some(Box::new(err)),
         }
     }
 }
@@ -664,7 +905,7 @@ impl From<std::io::Error> for DataProfilerError {
 /// without a filename rather than the misleading `'unknown'` placeholder.
 impl From<csv::Error> for DataProfilerError {
     fn from(err: csv::Error) -> Self {
-        DataProfilerError::csv_parsing(&err.to_string(), None)
+        DataProfilerError::csv_parsing_from(err, None)
     }
 }
 
@@ -672,48 +913,46 @@ impl From<csv::Error> for DataProfilerError {
 #[cfg(feature = "arrow")]
 impl From<arrow::error::ArrowError> for DataProfilerError {
     fn from(err: arrow::error::ArrowError) -> Self {
-        DataProfilerError::ArrowError {
-            message: err.to_string(),
-        }
+        DataProfilerError::arrow_error_from(err)
     }
 }
 
 /// Convert from serde_json::Error to DataProfilerError
 impl From<serde_json::Error> for DataProfilerError {
     fn from(err: serde_json::Error) -> Self {
-        DataProfilerError::JsonParsingError {
-            message: err.to_string(),
-        }
+        DataProfilerError::json_parsing_from(err)
     }
 }
 
 /// Convert from glob::PatternError to DataProfilerError
 impl From<glob::PatternError> for DataProfilerError {
     fn from(err: glob::PatternError) -> Self {
-        DataProfilerError::InvalidConfiguration {
-            message: format!("Invalid glob pattern: {}", err),
-            suggestion: "Check the glob pattern syntax".to_string(),
-        }
+        let message = format!("Invalid glob pattern: {}", err);
+        DataProfilerError::invalid_config_with_source(message, "Check the glob pattern syntax", err)
     }
 }
 
 /// Convert from toml::de::Error to DataProfilerError
 impl From<toml::de::Error> for DataProfilerError {
     fn from(err: toml::de::Error) -> Self {
-        DataProfilerError::InvalidConfiguration {
-            message: format!("Failed to parse TOML configuration: {}", err),
-            suggestion: "Check your configuration file syntax".to_string(),
-        }
+        let message = format!("Failed to parse TOML configuration: {}", err);
+        DataProfilerError::invalid_config_with_source(
+            message,
+            "Check your configuration file syntax",
+            err,
+        )
     }
 }
 
 /// Convert from toml::ser::Error to DataProfilerError
 impl From<toml::ser::Error> for DataProfilerError {
     fn from(err: toml::ser::Error) -> Self {
-        DataProfilerError::InvalidConfiguration {
-            message: format!("Failed to serialize configuration: {}", err),
-            suggestion: "Check configuration values for serialization issues".to_string(),
-        }
+        let message = format!("Failed to serialize configuration: {}", err);
+        DataProfilerError::invalid_config_with_source(
+            message,
+            "Check configuration values for serialization issues",
+            err,
+        )
     }
 }
 
@@ -734,18 +973,18 @@ impl AutoRecoveryManager {
     /// Attempt auto-recovery for a given error
     pub fn attempt_recovery<F, T>(
         &mut self,
-        error: &DataProfilerError,
+        error: DataProfilerError,
         retry_fn: F,
     ) -> Result<T, DataProfilerError>
     where
         F: Fn(RecoveryStrategy) -> Result<T, DataProfilerError>,
     {
         if !error.supports_auto_recovery() {
-            return Err(error.clone());
+            return Err(error);
         }
 
         let strategies = error.suggested_recovery_strategies();
-        let mut last_error: DataProfilerError = error.clone();
+        let mut last_error: DataProfilerError = error;
 
         for (attempt, strategy) in strategies.iter().enumerate() {
             if attempt >= self.config.max_attempts {
@@ -1020,5 +1259,153 @@ mod tests {
             "pool timed out connecting to postgres://user:topsecret@host/db",
         );
         assert!(!err.to_string().contains("topsecret"));
+    }
+
+    // --- source chain (#447) ---------------------------------------------
+    //
+    // The point of retaining a source is that a caller can recover the
+    // *concrete* originating error, not just a string that reads like it. Each
+    // test below therefore downcasts, rather than comparing rendered text.
+
+    use std::error::Error as _;
+
+    #[test]
+    fn io_error_retains_the_os_error_and_its_kind() {
+        let original = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied by acl");
+        let err = DataProfilerError::io_error(original);
+
+        let source = err.source().expect("io error must retain a source");
+        let io: &std::io::Error = source
+            .downcast_ref()
+            .expect("source must downcast to the original std::io::Error");
+        assert_eq!(io.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn from_io_error_retains_the_kind_even_when_the_message_is_rewritten() {
+        // PermissionDenied is the one branch that replaces the OS text, so it is
+        // the case where a flattened source would lose the most.
+        let original = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied by acl");
+        let err: DataProfilerError = original.into();
+
+        assert!(err.to_string().contains("Permission denied"));
+        let io: &std::io::Error = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("rewritten message must still retain the io::Error");
+        assert_eq!(io.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(io.to_string().contains("denied by acl"));
+    }
+
+    #[test]
+    fn from_json_error_retains_line_and_column() {
+        let original = serde_json::from_str::<serde_json::Value>("{oops}").unwrap_err();
+        let (line, column) = (original.line(), original.column());
+        let err: DataProfilerError = original.into();
+
+        let json: &serde_json::Error = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("source must downcast to serde_json::Error");
+        assert_eq!((json.line(), json.column()), (line, column));
+    }
+
+    #[test]
+    fn from_csv_error_retains_the_csv_error_kind() {
+        let mut reader = csv::ReaderBuilder::new()
+            .flexible(false)
+            .from_reader("a,b\n1,2,3\n".as_bytes());
+        let original = reader
+            .records()
+            .next()
+            .expect("one record")
+            .expect_err("ragged row must fail with flexible(false)");
+        let err: DataProfilerError = original.into();
+
+        let csv: &csv::Error = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("source must downcast to csv::Error");
+        assert!(matches!(csv.kind(), csv::ErrorKind::UnequalLengths { .. }));
+    }
+
+    #[test]
+    fn from_toml_error_retains_the_parse_error() {
+        let original = toml::from_str::<toml::Value>("key = [unclosed").unwrap_err();
+        let expected = original.to_string();
+        let err: DataProfilerError = original.into();
+
+        let toml_err: &toml::de::Error = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("source must downcast to toml::de::Error");
+        assert_eq!(toml_err.to_string(), expected);
+    }
+
+    #[test]
+    fn from_glob_error_retains_the_pattern_error() {
+        let original = glob::Pattern::new("[").unwrap_err();
+        let expected = original.to_string();
+        let err: DataProfilerError = original.into();
+
+        let glob_err: &glob::PatternError = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("source must downcast to glob::PatternError");
+        assert_eq!(glob_err.to_string(), expected);
+    }
+
+    #[test]
+    fn errors_built_without_a_cause_report_no_source() {
+        // "No source" must stay distinguishable from "source not retained":
+        // these variants genuinely have no originating error underneath.
+        assert!(
+            DataProfilerError::io_message("disk budget exceeded")
+                .source()
+                .is_none()
+        );
+        assert!(
+            DataProfilerError::json_parsing_error("not an object")
+                .source()
+                .is_none()
+        );
+        assert!(
+            DataProfilerError::arrow_error("downcast failed")
+                .source()
+                .is_none()
+        );
+        assert!(
+            DataProfilerError::file_not_found("/nope")
+                .source()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn retaining_a_source_does_not_change_the_rendered_message() {
+        // The #373 message contract is independent of the cause chain: the two
+        // constructions must be indistinguishable in output.
+        let original = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let text = original.to_string();
+
+        let with_source = DataProfilerError::io_error(original).to_string();
+        let without_source = DataProfilerError::io_message(&text).to_string();
+        assert_eq!(with_source, without_source);
+    }
+
+    #[test]
+    fn the_whole_chain_is_walkable_to_the_root() {
+        let original = std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "truncated");
+        let err = DataProfilerError::io_with_source("reading chunk 4", original);
+
+        let mut depth = 0;
+        let mut current: Option<&(dyn std::error::Error + 'static)> = Some(&err);
+        while let Some(e) = current {
+            current = e.source();
+            depth += 1;
+        }
+        // Exactly two links: the DataProfilerError and the io::Error beneath it.
+        // A wrapper type in between would make this 3 and break downcasting.
+        assert_eq!(depth, 2);
     }
 }

--- a/crates/dataprof-core/src/errors.rs
+++ b/crates/dataprof-core/src/errors.rs
@@ -98,7 +98,6 @@ pub enum RecoveryStrategy {
     MemoryOptimization,
 }
 
-/// Enhanced error types with more descriptive messages for DataProfiler
 /// Boxed originating error retained by the variants that can carry a cause.
 ///
 /// `Box` rather than `Arc` is deliberate. `thiserror` renders a boxed source
@@ -1327,6 +1326,44 @@ mod tests {
             .and_then(|s| s.downcast_ref())
             .expect("source must downcast to csv::Error");
         assert!(matches!(csv.kind(), csv::ErrorKind::UnequalLengths { .. }));
+    }
+
+    // Gated exactly like the conversion it covers: without the feature there is
+    // no `From<ArrowError>` impl to test.
+    #[cfg(feature = "arrow")]
+    #[test]
+    fn from_arrow_error_retains_the_arrow_error() {
+        let original = arrow::error::ArrowError::ComputeError("overflow in sum".to_string());
+        let expected = original.to_string();
+        let err: DataProfilerError = original.into();
+
+        assert!(matches!(err, DataProfilerError::ArrowError { .. }));
+        let arrow_err: &arrow::error::ArrowError = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("source must downcast to arrow::error::ArrowError");
+        assert_eq!(arrow_err.to_string(), expected);
+        assert!(matches!(
+            arrow_err,
+            arrow::error::ArrowError::ComputeError(_)
+        ));
+    }
+
+    // Parquet failures reach the user through `parquet_with_source`, which the
+    // reader paths use; this covers that constructor's retention contract with
+    // a stand-in error so the test needs no parquet dependency here.
+    #[test]
+    fn parquet_with_source_retains_the_reader_error() {
+        let original = std::io::Error::new(std::io::ErrorKind::InvalidData, "Corrupt footer");
+        let err =
+            DataProfilerError::parquet_with_source("Failed to create Parquet reader", original);
+
+        assert!(err.to_string().contains("Failed to create Parquet reader"));
+        let io: &std::io::Error = err
+            .source()
+            .and_then(|s| s.downcast_ref())
+            .expect("parquet errors must retain the reader failure");
+        assert_eq!(io.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/dataprof-core/src/sampling/sampler.rs
+++ b/crates/dataprof-core/src/sampling/sampler.rs
@@ -248,6 +248,7 @@ impl RowSampler {
                         suggestion: "Keep a single fixed-size stage and express the rest as \
                                      filters, e.g. multi_stage([systematic(10), reservoir(1000)])."
                             .to_string(),
+                        source: None,
                     });
                 }
                 *buffer = Some(SampleBuffer::new(*size));
@@ -266,6 +267,7 @@ impl RowSampler {
                                          stratified come first, e.g. \
                                          multi_stage([systematic(10), reservoir(1000)])."
                                 .to_string(),
+                            source: None,
                         });
                     }
                     Self::flatten(stage, filters, buffer)?;

--- a/crates/dataprof-csv/src/robust_csv.rs
+++ b/crates/dataprof-csv/src/robust_csv.rs
@@ -229,7 +229,7 @@ impl RobustCsvParser {
                 }
 
                 recovery_manager
-                    .attempt_recovery(&dp_error, |strategy| {
+                    .attempt_recovery(dp_error, |strategy| {
                         self.try_recovery_strategy(file_path, strategy)
                     })
                     .map_err(|error| error.into())

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -203,10 +203,10 @@ pub async fn analyze_database_with_options(
         });
     }
     if config.batch_size == 0 {
-        return Err(DataProfilerError::InvalidConfiguration {
-            message: "database batch_size must be greater than zero".to_string(),
-            suggestion: "Set batch_size to a positive number of rows.".to_string(),
-        });
+        return Err(DataProfilerError::invalid_config(
+            "database batch_size must be greater than zero",
+            "Set batch_size to a positive number of rows.",
+        ));
     }
     let mut connector = create_connector(config.clone())?;
 

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -65,19 +65,17 @@ fn peek_non_whitespace<R: std::io::BufRead>(
 
 /// Build a strict-mode error for a standard JSON document that is not exactly
 /// one value. Mirrors `dataprof_json::json_document_error`.
-fn json_document_error(err: &serde_json::Error) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!(
-            // One source line on purpose: see dataprof_json::json_document_error.
-            "malformed JSON document: {err}. A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
-        ),
-    }
+fn json_document_error(err: serde_json::Error) -> DataProfilerError {
+    let message = format!(
+        // One source line on purpose: see dataprof_json::json_document_error.
+        "malformed JSON document: {err}. A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
+    );
+    DataProfilerError::json_parsing_with_source(message, err)
 }
 
 fn malformed_json_array_error(message: &str) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!("malformed JSON array: {message}"),
-    }
+    // Callers hold a message, not the decoder error: nothing to retain.
+    DataProfilerError::json_parsing_error(&format!("malformed JSON array: {message}"))
 }
 
 /// One record read from a JSON or JSONL stream.
@@ -191,12 +189,11 @@ fn json_value_kind(value: &serde_json::Value) -> &'static str {
 /// distinct category from a syntax failure: the document parsed, it just does
 /// not hold records. `position` is 1-based over the records scanned so far.
 fn non_object_record_error(kind: &str, position: usize) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!(
-            "non-object JSON record at position {position}: \
-             expected an object with fields to profile, found {kind}"
-        ),
-    }
+    // No source: the document parsed, it simply does not hold records.
+    DataProfilerError::json_parsing_error(&format!(
+        "non-object JSON record at position {position}: \
+         expected an object with fields to profile, found {kind}"
+    ))
 }
 
 fn drain_to_end<R: std::io::BufRead>(reader: &mut R) -> Result<usize, DataProfilerError> {
@@ -520,7 +517,7 @@ impl AsyncStreamingProfiler {
 
     /// Map a `csv` crate error, pointing a strict-mode field-count failure at
     /// the option that would have recovered it instead.
-    fn csv_error(err: &csv::Error, flexible: bool) -> DataProfilerError {
+    fn csv_error(err: csv::Error, flexible: bool) -> DataProfilerError {
         let suggestion = if !flexible && matches!(err.kind(), csv::ErrorKind::UnequalLengths { .. })
         {
             "Set csv_flexible=true to recover ragged rows; every recovered row is \
@@ -528,10 +525,7 @@ impl AsyncStreamingProfiler {
         } else {
             "Check CSV formatting in the stream data"
         };
-        DataProfilerError::CsvParsingError {
-            message: err.to_string(),
-            suggestion: suggestion.to_string(),
-        }
+        DataProfilerError::csv_parsing_with_source(err.to_string(), suggestion, err)
     }
 
     /// Blocking reader task: uses the `csv` crate's RFC 4180-compliant parser
@@ -580,7 +574,7 @@ impl AsyncStreamingProfiler {
         // Send headers as the first chunk
         let headers = csv_reader
             .headers()
-            .map_err(|e| Self::csv_error(&e, flexible))?;
+            .map_err(|e| Self::csv_error(e, flexible))?;
 
         let header_fields: Vec<String> = headers.iter().map(|f| f.to_string()).collect();
         dataprof_core::validate_unique_column_names(&header_fields, "CSV header")?;
@@ -608,7 +602,7 @@ impl AsyncStreamingProfiler {
 
         while csv_reader
             .read_record(&mut record)
-            .map_err(|e| Self::csv_error(&e, flexible))?
+            .map_err(|e| Self::csv_error(e, flexible))?
         {
             // A field count differing from the header is a structural violation.
             // Counted here, before the row is queued, so the signal covers every
@@ -835,12 +829,13 @@ impl AsyncStreamingProfiler {
                                 // decoder's own line number is always 1 and
                                 // would mislead; its column is within the line
                                 // and so is also the column in the source.
-                                return Err(DataProfilerError::JsonParsingError {
-                                    message: format!(
-                                        "malformed JSON record on line {line_number}, column {}: a JSONL record must be one complete JSON value on one line",
-                                        e.column()
-                                    ),
-                                });
+                                let message = format!(
+                                    "malformed JSON record on line {line_number}, column {}: a JSONL record must be one complete JSON value on one line",
+                                    e.column()
+                                );
+                                return Err(DataProfilerError::json_parsing_with_source(
+                                    message, e,
+                                ));
                             }
                             // The offending line has already been consumed in
                             // full, so the next read starts at the next record.
@@ -887,7 +882,7 @@ impl AsyncStreamingProfiler {
                             }
                             Err(e) => {
                                 if error_policy == JsonErrorPolicy::Strict {
-                                    return Err(json_document_error(&e));
+                                    return Err(json_document_error(e));
                                 }
                                 malformed_records += 1;
                             }
@@ -994,9 +989,10 @@ impl AsyncStreamingProfiler {
                                 // to resync, so we stop here either way; strict mode
                                 // surfaces the failure instead of a partial profile.
                                 if error_policy == JsonErrorPolicy::Strict {
-                                    return Err(DataProfilerError::JsonParsingError {
-                                        message: format!("malformed JSON record: {e}"),
-                                    });
+                                    let message = format!("malformed JSON record: {e}");
+                                    return Err(DataProfilerError::json_parsing_with_source(
+                                        message, e,
+                                    ));
                                 }
                                 malformed_records += 1;
                                 drain_remainder = true;
@@ -1053,11 +1049,12 @@ impl AsyncStreamingProfiler {
         // Input made up entirely of malformed records must fail, matching the
         // file/bytes paths, rather than surfacing a generic "empty stream" error.
         if emitted_records == 0 && malformed_records > 0 {
-            return Err(DataProfilerError::JsonParsingError {
-                message: "No valid JSON records found \
-                          (every record was malformed or not a JSON object)"
-                    .to_string(),
-            });
+            // Aggregate over many discarded records: no single decoder error
+            // is the cause, so none is retained.
+            return Err(DataProfilerError::json_parsing_error(
+                "No valid JSON records found \
+                 (every record was malformed or not a JSON object)",
+            ));
         }
 
         // Flush remaining

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -191,7 +191,7 @@ where
                     }
                     JsonRecord::Malformed(err) => {
                         if config.error_policy == JsonErrorPolicy::Strict {
-                            return Err(malformed_jsonl_record_error(line_number, &err));
+                            return Err(malformed_jsonl_record_error(line_number, err));
                         }
                         malformed_lines += 1;
                     }
@@ -290,7 +290,7 @@ where
                             }
                             JsonRecord::Malformed(err) => {
                                 if config.error_policy == JsonErrorPolicy::Strict {
-                                    return Err(malformed_record_error(&err));
+                                    return Err(malformed_record_error(err));
                                 }
                                 malformed_lines += 1;
                                 drain_remainder = true;
@@ -431,7 +431,7 @@ where
         }
         Err(err) => {
             if config.error_policy == JsonErrorPolicy::Strict {
-                return Err(json_document_error(&err));
+                return Err(json_document_error(err));
             }
             Ok((0, 1, false))
         }
@@ -565,21 +565,20 @@ fn json_value_kind(value: &Value) -> &'static str {
 /// distinct category from a syntax failure: the document parsed, it just does
 /// not hold records. `position` is 1-based over the records scanned so far.
 fn non_object_record_error(kind: &str, position: usize) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!(
-            "non-object JSON record at position {position}: \
-             expected an object with fields to profile, found {kind}"
-        ),
-    }
+    // No source: the document parsed cleanly, it simply does not hold records,
+    // so there is no decoder error underneath to retain.
+    DataProfilerError::json_parsing_error(&format!(
+        "non-object JSON record at position {position}: \
+         expected an object with fields to profile, found {kind}"
+    ))
 }
 
 /// Build a strict-mode parse error from a serde failure. The serde message
 /// carries line/column context but never the record contents, so it is safe to
 /// surface directly.
-fn malformed_record_error(err: &serde_json::Error) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!("malformed JSON record: {err}"),
-    }
+fn malformed_record_error(err: serde_json::Error) -> DataProfilerError {
+    let message = format!("malformed JSON record: {err}");
+    DataProfilerError::json_parsing_with_source(message, err)
 }
 
 /// Build a strict-mode parse error for a JSONL record, located by its physical
@@ -589,19 +588,18 @@ fn malformed_record_error(err: &serde_json::Error) -> DataProfilerError {
 /// and would be misleading; the column it reports is within the line and so is
 /// also the column in the file. The record's text is never included. Matches the
 /// phrasing the Python bytes reader uses for the same failure.
-fn malformed_jsonl_record_error(line: usize, err: &serde_json::Error) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!(
-            "malformed JSON record on line {line}, column {}: a JSONL record must be one complete JSON value on one line",
-            err.column()
-        ),
-    }
+fn malformed_jsonl_record_error(line: usize, err: serde_json::Error) -> DataProfilerError {
+    let message = format!(
+        "malformed JSON record on line {line}, column {}: a JSONL record must be one complete JSON value on one line",
+        err.column()
+    );
+    DataProfilerError::json_parsing_with_source(message, err)
 }
 
 fn malformed_array_error(message: &str) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!("malformed JSON array: {message}"),
-    }
+    // Callers here hold only a message, not the decoder error, so there is
+    // nothing to retain.
+    DataProfilerError::json_parsing_error(&format!("malformed JSON array: {message}"))
 }
 
 /// Build a strict-mode error for a standard JSON document that is not exactly
@@ -610,15 +608,14 @@ fn malformed_array_error(message: &str) -> DataProfilerError {
 /// The most common cause is JSONL read with the JSON grammar — several objects
 /// back to back parse as one value plus trailing characters — so the message
 /// names the option that would read it correctly.
-fn json_document_error(err: &serde_json::Error) -> DataProfilerError {
-    DataProfilerError::JsonParsingError {
-        message: format!(
-            // One source line on purpose: rustfmt may join a `\`-continued
-            // literal and leave its indentation inside the string, which silently
-            // corrupted this very message once.
-            "malformed JSON document: {err}. A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
-        ),
-    }
+fn json_document_error(err: serde_json::Error) -> DataProfilerError {
+    let message = format!(
+        // One source line on purpose: rustfmt may join a `\`-continued
+        // literal and leave its indentation inside the string, which silently
+        // corrupted this very message once.
+        "malformed JSON document: {err}. A JSON source must hold exactly one array or object; for one record per line use format=\"jsonl\""
+    );
+    DataProfilerError::json_parsing_with_source(message, err)
 }
 
 fn drain_to_end<R: BufRead>(reader: &mut R) -> Result<(), DataProfilerError> {
@@ -881,12 +878,12 @@ pub fn analyze_json_file_with_options(
             } else {
                 ""
             };
-            return Err(DataProfilerError::JsonParsingError {
-                message: format!(
-                    "No valid JSON records found in file \
-                     (every record was malformed or not a JSON object){hint}"
-                ),
-            });
+            // Aggregate over many discarded records: no single decoder error
+            // is the cause, so none is retained.
+            return Err(DataProfilerError::json_parsing_error(&format!(
+                "No valid JSON records found in file \
+                 (every record was malformed or not a JSON object){hint}"
+            )));
         }
         // A row cap that stopped the scan before the first record still has to
         // be disclosed. Without this the report reads exactly like a complete

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -201,7 +201,7 @@ impl ArrowProfiler {
         }
         let csv_reader = arrow_builder
             .build(file)
-            .map_err(|error| map_arrow_csv_error(file_path, &error))?;
+            .map_err(|error| map_arrow_csv_error(file_path, error))?;
 
         // Process data in columnar batches
         let mut column_analyzers: std::collections::HashMap<String, ColumnAnalyzer> =
@@ -232,18 +232,15 @@ impl ArrowProfiler {
         let projection: Vec<usize> = (0..header_width).collect();
 
         for batch_result in csv_reader {
-            let mut batch = batch_result.map_err(|error| map_arrow_csv_error(file_path, &error))?;
+            let mut batch = batch_result.map_err(|error| map_arrow_csv_error(file_path, error))?;
 
             // Drop the overflow columns before anything observes the batch, so
             // duplicate tracking, hint bindings and the profiles themselves all
             // see exactly the columns the header declared.
             if batch.num_columns() > header_width {
-                batch =
-                    batch
-                        .project(&projection)
-                        .map_err(|error| DataProfilerError::ArrowError {
-                            message: error.to_string(),
-                        })?;
+                batch = batch
+                    .project(&projection)
+                    .map_err(DataProfilerError::arrow_error_from)?;
             }
 
             if let Some(max) = max_rows {
@@ -353,20 +350,18 @@ impl ArrowProfiler {
     }
 }
 
-fn map_arrow_csv_error(file_path: &Path, error: &arrow::error::ArrowError) -> DataProfilerError {
+fn map_arrow_csv_error(file_path: &Path, error: arrow::error::ArrowError) -> DataProfilerError {
     let message = error.to_string();
 
     if message.contains("incorrect number of fields") {
-        return DataProfilerError::CsvParsingError {
-            message,
-            suggestion: format!(
-                "The columnar engine sizes its schema from a pre-scan of '{}', so a row Arrow still finds ragged means the two parsers disagree on where records end — most often unbalanced quotes or an embedded newline. Use engine='auto' or engine='incremental', which parse the file only once.",
-                file_path.display()
-            ),
-        };
+        let suggestion = format!(
+            "The columnar engine sizes its schema from a pre-scan of '{}', so a row Arrow still finds ragged means the two parsers disagree on where records end — most often unbalanced quotes or an embedded newline. Use engine='auto' or engine='incremental', which parse the file only once.",
+            file_path.display()
+        );
+        return DataProfilerError::csv_parsing_with_source(message, suggestion, error);
     }
 
-    DataProfilerError::ArrowError { message }
+    DataProfilerError::arrow_with_source(message, error)
 }
 
 impl Default for ArrowProfiler {
@@ -460,81 +455,81 @@ impl ColumnAnalyzer {
                 if let Some(float_array) = array.as_any().downcast_ref::<Float64Array>() {
                     self.process_float64_array(float_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to Float64Array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to Float64Array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Float32 => {
                 if let Some(float_array) = array.as_any().downcast_ref::<Float32Array>() {
                     self.process_float32_array(float_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to Float32Array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to Float32Array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Int64 => {
                 if let Some(int_array) = array.as_any().downcast_ref::<Int64Array>() {
                     self.process_int64_array(int_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to Int64Array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to Int64Array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Int32 => {
                 if let Some(int_array) = array.as_any().downcast_ref::<Int32Array>() {
                     self.process_int32_array(int_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to Int32Array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to Int32Array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Utf8 => {
                 if let Some(string_array) = array.as_any().downcast_ref::<StringArray>() {
                     self.process_string_array(string_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to StringArray".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to StringArray",
+                    ));
                 }
             }
             arrow::datatypes::DataType::LargeUtf8 => {
                 if let Some(string_array) = array.as_any().downcast_ref::<LargeStringArray>() {
                     self.process_large_string_array(string_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to LargeStringArray".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to LargeStringArray",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Boolean => {
                 if let Some(bool_array) = array.as_any().downcast_ref::<BooleanArray>() {
                     self.process_boolean_array(bool_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to BooleanArray".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to BooleanArray",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Date32 => {
                 if let Some(date_array) = array.as_any().downcast_ref::<Date32Array>() {
                     self.process_date32_array(date_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to Date32Array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to Date32Array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Date64 => {
                 if let Some(date_array) = array.as_any().downcast_ref::<Date64Array>() {
                     self.process_date64_array(date_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast to Date64Array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast to Date64Array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Timestamp(_, _) => {
@@ -552,9 +547,9 @@ impl ColumnAnalyzer {
                 {
                     self.process_timestamp_second_array(ts_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast Timestamp array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast Timestamp array",
+                    ));
                 }
             }
             arrow::datatypes::DataType::Binary | arrow::datatypes::DataType::LargeBinary => {
@@ -563,9 +558,9 @@ impl ColumnAnalyzer {
                 } else if let Some(bin_array) = array.as_any().downcast_ref::<LargeBinaryArray>() {
                     self.process_large_binary_array(bin_array)?;
                 } else {
-                    return Err(DataProfilerError::ArrowError {
-                        message: "Failed to downcast Binary array".to_string(),
-                    });
+                    return Err(DataProfilerError::arrow_error(
+                        "Failed to downcast Binary array",
+                    ));
                 }
             }
             _ => {

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -49,30 +49,41 @@ impl HttpParquetReader {
         client: &Client,
         url: &str,
     ) -> Result<usize, DataProfilerError> {
-        let head_failure = match client.head(url).send().await {
+        let (head_failure, head_transport_error) = match client.head(url).send().await {
             Ok(head_res) if head_res.status().is_success() => {
                 if let Some(content_length) = Self::content_length_from_headers(head_res.headers())
                 {
                     return Ok(content_length);
                 }
-                "Server did not provide Content-Length header on HEAD".to_string()
+                (
+                    "Server did not provide Content-Length header on HEAD".to_string(),
+                    None,
+                )
             }
-            Ok(head_res) => {
-                format!("HTTP HEAD request returned status {}", head_res.status())
-            }
-            Err(error) => {
-                format!("Failed to HEAD url: {}", error)
-            }
+            Ok(head_res) => (
+                format!("HTTP HEAD request returned status {}", head_res.status()),
+                None,
+            ),
+            Err(error) => (format!("Failed to HEAD url: {}", error), Some(error)),
         };
 
         Self::probe_content_length_with_range(client, url)
             .await
-            .map_err(|probe_error| {
+            .map_err(|probe_failure| {
                 let mut message = head_failure;
                 message.push_str("; range probe fallback failed: ");
-                message.push_str(&probe_error);
+                message.push_str(&probe_failure.message);
 
-                DataProfilerError::parquet_error(&message)
+                // The probe is the more proximate failure, so its transport
+                // error is the cause when there is one; the HEAD error is the
+                // fallback for a probe that failed on a protocol condition
+                // (a 200 where 206 was required) rather than on transport.
+                // Neither exists when both failed on protocol alone, and then
+                // the error correctly reports no cause at all.
+                match probe_failure.transport_error.or(head_transport_error) {
+                    Some(error) => DataProfilerError::parquet_with_source(message, error),
+                    None => DataProfilerError::parquet_error(&message),
+                }
             })
     }
 
@@ -97,16 +108,24 @@ impl HttpParquetReader {
         total_size.parse::<usize>().ok()
     }
 
-    async fn probe_content_length_with_range(client: &Client, url: &str) -> Result<usize, String> {
+    async fn probe_content_length_with_range(
+        client: &Client,
+        url: &str,
+    ) -> Result<usize, ProbeFailure> {
         let response = client
             .get(url)
             .header(reqwest::header::RANGE, "bytes=0-0")
             .send()
             .await
-            .map_err(|error| format!("failed to fetch byte-range probe: {}", error))?;
+            .map_err(|error| {
+                ProbeFailure::transport(
+                    format!("failed to fetch byte-range probe: {}", error),
+                    error,
+                )
+            })?;
 
         if response.status() != reqwest::StatusCode::PARTIAL_CONTENT {
-            return Err(match response.status() {
+            return Err(ProbeFailure::protocol(match response.status() {
                 reqwest::StatusCode::OK => {
                     "server ignored Range header during size probe and returned 200 OK".to_string()
                 }
@@ -114,12 +133,43 @@ impl HttpParquetReader {
                     "expected 206 Partial Content from size probe, got {}",
                     status
                 ),
-            });
+            }));
         }
 
         Self::content_length_from_content_range(response.headers()).ok_or_else(|| {
-            "server did not provide a parseable Content-Range total during size probe".to_string()
+            ProbeFailure::protocol(
+                "server did not provide a parseable Content-Range total during size probe"
+                    .to_string(),
+            )
         })
+    }
+}
+
+/// Why a byte-range size probe could not determine the object's size.
+///
+/// Carries the transport error when there was one, so a network failure
+/// survives into the profiling error's cause chain instead of being flattened
+/// into the message. A probe that failed on a protocol condition — a 200 where
+/// 206 was required, an unparseable `Content-Range` — genuinely has no
+/// underlying error, and reports none.
+struct ProbeFailure {
+    message: String,
+    transport_error: Option<reqwest::Error>,
+}
+
+impl ProbeFailure {
+    fn transport(message: String, error: reqwest::Error) -> Self {
+        Self {
+            message,
+            transport_error: Some(error),
+        }
+    }
+
+    fn protocol(message: String) -> Self {
+        Self {
+            message,
+            transport_error: None,
+        }
     }
 }
 
@@ -361,6 +411,15 @@ mod tests {
     use std::thread::JoinHandle;
     use std::time::Duration;
 
+    /// How the mock server answers a ranged GET. `IgnoreRange` models the real
+    /// servers that answer 200 with the whole body regardless of `Range`, which
+    /// is the size probe's protocol-failure branch.
+    #[derive(Clone, Copy)]
+    enum RangeBehavior {
+        PartialContent,
+        IgnoreRange,
+    }
+
     #[derive(Clone, Copy)]
     enum HeadBehavior {
         WithContentLength,
@@ -426,6 +485,14 @@ mod tests {
     }
 
     fn spawn_mock_server(data: Vec<u8>, head_behavior: HeadBehavior) -> MockServer {
+        spawn_mock_server_with(data, head_behavior, RangeBehavior::PartialContent)
+    }
+
+    fn spawn_mock_server_with(
+        data: Vec<u8>,
+        head_behavior: HeadBehavior,
+        range_behavior: RangeBehavior,
+    ) -> MockServer {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         listener.set_nonblocking(true).unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -464,6 +531,19 @@ mod tests {
                                 .write_all(response.as_bytes())
                                 .expect("mock server HEAD response failed");
                         } else if request.starts_with("GET") {
+                            if matches!(range_behavior, RangeBehavior::IgnoreRange) {
+                                let response = format!(
+                                    "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                                    data.len()
+                                );
+                                stream
+                                    .write_all(response.as_bytes())
+                                    .expect("mock server GET response headers failed");
+                                stream
+                                    .write_all(&data)
+                                    .expect("mock server GET response body failed");
+                                continue;
+                            }
                             let (start, end) = parse_range_header(&request)
                                 .expect("mock server missing or invalid Range header");
                             let chunk = data
@@ -525,6 +605,62 @@ mod tests {
         writer.close().unwrap();
 
         buffer
+    }
+
+    #[tokio::test]
+    async fn transport_failure_retains_the_reqwest_error_as_source() {
+        use std::error::Error as _;
+
+        // Bind then drop, so the port is real but nothing is listening: both the
+        // HEAD and the range probe fail on transport rather than on protocol.
+        // This is the state the fix is meant to improve, not merely one it must
+        // preserve.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let url = format!("http://127.0.0.1:{}/missing.parquet", port);
+
+        // `.err()` rather than `expect_err`: the reader is not `Debug`.
+        let err = HttpParquetReader::try_new(&url)
+            .await
+            .err()
+            .expect("connecting to a closed port must fail");
+
+        assert!(matches!(err, DataProfilerError::ParquetError { .. }));
+        let source = err
+            .source()
+            .expect("a transport failure must be retained as the cause");
+        source
+            .downcast_ref::<reqwest::Error>()
+            .expect("source must downcast to the original reqwest::Error");
+    }
+
+    #[tokio::test]
+    async fn protocol_only_failure_reports_no_source() {
+        use std::error::Error as _;
+
+        // The server answers both requests, so nothing fails at the transport
+        // layer: HEAD returns 405 and the ranged GET returns 200 with the whole
+        // body. "No cause" has to stay distinct from "cause dropped".
+        let data: Vec<u8> = (0..64).collect();
+        let server = spawn_mock_server_with(
+            data,
+            HeadBehavior::MethodNotAllowed,
+            RangeBehavior::IgnoreRange,
+        );
+        let err = HttpParquetReader::try_new(server.url())
+            .await
+            .err()
+            .expect("a server that ignores Range cannot yield a size");
+
+        assert!(matches!(err, DataProfilerError::ParquetError { .. }));
+        assert!(
+            err.source().is_none(),
+            "a protocol-only failure must not invent a cause: {:?}",
+            err.source().map(|s| s.to_string())
+        );
+
+        server.join();
     }
 
     #[tokio::test]

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -29,8 +29,11 @@ impl HttpParquetReader {
             .connect_timeout(std::time::Duration::from_secs(10))
             .timeout(std::time::Duration::from_secs(30))
             .build()
-            .map_err(|e| DataProfilerError::ParquetError {
-                message: format!("Reqwest client builder failed: {}", e),
+            .map_err(|e| {
+                DataProfilerError::parquet_with_source(
+                    format!("Reqwest client builder failed: {}", e),
+                    e,
+                )
             })?;
 
         let content_length = Self::discover_content_length(&client, url).await?;
@@ -69,7 +72,7 @@ impl HttpParquetReader {
                 message.push_str("; range probe fallback failed: ");
                 message.push_str(&probe_error);
 
-                DataProfilerError::ParquetError { message }
+                DataProfilerError::parquet_error(&message)
             })
     }
 
@@ -254,8 +257,11 @@ pub async fn analyze_parquet_async_http_with_options(
 
     let builder = ParquetRecordBatchStreamBuilder::new(reader)
         .await
-        .map_err(|e| DataProfilerError::ParquetError {
-            message: format!("Failed to create Parquet stream builder: {}", e),
+        .map_err(|e| {
+            DataProfilerError::parquet_with_source(
+                format!("Failed to create Parquet stream builder: {}", e),
+                e,
+            )
         })?;
 
     let parquet_meta = builder.metadata().clone();
@@ -280,16 +286,22 @@ pub async fn analyze_parquet_async_http_with_options(
     let mut stream = builder
         .with_batch_size(config.batch_size)
         .build()
-        .map_err(|e| DataProfilerError::ParquetError {
-            message: format!("Failed to build Parquet stream: {}", e),
+        .map_err(|e| {
+            DataProfilerError::parquet_with_source(
+                format!("Failed to build Parquet stream: {}", e),
+                e,
+            )
         })?;
 
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
     analyzer.initialize_schema(arrow_schema.as_ref())?;
 
     while let Some(batch_result) = stream.next().await {
-        let batch = batch_result.map_err(|e| DataProfilerError::ParquetError {
-            message: format!("Failed to read Parquet async batch: {}", e),
+        let batch = batch_result.map_err(|e| {
+            DataProfilerError::parquet_with_source(
+                format!("Failed to read Parquet async batch: {}", e),
+                e,
+            )
         })?;
         analyzer.process_batch(&batch)?;
     }

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -239,9 +239,10 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
     let start = std::time::Instant::now();
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(chunks).map_err(|error| {
-        DataProfilerError::ParquetError {
-            message: format!("Failed to create Parquet reader: {}", error),
-        }
+        DataProfilerError::parquet_with_source(
+            format!("Failed to create Parquet reader: {}", error),
+            error,
+        )
     })?;
 
     let parquet_meta = builder.metadata();
@@ -270,17 +271,21 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
     if let Some(max) = config.max_rows {
         reader_builder = reader_builder.with_limit(max);
     }
-    let reader = reader_builder
-        .build()
-        .map_err(|error| DataProfilerError::ParquetError {
-            message: format!("Failed to build Parquet reader: {}", error),
-        })?;
+    let reader = reader_builder.build().map_err(|error| {
+        DataProfilerError::parquet_with_source(
+            format!("Failed to build Parquet reader: {}", error),
+            error,
+        )
+    })?;
 
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
     analyzer.initialize_schema(arrow_schema.as_ref())?;
     for batch_result in reader {
-        let batch = batch_result.map_err(|error| DataProfilerError::ParquetError {
-            message: format!("Failed to read Parquet batch: {}", error),
+        let batch = batch_result.map_err(|error| {
+            DataProfilerError::parquet_with_source(
+                format!("Failed to read Parquet batch: {}", error),
+                error,
+            )
         })?;
         analyzer.process_batch(&batch)?;
     }

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -203,9 +203,7 @@ fn infer_schema_parquet(path: &Path, start: Instant) -> Result<SchemaResult, Dat
     })?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
-        DataProfilerError::ParquetError {
-            message: format!("Failed to read Parquet metadata: {}", e),
-        }
+        DataProfilerError::parquet_with_source(format!("Failed to read Parquet metadata: {}", e), e)
     })?;
 
     let arrow_schema = builder.schema();
@@ -353,7 +351,7 @@ fn count_from_reader<R: Read>(
         FileFormat::Jsonl => {
             let mut count: u64 = 0;
             for line in buf_reader.lines() {
-                let line = line.map_err(|e| DataProfilerError::io_error(&e))?;
+                let line = line.map_err(DataProfilerError::io_error)?;
                 if !line.trim().is_empty() {
                     count += 1;
                 }
@@ -387,9 +385,10 @@ fn count_from_reader<R: Read>(
             }
             let mut de = serde_json::Deserializer::from_reader(buf_reader);
             let count = de.deserialize_seq(ArrayCountVisitor).map_err(|e| {
-                DataProfilerError::JsonParsingError {
-                    message: format!("Failed to parse JSON array: {}", e),
-                }
+                DataProfilerError::json_parsing_with_source(
+                    format!("Failed to parse JSON array: {}", e),
+                    e,
+                )
             })?;
             Ok(RowCountEstimate {
                 count,
@@ -420,9 +419,7 @@ fn count_parquet(path: &Path, start: Instant) -> Result<RowCountEstimate, DataPr
     })?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file).map_err(|e| {
-        DataProfilerError::ParquetError {
-            message: format!("Failed to read Parquet metadata: {}", e),
-        }
+        DataProfilerError::parquet_with_source(format!("Failed to read Parquet metadata: {}", e), e)
     })?;
 
     let count = builder.metadata().file_metadata().num_rows() as u64;
@@ -519,7 +516,7 @@ fn full_scan_jsonl<R: BufRead>(
 ) -> Result<RowCountEstimate, DataProfilerError> {
     let mut count: u64 = 0;
     for line in reader.lines() {
-        let line = line.map_err(|e| DataProfilerError::io_error(&e))?;
+        let line = line.map_err(DataProfilerError::io_error)?;
         if !line.trim().is_empty() {
             count += 1;
         }
@@ -585,7 +582,7 @@ fn sample_row_density_multi_offset(
     for w in 0..ROW_SAMPLE_WINDOWS {
         let offset = window_span * w as u64 + window_span / 2;
         file.seek(SeekFrom::Start(offset))
-            .map_err(|e| DataProfilerError::io_error(&e))?;
+            .map_err(DataProfilerError::io_error)?;
         let mut reader = BufReader::new(&mut file);
 
         // Each window seeks into the middle of the file and most likely lands
@@ -595,7 +592,7 @@ fn sample_row_density_multi_offset(
             let mut partial = String::new();
             reader
                 .read_line(&mut partial)
-                .map_err(|e| DataProfilerError::io_error(&e))?;
+                .map_err(DataProfilerError::io_error)?;
         }
 
         let mut win_bytes: u64 = 0;
@@ -606,7 +603,7 @@ fn sample_row_density_multi_offset(
             // the on-disk length (including `\r\n`) without a manual +1.
             let n = reader
                 .read_line(&mut line)
-                .map_err(|e| DataProfilerError::io_error(&e))?;
+                .map_err(DataProfilerError::io_error)?;
             if n == 0 {
                 break; // EOF
             }
@@ -724,9 +721,10 @@ fn count_json(
             // memory usage constant regardless of array size.
             let reader = BufReader::new(file);
             let arr: Vec<serde::de::IgnoredAny> = serde_json::from_reader(reader).map_err(|e| {
-                DataProfilerError::JsonParsingError {
-                    message: format!("Failed to parse JSON array: {}", e),
-                }
+                DataProfilerError::json_parsing_with_source(
+                    format!("Failed to parse JSON array: {}", e),
+                    e,
+                )
             })?;
 
             Ok(RowCountEstimate {
@@ -763,9 +761,7 @@ fn consume_leading_whitespace<R: BufRead>(reader: &mut R) -> Result<Option<u8>, 
     loop {
         let mut bytes_to_consume = 0;
         let first_non_whitespace = {
-            let buf = reader
-                .fill_buf()
-                .map_err(|e| DataProfilerError::io_error(&e))?;
+            let buf = reader.fill_buf().map_err(DataProfilerError::io_error)?;
 
             if buf.is_empty() {
                 return Ok(None);

--- a/crates/dataprof-python/src/errors.rs
+++ b/crates/dataprof-python/src/errors.rs
@@ -25,7 +25,53 @@ use dataprof::{DataProfilerError, ProfileReport, SemanticHints};
 ///
 /// The `DataProfilerError` `Display` already carries the actionable suggestion,
 /// so the message is passed through verbatim rather than re-wrapped.
+///
+/// Any retained cause chain (see `DataProfilerError`'s `ErrorSource`) is
+/// attached as the exception's `__cause__`, so `raise ... from ...` context
+/// shows the originating decoder or OS error in the traceback instead of it
+/// being visible only from Rust.
 pub(crate) fn analysis_error_to_py(err: &DataProfilerError) -> PyErr {
+    let py_err = analysis_error_to_py_uncaused(err);
+    match rust_cause_chain(err) {
+        Some(cause) => Python::attach(|py| {
+            py_err.set_cause(py, Some(cause));
+            py_err
+        }),
+        None => py_err,
+    }
+}
+
+/// Build the `__cause__` for a profiling error from its retained source chain.
+///
+/// Each link becomes its own exception so a multi-level chain stays visible in
+/// the traceback rather than being flattened into one message. Returns `None`
+/// when nothing was retained, which keeps "no cause recorded" distinct from
+/// "cause recorded but empty".
+fn rust_cause_chain(err: &DataProfilerError) -> Option<PyErr> {
+    let mut messages = Vec::new();
+    let mut current = std::error::Error::source(err);
+    while let Some(source) = current {
+        messages.push(source.to_string());
+        current = std::error::Error::source(source);
+    }
+    if messages.is_empty() {
+        return None;
+    }
+
+    // Built innermost-first so the outermost cause is the error directly
+    // beneath the profiling error, matching how Python renders chained causes.
+    let mut cause: Option<PyErr> = None;
+    for message in messages.into_iter().rev() {
+        let link = PyRuntimeError::new_err(message);
+        if let Some(inner) = cause.take() {
+            Python::attach(|py| link.set_cause(py, Some(inner)));
+        }
+        cause = Some(link);
+    }
+    cause
+}
+
+fn analysis_error_to_py_uncaused(err: &DataProfilerError) -> PyErr {
     let message = err.to_string();
     match err {
         DataProfilerError::InvalidSemanticHint { .. }

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -542,15 +542,13 @@ impl Profiler {
         if self.config.stop_condition.is_row_limit_only() {
             return Ok(());
         }
-        Err(DataProfilerError::InvalidConfiguration {
-            message: format!(
+        Err(DataProfilerError::invalid_config(
+            &format!(
                 "{what} supports only row-limit stop conditions (max_rows), not the one supplied"
             ),
-            suggestion:
-                "Use StopCondition::MaxRows, profile a CSV source with the auto or incremental \
-                 engine, or remove the stop condition."
-                    .to_string(),
-        })
+            "Use StopCondition::MaxRows, profile a CSV source with the auto or incremental \
+             engine, or remove the stop condition.",
+        ))
     }
 
     /// Whether a sampling strategy was configured.
@@ -568,12 +566,11 @@ impl Profiler {
         if !self.has_sampling() {
             return Ok(());
         }
-        Err(DataProfilerError::InvalidConfiguration {
-            message: format!("{what} cannot apply a sampling strategy"),
-            suggestion: "Profile a CSV source with the auto or incremental engine, which sample \
-                         row by row, or remove the sampling strategy."
-                .to_string(),
-        })
+        Err(DataProfilerError::invalid_config(
+            &format!("{what} cannot apply a sampling strategy"),
+            "Profile a CSV source with the auto or incremental engine, which sample \
+             row by row, or remove the sampling strategy.",
+        ))
     }
 
     /// The row cap implied by the configured stop condition, if any.
@@ -1109,18 +1106,12 @@ impl Profiler {
                 }
             }
             FileFormat::Csv | FileFormat::Json | FileFormat::Jsonl => {
-                let metadata =
-                    tokio::fs::metadata(path)
-                        .await
-                        .map_err(|e| DataProfilerError::IoError {
-                            message: format!("{}: {e}", path.display()),
-                        })?;
-                let file =
-                    tokio::fs::File::open(path)
-                        .await
-                        .map_err(|e| DataProfilerError::IoError {
-                            message: format!("{}: {e}", path.display()),
-                        })?;
+                let metadata = tokio::fs::metadata(path).await.map_err(|e| {
+                    DataProfilerError::io_with_source(format!("{}: {e}", path.display()), e)
+                })?;
+                let file = tokio::fs::File::open(path).await.map_err(|e| {
+                    DataProfilerError::io_with_source(format!("{}: {e}", path.display()), e)
+                })?;
                 let info = AsyncSourceInfo::new(path.display().to_string(), format)
                     .size_hint(Some(metadata.len()))
                     .source_system(dataprof_core::StreamSourceSystem::Custom("file".into()));

--- a/docs/architecture/public-api-inventory.md
+++ b/docs/architecture/public-api-inventory.md
@@ -61,8 +61,9 @@ the chain yields the `Arc` instead, every message still reads correctly, and
 every downcast silently returns `None`.
 
 **The cause-carrying variants are `#[non_exhaustive]`.** `CsvParsingError`,
-`IoError`, `JsonParsingError`, `ParquetError`, and `ArrowError` cannot be built
-with a struct expression from outside `dataprof-core`; use the constructors
+`IoError`, `JsonParsingError`, `ParquetError`, `ArrowError`, and
+`InvalidConfiguration` cannot be built with a struct expression from outside
+`dataprof-core`; use the constructors
 (`DataProfilerError::io_error`, `::json_parsing_with_source`,
 `::parquet_with_source`, and so on). Matching on them still works and must use
 `..`. This keeps adding a field to those variants a non-breaking change.
@@ -72,7 +73,7 @@ Downstream effects to expect when upgrading:
 | If you… | What to do |
 | --- | --- |
 | clone a `DataProfilerError` | Propagate it by value, or clone `to_string()` if only the text is needed. |
-| construct one of the five variants directly | Call the matching constructor instead. |
+| construct one of the six cause-carrying variants directly | Call the matching constructor instead (`invalid_config` and `invalid_config_with_source` for `InvalidConfiguration`). |
 | call `AutoRecoveryManager::attempt_recovery` | It takes the error by value now rather than by reference. |
 | call `DataProfilerError::io_error(&err)` | Pass the error by value: `map_err(DataProfilerError::io_error)`. |
 

--- a/docs/architecture/public-api-inventory.md
+++ b/docs/architecture/public-api-inventory.md
@@ -47,6 +47,35 @@ available through their owning workspace crates when needed.
 | Low-level acceleration and serialization helpers | Implementation details owned by `dataprof-metrics` and `dataprof-core`. |
 | Database row-processing helpers | Internal database pipeline details owned by `dataprof-db`. |
 
+## Error Type Compatibility
+
+`DataProfilerError` is a public enum, and two of its properties are
+compatibility-sensitive.
+
+**It is not `Clone`.** The variants that can carry a cause hold an
+`ErrorSource` (a boxed `dyn Error`), and neither that nor the errors it wraps
+(`std::io::Error`, `csv::Error`, ...) are cloneable. `Box` is used rather than
+`Arc` deliberately: only a boxed source lets `Error::source()` hand back the
+concrete error, so `downcast_ref::<std::io::Error>()` resolves. Behind an `Arc`
+the chain yields the `Arc` instead, every message still reads correctly, and
+every downcast silently returns `None`.
+
+**The cause-carrying variants are `#[non_exhaustive]`.** `CsvParsingError`,
+`IoError`, `JsonParsingError`, `ParquetError`, and `ArrowError` cannot be built
+with a struct expression from outside `dataprof-core`; use the constructors
+(`DataProfilerError::io_error`, `::json_parsing_with_source`,
+`::parquet_with_source`, and so on). Matching on them still works and must use
+`..`. This keeps adding a field to those variants a non-breaking change.
+
+Downstream effects to expect when upgrading:
+
+| If you… | What to do |
+| --- | --- |
+| clone a `DataProfilerError` | Propagate it by value, or clone `to_string()` if only the text is needed. |
+| construct one of the five variants directly | Call the matching constructor instead. |
+| call `AutoRecoveryManager::attempt_recovery` | It takes the error by value now rather than by reference. |
+| call `DataProfilerError::io_error(&err)` | Pass the error by value: `map_err(DataProfilerError::io_error)`. |
+
 ## Coverage Expectations
 
 Public API compile coverage should exercise:

--- a/python/tests/test_error_cause_chain.py
+++ b/python/tests/test_error_cause_chain.py
@@ -1,0 +1,69 @@
+"""The originating error must survive into Python as ``__cause__``.
+
+Rust-side, ``DataProfilerError`` retains the error it was built from (see the
+``ErrorSource`` type in ``dataprof-core``). These tests assert the Python half
+of that contract: a caller reading a traceback sees the decoder or OS error
+that actually failed, not only dataprof's summary of it.
+
+The distinction the suite has to hold onto is the project's usual one: absent
+means "no cause was recorded", and it must stay different from a cause that is
+recorded but empty.
+"""
+
+from __future__ import annotations
+
+import dataprof
+import pytest
+
+
+class TestErrorCauseChain:
+    def test_corrupt_parquet_surfaces_the_reader_error_as_cause(self, tmp_path):
+        # The parquet reader's own diagnostic ("Corrupt footer") is the detail a
+        # user needs and the part that used to be flattened into a string.
+        bogus = tmp_path / "broken.parquet"
+        bogus.write_bytes(b"NOTPARQUET" * 16)
+
+        with pytest.raises(Exception) as excinfo:
+            dataprof.profile(str(bogus))
+
+        cause = excinfo.value.__cause__
+        assert cause is not None, "the parquet reader error must be retained as __cause__"
+        assert "Parquet" in str(cause)
+
+    def test_parquet_bytes_path_agrees_with_the_file_path(self, tmp_path):
+        # Output parity: the two input paths must not disagree about whether a
+        # cause was recorded.
+        payload = b"NOTPARQUET" * 16
+        bogus = tmp_path / "broken.parquet"
+        bogus.write_bytes(payload)
+
+        with pytest.raises(Exception) as from_file:
+            dataprof.profile(str(bogus))
+        with pytest.raises(Exception) as from_bytes:
+            dataprof.profile(payload, format="parquet")
+
+        assert (from_file.value.__cause__ is None) == (from_bytes.value.__cause__ is None)
+        assert str(from_file.value.__cause__) == str(from_bytes.value.__cause__)
+
+    def test_missing_file_records_no_cause(self, tmp_path):
+        # Nothing failed underneath here: dataprof checked for the file and it
+        # was not there. A fabricated __cause__ would be noise.
+        with pytest.raises(FileNotFoundError) as excinfo:
+            dataprof.profile(str(tmp_path / "absent.csv"))
+        assert excinfo.value.__cause__ is None
+
+    def test_cause_is_not_the_exception_itself(self, tmp_path):
+        # Guards against wiring __cause__ to the wrapper, which would render as
+        # a plausible-looking but circular chain.
+        bogus = tmp_path / "broken.parquet"
+        bogus.write_bytes(b"NOTPARQUET" * 16)
+
+        with pytest.raises(Exception) as excinfo:
+            dataprof.profile(str(bogus))
+
+        err = excinfo.value
+        # Assert the cause exists first: without this the checks below pass
+        # trivially on None and the test guards nothing.
+        assert err.__cause__ is not None
+        assert err.__cause__ is not err
+        assert str(err.__cause__) != str(err)


### PR DESCRIPTION
Closes #447.

## The problem

`DataProfilerError`'s `From` conversions flattened every cause into a `String`,
so `std::error::Error::source()` returned `None` for essentially every value and
callers could not reach the error that actually failed. The same flattening
reached Python, where exceptions carried a message and no `__cause__`.

## What changed

Six variants now carry an optional boxed source — `CsvParsingError`, `IoError`,
`JsonParsingError`, `ParquetError`, `ArrowError`, `InvalidConfiguration` — and
all eight `From` impls retain their input rather than stringifying it. That
covers the full audit list in the issue: I/O, CSV, JSON, Arrow, Parquet, TOML,
glob.

### `Box` over `Arc` is load-bearing, not style

thiserror renders a boxed source through `&**b`, so `source()` hands back the
**concrete** error and `downcast_ref::<std::io::Error>()` resolves. Behind an
`Arc` the chain yields the `Arc` itself:

```
Box:  [0] "io failed: cannot read" | io_downcast=None
      [1] "denied by acl"          | io_downcast=Some(PermissionDenied)

Arc:  [0] "io failed: cannot read" | io_downcast=None
      [1] "denied by acl"          | io_downcast=None      <-- the Arc
      [2] "denied by acl"          | io_downcast=Some(PermissionDenied)
```

The `Arc` version compiles, keeps `Clone`, and renders every message
identically — it just silently fails every downcast, which is the one
capability this work exists to provide. I switched the alias to `Arc` on the
real tree to confirm: it compiles and **breaks four tests**. That is why the
tests downcast instead of comparing rendered text.

### The `Clone` question the issue left open

Resolved by removal: `DataProfilerError` is no longer `Clone`, because a boxed
`dyn Error` is not, and neither are the errors it wraps. Its only consumer was
`AutoRecoveryManager::attempt_recovery`, which now takes the error by value
(one call site).

### Compatibility

The cause-carrying variants are `#[non_exhaustive]`, so adding a field to them
later is no longer breaking. Construction outside `dataprof-core` goes through
constructors; matching is unaffected beyond needing `..`. Documented as
compatibility-sensitive in `docs/architecture/public-api-inventory.md`, with an
upgrade table.

### Python

Exceptions now carry the chain as `__cause__`, one exception per link, so a
corrupt Parquet footer shows up in the traceback:

```
ValueError: Parquet processing failed: Failed to create Parquet reader...
  __cause__ = RuntimeError("Parquet error: Invalid Parquet file. Corrupt footer")
```

Errors with nothing retained keep `__cause__` as `None` — absent stays distinct
from empty, per the project's usual rule.

## Verification

- `cargo clippy --all --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — 41 test binaries, no failures
- `uv run pytest python/tests` — 999 passed, 9 skipped (db/symlink)
- `ruff format`, `ruff check`, `ty check` — clean
- Rust and Python examples run
- Display output unchanged; the two reflowed message literals were printed and
  confirmed byte-identical

Each source-retention fix was reverted **separately** and its test confirmed to
fail without it: `From<io::Error>`, `From<serde_json::Error>`,
`From<csv::Error>`, and the `Box`/`Arc` choice. The Python `__cause__` wiring
was disabled and rebuilt to confirm the same.

Being precise about what the tests do **not** discriminate: of the four Python
tests, only `test_corrupt_parquet_surfaces_the_reader_error_as_cause` fails when
the wiring is removed. The parity and no-cause tests are controls for a
*wrong* cause, not a missing one. `the_whole_chain_is_walkable_to_the_root`
passes under `Arc` too — the downcast assertions are what catch that.
