### PR TITLE
chore: normalize line endings with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Line endings
+#
+# Every text file is stored and checked out as LF, whatever a contributor's
+# `core.autocrlf` happens to be. Git on Windows defaults that setting to
+# `true`, which stores LF but checks CRLF out; the working tree then disagrees
+# with the repository and the damage is quiet rather than loud:
+#
+#   * `cargo fmt --check` and `ruff format --check` flag files nobody touched
+#   * scripts that split on "\n" stop matching, for no visible reason
+#   * generated files (docs/schema/) show as modified with an empty diff
+#
+# Every text file here is already stored as LF, so this governs how files are
+# checked out, not what is committed. Adding it produces no content change.
+* text=auto eol=lf
+
+# Binary files. `text=auto` detects these on content alone, but naming them
+# keeps a misdetection from corrupting an asset or a test fixture — a Parquet
+# file with its bytes "converted" would still open and profile wrongly.
+*.png binary
+*.jpg binary
+*.parquet binary
+
+# Build artefacts, should any ever be committed as a fixture.
+*.whl binary
+*.so binary
+*.pyd binary
+*.dll binary


### PR DESCRIPTION
The repository has no `.gitattributes`. Git on Windows defaults `core.autocrlf`
to `true`, which stores LF and checks CRLF out, so the working tree disagrees
with the repository on every text file.

The failure mode is quiet rather than loud:

* `cargo fmt --check` and `ruff format --check` flag files nobody edited
* scripts that split on `"\n"` stop matching, with nothing to point at
* regenerating `docs/schema/` leaves a file git reports as **modified with an
  empty diff** — which is exactly what happened while working on #617

## This changes checkout behaviour, not content

Every text file here is already stored as LF:

```
$ git ls-files --eol | awk '{print $1, $2}' | sort | uniq -c
    305 i/lf w/crlf      <- LF in the index, CRLF in the working tree
      8 i/-text w/-text  <- binaries
      4 i/lf w/lf
      1 i/none w/none
```

So `* text=auto eol=lf` only governs how files come out. `git add
--renormalize .` stages nothing beyond the new file — there is no content
rewrite in this PR, and no reflow of history.

Binary types are named explicitly. `text=auto` already detects them by content,
but a misdetection on a Parquet fixture would be the worst kind of bug here: the
file would still open and profile, just wrongly.

## Verification

Re-checked out the entire tree with the attributes in place:

```
$ git ls-files --eol | awk '{print $1, $2}' | sort | uniq -c
    310 i/lf w/lf
      8 i/-text w/-text
      1 i/none w/none
```

- A real re-checkout of `AGENTS.md` went from 89 CRLF to 89 bare LF, confirming
  the attribute takes effect rather than merely being present
- The 8 binaries stayed `-text`
- `cargo fmt --all -- --check` and `ruff format --check` pass on the LF tree
- `ruff check` passes
- Regenerating the profile schema now leaves `docs/schema/` clean, where it
  previously reported a phantom modification

## Note for reviewers

After this merges, existing local clones keep their CRLF working trees until the
files are re-checked out. `git add --renormalize . && git checkout -- .` (or a
fresh clone) brings a clone in line. Nothing breaks in the meantime — the index
is LF either way.
