### PR TITLE
fix(python): document the source-build recipe and guard the shipped feature set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,14 @@ build:  ## Build the Python extension (release)
 dev:  ## Build the Python extension (debug, fast)
 	uv run maturin develop
 
+# The database targets repeat the shipped feature set on purpose: --features
+# replaces [tool.maturin] features rather than extending it, so a shorter list
+# builds database support while dropping async and remote Parquet.
 build-db:  ## Build the Python extension with database support (release)
-	uv run maturin develop --release --features "python,python-async,database,sqlite"
+	uv run maturin develop --release --features "python,python-async,async-streaming,parquet-async,database,sqlite"
 
 dev-db:  ## Build the Python extension with database support (debug, fast)
-	uv run maturin develop --features "python,python-async,database,sqlite"
+	uv run maturin develop --features "python,python-async,async-streaming,parquet-async,database,sqlite"
 
 # ── Test ─────────────────────────────────────────
 

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -24,8 +24,15 @@ dataprof = { version = "0.10", features = ["postgres"] }
 For local Python extension development:
 
 ```bash
-uv run maturin develop --features "python,python-async,database,sqlite"
+uv run maturin develop --features "python,python-async,async-streaming,parquet-async,database,sqlite"
 ```
+
+The list is long because `--features` **replaces** `[tool.maturin] features`
+rather than adding to it: building with only `"python,python-async,database,
+sqlite"` produces a package with database support and no async, URL, or remote
+Parquet support, which the published wheel does include. See
+[the Python README](../python/README.md#database-profiling-source-build-only)
+for the pip-from-sdist form.
 
 ## Supported Databases
 
@@ -46,7 +53,7 @@ on. Build the extension from a checkout with `python-async`, `database`, and the
 connector feature you need first:
 
 ```bash
-uv run maturin develop --features "python,python-async,database,sqlite"
+uv run maturin develop --features "python,python-async,async-streaming,parquet-async,database,sqlite"
 ```
 
 Then the following APIs become available:

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -23,11 +23,16 @@ and remote Parquet all work on a bare `pip install dataprof`.
 
 Database profiling is the one documented feature the wheel does not contain.
 Connectors are a compile-time feature rather than a Python dependency, so no
-extra can install them; they need a build from a checkout of this repository:
+extra can install them; they need a build from source, either with pip from the
+published sdist or from a checkout:
 
 ```bash
-uv run maturin develop --features "python,python-async,database,sqlite"
+pip install dataprof --no-binary dataprof   --config-settings="build-args=--features python,python-async,async-streaming,parquet-async,database,sqlite"
 ```
+
+The feature list has to be complete, not just the extra parts. See
+[Database Profiling](#database-profiling-source-build-only) for why, and for
+the checkout equivalent.
 
 Inspect the current installation without importing optional packages or trying
 a network/database operation:
@@ -680,11 +685,55 @@ count = await quick_row_count_stream(csv_bytes, format="csv")
 Async database functions for PostgreSQL, MySQL, and SQLite are **not** in the
 published wheels, and there is no extra that installs them. On a wheel install
 they exist as stubs that raise `ImportError` when called, and
-`dp.capabilities().database` is `False`. Build the extension from a checkout
-with `python-async`, `database`, and the connector features you need:
+`dp.capabilities().database` is `False`. They need a source build with
+`python-async`, `database`, and the connector features you want.
+
+### From the published sdist, with pip
+
+No checkout required:
 
 ```bash
-uv run maturin develop --features "python,python-async,database,sqlite"
+pip install dataprof --no-binary dataprof   --config-settings="build-args=--features python,python-async,async-streaming,parquet-async,database,sqlite"
+```
+
+### From a checkout
+
+```bash
+uv run maturin develop --features "python,python-async,async-streaming,parquet-async,database,sqlite"
+```
+
+### List every feature you want, not only the extra ones
+
+`--features` **replaces** the `[tool.maturin] features` list in
+`pyproject.toml`; it does not add to it. This is the part that bites, because
+the result looks like it worked:
+
+```bash
+# Wrong: builds database support and silently drops async, URL profiling,
+# and remote Parquet — surface that a plain `pip install dataprof` includes.
+--features "python,python-async,database,sqlite"
+```
+
+That command yields `capabilities().database == True` alongside
+`async_streaming == False`, `url_profiling == False`, and
+`remote_parquet == False`. Nothing errors; the package is simply smaller than
+the published wheel. The lists above are the shipped set plus the database
+features, which is why they are long.
+
+`database` on its own is also not enough: the connectors are reported only when
+`python-async` is compiled in as well.
+
+A source build needs a Rust toolchain (1.96 or later). `postgres` and `mysql`
+are pure Rust; `sqlite` compiles `libsqlite3-sys`, which is C.
+
+Check what you actually got before relying on it:
+
+```python
+import dataprof as dp
+
+caps = dp.capabilities()
+assert caps.database and "sqlite" in caps.database_connectors
+assert caps.async_streaming  # still present, because the list above kept it
 ```
 
 Then the following APIs become available:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -95,8 +95,11 @@ except ImportError:
         def _stub(*_args, **_kwargs):
             raise ImportError(
                 f"{name}() requires database support, which is not compiled into "
-                "the published wheels. Rebuild from source with e.g. "
-                "maturin develop --features 'python,python-async,database,sqlite'"
+                "the published wheels. Rebuild from source with the shipped feature "
+                "set plus the connectors you need, e.g. maturin develop --features "
+                "'python,python-async,async-streaming,parquet-async,database,sqlite'. "
+                "--features replaces the default list rather than extending it, so a "
+                "shorter list silently drops async and remote Parquet support."
             )
 
         _stub.__name__ = name

--- a/python/tests/test_column_order.py
+++ b/python/tests/test_column_order.py
@@ -113,8 +113,8 @@ def test_to_dict_export_keeps_report_column_order(tmp_path):
 _HAS_DATABASE = dataprof.capabilities().database
 requires_database = pytest.mark.skipif(
     not _HAS_DATABASE,
-    reason="Database support not compiled. Build with --features "
-    "'python,python-async,database,sqlite'.",
+    reason="Database support not compiled. Build with: uv run maturin develop "
+    "--features 'python,python-async,async-streaming,parquet-async,database,sqlite'.",
 )
 
 

--- a/python/tests/test_database_api.py
+++ b/python/tests/test_database_api.py
@@ -1,7 +1,8 @@
-"""Database API integration tests.
+r"""Database API integration tests.
 
 These tests require building with database feature flags:
-    uv run maturin develop --features "python,python-async,database,sqlite"
+    uv run maturin develop \
+        --features "python,python-async,async-streaming,parquet-async,database,sqlite"
 
 Or use the Makefile shortcut:
     make dev-db

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -1,4 +1,4 @@
-"""``metrics``, ``quality_dimensions`` and ``locale`` apply to queries too (#536).
+r"""``metrics``, ``quality_dimensions`` and ``locale`` apply to queries too (#536).
 
 #494 made these options take effect on every file format and transport. The
 database path was left out of that pass: it hardcoded quality on and called
@@ -11,7 +11,8 @@ two to agree — on what was analyzed, and on the quality numbers themselves.
 
 Requires building with database feature flags::
 
-    uv run maturin develop --features "python,python-async,database,sqlite"
+    uv run maturin develop \
+        --features "python,python-async,async-streaming,parquet-async,database,sqlite"
 """
 
 from __future__ import annotations

--- a/python/tests/test_wheel_feature_single_source.py
+++ b/python/tests/test_wheel_feature_single_source.py
@@ -242,7 +242,7 @@ def _documented_feature_lists(text: str) -> list[tuple[str, list[str]]]:
     one string. A bare `--features` fragment with no command name on the line is
     ignored: the README shows one on purpose, as the example of what not to do.
     """
-    joined = re.sub(r"\\s*\n\s*", " ", text)
+    joined = re.sub(r"\\\s*\n\s*", " ", text)
     joined = re.sub(r'"\s*\n\s*"', "", joined)
     found = []
     for line in joined.splitlines():
@@ -284,3 +284,33 @@ def test_documented_source_builds_keep_everything_the_wheel_ships():
             )
             checked += 1
     assert checked, "no documented source-build commands found; has the wording changed?"
+
+
+def test_feature_lists_survive_shell_continuations():
+    r"""The parser must join a `\`-continued command however it is spaced.
+
+    `--features` often sits on the continuation line, so a join that misses
+    leaves the command invisible to the guards below: the flag line carries no
+    command name and is filtered out, and the check silently passes on a
+    command it never read. Trailing whitespace after the backslash is the case
+    that matters, because nothing renders it.
+    """
+    backslash = chr(92)
+    command = (
+        "pip install dataprof --no-binary dataprof {bs}{pad}\n"
+        '  --config-settings="build-args=--features python,parquet-async"'
+    )
+
+    for pad in ("", " ", "   "):
+        text = command.format(bs=backslash, pad=pad)
+        found = _documented_feature_lists(text)
+        assert found, f"continuation with {len(pad)} trailing space(s) was not joined"
+        assert found[0][1] == ["python", "parquet-async"]
+
+
+def test_bare_feature_fragments_are_not_treated_as_commands():
+    """The README shows an incomplete `--features` line on purpose, as the
+    example of what not to do. Counting it as a documented command would make
+    the docs guard fail on its own warning."""
+    text = '# Wrong: drops async support\n--features "python,python-async,database,sqlite"'
+    assert _documented_feature_lists(text) == []

--- a/python/tests/test_wheel_feature_single_source.py
+++ b/python/tests/test_wheel_feature_single_source.py
@@ -105,3 +105,182 @@ def test_release_workflow_does_not_duplicate_the_feature_flag():
             f"maturin step must not pass --features ({line!r}); the shipped set is "
             "declared once, in [tool.maturin] features in pyproject.toml"
         )
+
+
+# --- the smoke test must keep pace with what we ship (#590) -----------------
+
+WHEEL_SMOKE = REPO_ROOT / ".github/scripts/wheel_smoke.py"
+
+# What each shipped feature is supposed to turn on in `dataprof.capabilities()`.
+# Derived from `crates/dataprof-python/src/lib.rs`, where the flags are set from
+# `cfg!`, and `python/dataprof/__init__.py`, which maps them to the public
+# names. A feature that is only a prerequisite turns nothing on by itself.
+SHIPPED_FEATURE_CAPABILITIES: dict[str, tuple[str, ...]] = {
+    "python": (),
+    "python-async": (),
+    "async-streaming": ("async_streaming", "url_profiling"),
+    "parquet-async": ("remote_parquet",),
+}
+
+
+def test_every_shipped_feature_has_a_declared_capability_meaning():
+    """Adding a feature to the wheel must not be possible without saying what it
+    turns on.
+
+    This is the drift that would otherwise be silent: the shipped set grows, the
+    wheel smoke test keeps passing because it never learned to check the new
+    surface, and a wheel missing that surface ships green.
+    """
+    declared = set(_tool_maturin_features())
+    mapped = set(SHIPPED_FEATURE_CAPABILITIES)
+    assert declared == mapped, (
+        f"[tool.maturin] features and SHIPPED_FEATURE_CAPABILITIES disagree: "
+        f"only in pyproject={sorted(declared - mapped)}, "
+        f"only here={sorted(mapped - declared)}. Update this map and add the "
+        f"matching assertion to {WHEEL_SMOKE.name}."
+    )
+
+
+def test_wheel_smoke_asserts_every_shipped_capability():
+    """Every capability the shipped features turn on is asserted against the
+    installed wheel.
+
+    `capabilities()` reads compile-time `cfg!` flags, so only a check running on
+    the built artifact can catch a feature that failed to compile in.
+    """
+    smoke = WHEEL_SMOKE.read_text(encoding="utf-8")
+    expected = sorted({name for names in SHIPPED_FEATURE_CAPABILITIES.values() for name in names})
+    assert expected, "the shipped feature set turns on no capability at all"
+    missing = [name for name in expected if f"caps.{name}" not in smoke]
+    assert not missing, (
+        f"{WHEEL_SMOKE.name} never asserts {missing} against the installed wheel; "
+        "a wheel built without those features would pass the smoke job."
+    )
+
+
+def test_wheel_smoke_asserts_the_deliberate_absence_of_database():
+    """The other half of the contract is a negative.
+
+    Database connectors are deliberately excluded (#588), so the smoke test has
+    to prove they are absent. Without this, quietly shipping them — or shipping
+    a build that reports them while the decode path is still wrong — would pass.
+    """
+    smoke = WHEEL_SMOKE.read_text(encoding="utf-8")
+    assert "not caps.database" in smoke, (
+        f"{WHEEL_SMOKE.name} must assert that database support is absent from the wheel"
+    )
+    assert "database" not in _tool_maturin_features(), (
+        "database is in the shipped feature set; update the smoke test's negative "
+        "assertion and the source-build docs before landing that"
+    )
+
+
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+
+# The CI jobs that must exercise the configuration users actually receive, and
+# so must never pass `--features`. Jobs deliberately building a different set
+# (the async-URL matrix, the database legs) are not listed and are free to.
+SHIPPED_SET_JOBS = ("python-tests", "examples-smoke")
+
+
+def _job_body(workflow: str, job: str) -> str:
+    """The lines of one top-level job, up to the next job key."""
+    lines = workflow.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line == f"  {job}:"),
+        None,
+    )
+    assert start is not None, f"{CI_WORKFLOW.name} has no job named {job!r}"
+    body = []
+    for line in lines[start + 1 :]:
+        if re.match(r"^  \S", line):  # the next top-level job key
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def test_shipped_set_jobs_build_without_a_feature_flag():
+    """The jobs that run the suite must build exactly what ships.
+
+    `maturin develop` with no `--features` falls back to `[tool.maturin]
+    features`, so these jobs track the shipped set automatically. Passing the
+    flag here would pin them to a set of their own, and the configuration users
+    receive would go untested by any job — every one of them building either
+    more or less than it (#590).
+    """
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    for job in SHIPPED_SET_JOBS:
+        body = _job_body(workflow, job)
+        develop = [line.strip() for line in body.splitlines() if "maturin develop" in line]
+        assert develop, f"job {job!r} no longer builds the extension with maturin develop"
+        for line in develop:
+            assert "--features" not in line, (
+                f"job {job!r} pins its own feature set ({line!r}); it must build the "
+                "shipped set declared in [tool.maturin] features"
+            )
+
+
+# --- documented source-build commands must not downgrade the build (#592) ----
+
+# Docs that tell a user how to build the extension from source.
+SOURCE_BUILD_DOCS = (
+    "docs/python/README.md",
+    "docs/guides/database-connectors.md",
+    "Makefile",
+    "python/dataprof/__init__.py",
+    "python/tests/test_column_order.py",
+    "python/tests/test_database_api.py",
+    "python/tests/test_database_option_parity.py",
+)
+
+
+def _documented_feature_lists(text: str) -> list[tuple[str, list[str]]]:
+    r"""Every `--features` list belonging to a real build command or message.
+
+    Shell continuations are joined first, then adjacent Python string literals,
+    so a command or an error message split across source lines is still seen as
+    one string. A bare `--features` fragment with no command name on the line is
+    ignored: the README shows one on purpose, as the example of what not to do.
+    """
+    joined = re.sub(r"\\s*\n\s*", " ", text)
+    joined = re.sub(r'"\s*\n\s*"', "", joined)
+    found = []
+    for line in joined.splitlines():
+        stripped = line.strip()
+        if "maturin" not in stripped and "pip install" not in stripped:
+            continue
+        match = re.search(r"""--features[= ]["']?([a-z0-9,\-]+)""", stripped)
+        if match:
+            found.append((stripped, match.group(1).split(",")))
+    return found
+
+
+def test_documented_source_builds_keep_everything_the_wheel_ships():
+    """A source build must be a superset of the wheel, never a downgrade.
+
+    `--features` replaces `[tool.maturin] features` rather than extending it, so
+    a documented command that lists only the extra features quietly produces a
+    package *smaller* than `pip install dataprof` — database support, but no
+    async, URL profiling, or remote Parquet. Nothing errors, which is what makes
+    it worth a test (#592).
+    """
+    shipped = set(_tool_maturin_features())
+    checked = 0
+    for relative in SOURCE_BUILD_DOCS:
+        path = REPO_ROOT / relative
+        commands = _documented_feature_lists(path.read_text(encoding="utf-8"))
+        # A listed file that matches nothing checks nothing, and would sit here
+        # looking like coverage it does not provide.
+        assert commands, (
+            f"{relative} is listed as a source-build instruction but no build "
+            "command was found in it; fix the matcher or drop the file"
+        )
+        for command, features in commands:
+            missing = sorted(shipped - set(features))
+            assert not missing, (
+                f"{relative} documents a build that drops {missing} from the shipped "
+                f"feature set: {command!r}. `--features` replaces the pyproject list, "
+                "so every documented command must repeat it in full."
+            )
+            checked += 1
+    assert checked, "no documented source-build commands found; has the wording changed?"


### PR DESCRIPTION
Closes #590, closes #592.

## What I found

Every documented way to build dataprof with database support produced a package
**smaller than the published wheel**.

`--features` *replaces* `[tool.maturin] features` rather than extending it, so
the command in our docs:

```bash
uv run maturin develop --features "python,python-async,database,sqlite"
```

produces:

```
database: true   BUT   async_streaming: false, url_profiling: false, remote_parquet: false
```

Database support, minus the async/URL/remote-Parquet surface a plain
`pip install dataprof` already gives you. Nothing errors — the build is just
quietly worse than the wheel. That command was in the Python README, the
connector guide, **two Makefile targets**, the `ImportError` raised by the
database stubs, and three test docstrings. All now carry the shipped set plus
the connectors.

## #592: the pip recipe, verified

Built an sdist and installed it into a clean venv:

```bash
pip install dataprof --no-binary dataprof \
  --config-settings="build-args=--features python,python-async,async-streaming,parquet-async,database,sqlite"
```

Result:

```json
{"async_streaming": true, "url_profiling": true, "remote_parquet": true,
 "local_parquet": true, "database": true}   connectors: ('sqlite',)
```

**Append vs replace: it replaces.** Proved by installing the same sdist with
`build-args=--features python`, which came back with `async_streaming: false`,
`url_profiling: false`, `remote_parquet: false`.

One correction to the issue's premise: it expected a replace to drop the
`python` feature and leave "an extension module with no bindings registered".
That does not happen — `python = []` is an empty feature and no
`cfg(feature = "python")` exists anywhere in the sources, so omitting it changes
nothing. The real hazard is losing async and remote Parquet, and that is what
the docs now warn about.

## #590: what was actually left

Both halves were already built — the primary pytest job builds the shipped set
(no `--features`, so it tracks pyproject) and runs the whole suite including
`test_async_url_api.py`, and `wheel_smoke.py` asserts `capabilities()` against a
wheel installed in a bare venv. What was missing was anything keeping that true.
Four guards added:

| Guard | Breaks when |
| --- | --- |
| every shipped feature declares what it turns on | a feature is added to the wheel with no stated meaning |
| the smoke script asserts every one of those capabilities | the shipped set grows and the smoke test doesn't learn to check it |
| the smoke script keeps asserting database is **absent** | connectors ship without the negative assertion being revisited |
| the suite-running jobs pass no `--features` | a job pins its own set and the shipped config goes untested |

Plus the docs guard: every documented build command must be a superset of the
shipped set, so these instructions cannot rot the same way again. It covers 11
commands across 7 files, and asserts each listed file yields at least one match
— a file that matched nothing would sit there looking like coverage it wasn't
providing, which it did on the first attempt.

### The acceptance item

> Confirm the guard works by building a wheel with a feature deliberately
> removed and checking the job fails.

Done, against a real wheel built with the async features removed:

```
acceptance: async is in the base wheel
AssertionError: capabilities() reports async_streaming
EXIT CODE: 1
```

This is a one-off verification rather than a new CI job: it needs a second full
wheel build, and the static guards above cover the drift that is actually
likely. Say the word if you'd rather pay for it in CI.

## Verification

- `uv run pytest python/tests` — 1004 passed, 9 skipped
- `ruff format`, `ruff check`, `ty check`, `cargo fmt --check` — clean
- Each new guard was reverted and confirmed to fail: restoring the short feature
  list to the connector guide fails the docs guard; adding `database` to the
  shipped set fails two of the smoke guards

One note: `test_save_parquet` failed once during a run that overlapped a
concurrent Rust build, then passed in isolation and on every rerun. This PR
changes no code it exercises, but flagging it rather than burying it.

## Review follow-up

Copilot flagged the continuation-joining regex in the docs guard as
malformed. It was written as:

```python
re.sub(r"\\s*\n\s*", " ", text)   # backslash, then zero or more "s"
re.sub(r"\\\s*\n\s*", " ", text)  # backslash, then optional whitespace
```

The first is what shipped; the second is what was meant. Correct catch, fixed.

The predicted consequence does not occur today, though. Every continuation in
these files puts the backslash immediately before the newline, so both
patterns find the same **11** commands across the 7 guarded files — measured
by running each pattern over all of them. The defect was latent, not live.

It stops being latent with one trailing space after a backslash, and it fails
silently rather than spuriously: the flag line carries no command name, so it
is filtered out and the guard passes on a command it never read. A parser test
now feeds the same command with zero, one, and three trailing spaces; it fails
against the old pattern.
