### PR TITLE
docs: add compiling Rust examples to the JSON and Parquet entry points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,11 @@ jobs:
             commands: |
               cargo test --test public_api_facade --all-features
               cargo test -p dataprof-engines --all-features
+              # `cargo test --lib`/`--doc` at the root only covers the root
+              # `dataprof` package, so a member crate runs only if it is named
+              # here. dataprof-json carries doctests that would otherwise never
+              # be compiled by CI.
+              cargo test -p dataprof-json --all-features
               cargo test -p dataprof-parquet --all-features
               cargo test -p dataprof-partial --all-features
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
         cargo test --locked --test public_api_facade --no-default-features --features async-streaming
         cargo test --locked --test public_api_facade --all-features
         cargo test --locked -p dataprof-engines --all-features
+        cargo test --locked -p dataprof-json --all-features
         cargo test --locked -p dataprof-parquet --all-features
         cargo test --locked -p dataprof-partial --all-features
         cargo check --locked -p dataprof-python --all-features

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -1,3 +1,31 @@
+//! JSON and JSONL scanning and profiling for `dataprof`.
+//!
+//! This crate is an implementation detail of the `dataprof` facade, which
+//! re-exports [`JsonParserConfig`], [`analyze_json_from_reader`], and
+//! [`analyze_json_file`]. Depend on `dataprof` unless you need JSON support
+//! without the rest of the workspace.
+//!
+//! Two entry shapes are offered. [`scan_json_from_reader`] hands each record to
+//! a callback and reports what it read; [`analyze_json_from_reader`] and
+//! [`analyze_json_file`] build column profiles and a full report on top of it.
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::io::Cursor;
+//!
+//! use dataprof_json::{JsonParserConfig, analyze_json_from_reader};
+//!
+//! let jsonl = "{\"id\": 1, \"city\": \"Rome\"}\n{\"id\": 2, \"city\": \"Milan\"}\n";
+//! let (profiles, _stats, rows_read, malformed_lines, _format) =
+//!     analyze_json_from_reader(Cursor::new(jsonl), &JsonParserConfig::jsonl())?;
+//!
+//! assert_eq!(rows_read, 2);
+//! assert_eq!(malformed_lines, 0);
+//! assert_eq!(profiles[0].name, "id");
+//! # Ok(())
+//! # }
+//! ```
+
 use std::collections::{HashMap, HashSet};
 use std::io::BufRead;
 use std::path::Path;
@@ -32,6 +60,38 @@ pub enum JsonFormat {
 }
 
 /// Configuration for JSON/JSONL parsing and scanning.
+///
+/// The default detects the grammar from the input and reads every record,
+/// skipping malformed ones. The two format constructors say which grammar to
+/// read with, which is what a caller who knows should do: detection cannot tell
+/// a JSON object document from a JSONL file, since both open with `{`.
+///
+/// # Examples
+///
+/// The same two records under each grammar:
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Cursor;
+///
+/// use dataprof_json::{JsonParserConfig, scan_json_from_reader};
+///
+/// let document = r#"[{"id": 1}, {"id": 2}]"#;
+/// let lines = "{\"id\": 1}\n{\"id\": 2}\n";
+///
+/// let from_document = scan_json_from_reader(
+///     Cursor::new(document),
+///     &JsonParserConfig::json_document(),
+///     |_| {},
+/// )?;
+/// let from_lines =
+///     scan_json_from_reader(Cursor::new(lines), &JsonParserConfig::jsonl(), |_| {})?;
+///
+/// assert_eq!(from_document.rows_read, 2);
+/// assert_eq!(from_lines.rows_read, 2);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone, Default)]
 pub struct JsonParserConfig {
     /// The grammar to read with. `None` detects it from the first byte, which
@@ -49,12 +109,73 @@ pub struct JsonParserConfig {
 
 impl JsonParserConfig {
     /// Set the maximum number of rows to process.
+    ///
+    /// The cap counts profileable records, not lines: blank lines and records
+    /// skipped as malformed do not consume it.
+    ///
+    /// A cap is only *truncation* when a record still remained once it was
+    /// reached, so a source holding exactly `max_rows` records reads as
+    /// complete. [`JsonScanSummary::truncated`] carries that distinction, and
+    /// [`analyze_json_file`] turns it into a [`TruncationReason::MaxRows`] on
+    /// the report.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::io::Cursor;
+    ///
+    /// use dataprof_json::{JsonParserConfig, scan_json_from_reader};
+    ///
+    /// let lines = "{\"id\": 1}\n{\"id\": 2}\n{\"id\": 3}\n";
+    ///
+    /// // Two of three records: a third remained, so the scan was cut short.
+    /// let capped = JsonParserConfig::jsonl().with_max_rows(2);
+    /// let summary = scan_json_from_reader(Cursor::new(lines), &capped, |_| {})?;
+    /// assert_eq!(summary.rows_read, 2);
+    /// assert!(summary.truncated);
+    ///
+    /// // A cap the source never reaches past is a complete read, not a
+    /// // truncated one.
+    /// let exact = JsonParserConfig::jsonl().with_max_rows(3);
+    /// let summary = scan_json_from_reader(Cursor::new(lines), &exact, |_| {})?;
+    /// assert_eq!(summary.rows_read, 3);
+    /// assert!(!summary.truncated);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn with_max_rows(mut self, max_rows: usize) -> Self {
         self.max_rows = Some(max_rows);
         self
     }
 
     /// Set how malformed records are handled.
+    ///
+    /// Under the default [`JsonErrorPolicy::Skip`] a malformed record is
+    /// counted in [`JsonScanSummary::malformed_lines`] and scanning continues,
+    /// so a partial profile never looks like a clean one. Under
+    /// [`JsonErrorPolicy::Strict`] the first one fails the scan.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::io::Cursor;
+    ///
+    /// use dataprof_json::{JsonErrorPolicy, JsonParserConfig, scan_json_from_reader};
+    ///
+    /// let lines = "{\"id\": 1}\nnot json\n{\"id\": 2}\n";
+    ///
+    /// let skipping = JsonParserConfig::jsonl();
+    /// let summary = scan_json_from_reader(Cursor::new(lines), &skipping, |_| {})?;
+    /// assert_eq!(summary.rows_read, 2);
+    /// assert_eq!(summary.malformed_lines, 1);
+    ///
+    /// let strict = JsonParserConfig::jsonl().with_error_policy(JsonErrorPolicy::Strict);
+    /// assert!(scan_json_from_reader(Cursor::new(lines), &strict, |_| {}).is_err());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn with_error_policy(mut self, policy: JsonErrorPolicy) -> Self {
         self.error_policy = policy;
         self
@@ -125,6 +246,68 @@ pub struct JsonScanSummary {
 /// [`JsonErrorPolicy::Skip`] it is counted in
 /// [`JsonScanSummary::malformed_lines`] and scanning continues with the next
 /// record, and under [`JsonErrorPolicy::Strict`] the first one fails the scan.
+///
+/// # Examples
+///
+/// Reading JSONL, keeping one field per record:
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Cursor;
+///
+/// use dataprof_json::{JsonParserConfig, scan_json_from_reader};
+///
+/// let lines = "{\"city\": \"Rome\", \"pop\": 2800000}\n\
+///              {\"city\": \"Milan\", \"pop\": 1400000}\n";
+///
+/// let mut cities = Vec::new();
+/// let summary = scan_json_from_reader(
+///     Cursor::new(lines),
+///     &JsonParserConfig::jsonl(),
+///     |object| {
+///         if let Some(city) = object.get("city").and_then(|value| value.as_str()) {
+///             cities.push(city.to_string());
+///         }
+///     },
+/// )?;
+///
+/// assert_eq!(cities, ["Rome", "Milan"]);
+/// assert_eq!(summary.rows_read, 2);
+/// assert!(!summary.truncated);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The same records as a JSON array. The array streams element by element, and
+/// a record may be pretty-printed across lines because whitespace carries no
+/// meaning under this grammar:
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Cursor;
+///
+/// use dataprof_json::{JsonParserConfig, scan_json_from_reader};
+///
+/// let document = r#"[
+///     {"city": "Rome", "pop": 2800000},
+///     {"city": "Milan", "pop": 1400000}
+/// ]"#;
+///
+/// let mut total = 0u64;
+/// let summary = scan_json_from_reader(
+///     Cursor::new(document),
+///     &JsonParserConfig::json_document(),
+///     |object| {
+///         total += object.get("pop").and_then(|value| value.as_u64()).unwrap_or(0);
+///     },
+/// )?;
+///
+/// assert_eq!(total, 4_200_000);
+/// assert_eq!(summary.rows_read, 2);
+/// assert_eq!(summary.malformed_lines, 0);
+/// # Ok(())
+/// # }
+/// ```
 pub fn scan_json_from_reader<R, F>(
     reader: R,
     config: &JsonParserConfig,
@@ -710,6 +893,37 @@ fn feed_json_object(
 /// fields that only appear in later records appended in first-seen order. This
 /// matches CSV (header order) and Parquet (schema order), so the same logical
 /// dataset profiles to the same column order in every format.
+///
+/// # Examples
+///
+/// The second record lists its fields in a different order and adds one. The
+/// first record still decides the order, and the new field is appended:
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Cursor;
+///
+/// use dataprof_json::{JsonParserConfig, analyze_json_from_reader};
+///
+/// let lines = "{\"id\": 1, \"city\": \"Rome\"}\n\
+///              {\"city\": \"Milan\", \"id\": 2, \"region\": \"Lombardy\"}\n";
+///
+/// let (profiles, _stats, rows_read, malformed_lines, format) =
+///     analyze_json_from_reader(Cursor::new(lines), &JsonParserConfig::jsonl())?;
+///
+/// let names: Vec<&str> = profiles.iter().map(|profile| profile.name.as_str()).collect();
+/// assert_eq!(names, ["id", "city", "region"]);
+/// assert_eq!(rows_read, 2);
+/// assert_eq!(malformed_lines, 0);
+/// assert_eq!(format, dataprof_core::FileFormat::Jsonl);
+///
+/// // The first record has no `region`, which counts as a missing value.
+/// let region = &profiles[2];
+/// assert_eq!(region.total_count, 2);
+/// assert_eq!(region.null_count, 1);
+/// # Ok(())
+/// # }
+/// ```
 pub fn analyze_json_from_reader<R: BufRead>(
     reader: R,
     config: &JsonParserConfig,
@@ -800,6 +1014,32 @@ fn analyze_json_from_reader_full<R: BufRead>(
 }
 
 /// Analyze a JSON or JSONL file, returning a full [`ProfileReport`].
+///
+/// With no explicit [`JsonParserConfig::format`] the file extension decides:
+/// `.json` reads as a standard document, `.jsonl` and `.ndjson` as JSON Lines,
+/// and any other name falls back to sniffing the first byte.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Write;
+///
+/// use dataprof_json::{JsonParserConfig, analyze_json_file};
+///
+/// let mut file = tempfile::NamedTempFile::with_suffix(".jsonl")?;
+/// writeln!(file, "{{\"id\": 1, \"score\": 9.5}}")?;
+/// writeln!(file, "{{\"id\": 2, \"score\": 7.0}}")?;
+/// file.flush()?;
+///
+/// let report = analyze_json_file(file.path(), &JsonParserConfig::default())?;
+///
+/// assert_eq!(report.execution.rows_processed, 2);
+/// assert_eq!(report.execution.columns_detected, 2);
+/// assert!(report.execution.truncation_reason.is_none());
+/// # Ok(())
+/// # }
+/// ```
 pub fn analyze_json_file(
     file_path: &Path,
     config: &JsonParserConfig,

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -293,16 +293,20 @@ pub struct JsonScanSummary {
 ///     {"city": "Milan", "pop": 1400000}
 /// ]"#;
 ///
-/// let mut total = 0u64;
+/// let mut populations = Vec::new();
 /// let summary = scan_json_from_reader(
 ///     Cursor::new(document),
 ///     &JsonParserConfig::json_document(),
 ///     |object| {
-///         total += object.get("pop").and_then(|value| value.as_u64()).unwrap_or(0);
+///         // A field that is absent, or present but not a number, stays
+///         // `None`. Reading it as 0 instead would turn a missing value into
+///         // a real measurement, which is the one thing a profile must never
+///         // do.
+///         populations.push(object.get("pop").and_then(|value| value.as_u64()));
 ///     },
 /// )?;
 ///
-/// assert_eq!(total, 4_200_000);
+/// assert_eq!(populations, [Some(2_800_000), Some(1_400_000)]);
 /// assert_eq!(summary.rows_read, 2);
 /// assert_eq!(summary.malformed_lines, 0);
 /// # Ok(())

--- a/crates/dataprof-parquet/src/lib.rs
+++ b/crates/dataprof-parquet/src/lib.rs
@@ -1,3 +1,30 @@
+//! Parquet and Arrow profiling for `dataprof`.
+//!
+//! This crate is an implementation detail of the `dataprof` facade, which
+//! re-exports `ParquetConfig`, `is_parquet_file`, `analyze_parquet_with_config`,
+//! and `analyze_parquet_bytes` under its own `parquet` feature. Depend on
+//! `dataprof` unless you need Parquet support without the rest of the
+//! workspace.
+//!
+//! # Features
+//!
+//! Nothing is enabled by default, and every entry point below is gated, so the
+//! names here are written as code rather than as links: a link to a gated item
+//! does not resolve when the docs are built without its feature.
+//!
+//! - `arrow` — `RecordBatchAnalyzer` and `ArrowProfiler`, which profile Arrow
+//!   record batches and CSV read through Arrow. Neither is re-exported by the
+//!   facade; they are the entry points for callers who already hold Arrow data.
+//! - `parquet` — the file and byte-buffer entry points in this crate's root.
+//!   Implies `arrow`.
+//! - `parquet-async` — `analyze_parquet_async_http` and `HttpParquetReader`,
+//!   for reading a remote file over HTTP range requests. Implies `parquet`.
+//!
+//! Where an example names a shared type — `TruncationReason`, say — it reaches
+//! for `dataprof_core`, since that is the crate a doctest here can link against.
+//! The facade re-exports the same items as `dataprof::TruncationReason`, and a
+//! caller depending on `dataprof` should use those.
+
 #[cfg(feature = "arrow")]
 mod arrow_profiler;
 

--- a/crates/dataprof-parquet/src/lib.rs
+++ b/crates/dataprof-parquet/src/lib.rs
@@ -12,9 +12,12 @@
 //! names here are written as code rather than as links: a link to a gated item
 //! does not resolve when the docs are built without its feature.
 //!
-//! - `arrow` — `RecordBatchAnalyzer` and `ArrowProfiler`, which profile Arrow
-//!   record batches and CSV read through Arrow. Neither is re-exported by the
-//!   facade; they are the entry points for callers who already hold Arrow data.
+//! - `arrow` — two profilers that differ in what they consume.
+//!   `RecordBatchAnalyzer` takes Arrow record batches, and is the entry point
+//!   for a caller who already holds Arrow data and has no file to point at.
+//!   `ArrowProfiler` reads a CSV file, using Arrow as its engine rather than as
+//!   its input; its only analysis method is `analyze_csv_file`. Neither is
+//!   re-exported by the facade.
 //! - `parquet` — the file and byte-buffer entry points in this crate's root.
 //!   Implies `arrow`.
 //! - `parquet-async` — `analyze_parquet_async_http` and `HttpParquetReader`,

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -13,6 +13,58 @@ use dataprof_core::{
 use dataprof_runtime::{ProfileReport, ReportAssembler};
 
 /// Check if a file is a valid Parquet file by examining its magic number.
+///
+/// Checks the `PAR1` marker at both ends of the file, which is enough to route
+/// an input to the right reader but says nothing about whether the footer and
+/// row groups are intact. Anything unreadable answers `false` rather than
+/// erroring: a missing path, a directory, a permissions error. The question is
+/// only which reader an input should go to.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Write;
+///
+/// use dataprof_parquet::is_parquet_file;
+///
+/// let mut parquet = tempfile::NamedTempFile::new()?;
+/// parquet.write_all(&sample_parquet()?)?;
+/// parquet.flush()?;
+/// assert!(is_parquet_file(parquet.path()));
+///
+/// let mut csv = tempfile::NamedTempFile::new()?;
+/// csv.write_all(b"id,city\n1,Rome\n")?;
+/// csv.flush()?;
+/// assert!(!is_parquet_file(csv.path()));
+///
+/// // A path that does not exist is simply not a Parquet file.
+/// assert!(!is_parquet_file(std::path::Path::new("no/such/file.parquet")));
+/// # Ok(())
+/// # }
+/// # fn sample_parquet() -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+/// #     use std::sync::Arc;
+/// #     use arrow::array::{Int32Array, StringArray};
+/// #     use arrow::datatypes::{DataType, Field, Schema};
+/// #     use arrow::record_batch::RecordBatch;
+/// #     let schema = Arc::new(Schema::new(vec![
+/// #         Field::new("id", DataType::Int32, false),
+/// #         Field::new("city", DataType::Utf8, true),
+/// #     ]));
+/// #     let batch = RecordBatch::try_new(
+/// #         schema.clone(),
+/// #         vec![
+/// #             Arc::new(Int32Array::from(vec![1, 2, 3])),
+/// #             Arc::new(StringArray::from(vec![Some("Rome"), None, Some("Milan")])),
+/// #         ],
+/// #     )?;
+/// #     let mut buffer = Vec::new();
+/// #     let mut writer = parquet::arrow::ArrowWriter::try_new(&mut buffer, schema, None)?;
+/// #     writer.write(&batch)?;
+/// #     writer.close()?;
+/// #     Ok(bytes::Bytes::from(buffer))
+/// # }
+/// ```
 pub fn is_parquet_file(file_path: &Path) -> bool {
     let mut file = match File::open(file_path) {
         Ok(file) => file,
@@ -50,6 +102,28 @@ pub fn is_parquet_file(file_path: &Path) -> bool {
 }
 
 /// Configuration options for Parquet analysis.
+///
+/// `batch_size` is how many rows the Arrow reader materialises at a time. It
+/// trades memory for fewer reader round trips and does not change any profiled
+/// number; [`ParquetConfig::adaptive_batch_size`] picks a reasonable value from
+/// a file size. `max_rows` caps how much of the file is read; see
+/// [`ParquetConfig::with_max_rows`].
+///
+/// # Examples
+///
+/// ```
+/// use dataprof_parquet::ParquetConfig;
+///
+/// let config = ParquetConfig::default();
+/// assert_eq!(config.batch_size, 8192);
+/// assert_eq!(config.max_rows, None);
+///
+/// // Size the batches for a ~500 MB file, and read the first 1,000 rows only.
+/// let config = ParquetConfig::batch_size(ParquetConfig::adaptive_batch_size(500 * 1024 * 1024))
+///     .with_max_rows(1_000);
+/// assert_eq!(config.batch_size, 16384);
+/// assert_eq!(config.max_rows, Some(1_000));
+/// ```
 #[derive(Debug, Clone)]
 pub struct ParquetConfig {
     pub batch_size: usize,
@@ -75,6 +149,61 @@ impl ParquetConfig {
     }
 
     /// Cap the number of rows read from the file.
+    ///
+    /// A cap is only *truncation* when the file holds more rows than the cap,
+    /// so a file with exactly `max_rows` rows is reported as read in full.
+    /// Parquet records its row count in the footer, so this is decided from
+    /// what the file holds rather than inferred from how much was read.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use dataprof_core::TruncationReason;
+    /// use dataprof_parquet::{ParquetConfig, analyze_parquet_bytes};
+    ///
+    /// let data = sample_parquet()?; // three rows
+    ///
+    /// let capped = ParquetConfig::default().with_max_rows(2);
+    /// let report =
+    ///     analyze_parquet_bytes(data.clone(), "sample", &capped, None, &Default::default())?;
+    /// assert_eq!(report.execution.rows_processed, 2);
+    /// assert!(matches!(
+    ///     report.execution.truncation_reason,
+    ///     Some(TruncationReason::MaxRows(2))
+    /// ));
+    ///
+    /// // A cap the file never exceeds is a complete read, not a truncated one.
+    /// let exact = ParquetConfig::default().with_max_rows(3);
+    /// let report =
+    ///     analyze_parquet_bytes(data, "sample", &exact, None, &Default::default())?;
+    /// assert_eq!(report.execution.rows_processed, 3);
+    /// assert!(report.execution.truncation_reason.is_none());
+    /// # Ok(())
+    /// # }
+    /// # fn sample_parquet() -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+    /// #     use std::sync::Arc;
+    /// #     use arrow::array::{Int32Array, StringArray};
+    /// #     use arrow::datatypes::{DataType, Field, Schema};
+    /// #     use arrow::record_batch::RecordBatch;
+    /// #     let schema = Arc::new(Schema::new(vec![
+    /// #         Field::new("id", DataType::Int32, false),
+    /// #         Field::new("city", DataType::Utf8, true),
+    /// #     ]));
+    /// #     let batch = RecordBatch::try_new(
+    /// #         schema.clone(),
+    /// #         vec![
+    /// #             Arc::new(Int32Array::from(vec![1, 2, 3])),
+    /// #             Arc::new(StringArray::from(vec![Some("Rome"), None, Some("Milan")])),
+    /// #         ],
+    /// #     )?;
+    /// #     let mut buffer = Vec::new();
+    /// #     let mut writer = parquet::arrow::ArrowWriter::try_new(&mut buffer, schema, None)?;
+    /// #     writer.write(&batch)?;
+    /// #     writer.close()?;
+    /// #     Ok(bytes::Bytes::from(buffer))
+    /// # }
+    /// ```
     pub fn with_max_rows(mut self, max_rows: usize) -> Self {
         self.max_rows = Some(max_rows);
         self
@@ -91,6 +220,11 @@ impl ParquetConfig {
     }
 }
 
+/// Analyze a Parquet file with default settings and every quality dimension.
+///
+/// The shortest entry point: [`analyze_parquet_with_config`] takes a
+/// [`ParquetConfig`], and [`analyze_parquet_with_options`] takes the full
+/// analysis selection.
 pub fn analyze_parquet_with_quality(file_path: &Path) -> Result<ProfileReport, DataProfilerError> {
     analyze_parquet_with_quality_dims(file_path, None)
 }
@@ -115,6 +249,63 @@ pub fn analyze_parquet_with_quality_dims_and_hints(
     )
 }
 
+/// Analyze a Parquet file with an explicit [`ParquetConfig`].
+///
+/// Columns come back in schema order, which is the same ordering contract the
+/// CSV and JSON readers hold to, so one logical dataset profiles to the same
+/// column order in every format.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::io::Write;
+///
+/// use dataprof_parquet::{ParquetConfig, analyze_parquet_with_config};
+///
+/// let mut file = tempfile::NamedTempFile::new()?;
+/// file.write_all(&sample_parquet()?)?;
+/// file.flush()?;
+///
+/// let report = analyze_parquet_with_config(file.path(), &ParquetConfig::default())?;
+///
+/// assert_eq!(report.execution.rows_processed, 3);
+/// let names: Vec<&str> = report
+///     .column_profiles
+///     .iter()
+///     .map(|profile| profile.name.as_str())
+///     .collect();
+/// assert_eq!(names, ["id", "city"]);
+///
+/// // Arrow nulls are counted as missing values, not as empty strings.
+/// let city = &report.column_profiles[1];
+/// assert_eq!(city.total_count, 3);
+/// assert_eq!(city.null_count, 1);
+/// # Ok(())
+/// # }
+/// # fn sample_parquet() -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+/// #     use std::sync::Arc;
+/// #     use arrow::array::{Int32Array, StringArray};
+/// #     use arrow::datatypes::{DataType, Field, Schema};
+/// #     use arrow::record_batch::RecordBatch;
+/// #     let schema = Arc::new(Schema::new(vec![
+/// #         Field::new("id", DataType::Int32, false),
+/// #         Field::new("city", DataType::Utf8, true),
+/// #     ]));
+/// #     let batch = RecordBatch::try_new(
+/// #         schema.clone(),
+/// #         vec![
+/// #             Arc::new(Int32Array::from(vec![1, 2, 3])),
+/// #             Arc::new(StringArray::from(vec![Some("Rome"), None, Some("Milan")])),
+/// #         ],
+/// #     )?;
+/// #     let mut buffer = Vec::new();
+/// #     let mut writer = parquet::arrow::ArrowWriter::try_new(&mut buffer, schema, None)?;
+/// #     writer.write(&batch)?;
+/// #     writer.close()?;
+/// #     Ok(bytes::Bytes::from(buffer))
+/// # }
+/// ```
 pub fn analyze_parquet_with_config(
     file_path: &Path,
     config: &ParquetConfig,
@@ -140,6 +331,53 @@ pub fn analyze_parquet_with_config_dims(
 /// Reads through the same Arrow reader as [`analyze_parquet_with_config_dims_and_hints`],
 /// so a buffer and the file holding those same bytes profile identically. `name`
 /// labels the source in the report, since an in-memory buffer has no path.
+///
+/// # Examples
+///
+/// Encoding a batch and profiling it without a temporary file. This is the
+/// helper the other examples in this crate hide:
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::sync::Arc;
+///
+/// use arrow::array::{Int32Array, StringArray};
+/// use arrow::datatypes::{DataType, Field, Schema};
+/// use arrow::record_batch::RecordBatch;
+/// use bytes::Bytes;
+/// use dataprof_parquet::{ParquetConfig, analyze_parquet_bytes};
+/// use parquet::arrow::ArrowWriter;
+///
+/// let schema = Arc::new(Schema::new(vec![
+///     Field::new("id", DataType::Int32, false),
+///     Field::new("city", DataType::Utf8, true),
+/// ]));
+/// let batch = RecordBatch::try_new(
+///     schema.clone(),
+///     vec![
+///         Arc::new(Int32Array::from(vec![1, 2, 3])),
+///         Arc::new(StringArray::from(vec![Some("Rome"), None, Some("Milan")])),
+///     ],
+/// )?;
+///
+/// let mut buffer = Vec::new();
+/// let mut writer = ArrowWriter::try_new(&mut buffer, schema, None)?;
+/// writer.write(&batch)?;
+/// writer.close()?;
+///
+/// let report = analyze_parquet_bytes(
+///     Bytes::from(buffer),
+///     "cities",
+///     &ParquetConfig::default(),
+///     None,
+///     &Default::default(),
+/// )?;
+///
+/// assert_eq!(report.execution.rows_processed, 3);
+/// assert_eq!(report.column_profiles[1].null_count, 1);
+/// # Ok(())
+/// # }
+/// ```
 pub fn analyze_parquet_bytes(
     data: Bytes,
     name: &str,

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -122,6 +122,58 @@ fn observe_batch_rows(
 }
 
 /// Analyzer for processing multiple RecordBatches and building column profiles.
+///
+/// The entry point for callers who already hold Arrow data and have no file to
+/// point at. Feed every batch through [`RecordBatchAnalyzer::process_batch`],
+/// then call [`RecordBatchAnalyzer::to_profiles`] once; the statistics are
+/// accumulated across batches, so profiling one batch of 300 rows and three
+/// batches of 100 gives the same answer.
+///
+/// Column order follows the schema, and
+/// [`RecordBatchAnalyzer::initialize_schema`] seeds it up front. Call it
+/// explicitly when a source may yield no batches at all, so a schema-bearing
+/// but empty dataset still profiles to its columns with zero counts instead of
+/// to no columns.
+///
+/// This type is not re-exported by the `dataprof` facade; it needs this crate's
+/// `arrow` feature.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use std::sync::Arc;
+///
+/// use arrow::array::{Int32Array, StringArray};
+/// use arrow::datatypes::{DataType, Field, Schema};
+/// use arrow::record_batch::RecordBatch;
+/// use dataprof_parquet::RecordBatchAnalyzer;
+///
+/// let schema = Arc::new(Schema::new(vec![
+///     Field::new("id", DataType::Int32, false),
+///     Field::new("city", DataType::Utf8, true),
+/// ]));
+/// let batch = RecordBatch::try_new(
+///     schema.clone(),
+///     vec![
+///         Arc::new(Int32Array::from(vec![1, 2, 3])),
+///         Arc::new(StringArray::from(vec![Some("Rome"), None, Some("Milan")])),
+///     ],
+/// )?;
+///
+/// let mut analyzer = RecordBatchAnalyzer::new();
+/// analyzer.initialize_schema(schema.as_ref())?;
+/// analyzer.process_batch(&batch)?;
+///
+/// assert_eq!(analyzer.total_rows(), 3);
+///
+/// let profiles = analyzer.to_profiles(false, false, None);
+/// let names: Vec<&str> = profiles.iter().map(|profile| profile.name.as_str()).collect();
+/// assert_eq!(names, ["id", "city"]);
+/// assert_eq!(profiles[1].null_count, 1);
+/// # Ok(())
+/// # }
+/// ```
 pub struct RecordBatchAnalyzer {
     column_analyzers: HashMap<String, ColumnAnalyzer>,
     column_order: Vec<String>,


### PR DESCRIPTION
Closes #379
Closes #502

Both issues ask for the same thing in the two crates that had no rustdoc
examples at all, so they are done together.

## What changed

**`dataprof-json`** (#379) — examples on `JsonParserConfig` and its format
constructors, `with_max_rows`, `with_error_policy`, `scan_json_from_reader`,
`analyze_json_from_reader`, and `analyze_json_file`, plus a crate-level header.

**`dataprof-parquet`** (#502) — examples on `ParquetConfig`, `with_max_rows`,
`is_parquet_file`, `analyze_parquet_with_config`, `analyze_parquet_bytes`, and
`RecordBatchAnalyzer`, plus a crate-level header listing the feature gates.

Every example is a real doctest that asserts on values rather than only
compiling; nothing is `no_run` and nothing teaches `unwrap()` on a public path.
Parquet inputs are built as in-memory Arrow batches — `analyze_parquet_bytes`
shows that construction in full, and the examples that need a file hide the
same helper behind `#` lines.

The row-cap examples pin down the distinction the code already draws: a cap is
truncation only when a record still remained once it was reached, so a source
holding exactly `max_rows` records reads as complete. Both crates get the same
treatment, so the two readers document one rule.

## The CI commit

While checking that the new doctests were gated, I found they were not.
`cargo test --lib` and `cargo test --doc` at the workspace root cover only the
root `dataprof` package; a member crate runs only where it is named with `-p`,
and CI names dataprof-engines, dataprof-parquet, and dataprof-partial.
dataprof-json was named nowhere, so its 52 unit tests never ran either. The
second commit adds it to the same scope and to the release gate.

That is a partial fix: dataprof-core, dataprof-metrics, dataprof-csv, and
dataprof-runtime are still untested in CI for the same reason. Worth its own
issue rather than widening this PR.

## Verification

```
cargo +1.98 fmt --all -- --check
cargo +1.98 clippy -p dataprof-json -p dataprof-parquet --all-targets --all-features -- -D warnings
cargo +1.98 test -p dataprof-json --all-features      # 52 unit + 8 doctests
cargo +1.98 test -p dataprof-parquet --all-features   # 37 unit + 6 doctests
cargo +1.98 doc -p dataprof-json -p dataprof-parquet --no-deps                  # 0 warnings
cargo +1.98 doc -p dataprof-json -p dataprof-parquet --no-deps --all-features   # 0 warnings
```

The no-features rustdoc run is why the `dataprof-parquet` crate header names its
entry points as code spans instead of intra-doc links: every one of them is
behind a feature gate, and a link to a gated item is unresolved whenever the
docs are built without that feature, which is what docs.rs does by default. That
was eight warnings before the change. Item-level docs, whose items are compiled
whenever the doc is, use intra-doc links throughout.

One doctest assertion was perturbed (`MaxRows(2)` → `MaxRows(3)`) and confirmed
to fail, then restored, to check the examples discriminate rather than merely
run.
