### PR TITLE
fix(metrics): compare real dates in timeliness, not years or raw strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,10 @@ jobs:
     # job was killed 87s later during the post-job cache save, so nothing was
     # written — leaving the next run on that same lockfile cold too. The
     # timeout has to clear the build *and* the save, or the job cannot recover.
-    timeout-minutes: 35
+    #
+    # Raised 35 -> 45 when the scope went from four member crates to eight: the
+    # cold figure above was measured against the smaller list.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -149,14 +152,21 @@ jobs:
           - scope: all-features-crates
             commands: |
               cargo test --test public_api_facade --all-features
-              cargo test -p dataprof-engines --all-features
               # `cargo test --lib`/`--doc` at the root only covers the root
               # `dataprof` package, so a member crate runs only if it is named
-              # here. dataprof-json carries doctests that would otherwise never
-              # be compiled by CI.
+              # here. Every library member is listed: leaving one out silently
+              # ungates its whole suite, which is how 517 tests in core,
+              # metrics, csv and runtime went unrun. dataprof-db and
+              # dataprof-python are deliberately absent, covered by the
+              # database and Python jobs respectively.
+              cargo test -p dataprof-core --all-features
+              cargo test -p dataprof-csv --all-features
+              cargo test -p dataprof-engines --all-features
               cargo test -p dataprof-json --all-features
+              cargo test -p dataprof-metrics --all-features
               cargo test -p dataprof-parquet --all-features
               cargo test -p dataprof-partial --all-features
+              cargo test -p dataprof-runtime --all-features
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1

--- a/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
@@ -3,12 +3,12 @@
 //! Measures the currentness and temporal validity of data.
 //! Key metrics: future dates, stale data ratio, temporal violations.
 
-use super::utils::extract_year;
+use super::utils::extract_date;
 use crate::analysis::inference::is_null_like_token;
 use crate::core::config::IsoQualityConfig;
 use crate::core::errors::DataProfilerError;
-use chrono::Datelike;
-use std::collections::HashMap;
+use chrono::{Datelike, NaiveDate, Utc};
+use std::collections::{HashMap, HashSet};
 
 /// Timeliness metrics container
 #[derive(Debug)]
@@ -24,11 +24,29 @@ pub(crate) struct TimelinessMetrics {
 /// Calculator for timeliness dimension metrics
 pub(crate) struct TimelinessCalculator<'a> {
     thresholds: &'a IsoQualityConfig,
+    /// "Now" for every comparison this calculator makes.
+    ///
+    /// Captured once at construction so a single report cannot straddle a
+    /// midnight boundary and classify two equal values differently, and so
+    /// tests can pin it. Internal only: the public API still reads the clock.
+    reference_date: NaiveDate,
 }
 
 impl<'a> TimelinessCalculator<'a> {
     pub fn new(thresholds: &'a IsoQualityConfig) -> Self {
-        Self { thresholds }
+        Self::with_reference_date(thresholds, Utc::now().date_naive())
+    }
+
+    /// Construct with an explicit "now", so assertions do not rot as the
+    /// calendar advances.
+    pub(crate) fn with_reference_date(
+        thresholds: &'a IsoQualityConfig,
+        reference_date: NaiveDate,
+    ) -> Self {
+        Self {
+            thresholds,
+            reference_date,
+        }
     }
 
     /// Calculate timeliness dimension metrics
@@ -68,8 +86,7 @@ impl<'a> TimelinessCalculator<'a> {
         let mut checked = 0;
         let mut invalid_dates = 0;
 
-        let current_year = chrono::Utc::now().year();
-        let threshold_year = current_year - self.thresholds.max_data_age_years as i32;
+        let threshold_year = self.reference_date.year() - self.thresholds.max_data_age_years as i32;
 
         for column_name in temporal_columns {
             let Some(column_data) = data.get(column_name) else {
@@ -81,12 +98,17 @@ impl<'a> TimelinessCalculator<'a> {
                 }
                 checked += 1;
 
-                if let Some(year) = extract_year(value) {
+                if let Some(date) = extract_date(value) {
                     valid_dates += 1;
-                    if year > current_year {
+                    // Compare the whole date, not its year. A year-only test
+                    // cannot see any future date inside the current calendar
+                    // year, which on 1 January hides an entire year of them.
+                    if date > self.reference_date {
                         future_count += 1;
                     }
-                    if year < threshold_year {
+                    // Staleness stays at year granularity because its threshold
+                    // is expressed in whole years.
+                    if date.year() < threshold_year {
                         stale_dates += 1;
                     }
                 } else {
@@ -124,39 +146,56 @@ impl<'a> TimelinessCalculator<'a> {
             ("from_date", "to_date"),
         ];
 
+        // The role patterns overlap: `start_date`/`end_date` is matched by both
+        // ("start_date", "end_date") and ("start", "end"). Without this the same
+        // two columns are compared once per matching pattern, and every pair and
+        // every violation is counted as many times as patterns happened to hit.
+        let mut evaluated: HashSet<(&str, &str)> = HashSet::new();
+
         for (start_col, end_col) in &temporal_pairs {
             // Resolve ambiguous role matches in the order supplied by the user.
             // Iterating `data` here would make the selected pair depend on the
             // randomized iteration order of its HashMap.
-            let start_data = temporal_columns.iter().find_map(|name| {
-                name.to_lowercase()
-                    .contains(start_col)
-                    .then(|| data.get(name))
-                    .flatten()
-            });
-            let end_data = temporal_columns.iter().find_map(|name| {
-                name.to_lowercase()
-                    .contains(end_col)
-                    .then(|| data.get(name))
-                    .flatten()
-            });
+            let start_match = temporal_columns
+                .iter()
+                .find(|name| name.to_lowercase().contains(start_col))
+                .and_then(|name| data.get(name).map(|values| (name.as_str(), values)));
+            let end_match = temporal_columns
+                .iter()
+                .find(|name| name.to_lowercase().contains(end_col))
+                .and_then(|name| data.get(name).map(|values| (name.as_str(), values)));
 
-            if let (Some(start_values), Some(end_values)) = (start_data, end_data) {
-                for (start_val, end_val) in start_values.iter().zip(end_values.iter()) {
-                    if is_null_like_token(start_val.trim()) || is_null_like_token(end_val.trim()) {
-                        continue;
-                    }
+            let (Some((start_name, start_values)), Some((end_name, end_values))) =
+                (start_match, end_match)
+            else {
+                continue;
+            };
 
-                    // Invalid calendar values are already reported by
-                    // `invalid_date_values` and cannot form a meaningful pair.
-                    if extract_year(start_val).is_none() || extract_year(end_val).is_none() {
-                        continue;
-                    }
-                    pairs_checked += 1;
-                    // Compare as sortable strings (works for ISO dates YYYY-MM-DD)
-                    if start_val > end_val {
-                        violations += 1;
-                    }
+            // A column cannot be both ends of the same comparison: "start" and
+            // "end" both match a lone `start_end_date`, which would compare it
+            // with itself and report a clean pair that was never checked.
+            if start_name == end_name || !evaluated.insert((start_name, end_name)) {
+                continue;
+            }
+
+            for (start_val, end_val) in start_values.iter().zip(end_values.iter()) {
+                if is_null_like_token(start_val.trim()) || is_null_like_token(end_val.trim()) {
+                    continue;
+                }
+
+                // Invalid calendar values are already reported by
+                // `invalid_date_values` and cannot form a meaningful pair.
+                let (Some(start_date), Some(end_date)) =
+                    (extract_date(start_val), extract_date(end_val))
+                else {
+                    continue;
+                };
+                pairs_checked += 1;
+                // Compare parsed dates. The previous string comparison only held
+                // for ISO values: `DD/MM/YYYY` and `MM/DD/YYYY` sort by day and
+                // month first, which both hid real inversions and invented ones.
+                if start_date > end_date {
+                    violations += 1;
                 }
             }
         }
@@ -282,5 +321,273 @@ mod tests {
             )
             .expect("secondary-first timeliness metrics");
         assert_eq!(secondary_first.temporal_violations, 1);
+    }
+
+    // ---------------------------------------------------------------- #378
+    // Deterministic coverage for the timeliness calculator. Every case pins
+    // "now" through `with_reference_date`, so no assertion here changes result
+    // as the calendar advances.
+
+    /// A fixed "today" for every case below.
+    fn reference() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 15).expect("valid reference date")
+    }
+
+    /// Default freshness policy is 5 years, so the stale cutoff is 2021.
+    fn config() -> IsoQualityConfig {
+        IsoQualityConfig::default()
+    }
+
+    fn column(name: &str, values: &[&str]) -> HashMap<String, Vec<String>> {
+        HashMap::from([(
+            name.to_string(),
+            values.iter().map(|value| value.to_string()).collect(),
+        )])
+    }
+
+    fn metrics_for(
+        thresholds: &IsoQualityConfig,
+        data: &HashMap<String, Vec<String>>,
+        temporal_columns: &[&str],
+    ) -> TimelinessMetrics {
+        let named: Vec<String> = temporal_columns
+            .iter()
+            .map(|name| name.to_string())
+            .collect();
+        TimelinessCalculator::with_reference_date(thresholds, reference())
+            .calculate(data, &named)
+            .expect("timeliness metrics")
+    }
+
+    #[test]
+    fn no_date_columns_assesses_nothing() {
+        let data = column("label", &["alpha", "beta"]);
+        let metrics = metrics_for(&config(), &data, &[]);
+
+        assert_eq!(metrics.date_values_checked, 0);
+        assert_eq!(metrics.invalid_date_values, 0);
+        assert_eq!(metrics.future_dates_count, 0);
+        assert_eq!(metrics.stale_data_ratio, 0.0);
+        assert_eq!(metrics.temporal_pairs_checked, 0);
+        assert_eq!(metrics.temporal_violations, 0);
+    }
+
+    #[test]
+    fn empty_column_assesses_nothing() {
+        let data = column("event_date", &[]);
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(metrics.date_values_checked, 0);
+        assert_eq!(metrics.future_dates_count, 0);
+        assert_eq!(metrics.stale_data_ratio, 0.0);
+    }
+
+    #[test]
+    fn single_recent_value_is_neither_future_nor_stale() {
+        let data = column("event_date", &["2026-06-14"]);
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(metrics.date_values_checked, 1);
+        assert_eq!(metrics.future_dates_count, 0);
+        assert_eq!(metrics.stale_data_ratio, 0.0);
+    }
+
+    #[test]
+    fn past_dates_within_the_freshness_window_are_clean() {
+        let data = column("event_date", &["2022-01-01", "2024-06-01", "2026-06-14"]);
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(metrics.date_values_checked, 3);
+        assert_eq!(metrics.future_dates_count, 0);
+        assert_eq!(metrics.stale_data_ratio, 0.0);
+    }
+
+    #[test]
+    fn future_dates_inside_the_current_year_are_counted() {
+        // Regression: comparing years alone reported 0 future dates for every
+        // value between today and 31 December.
+        let data = column(
+            "event_date",
+            &[
+                "2026-06-16", // tomorrow
+                "2026-07-01", // later the same year
+                "2026-12-31", // last day of the same year
+                "2027-01-01", // next year, caught even by the year-only check
+            ],
+        );
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(
+            metrics.future_dates_count, 4,
+            "every value after the reference date is in the future"
+        );
+        assert_eq!(metrics.date_values_checked, 4);
+    }
+
+    #[test]
+    fn one_future_date_among_past_ones_is_counted_once() {
+        let data = column("event_date", &["2026-06-14", "2026-06-16", "2025-01-01"]);
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(metrics.future_dates_count, 1);
+    }
+
+    #[test]
+    fn the_reference_date_itself_is_not_future() {
+        let data = column("event_date", &["2026-06-15"]);
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(metrics.future_dates_count, 0, "today is not in the future");
+    }
+
+    #[test]
+    fn values_beyond_the_stale_threshold_are_reported_as_a_percentage() {
+        // Reference year 2026 and a 5-year policy put the cutoff at 2021.
+        let data = column(
+            "event_date",
+            &["2019-01-01", "2020-12-31", "2021-01-01", "2026-01-01"],
+        );
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(
+            metrics.stale_data_ratio, 50.0,
+            "two of four values fall before the cutoff, on the 0-100 scale"
+        );
+    }
+
+    #[test]
+    fn a_shorter_freshness_policy_makes_more_values_stale() {
+        let mut thresholds = config();
+        thresholds.max_data_age_years = 2.0; // cutoff 2024
+        let data = column("event_date", &["2022-01-01", "2023-01-01", "2025-01-01"]);
+        let metrics = metrics_for(&thresholds, &data, &["event_date"]);
+
+        assert!(
+            (metrics.stale_data_ratio - (2.0 / 3.0 * 100.0)).abs() < 1e-9,
+            "expected two of three stale, got {}",
+            metrics.stale_data_ratio
+        );
+    }
+
+    #[test]
+    fn ordered_temporal_values_report_no_violation() {
+        let data = HashMap::from([
+            ("start_date".to_string(), vec!["2023-01-01".to_string()]),
+            ("end_date".to_string(), vec!["2023-06-01".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(metrics.temporal_violations, 0);
+        assert_eq!(metrics.temporal_pairs_checked, 1);
+    }
+
+    #[test]
+    fn out_of_order_temporal_values_report_a_violation() {
+        let data = HashMap::from([
+            ("start_date".to_string(), vec!["2023-06-01".to_string()]),
+            ("end_date".to_string(), vec!["2023-01-01".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(metrics.temporal_violations, 1);
+        assert_eq!(metrics.temporal_pairs_checked, 1);
+    }
+
+    #[test]
+    fn day_first_dates_are_ordered_by_calendar_not_by_text() {
+        // Regression: `start_val > end_val` compared raw strings. `DD/MM/YYYY`
+        // sorts by day first, so a real inversion read as clean.
+        let data = HashMap::from([
+            ("start_date".to_string(), vec!["15/01/2023".to_string()]),
+            ("end_date".to_string(), vec!["20/03/2022".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(
+            metrics.temporal_violations, 1,
+            "January 2023 starts after March 2022 ends"
+        );
+        assert_eq!(metrics.temporal_pairs_checked, 1);
+    }
+
+    #[test]
+    fn day_first_dates_in_valid_order_report_no_violation() {
+        // The same bug in the other direction: text ordering invented a
+        // violation for a correctly ordered pair.
+        let data = HashMap::from([
+            ("start_date".to_string(), vec!["20/03/2022".to_string()]),
+            ("end_date".to_string(), vec!["15/01/2023".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(
+            metrics.temporal_violations, 0,
+            "March 2022 to January 2023 runs forwards"
+        );
+        assert_eq!(metrics.temporal_pairs_checked, 1);
+    }
+
+    #[test]
+    fn overlapping_role_patterns_evaluate_a_column_pair_once() {
+        // Regression: `start_date`/`end_date` matched both the
+        // ("start_date", "end_date") and ("start", "end") patterns, so every
+        // row of the pair was compared and counted twice.
+        let data = HashMap::from([
+            ("start_date".to_string(), vec!["2023-05-01".to_string()]),
+            ("end_date".to_string(), vec!["2023-04-01".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(
+            metrics.temporal_pairs_checked, 1,
+            "one row of one column pair is one comparison"
+        );
+        assert_eq!(metrics.temporal_violations, 1);
+    }
+
+    #[test]
+    fn null_tokens_in_a_pair_are_skipped_rather_than_compared() {
+        let data = HashMap::from([
+            (
+                "start_date".to_string(),
+                vec!["2023-06-01".to_string(), "".to_string()],
+            ),
+            (
+                "end_date".to_string(),
+                vec!["2023-01-01".to_string(), "2023-01-01".to_string()],
+            ),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(metrics.temporal_pairs_checked, 1, "only one complete pair");
+        assert_eq!(metrics.temporal_violations, 1);
+    }
+
+    #[test]
+    fn unparseable_values_are_invalid_rather_than_future_or_stale() {
+        // Absence rule: a value that is not a date must not be silently read as
+        // a valid timestamp in either direction.
+        let data = column("event_date", &["2024-13-45", "not a date", "2026-06-14"]);
+        let metrics = metrics_for(&config(), &data, &["event_date"]);
+
+        assert_eq!(
+            metrics.date_values_checked, 3,
+            "the denominator is complete"
+        );
+        assert_eq!(metrics.invalid_date_values, 2);
+        assert_eq!(metrics.future_dates_count, 0);
+        assert_eq!(metrics.stale_data_ratio, 0.0);
+    }
+
+    #[test]
+    fn invalid_values_do_not_form_temporal_pairs() {
+        let data = HashMap::from([
+            ("start_date".to_string(), vec!["2024-13-45".to_string()]),
+            ("end_date".to_string(), vec!["2023-01-01".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["start_date", "end_date"]);
+
+        assert_eq!(metrics.temporal_pairs_checked, 0);
+        assert_eq!(metrics.temporal_violations, 0);
     }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/timeliness.rs
@@ -156,14 +156,19 @@ impl<'a> TimelinessCalculator<'a> {
             // Resolve ambiguous role matches in the order supplied by the user.
             // Iterating `data` here would make the selected pair depend on the
             // randomized iteration order of its HashMap.
-            let start_match = temporal_columns
-                .iter()
-                .find(|name| name.to_lowercase().contains(start_col))
-                .and_then(|name| data.get(name).map(|values| (name.as_str(), values)));
-            let end_match = temporal_columns
-                .iter()
-                .find(|name| name.to_lowercase().contains(end_col))
-                .and_then(|name| data.get(name).map(|values| (name.as_str(), values)));
+            // `find_map`, not `find(..).and_then(..)`: a name the caller listed
+            // but the data does not carry must not end the search, or it hides
+            // a later name that fills the same role and does have values.
+            let resolve = |role: &str| {
+                temporal_columns.iter().find_map(|name| {
+                    name.to_lowercase()
+                        .contains(role)
+                        .then(|| data.get(name).map(|values| (name.as_str(), values)))
+                        .flatten()
+                })
+            };
+            let start_match = resolve(start_col);
+            let end_match = resolve(end_col);
 
             let (Some((start_name, start_values)), Some((end_name, end_values))) =
                 (start_match, end_match)
@@ -589,5 +594,20 @@ mod tests {
 
         assert_eq!(metrics.temporal_pairs_checked, 0);
         assert_eq!(metrics.temporal_violations, 0);
+    }
+
+    #[test]
+    fn a_named_column_absent_from_the_data_does_not_hide_a_later_pair() {
+        // A temporal column the caller named but the data does not carry must
+        // not stop the search: the next name matching the same role, and
+        // present, is still a valid pair.
+        let data = HashMap::from([
+            ("primary_start".to_string(), vec!["2023-06-01".to_string()]),
+            ("end".to_string(), vec!["2023-01-01".to_string()]),
+        ]);
+        let metrics = metrics_for(&config(), &data, &["missing_start", "primary_start", "end"]);
+
+        assert_eq!(metrics.temporal_pairs_checked, 1);
+        assert_eq!(metrics.temporal_violations, 1);
     }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/utils.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/utils.rs
@@ -3,10 +3,11 @@
 //! Contains regex patterns, validation helpers, and common functions
 //! used across all metric dimensions.
 
+use chrono::NaiveDate;
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::stats::datetime::parse_raw_datetime_year;
+use crate::stats::datetime::{parse_raw_datetime_date, parse_raw_datetime_year};
 
 // Pre-compile date validation regex patterns for better performance
 pub(crate) static DATE_VALIDATION_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
@@ -173,6 +174,15 @@ fn identifier_words(column_name: &str) -> Vec<&str> {
 /// Supports: YYYY-MM-DD, DD/MM/YYYY, DD-MM-YYYY, YYYY/MM/DD
 pub(crate) fn extract_year(date_str: &str) -> Option<i32> {
     parse_raw_datetime_year(date_str)
+}
+
+/// Extract the full calendar date from the same formats [`extract_year`] accepts.
+///
+/// Required wherever dates are ordered or compared against a reference point:
+/// two of the supported formats put the day first, so neither the year alone
+/// nor the raw string orders them correctly.
+pub(crate) fn extract_date(date_str: &str) -> Option<NaiveDate> {
+    parse_raw_datetime_date(date_str)
 }
 
 /// Calculate percentile using linear interpolation (Type 7 - R/Excel default)

--- a/crates/dataprof-metrics/src/stats/datetime.rs
+++ b/crates/dataprof-metrics/src/stats/datetime.rs
@@ -133,17 +133,30 @@ fn parse_flexible_full(s: &str) -> Option<ParsedDateTime> {
     None
 }
 
-/// Parse a raw quality-metric value and return its calendar year.
+/// Parse a raw quality-metric value and return its calendar date.
 ///
 /// Unlike the descriptive datetime statistics path, quality predicates do not
 /// normalize surrounding whitespace: a value must be directly parseable as it
 /// appeared in the source. The calendar parser validates month/day ranges, so
 /// shape-only strings such as `2024-13-45` are rejected.
-pub(crate) fn parse_raw_datetime_year(s: &str) -> Option<i32> {
+///
+/// Prefer this over [`parse_raw_datetime_year`] whenever the caller compares
+/// values against each other or against a reference point. The supported
+/// formats include `DD/MM/YYYY` and `MM/DD/YYYY`, which do not sort
+/// lexicographically and cannot be ordered by year alone.
+pub(crate) fn parse_raw_datetime_date(s: &str) -> Option<NaiveDate> {
     if !looks_like_raw_datetime_candidate(s) {
         return None;
     }
-    parse_flexible_full(s).map(|parsed| parsed.date.year())
+    parse_flexible_full(s).map(|parsed| parsed.date)
+}
+
+/// Parse a raw quality-metric value and return its calendar year.
+///
+/// A year is the right granularity only for thresholds expressed in whole
+/// years. Anything finer must use [`parse_raw_datetime_date`].
+pub(crate) fn parse_raw_datetime_year(s: &str) -> Option<i32> {
+    parse_raw_datetime_date(s).map(|date| date.year())
 }
 
 /// Cheap shape check before attempting the multi-format chrono parser.


### PR DESCRIPTION
Closes #378

Found during a dogfooding pass before the 0.11 release. Three defects in the
timeliness calculator, each producing a confident wrong number rather than an
error, which AGENTS.md calls the worst bug class for a profiler.

## 1. Future dates inside the current year were invisible

`future_dates_count` compared calendar years:

```rust
let current_year = chrono::Utc::now().year();
if year > current_year { future_count += 1; }
```

Measured on master, with today at 2026-08-25:

| value | offset | reported future |
| --- | --- | --- |
| 2026-08-26 | +1 day | 0 |
| 2026-12-31 | +128 days | 0 |
| 2027-01-01 | +129 days | 1 |

A file whose every date was tomorrow reported `future_dates_count: 0` and
scored **100.0** on timeliness. The blind window is up to 364 days and covers
the everyday causes of future-dating: timezone off-by-ones, clock skew, ETL date
arithmetic. Far-future dates, the rare case, were the only ones caught.

After: the same file reports 5 future dates and scores 0.0.

## 2. Ordering compared raw strings, not dates

```rust
// Compare as sortable strings (works for ISO dates YYYY-MM-DD)
if start_val > end_val { violations += 1; }
```

The comment is accurate about ISO and the parser accepts four more formats that
put the day or month first. Measured on master:

| start | end | truth | before | after |
| --- | --- | --- | --- | --- |
| 15/01/2023 | 20/03/2022 | violation | 0 | 1 |
| 20/03/2022 | 15/01/2023 | valid | 2 | 0 |
| 20/06/2023 | 10/02/2023 | violation | 2 | 1 |
| 01/15/2023 | 03/20/2022 | violation | 0 | 1 |

Wrong in both directions: real inversions hidden, correct pairs flagged.

## 3. Every pair counted twice

`start_date`/`end_date` is matched by both `("start_date", "end_date")` and
`("start", "end")`, because matching is `contains()`. One row of one pair
reported `temporal_pairs_checked: 2`. Visible in the table above, where the
"valid" row reports 2 violations rather than 1.

Also guarded: a lone `start_end_date` matches both roles and would have been
compared against itself, reporting a clean pair that was never checked.

## The fix

Parse the full date once and compare dates. `parse_raw_datetime_year` already
discarded month and day from a complete parse, so this exposes what was already
there rather than parsing again. Staleness deliberately stays at year
granularity, because `max_data_age_years` is expressed in whole years.

Timeliness now takes "now" from a reference date captured at construction, so a
report cannot straddle midnight and classify two equal values differently.

## On #378

#378 asked for deterministic coverage and specified "no user-visible metric
semantics change in this PR". Writing those tests is what surfaced the defects,
so the numbers do change. The full case matrix it listed is covered: no date
columns, empty and single-value inputs, past dates within the freshness window,
future dates, values beyond the stale threshold, ordered and out-of-order pairs,
malformed values. Every case pins "now", so no assertion rots as the calendar
advances.

## Verification

```
cargo +1.98 fmt --all -- --check
cargo +1.98 clippy -p dataprof-metrics --all-targets --all-features -- -D warnings
cargo +1.98 test -p dataprof-metrics      # 256 passed
cargo +1.98 test --workspace              # 0 failures
uv run pytest python/tests -q             # 1006 passed, 9 skipped
```

Each of the three fixes was reverted **independently** and the suite re-run, to
check the tests discriminate each one rather than merely catching something:

| reverted part | tests that caught it |
| --- | --- |
| date -> year comparison | 2 |
| date -> raw string ordering | 2 |
| pattern dedup removed | 6 |

Nothing in the workspace or the Python suite depended on the old behaviour.
