### PR TITLE
docs: add software citation metadata and rewrite the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,10 +7,13 @@
 
 ## How it was verified
 
-<!-- Paste the commands you actually ran and what they reported. Run the checks
-     that match what you touched; a docs change does not need the workspace. -->
+<!-- Replace the example below with the commands you actually ran and what they
+     reported. Run the checks that match what you touched; a docs change does
+     not need the workspace. -->
 
-```
+```console
+$ cargo test -p dataprof-core
+test result: ok. 156 passed; 0 failed
 ```
 
 <details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,100 +1,71 @@
-# Pull Request
+## What changed
 
-**👋 Thank you for contributing to dataprof!** 
+<!-- The behaviour or problem, in a sentence or two. What does a user get that
+     they did not have before, or what stops going wrong? -->
 
-Please fill out this template to help us understand your changes.
+**Related issue:** Closes #
 
-## 📝 Summary
+## How it was verified
 
-Brief description of the changes in this PR. What problem does it solve or what feature does it add?
+<!-- Paste the commands you actually ran and what they reported. Run the checks
+     that match what you touched; a docs change does not need the workspace. -->
 
-## 🔧 Type of Change
-
-Select the type(s) of change:
-
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] ✨ New feature (non-breaking change that adds functionality)
-- [ ] 🚨 Breaking change (would cause existing functionality to not work as expected)
-- [ ] 📚 Documentation update
-- [ ] ⚡ Performance improvement
-- [ ] 🎨 Code refactoring (no functional changes)
-
-## 📋 Changes Made
-
-Describe the specific changes:
-
-- Change 1
-- Change 2
-- Change 3
-
-**Related Issue:** Closes #(issue number)
-
-## 🧪 Testing
-
-### How did you test this?
-
-Describe your testing approach:
-
-- [ ] Tested locally with `cargo test`
-- [ ] Added new tests for this feature
-- [ ] All existing tests pass
-- [ ] Tested with sample data files
-- [ ] Tested edge cases (empty files, large files, etc.)
-
-### Test Commands Run
-
-```bash
-cargo test --all
-cargo clippy --all --all-targets
-cargo fmt --all -- --check
-cargo build --release
+```
 ```
 
-Include any specific test scenarios or data used.
+<details>
+<summary>Commands by area (expand for the usual ones)</summary>
 
-## 📖 Documentation
+**Rust** — CI pins Rust 1.98, so prefer `cargo +1.98` when your local toolchain differs:
 
-- [ ] Updated README.md if user-facing changes
-- [ ] Added/updated inline code comments
-- [ ] Updated docs/ folder if architectural changes
-- [ ] No documentation changes needed
+```bash
+cargo test -p <crate-you-changed>
+cargo fmt --all
+cargo clippy --all --all-targets -- -D warnings
+```
 
-## ⚡ Performance Impact
+**Python:**
 
-- [ ] No performance impact
-- [ ] Performance improved
-- [ ] Performance may be affected (explain below)
+```bash
+uv run maturin develop
+uv run pytest python/tests/<file-you-changed>.py -q
+uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
+uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
+uv run ty check python/
+```
 
-**Details (if applicable):**
+**Docs or examples** — build the examples you touched; CI runs them:
 
-## 🚨 Breaking Changes
+```bash
+cargo run --example <example-you-changed>
+```
 
-If this is a breaking change, describe:
+**Serialized report schema** — only if you changed a `ProfileReport` field or its
+Serde attributes. See the
+[report schema release checklist](https://github.com/AndreaBozzo/dataprof/blob/master/docs/CONTRIBUTING.md#report-schema-release-checklist):
 
-- What breaks
-- Migration path for users
+```bash
+cargo run --example generate_profile_schema
+cargo test --test profile_report_schema
+```
 
-**If no breaking changes, just check:** [ ] No breaking changes
+</details>
 
-## 📌 Additional Notes
+## Anything reviewers should know
 
-Any additional context for reviewers:
+<!-- Delete the lines that do not apply. -->
 
-- Screenshots/examples (if applicable)
-- Related PRs or discussions
-- Implementation notes
+- **Breaking change:** what breaks, and what a user does instead.
+- **Feature flags:** which flags gate this, and what happens without them.
+- **Generated schema:** the regenerated artifact is included in this PR.
 
 ---
 
-## ✅ Checklist
+<!-- One behaviour change, or one documentation/example slice, per PR. If an
+     issue lists several scenarios, implementing one and leaving follow-ups is
+     welcome. -->
 
-- [ ] Code builds without warnings
-- [ ] No linting errors (`cargo clippy`)
-- [ ] Code is formatted (`cargo fmt`)
-- [ ] All tests pass
-- [ ] Self-reviewed my code
-- [ ] Comments added for complex logic
-- [ ] No hardcoded secrets or sensitive data
-
-**Need help?** See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines and [docs/](../../docs/) for architecture details.
-
+New here? [docs/CONTRIBUTING.md](https://github.com/AndreaBozzo/dataprof/blob/master/docs/CONTRIBUTING.md)
+covers setup and the review process, and
+[AGENTS.md](https://github.com/AndreaBozzo/dataprof/blob/master/AGENTS.md)
+is the condensed version of the same conventions.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+# Citation metadata for the dataprof software.
+#
+# This file describes the software only. dataprof has no associated
+# publication, DOI, or archival record, so there is deliberately no
+# `preferred-citation`, `doi`, or `identifiers` entry here. Do not add one
+# unless a publication actually exists: GitHub renders whatever this file
+# claims, and an invented citation is worse than none.
+#
+# At each release, update `version` and `date-released` to match the tag.
+# Nothing else here changes from one release to the next.
+cff-version: 1.2.0
+title: dataprof
+message: >-
+  If you use dataprof in your work, please cite it using the metadata in this
+  file. GitHub's "Cite this repository" button generates APA and BibTeX from it.
+type: software
+authors:
+  - family-names: Bozzo
+    given-names: Andrea
+    email: andreabozzo92@gmail.com
+repository-code: https://github.com/AndreaBozzo/dataprof
+url: https://andreabozzo.github.io/dataprof/
+abstract: >-
+  dataprof is a local, deterministic data profiling and quality assessment
+  library for CSV, JSON, JSONL, and Parquet sources. It is a Rust workspace with
+  a PyO3-based Python package on top, and reports ISO 8000/25012 quality
+  dimensions alongside column statistics, type inference, and pattern
+  detection. It profiles data and reports on it; it does not transform, clean,
+  or move it.
+keywords:
+  - data profiling
+  - data quality
+  - data engineering
+  - rust
+  - python
+  - csv
+  - parquet
+license:
+  - MIT
+  - Apache-2.0
+version: 0.10.0
+date-released: '2026-07-24'

--- a/README.md
+++ b/README.md
@@ -237,26 +237,15 @@ certified by ISO. Rust callers can customize the relative weights through
 
 - [Archived CLI Guide](docs/archive/CLI_USAGE_GUIDE.md) -- pre-0.8 reference only
 
-## Academic Work
+## Citing dataprof
 
-dataprof is the subject of a research paper submitted to **IEEE ScalCom 2026**:
+Use the **Cite this repository** button in the GitHub sidebar, which generates
+APA and BibTeX from [`CITATION.cff`](CITATION.cff), or read that file directly.
 
-> A. Bozzo, "A Compiled Paradigm for Scalable and Sustainable Edge AI: Out-of-Core Execution and SIMD Acceleration in Telemetry Profiling," *IEEE ScalCom 2026* (under review).
-> [[Repository & reproducible benchmarks]](https://github.com/AndreaBozzo/scalcom2026-dataprof)
-
-The paper benchmarks dataprof against YData Profiling, Polars, and pandas across execution efficiency, memory scalability, energy consumption, and zero-copy interoperability in constrained Edge AI environments.
-
-### BibTeX
-
-```bibtex
-@inproceedings{bozzo2026compiled,
-  author={Bozzo, Andrea},
-  title={A Compiled Paradigm for Scalable and Sustainable Edge AI: Out-of-Core Execution and SIMD Acceleration in Telemetry Profiling},
-  booktitle={2026 IEEE International Conference on Scalable Computing and Communications (ScalCom)},
-  year={2026},
-  note={Under review}
-}
-```
+The citation is for the software. dataprof has no associated publication or DOI,
+so `CITATION.cff` carries no `preferred-citation` entry and the generated BibTeX
+is a `@misc` software record. Reproducible benchmark material lives in
+[scalcom2026-dataprof](https://github.com/AndreaBozzo/scalcom2026-dataprof).
 
 
 ## License

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Run the complete contributor setup smoke path from the repository root:
 python .github/scripts/contributor_smoke.py
 ```
 
-The runner stops at the first failure and executes this focused sequence:
+The runner stops at the first failure and executes exactly these five steps:
 
 ```bash
 # Install Python dev dependencies
@@ -53,11 +53,23 @@ uv run pytest python/tests/test_python_api.py -q
 # Run focused Rust tests
 cargo test -p dataprof-core
 cargo test -p dataprof-python
+```
 
-# Run formatting and lint checks before submitting PR
+It does not lint or format. Those are separate, and CI runs them over the same
+paths, so run the ones covering what you changed before you open a PR. CI checks
+formatting with `ruff format --check`; locally you want the rewriting form
+below:
+
+```bash
+# Rust. CI pins 1.98; use `cargo +1.98` if your default toolchain differs.
 cargo fmt --all
-uv run ruff check python/dataprof python/tests
 cargo clippy --all --all-targets -- -D warnings
+
+# Python. The paths matter: CI checks the scripts directories too, so a
+# narrower path can pass locally and still fail there.
+uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
+uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
+uv run ty check python/
 ```
 
 You do not need to run every expensive workspace check for a small docs or
@@ -198,9 +210,9 @@ Opening a pull request fills the body in from
 there is nothing to copy by hand. It asks for what changed, the related issue,
 and the commands you ran to verify it.
 
-Run the checks that match what you touched rather than the whole workspace: the
-template lists the usual ones per area, and they are the same commands as
-[Build & Test](#build--test) above.
+Run the checks that match what you touched rather than the whole workspace. The
+template collapses the usual ones per area into a `<details>` block, drawn from
+the lint and format commands in [Build & Test](#build--test) above.
 
 ### Review Process
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -193,24 +193,14 @@ nearby, open a follow-up issue or separate PR.
 
 ### PR Description Template
 
-```markdown
-## Description
-Brief summary of changes
+Opening a pull request fills the body in from
+[`.github/pull_request_template.md`](../.github/pull_request_template.md), so
+there is nothing to copy by hand. It asks for what changed, the related issue,
+and the commands you ran to verify it.
 
-## Related Issues
-Closes #123
-
-## Changes Made
-- Change 1
-- Change 2
-- Change 3
-
-## Testing
-How did you test this?
-
-## Breaking Changes
-Any breaking changes? Document them here.
-```
+Run the checks that match what you touched rather than the whole workspace: the
+template lists the usual ones per area, and they are the same commands as
+[Build & Test](#build--test) above.
 
 ### Review Process
 

--- a/site/index.html
+++ b/site/index.html
@@ -218,7 +218,7 @@
       <a href="#answers">Why</a>
       <a href="#quickstart">Quickstart</a>
       <a href="#quality">Quality model</a>
-      <a href="#research">Research</a>
+      <a href="#citing">Citing</a>
       <a href="benchmarks/">Benchmarks</a>
       <a class="nav-cta" href="https://github.com/AndreaBozzo/dataprof">GitHub&nbsp;&rarr;</a>
     </nav>
@@ -479,34 +479,17 @@ delta = before.<span class="t-fn">compare</span>(dp.<span class="t-fn">profile</
     </div>
   </section>
 
-  <section id="research" class="block wrap">
+  <section id="citing" class="block wrap">
     <div class="section-head">
-      <span class="eyebrow">Academic work</span>
-      <h2>A reproducible performance study</h2>
+      <span class="eyebrow">Citing</span>
+      <h2>Citing dataprof</h2>
     </div>
     <div class="card paper-card">
-      <p>dataprof is the subject of a paper submitted to <strong>IEEE ScalCom 2026</strong>,
-        benchmarking it against YData Profiling, Polars, and pandas across execution efficiency,
-        memory scalability, energy consumption, and zero-copy interoperability in constrained
-        Edge AI environments.</p>
-      <blockquote>
-        A. Bozzo, &ldquo;A Compiled Paradigm for Scalable and Sustainable Edge AI: Out-of-Core
-        Execution and SIMD Acceleration in Telemetry Profiling,&rdquo;
-        <em>IEEE ScalCom 2026</em> (under review).
-      </blockquote>
-      <p><a href="https://github.com/AndreaBozzo/scalcom2026-dataprof">Repository &amp; reproducible benchmarks &rarr;</a></p>
-      <details>
-        <summary>BibTeX</summary>
-        <pre><code>@inproceedings{bozzo2026compiled,
-  author={Bozzo, Andrea},
-  title={A Compiled Paradigm for Scalable and Sustainable Edge AI:
-         Out-of-Core Execution and SIMD Acceleration in Telemetry Profiling},
-  booktitle={2026 IEEE International Conference on Scalable Computing
-             and Communications (ScalCom)},
-  year={2026},
-  note={Under review}
-}</code></pre>
-      </details>
+      <p>dataprof has no associated publication or DOI, so the citation is for the
+        software itself. GitHub&rsquo;s <strong>Cite this repository</strong> button generates
+        APA and BibTeX from
+        <a href="https://github.com/AndreaBozzo/dataprof/blob/master/CITATION.cff">CITATION.cff</a>.</p>
+      <p><a href="https://github.com/AndreaBozzo/scalcom2026-dataprof">Reproducible benchmark material &rarr;</a></p>
     </div>
   </section>
 


### PR DESCRIPTION
Closes #504
Closes #499

Two single-file community items from the 0.11 track, taken together because
both are about the surface a newcomer or a citing user meets first.

## #504 — software citation

`CITATION.cff` describes dataprof as software: `type: software`, no
`preferred-citation`, no DOI, no venue. GitHub's "Cite this repository" button
renders it as a `@misc` record:

```
Bozzo A. (2026). dataprof (version 0.10.0).
URL: https://andreabozzo.github.io/dataprof/
```

Validated against the CFF 1.2.0 schema with `cffconvert`. A header comment names
the only two fields that move at release time (`version`, `date-released`), so a
future maintainer updates it without inventing a publication record.

### One thing the issue did not scope

The README **and** the website both presented the manuscript as under review at
IEEE ScalCom 2026, with an `@inproceedings` entry naming the proceedings and
`note={Under review}`. #504 states the manuscript was not accepted and is not
going to be published in its current form, so both were claiming a citation the
issue exists to prevent, and "under review" was no longer true either.

Both are replaced with a "Citing dataprof" section pointing at the CFF. Adding
`CITATION.cff` while leaving them would have put two contradictory citation
stories in the same project.

The link to
[scalcom2026-dataprof](https://github.com/AndreaBozzo/scalcom2026-dataprof) is
kept in both places: the reproducible benchmark material stands on its own
regardless of the manuscript's fate. The site nav entry moved with the section,
and I checked every in-page anchor still resolves.

## #499 — pull request template

The old template's "Need help?" links pointed at `../../CONTRIBUTING.md` and
`../../docs/`. Those resolve above the repository root, and there is no
`CONTRIBUTING.md` at root — the guide is `docs/CONTRIBUTING.md`. Its suggested
commands were `cargo test --all`, `cargo clippy --all --all-targets`,
`cargo fmt` and `cargo build --release`, so a docs-only change was told to build
the workspace, and the Python extension's uv/Ruff/ty workflow appeared nowhere.

The new template asks for what changed, the related issue, and the commands
actually run. Per-area suggestions sit in a collapsed `<details>` block so the
visible form stays short:

| area | offered |
| --- | --- |
| Rust | `cargo test -p <crate>`, `cargo fmt --all`, `cargo clippy --all --all-targets -- -D warnings`, with the 1.98 pin noted |
| Python | `uv run maturin develop`, focused `pytest`, `ruff format`, `ruff check`, `uv run ty check python/` |
| Docs/examples | the example touched, not the workspace |
| Report schema | `generate_profile_schema` + `profile_report_schema`, only when a serialized field moved |

Links are absolute so they resolve from a fork's PR body as well as this one.

`docs/CONTRIBUTING.md` carried a **second, different** PR template inline. Two
templates drift and only one is ever filled in, so that section now points at
the real one. Not in the issue's scope, but refreshing one template while
leaving a competing copy would not have fixed the problem the issue describes.

## Verification

```
cffconvert --validate                      # CFF 1.2.0 valid
cffconvert -f apalike / -f bibtex          # @misc, no venue, no DOI
uv run ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check  python/ .github/scripts/ .claude/skills/dataprof/scripts/
```

Plus a script over `README.md`, `docs/CONTRIBUTING.md` and the template checking
every repository-relative markdown link resolves on disk (none broken), and one
over `site/index.html` checking every `href="#..."` matches an `id` (no dangling
anchors). No Rust or Python source changed, so the workspace suites were not run.
