### PR TITLE
fix: preserve numeric and CSV profiling correctness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,9 +531,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ uv pip install dataprof
 
 Requires Python 3.10 or newer.
 
-The pre-built PyPI wheels have **no Python dependencies**. Everything below runs on a bare `pip install dataprof`: local files, dicts, row dicts, bytes buffers, and every export in this section. Install the `pandas` extra only for the pandas-typed exports (`to_dataframe()`, `describe()` as a DataFrame) and for Parquet *byte buffers*. Async profiling, including HTTP URLs and remote Parquet, is in the wheel too; database connectors are the one documented feature that still needs a source build.
+The pre-built PyPI wheels have **no Python dependencies**. Everything below runs on a bare `pip install dataprof`: local files, dicts, row dicts, byte buffers (including Parquet), and every export in this section. Install the `pandas` extra only for the pandas-typed exports (`to_dataframe()`, `describe()` as a DataFrame). Async profiling, including HTTP URLs and remote Parquet, is in the wheel too; database connectors are the one documented feature that still needs a source build.
 
 #### 1. Profile
 
@@ -184,7 +184,7 @@ For the leanest Rust build, use `default-features = false` or `cargo --no-defaul
 | pandas / polars DataFrame | Columnar | Python API only |
 | Arrow RecordBatch | Columnar | Via PyCapsule (zero-copy) or Rust API |
 | dict / list of dicts | Columnar | Python API only; no dependencies |
-| bytes / BytesIO | Columnar | Python API only; requires `format=`. CSV, JSON and JSONL need no dependencies; Parquet bytes need the `pandas` extra |
+| bytes / BytesIO | Columnar | Python API only; requires `format=`. CSV, JSON, JSONL, and Parquet need no Python dependencies |
 | Async byte stream | Incremental | Any `AsyncRead` source (HTTP, WebSocket, etc.) |
 
 Reported columns follow source order in every format and on every transport: the

--- a/crates/dataprof-core/src/sampling/chunk_size.rs
+++ b/crates/dataprof-core/src/sampling/chunk_size.rs
@@ -2,19 +2,19 @@ use sysinfo::System;
 
 /// How much data a streaming engine reads per chunk.
 ///
-/// **The unit is bytes, everywhere.** Chunk size bounds how much of the source
-/// is resident at once, so it is expressed in the unit that actually bounds
-/// memory rather than in rows, whose width varies per dataset. Every engine and
-/// binding agrees: `ChunkSize::Fixed(65_536)` and Python's `chunk_size=65536`
-/// both mean 64 KiB per chunk, whether the source is a file, a byte stream, or
-/// a URL.
+/// **The unit is bytes, everywhere.** Chunk size targets how much of the source
+/// is read at once, so it is expressed in bytes rather than rows, whose width
+/// varies per dataset. Every engine and binding agrees:
+/// `ChunkSize::Fixed(65_536)` and Python's `chunk_size=65536` both mean a
+/// 64 KiB target, whether the source is a file, a byte stream, or a URL. A
+/// parser may exceed that target to keep one logical record intact.
 ///
 /// Chunk size never changes *what* a profile contains — only the granularity at
 /// which the source is read, progress is emitted, and chunk-level stop
 /// conditions are evaluated.
 #[derive(Debug, Clone, Default)]
 pub enum ChunkSize {
-    /// Fixed chunk size in **bytes**.
+    /// Fixed chunk-size target in **bytes**.
     Fixed(usize),
 
     /// Let the engine choose the chunk size (default).

--- a/crates/dataprof-csv/src/memmap_reader.rs
+++ b/crates/dataprof-csv/src/memmap_reader.rs
@@ -95,7 +95,23 @@ impl MemoryMappedCsvReader {
         let delimiter = csv_config
             .and_then(|config| config.delimiter)
             .unwrap_or(b',');
-        let end = self.csv_record_boundary(start, chunk_size.max(1), quote, delimiter);
+        let mut end = self.csv_record_boundary(start, chunk_size.max(1), quote, delimiter);
+
+        // A chunk containing only leading record terminators makes the csv
+        // crate synthesize an empty header at EOF. The following chunk would
+        // then treat the real header as data. When the first target lands in a
+        // run of blank lines, include the first non-blank logical record too so
+        // header discovery has the same view as a full-file reader.
+        if has_headers && offset == 0 {
+            let header_start = self
+                .mmap
+                .iter()
+                .take_while(|&&byte| matches!(byte, b'\r' | b'\n'))
+                .count();
+            if end <= header_start && header_start < self.mmap.len() {
+                end = self.csv_record_boundary(header_start, 1, quote, delimiter);
+            }
+        }
         let chunk_data = &self.mmap[start..end];
         let actual_bytes = chunk_data.len();
 
@@ -180,6 +196,14 @@ impl MemoryMappedCsvReader {
             index += 1;
         }
 
+        // A target at EOF owns the final unterminated record as well as every
+        // earlier terminated one. Returning the last separator here would
+        // unnecessarily defer that final record to a second chunk and would
+        // make a whole-file logical-record sample incomplete.
+        if target == self.mmap.len() {
+            return target;
+        }
+
         if let Some(boundary) = last_boundary {
             return boundary;
         }
@@ -262,27 +286,38 @@ impl MemoryMappedCsvReader {
         (&chunk[start_pos..end_pos], end_pos)
     }
 
-    /// Estimate the number of rows in the file by sampling.
+    /// Estimate the number of logical CSV records using the default parser
+    /// configuration.
+    ///
+    /// Retained as the backwards-compatible form of
+    /// [`Self::estimate_csv_record_count`].
     pub fn estimate_row_count(&self) -> Result<usize> {
+        self.estimate_csv_record_count(None)
+    }
+
+    /// Estimate the number of logical CSV records in the file by sampling.
+    ///
+    /// The sample uses [`Self::read_csv_chunk`], so quoted multiline fields,
+    /// CR/LF/CRLF terminators, delimiters, and blank-record handling match the
+    /// records that incremental profiling will actually consume.
+    pub fn estimate_csv_record_count(&self, csv_config: Option<&CsvParserConfig>) -> Result<usize> {
         const SAMPLE_SIZE: usize = 64 * 1024;
 
-        if self.file_size < SAMPLE_SIZE as u64 {
-            let cursor = Cursor::new(&*self.mmap);
-            let reader = BufReader::new(cursor);
-            return Ok(reader.lines().count());
-        }
-
-        let sample_data = &self.mmap[0..SAMPLE_SIZE];
-        let cursor = Cursor::new(sample_data);
-        let reader = BufReader::new(cursor);
-
-        let sample_lines = reader.lines().count();
-        if sample_lines == 0 {
+        if self.mmap.is_empty() {
             return Ok(0);
         }
 
-        let estimated_rows = (self.file_size * sample_lines as u64) / SAMPLE_SIZE as u64;
-        Ok(estimated_rows as usize)
+        let (_, records, sampled_bytes) = self.read_csv_chunk(0, SAMPLE_SIZE, false, csv_config)?;
+        if sampled_bytes == 0 || records.is_empty() {
+            return Ok(0);
+        }
+        if sampled_bytes == self.mmap.len() {
+            return Ok(records.len());
+        }
+
+        let estimated_records =
+            (self.file_size as u128 * records.len() as u128) / sampled_bytes as u128;
+        Ok(estimated_records.min(usize::MAX as u128) as usize)
     }
 
     /// Check for memory leaks in the memory tracker.
@@ -351,6 +386,37 @@ mod tests {
 
         assert!(estimated > 90 && estimated < 120);
 
+        Ok(())
+    }
+
+    #[test]
+    fn row_estimation_counts_logical_csv_records() -> Result<()> {
+        let cases: [(&str, &[u8], Option<CsvParserConfig>); 3] = [
+            (
+                "quoted multiline",
+                b"id,bio\n1,\"hello\nworld\"\n2,plain",
+                None,
+            ),
+            ("lone CR", b"id,value\r1,x\r2,y", None),
+            (
+                "custom delimiter",
+                b"id;bio\r1;\"hello\nworld\"\r2;plain",
+                Some(CsvParserConfig::default().with_delimiter(b';')),
+            ),
+        ];
+
+        for (case, payload, config) in cases {
+            let mut temp_file = NamedTempFile::new()?;
+            temp_file.write_all(payload)?;
+            temp_file.flush()?;
+
+            let reader = MemoryMappedCsvReader::new(temp_file.path())?;
+            assert_eq!(
+                reader.estimate_csv_record_count(config.as_ref())?,
+                3,
+                "case={case}"
+            );
+        }
         Ok(())
     }
 
@@ -424,6 +490,40 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].iter().collect::<Vec<_>>(), ["1", "2"]);
         assert_eq!(records[1].iter().collect::<Vec<_>>(), ["3", "4"]);
+        Ok(())
+    }
+
+    #[test]
+    fn csv_chunk_skips_leading_blank_lines_before_header() -> Result<()> {
+        let payload = b"\n\r\n\ralpha,beta\n1,2";
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(payload)?;
+        temp_file.flush()?;
+
+        let reader = MemoryMappedCsvReader::new(temp_file.path())?;
+        let mut offset = 0u64;
+        let mut headers = None;
+        let mut records = Vec::new();
+
+        loop {
+            let (chunk_headers, chunk_records, bytes) =
+                reader.read_csv_chunk(offset, 1, headers.is_none(), None)?;
+            if bytes == 0 {
+                break;
+            }
+            if headers.is_none() {
+                headers = chunk_headers;
+            }
+            records.extend(chunk_records);
+            offset += bytes as u64;
+        }
+
+        assert_eq!(
+            headers.expect("header").iter().collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].iter().collect::<Vec<_>>(), ["1", "2"]);
         Ok(())
     }
 

--- a/crates/dataprof-csv/src/memmap_reader.rs
+++ b/crates/dataprof-csv/src/memmap_reader.rs
@@ -86,13 +86,19 @@ impl MemoryMappedCsvReader {
         has_headers: bool,
         csv_config: Option<&CsvParserConfig>,
     ) -> Result<(Option<csv::StringRecord>, Vec<csv::StringRecord>, usize)> {
-        let (lines, actual_bytes) = self.read_chunk(offset, chunk_size)?;
-
-        if lines.is_empty() {
+        let start = offset as usize;
+        if start >= self.mmap.len() {
             return Ok((None, Vec::new(), 0));
         }
 
-        let chunk_data = lines.join("\n");
+        let quote = csv_config.map_or(b'"', |config| config.quote_char);
+        let delimiter = csv_config
+            .and_then(|config| config.delimiter)
+            .unwrap_or(b',');
+        let end = self.csv_record_boundary(start, chunk_size.max(1), quote, delimiter);
+        let chunk_data = &self.mmap[start..end];
+        let actual_bytes = chunk_data.len();
+
         let mut builder = csv::ReaderBuilder::new();
         builder.has_headers(has_headers && offset == 0);
         if let Some(config) = csv_config {
@@ -105,7 +111,7 @@ impl MemoryMappedCsvReader {
                 builder.trim(csv::Trim::All);
             }
         }
-        let mut reader = builder.from_reader(Cursor::new(chunk_data.as_bytes()));
+        let mut reader = builder.from_reader(chunk_data);
 
         let headers = if has_headers && offset == 0 {
             Some(reader.headers()?.clone())
@@ -119,6 +125,82 @@ impl MemoryMappedCsvReader {
         }
 
         Ok((headers, records, actual_bytes))
+    }
+
+    /// Return a byte boundary that never splits an RFC 4180 record.
+    ///
+    /// `chunk_size` is a working-set target, not permission to hand a partial
+    /// header or record to the CSV decoder. Prefer the last complete record at
+    /// or before the target. If the first record itself is larger, extend just
+    /// far enough to include it. The latter is unavoidable for any parser that
+    /// returns a complete cell, and prevents a long header/record from being
+    /// silently discarded.
+    fn csv_record_boundary(
+        &self,
+        start: usize,
+        chunk_size: usize,
+        quote: u8,
+        delimiter: u8,
+    ) -> usize {
+        let target = start.saturating_add(chunk_size).min(self.mmap.len());
+        let mut index = start;
+        let mut in_quotes = false;
+        let mut at_field_start = true;
+        let mut last_boundary = None;
+
+        while index < target {
+            let byte = self.mmap[index];
+            if in_quotes && byte == quote {
+                // Two quotes inside a quoted field encode one literal quote;
+                // neither ends the field.
+                if self.mmap.get(index + 1) == Some(&quote) {
+                    index += 2;
+                    continue;
+                }
+                in_quotes = false;
+            } else if !in_quotes && at_field_start && byte == quote {
+                in_quotes = true;
+                at_field_start = false;
+            } else if !in_quotes && byte == delimiter {
+                at_field_start = true;
+            } else if !in_quotes && byte == b'\n' {
+                last_boundary = Some(index + 1);
+                at_field_start = true;
+            } else if !in_quotes && byte != b'\r' {
+                at_field_start = false;
+            }
+            index += 1;
+        }
+
+        if let Some(boundary) = last_boundary {
+            return boundary;
+        }
+
+        // No complete record fit. Continue from the quote state at `target`
+        // until the current logical record ends, or include the final
+        // unterminated record so the CSV crate can validate it honestly.
+        while index < self.mmap.len() {
+            let byte = self.mmap[index];
+            if in_quotes && byte == quote {
+                if self.mmap.get(index + 1) == Some(&quote) {
+                    index += 2;
+                    continue;
+                }
+                in_quotes = false;
+            } else if !in_quotes && at_field_start && byte == quote {
+                in_quotes = true;
+                at_field_start = false;
+            } else if !in_quotes && byte == delimiter {
+                at_field_start = true;
+            } else if !in_quotes && byte == b'\n' {
+                return index + 1;
+            } else if !in_quotes && byte != b'\r' {
+                at_field_start = false;
+            }
+            index += 1;
+        }
+
+        self.mmap.len()
     }
 
     /// Find the next line boundary to avoid cutting CSV records in half.
@@ -291,6 +373,87 @@ mod tests {
             "Expected {expected_rows} rows but got {total_records} — rows lost at chunk boundaries"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn csv_chunk_smaller_than_header_preserves_schema_and_rows() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        write!(temp_file, "alpha,beta\n1,2\n3,4\n")?;
+        temp_file.flush()?;
+
+        let reader = MemoryMappedCsvReader::new(temp_file.path())?;
+        let mut offset = 0u64;
+        let mut headers = None;
+        let mut records = Vec::new();
+
+        loop {
+            let (chunk_headers, chunk_records, bytes) =
+                reader.read_csv_chunk(offset, 5, headers.is_none(), None)?;
+            if bytes == 0 {
+                break;
+            }
+            if headers.is_none() {
+                headers = chunk_headers;
+            }
+            records.extend(chunk_records);
+            offset += bytes as u64;
+        }
+
+        assert_eq!(
+            headers.expect("header").iter().collect::<Vec<_>>(),
+            ["alpha", "beta"]
+        );
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].iter().collect::<Vec<_>>(), ["1", "2"]);
+        assert_eq!(records[1].iter().collect::<Vec<_>>(), ["3", "4"]);
+        Ok(())
+    }
+
+    #[test]
+    fn csv_chunk_preserves_multiline_quoted_records() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        let payload = b"id,bio\r\n1,\"hello \"\"quoted\"\"\nworld\"\r\n2,plain";
+        temp_file.write_all(payload)?;
+        temp_file.flush()?;
+
+        let reader = MemoryMappedCsvReader::new(temp_file.path())?;
+        for chunk_size in 1..=payload.len() + 1 {
+            let mut offset = 0u64;
+            let mut headers = None;
+            let mut records = Vec::new();
+
+            loop {
+                let (chunk_headers, chunk_records, bytes) =
+                    reader.read_csv_chunk(offset, chunk_size, headers.is_none(), None)?;
+                if bytes == 0 {
+                    break;
+                }
+                if headers.is_none() {
+                    headers = chunk_headers;
+                }
+                records.extend(chunk_records);
+                offset += bytes as u64;
+            }
+
+            assert_eq!(
+                headers.expect("header").iter().collect::<Vec<_>>(),
+                ["id", "bio"],
+                "chunk_size={chunk_size}"
+            );
+            assert_eq!(records.len(), 2, "chunk_size={chunk_size}");
+            assert_eq!(records[0].get(0), Some("1"), "chunk_size={chunk_size}");
+            assert_eq!(
+                records[0].get(1),
+                Some("hello \"quoted\"\nworld"),
+                "chunk_size={chunk_size}"
+            );
+            assert_eq!(
+                records[1].iter().collect::<Vec<_>>(),
+                ["2", "plain"],
+                "chunk_size={chunk_size}"
+            );
+        }
         Ok(())
     }
 }

--- a/crates/dataprof-csv/src/memmap_reader.rs
+++ b/crates/dataprof-csv/src/memmap_reader.rs
@@ -163,10 +163,18 @@ impl MemoryMappedCsvReader {
                 at_field_start = false;
             } else if !in_quotes && byte == delimiter {
                 at_field_start = true;
-            } else if !in_quotes && byte == b'\n' {
-                last_boundary = Some(index + 1);
+            } else if !in_quotes && let Some(boundary) = self.csv_record_terminator_end(index) {
+                // A CRLF whose CR is the target's last byte crosses the target
+                // by one. Prefer an earlier complete record when one exists;
+                // otherwise include the LF so the pair is never split.
+                if boundary > target && last_boundary.is_some() {
+                    break;
+                }
+                last_boundary = Some(boundary);
                 at_field_start = true;
-            } else if !in_quotes && byte != b'\r' {
+                index = boundary;
+                continue;
+            } else if !in_quotes {
                 at_field_start = false;
             }
             index += 1;
@@ -192,15 +200,24 @@ impl MemoryMappedCsvReader {
                 at_field_start = false;
             } else if !in_quotes && byte == delimiter {
                 at_field_start = true;
-            } else if !in_quotes && byte == b'\n' {
-                return index + 1;
-            } else if !in_quotes && byte != b'\r' {
+            } else if !in_quotes && let Some(boundary) = self.csv_record_terminator_end(index) {
+                return boundary;
+            } else if !in_quotes {
                 at_field_start = false;
             }
             index += 1;
         }
 
         self.mmap.len()
+    }
+
+    /// End offset for the CSV crate's default CR, LF, or CRLF terminator.
+    fn csv_record_terminator_end(&self, index: usize) -> Option<usize> {
+        match self.mmap[index] {
+            b'\r' if self.mmap.get(index + 1) == Some(&b'\n') => Some(index + 2),
+            b'\r' | b'\n' => Some(index + 1),
+            _ => None,
+        }
     }
 
     /// Find the next line boundary to avoid cutting CSV records in half.
@@ -411,48 +428,70 @@ mod tests {
     }
 
     #[test]
-    fn csv_chunk_preserves_multiline_quoted_records() -> Result<()> {
-        let mut temp_file = NamedTempFile::new()?;
-        let payload = b"id,bio\r\n1,\"hello \"\"quoted\"\"\nworld\"\r\n2,plain";
-        temp_file.write_all(payload)?;
-        temp_file.flush()?;
+    fn csv_chunk_preserves_multiline_records_for_every_terminator() -> Result<()> {
+        let cases: [(&str, &[u8], &str); 2] = [
+            (
+                "crlf",
+                b"id,bio\r\n1,\"hello \"\"quoted\"\"\nworld\"\r\n2,plain",
+                "hello \"quoted\"\nworld",
+            ),
+            (
+                "lone-cr",
+                b"id,bio\r1,\"hello\nworld\"\r2,plain",
+                "hello\nworld",
+            ),
+        ];
 
-        let reader = MemoryMappedCsvReader::new(temp_file.path())?;
-        for chunk_size in 1..=payload.len() + 1 {
-            let mut offset = 0u64;
-            let mut headers = None;
-            let mut records = Vec::new();
+        for (terminator, payload, expected_bio) in cases {
+            let mut temp_file = NamedTempFile::new()?;
+            temp_file.write_all(payload)?;
+            temp_file.flush()?;
 
-            loop {
-                let (chunk_headers, chunk_records, bytes) =
-                    reader.read_csv_chunk(offset, chunk_size, headers.is_none(), None)?;
-                if bytes == 0 {
-                    break;
+            let reader = MemoryMappedCsvReader::new(temp_file.path())?;
+            for chunk_size in 1..=payload.len() + 1 {
+                let mut offset = 0u64;
+                let mut headers = None;
+                let mut records = Vec::new();
+
+                loop {
+                    let (chunk_headers, chunk_records, bytes) =
+                        reader.read_csv_chunk(offset, chunk_size, headers.is_none(), None)?;
+                    if bytes == 0 {
+                        break;
+                    }
+                    if headers.is_none() {
+                        headers = chunk_headers;
+                    }
+                    records.extend(chunk_records);
+                    offset += bytes as u64;
                 }
-                if headers.is_none() {
-                    headers = chunk_headers;
-                }
-                records.extend(chunk_records);
-                offset += bytes as u64;
+
+                assert_eq!(
+                    headers.expect("header").iter().collect::<Vec<_>>(),
+                    ["id", "bio"],
+                    "terminator={terminator}, chunk_size={chunk_size}"
+                );
+                assert_eq!(
+                    records.len(),
+                    2,
+                    "terminator={terminator}, chunk_size={chunk_size}"
+                );
+                assert_eq!(
+                    records[0].get(0),
+                    Some("1"),
+                    "terminator={terminator}, chunk_size={chunk_size}"
+                );
+                assert_eq!(
+                    records[0].get(1),
+                    Some(expected_bio),
+                    "terminator={terminator}, chunk_size={chunk_size}"
+                );
+                assert_eq!(
+                    records[1].iter().collect::<Vec<_>>(),
+                    ["2", "plain"],
+                    "terminator={terminator}, chunk_size={chunk_size}"
+                );
             }
-
-            assert_eq!(
-                headers.expect("header").iter().collect::<Vec<_>>(),
-                ["id", "bio"],
-                "chunk_size={chunk_size}"
-            );
-            assert_eq!(records.len(), 2, "chunk_size={chunk_size}");
-            assert_eq!(records[0].get(0), Some("1"), "chunk_size={chunk_size}");
-            assert_eq!(
-                records[0].get(1),
-                Some("hello \"quoted\"\nworld"),
-                "chunk_size={chunk_size}"
-            );
-            assert_eq!(
-                records[1].iter().collect::<Vec<_>>(),
-                ["2", "plain"],
-                "chunk_size={chunk_size}"
-            );
         }
         Ok(())
     }

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -106,7 +106,7 @@ impl IncrementalProfiler {
         let _file_size_mb = file_size_bytes as f64 / 1_048_576.0;
 
         // Estimate total rows for progress tracking
-        let estimated_total_rows = reader.estimate_row_count()?;
+        let estimated_total_rows = reader.estimate_csv_record_count(self.csv_config.as_ref())?;
         let source_has_header = self
             .csv_config
             .as_ref()
@@ -599,6 +599,59 @@ mod tests {
                 .map(|column| (column.name.as_str(), column.total_count))
                 .collect::<Vec<_>>(),
             [("column_0", 2), ("column_1", 2)]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn logical_csv_records_drive_the_progress_estimate() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        write!(temp_file, "id,bio\r1,\"hello\nworld\"\r2,plain")?;
+        temp_file.flush()?;
+
+        let estimated_rows = Arc::new(Mutex::new(None));
+        let captured_estimate = Arc::clone(&estimated_rows);
+        let progress = ProgressSink::Callback(Arc::new(move |event| {
+            if let ProgressEvent::Started {
+                estimated_total_rows,
+                ..
+            } = event
+            {
+                *captured_estimate.lock().expect("progress estimate lock") = estimated_total_rows;
+            }
+        }));
+
+        let report = IncrementalProfiler::new()
+            .chunk_size(ChunkSize::Fixed(1))
+            .progress(progress, Duration::ZERO)
+            .analyze_file(temp_file.path())?;
+
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(
+            *estimated_rows.lock().expect("progress estimate lock"),
+            Some(2)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn leading_blank_lines_do_not_replace_the_csv_header() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        write!(temp_file, "\nalpha,beta\n1,2")?;
+        temp_file.flush()?;
+
+        let report = IncrementalProfiler::new()
+            .chunk_size(ChunkSize::Fixed(1))
+            .analyze_file(temp_file.path())?;
+
+        assert_eq!(report.execution.rows_processed, 1);
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| (column.name.as_str(), column.total_count))
+                .collect::<Vec<_>>(),
+            [("alpha", 1), ("beta", 1)]
         );
         Ok(())
     }

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -145,10 +145,15 @@ impl IncrementalProfiler {
 
         // Process file in chunks using true streaming
         loop {
+            let source_has_header = self
+                .csv_config
+                .as_ref()
+                .is_none_or(|config| config.has_header);
+            let first_chunk = headers.is_none();
             let (chunk_headers, records, actual_bytes) = reader.read_csv_chunk(
                 offset,
                 chunk_size_bytes,
-                headers.is_none(),
+                first_chunk && source_has_header,
                 self.csv_config.as_ref(),
             )?;
 
@@ -168,6 +173,21 @@ impl IncrementalProfiler {
                     column_stats.init_columns(&names);
                     progress_tracker.emit_schema(names);
                 }
+            }
+            if headers.is_none()
+                && first_chunk
+                && !source_has_header
+                && let Some(first_record) = records.first()
+            {
+                let generated = csv::StringRecord::from(
+                    (0..first_record.len())
+                        .map(|index| format!("column_{index}"))
+                        .collect::<Vec<_>>(),
+                );
+                let names: Vec<String> = generated.iter().map(str::to_string).collect();
+                column_stats.init_columns(&names);
+                progress_tracker.emit_schema(names);
+                headers = Some(generated);
             }
 
             // Process this chunk incrementally
@@ -537,6 +557,30 @@ mod tests {
         let report = profiler.analyze_file(temp_file.path())?;
         assert_eq!(report.column_profiles.len(), 2);
 
+        Ok(())
+    }
+
+    #[test]
+    fn headerless_csv_keeps_the_first_record_and_generates_column_names() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        write!(temp_file, "1,Alice\n2,Bob")?;
+        temp_file.flush()?;
+
+        let report = IncrementalProfiler::new()
+            .chunk_size(ChunkSize::Fixed(1))
+            .csv_config(CsvParserConfig::default().has_header(false))
+            .analyze_file(temp_file.path())?;
+
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.ragged_row_count, 0);
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| (column.name.as_str(), column.total_count))
+                .collect::<Vec<_>>(),
+            [("column_0", 2), ("column_1", 2)]
+        );
         Ok(())
     }
 

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -107,6 +107,15 @@ impl IncrementalProfiler {
 
         // Estimate total rows for progress tracking
         let estimated_total_rows = reader.estimate_row_count()?;
+        let source_has_header = self
+            .csv_config
+            .as_ref()
+            .is_none_or(|config| config.has_header);
+        let estimated_data_rows = if source_has_header {
+            estimated_total_rows.saturating_sub(1)
+        } else {
+            estimated_total_rows
+        };
 
         // Calculate optimal chunk size based on memory limit and file size
         let chunk_size_bytes = self.calculate_optimal_chunk_size(file_size_bytes);
@@ -120,11 +129,8 @@ impl IncrementalProfiler {
 
         // Initialize stop condition evaluator
         let mut stop_eval = StopEvaluator::new(self.stop_condition.clone())
-            .with_estimated_total(estimated_total_rows as u64);
+            .with_estimated_total(estimated_data_rows as u64);
         let mut schema_tracker = SchemaStabilityTracker::from_condition(&self.stop_condition);
-
-        // estimate_row_count includes the header line; subtract 1 for data-only count
-        let estimated_data_rows = estimated_total_rows.saturating_sub(1);
 
         progress_tracker.emit_started(Some(estimated_data_rows), Some(file_size_bytes));
 
@@ -145,10 +151,6 @@ impl IncrementalProfiler {
 
         // Process file in chunks using true streaming
         loop {
-            let source_has_header = self
-                .csv_config
-                .as_ref()
-                .is_none_or(|config| config.has_header);
             let first_chunk = headers.is_none();
             let (chunk_headers, records, actual_bytes) = reader.read_csv_chunk(
                 offset,
@@ -492,8 +494,9 @@ impl Default for IncrementalProfiler {
 mod tests {
     use super::*;
     use anyhow::Result;
-    use dataprof_core::{ColumnStats, DataType, TruncationReason};
+    use dataprof_core::{ColumnStats, DataType, ProgressEvent, TruncationReason};
     use std::io::Write;
+    use std::sync::{Arc, Mutex};
     use tempfile::NamedTempFile;
 
     #[test]
@@ -566,13 +569,29 @@ mod tests {
         write!(temp_file, "1,Alice\n2,Bob")?;
         temp_file.flush()?;
 
+        let estimated_rows = Arc::new(Mutex::new(None));
+        let captured_estimate = Arc::clone(&estimated_rows);
+        let progress = ProgressSink::Callback(Arc::new(move |event| {
+            if let ProgressEvent::Started {
+                estimated_total_rows,
+                ..
+            } = event
+            {
+                *captured_estimate.lock().expect("progress estimate lock") = estimated_total_rows;
+            }
+        }));
         let report = IncrementalProfiler::new()
             .chunk_size(ChunkSize::Fixed(1))
             .csv_config(CsvParserConfig::default().has_header(false))
+            .progress(progress, Duration::ZERO)
             .analyze_file(temp_file.path())?;
 
         assert_eq!(report.execution.rows_processed, 2);
         assert_eq!(report.execution.ragged_row_count, 0);
+        assert_eq!(
+            *estimated_rows.lock().expect("progress estimate lock"),
+            Some(2)
+        );
         assert_eq!(
             report
                 .column_profiles

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -253,6 +253,13 @@ mod tests {
 
         assert_eq!(profile.null_count, 0); // Trimmed values are not null
         assert!(matches!(profile.data_type, DataType::Integer));
+        assert_eq!(profile.invalid_count, Some(0));
+        let ColumnStats::Numeric(stats) = profile.stats else {
+            panic!("whitespace-padded integers should have numeric statistics");
+        };
+        assert_eq!(stats.min, 1.0);
+        assert_eq!(stats.max, 3.0);
+        assert_eq!(stats.mean, 2.0);
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
@@ -81,7 +81,7 @@ impl<'a> AccuracyCalculator<'a> {
                         if is_null_like_token(v.trim()) {
                             None
                         } else {
-                            v.parse::<f64>().ok().filter(|n| n.is_finite())
+                            v.trim().parse::<f64>().ok().filter(|n| n.is_finite())
                         }
                     })
                     .collect();
@@ -163,7 +163,7 @@ impl<'a> AccuracyCalculator<'a> {
                 continue;
             }
 
-            if let Ok(num_value) = value.parse::<f64>() {
+            if let Ok(num_value) = value.trim().parse::<f64>() {
                 if !num_value.is_finite() {
                     continue;
                 }
@@ -214,7 +214,7 @@ impl<'a> AccuracyCalculator<'a> {
                         if is_null_like_token(v.trim()) {
                             None
                         } else {
-                            v.parse::<f64>().ok()
+                            v.trim().parse::<f64>().ok()
                         }
                     })
                     .filter(|&num| num < 0.0)
@@ -283,9 +283,9 @@ mod tests {
         let data = HashMap::from([(
             "pressure".to_string(),
             vec![
-                "101325".to_string(),
-                "-500".to_string(),
-                "100900".to_string(),
+                " 101325".to_string(),
+                " -500 ".to_string(),
+                "100900 ".to_string(),
             ],
         )]);
         let profiles = vec![numeric_profile("pressure")];
@@ -299,5 +299,6 @@ mod tests {
             .calculate_with_positive_columns(&data, &profiles, &["pressure".to_string()])
             .expect("accuracy metrics should compute");
         assert_eq!(with_hint.negative_values_in_positive, 1);
+        assert_eq!(with_hint.numeric_values_checked, 3);
     }
 }

--- a/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/accuracy.rs
@@ -214,7 +214,7 @@ impl<'a> AccuracyCalculator<'a> {
                         if is_null_like_token(v.trim()) {
                             None
                         } else {
-                            v.trim().parse::<f64>().ok()
+                            v.trim().parse::<f64>().ok().filter(|n| n.is_finite())
                         }
                     })
                     .filter(|&num| num < 0.0)
@@ -286,6 +286,9 @@ mod tests {
                 " 101325".to_string(),
                 " -500 ".to_string(),
                 "100900 ".to_string(),
+                " -inf ".to_string(),
+                "NaN".to_string(),
+                "inf".to_string(),
             ],
         )]);
         let profiles = vec![numeric_profile("pressure")];

--- a/crates/dataprof-metrics/src/analysis/metrics/hint_binding.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/hint_binding.rs
@@ -107,7 +107,10 @@ fn count_matches(values: &[String], kind: SemanticHintKind) -> (usize, usize) {
 pub fn value_matches_hint(value: &str, kind: SemanticHintKind) -> bool {
     match kind {
         // Mirror accuracy.rs: numeric cells accept surrounding whitespace.
-        SemanticHintKind::Positive => value.trim().parse::<f64>().is_ok(),
+        SemanticHintKind::Positive => value
+            .trim()
+            .parse::<f64>()
+            .is_ok_and(|number| number.is_finite()),
         // Mirror timeliness.rs: it extracts a year from the original cell.
         SemanticHintKind::Temporal => extract_year(value).is_some(),
         // Identifier binding is structural and is not value-driven.
@@ -187,7 +190,7 @@ mod tests {
         // quality predicates require the raw date to be directly parseable.
         // Binding evidence must make the same distinction.
         let d = data(&[
-            ("pressure", &[" 101325", "100900"]),
+            ("pressure", &[" 101325", "100900", " -inf "]),
             ("event", &[" 2020-01-01", "2022-06-15"]),
         ]);
         let hints = SemanticHints::new(vec!["pressure".to_string()], vec![])
@@ -198,7 +201,7 @@ mod tests {
             .iter()
             .find(|b| b.column == "pressure")
             .expect("positive binding");
-        assert_eq!(positive.checked_values, 2);
+        assert_eq!(positive.checked_values, 3);
         assert_eq!(positive.matched_values, 2);
 
         let temporal = bindings

--- a/crates/dataprof-metrics/src/analysis/metrics/hint_binding.rs
+++ b/crates/dataprof-metrics/src/analysis/metrics/hint_binding.rs
@@ -80,11 +80,10 @@ fn binding(
 /// Count `(non-null values, values satisfying `pred`)`.
 ///
 /// Mirrors the quality calculators exactly: the null-like check runs on the
-/// trimmed token, but `pred` sees the *original* value. `accuracy.rs` and
-/// `timeliness.rs` parse the raw string (`v.parse::<f64>()`,
-/// `extract_year(value)`), and neither `parse::<f64>()` nor `extract_year`
-/// tolerates surrounding whitespace, so trimming here would let this evidence
-/// accept values the calculators reject (e.g. `" 1"`, `" 2020-01-01"`).
+/// trimmed token, while `pred` receives the original value and applies the
+/// normalization appropriate to its metric. Numeric quality calculations
+/// accept surrounding whitespace; temporal quality predicates deliberately do
+/// not.
 fn count_matches(values: &[String], kind: SemanticHintKind) -> (usize, usize) {
     let mut checked = 0;
     let mut matched = 0;
@@ -107,8 +106,8 @@ fn count_matches(values: &[String], kind: SemanticHintKind) -> (usize, usize) {
 /// binding evidence from drifting away from the sampled quality calculation.
 pub fn value_matches_hint(value: &str, kind: SemanticHintKind) -> bool {
     match kind {
-        // Mirror accuracy.rs: it parses the original, untrimmed cell.
-        SemanticHintKind::Positive => value.parse::<f64>().is_ok(),
+        // Mirror accuracy.rs: numeric cells accept surrounding whitespace.
+        SemanticHintKind::Positive => value.trim().parse::<f64>().is_ok(),
         // Mirror timeliness.rs: it extracts a year from the original cell.
         SemanticHintKind::Temporal => extract_year(value).is_some(),
         // Identifier binding is structural and is not value-driven.
@@ -183,10 +182,10 @@ mod tests {
     }
 
     #[test]
-    fn whitespace_padded_values_match_the_calculators_not_a_trimmed_view() {
-        // The calculators parse the raw string, and neither `parse::<f64>()` nor
-        // `extract_year` accepts surrounding whitespace. Binding evidence must
-        // agree, so a padded value is counted as considered but not matched.
+    fn whitespace_padded_values_match_each_calculators_normalization() {
+        // Numeric calculators accept surrounding whitespace while temporal
+        // quality predicates require the raw date to be directly parseable.
+        // Binding evidence must make the same distinction.
         let d = data(&[
             ("pressure", &[" 101325", "100900"]),
             ("event", &[" 2020-01-01", "2022-06-15"]),
@@ -200,7 +199,7 @@ mod tests {
             .find(|b| b.column == "pressure")
             .expect("positive binding");
         assert_eq!(positive.checked_values, 2);
-        assert_eq!(positive.matched_values, 1);
+        assert_eq!(positive.matched_values, 2);
 
         let temporal = bindings
             .iter()

--- a/crates/dataprof-metrics/src/stats/numeric.rs
+++ b/crates/dataprof-metrics/src/stats/numeric.rs
@@ -21,7 +21,7 @@ pub fn compute_numeric_stats_with_parsed_count(data: &[String]) -> (NumericStats
     // (nulls, tokens like "N/A"), excluded from numeric stats by design.
     let numbers: Vec<f64> = data
         .iter()
-        .filter_map(|s| s.parse::<f64>().ok())
+        .filter_map(|s| s.trim().parse::<f64>().ok())
         .filter(|x| x.is_finite())
         .collect();
     let parsed_count = numbers.len();

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -104,8 +104,7 @@ impl ArrowProfiler {
     /// its time on; the per-value analysis is.
     fn pre_scan(&self, file_path: &Path) -> Result<CsvPreScan, DataProfilerError> {
         let mut builder = csv::ReaderBuilder::new();
-        builder.has_headers(true);
-        let (flexible, max_rows) = match self.csv_config {
+        let (has_header, flexible, max_rows) = match self.csv_config {
             Some(ref config) => {
                 if let Some(delim) = config.delimiter {
                     builder.delimiter(delim);
@@ -114,10 +113,11 @@ impl ArrowProfiler {
                 if config.trim_whitespace {
                     builder.trim(csv::Trim::All);
                 }
-                (config.flexible, config.max_rows)
+                (config.has_header, config.flexible, config.max_rows)
             }
-            None => (false, None),
+            None => (true, false, None),
         };
+        builder.has_headers(has_header);
         // Strict parsing rejects here, one reader earlier than Arrow would, so
         // the caller gets the same field-count diagnostic as every other path
         // instead of Arrow's "incorrect number of fields".
@@ -160,15 +160,26 @@ impl ArrowProfiler {
         // `pre_scan` for why Arrow cannot supply either.
         let scan = self.pre_scan(file_path)?;
         let headers = scan.headers;
+        let has_header = self
+            .csv_config
+            .as_ref()
+            .is_none_or(|config| config.has_header);
 
         // Reject duplicate headers before building the name-keyed analyzer map,
         // which would otherwise merge two columns into one profile.
-        let header_names: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
-        dataprof_core::validate_unique_column_names(&header_names, "CSV header")?;
+        let header_names: Vec<String> = if has_header {
+            let names = headers.iter().map(str::to_string).collect::<Vec<_>>();
+            dataprof_core::validate_unique_column_names(&names, "CSV header")?;
+            names
+        } else {
+            (0..headers.len())
+                .map(|index| format!("column_{index}"))
+                .collect()
+        };
         let header_width = header_names.len();
 
         let mut fields = Vec::new();
-        for header in headers.iter() {
+        for header in &header_names {
             // Start with string type, Arrow will convert during processing
             fields.push(Field::new(header, arrow::datatypes::DataType::Utf8, true));
         }
@@ -189,7 +200,7 @@ impl ArrowProfiler {
         // Now create Arrow reader with proper schema
         let file = File::open(file_path)?;
         let mut arrow_builder = ReaderBuilder::new(schema.clone())
-            .with_header(true)
+            .with_header(has_header)
             .with_batch_size(self.batch_size);
         if let Some(ref config) = self.csv_config {
             if let Some(delim) = config.delimiter {
@@ -290,9 +301,8 @@ impl ArrowProfiler {
         let mut column_profiles = Vec::new();
         let mut sample_columns = std::collections::HashMap::new();
 
-        for header in headers.iter() {
-            let name = header.to_string();
-            if let Some(analyzer) = column_analyzers.get(&name) {
+        for name in &header_names {
+            if let Some(analyzer) = column_analyzers.get(name) {
                 let profile = analyzer.to_column_profile(
                     name.clone(),
                     skip_stats,
@@ -301,7 +311,7 @@ impl ArrowProfiler {
                     &self.semantic_hints,
                 );
                 column_profiles.push(profile);
-                sample_columns.insert(name, analyzer.get_sample_values());
+                sample_columns.insert(name.clone(), analyzer.get_sample_values());
             }
         }
 
@@ -337,7 +347,9 @@ impl ArrowProfiler {
         if MetricPack::include_quality(packs) && !empty_source {
             assembler = assembler
                 .with_quality_data(sample_columns)
-                .with_exact_value_hint_bindings(hint_bindings.bindings(headers.iter()))
+                .with_exact_value_hint_bindings(
+                    hint_bindings.bindings(header_names.iter().map(String::as_str)),
+                )
                 .with_semantic_hints(self.semantic_hints.clone());
             if let Some(ref dims) = self.quality_dimensions {
                 assembler = assembler.with_requested_dimensions(dims.clone());
@@ -643,7 +655,7 @@ impl ColumnAnalyzer {
                 // fed so numeric stats never fall back to the sample.
                 // decode-audit: no-data — a cell that does not parse is a
                 // non-numeric value, excluded from numeric stats by design.
-                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                if let Some(number) = value.trim().parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }
 
@@ -669,7 +681,7 @@ impl ColumnAnalyzer {
                 self.update_text_stats(value);
                 // decode-audit: no-data — a cell that does not parse is a
                 // non-numeric value, excluded from numeric stats by design.
-                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                if let Some(number) = value.trim().parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }
 
@@ -1169,6 +1181,30 @@ mod tests {
         // Padding the row is the recovery; reporting it is the contract (#470).
         assert_eq!(report.execution.ragged_row_count, 1);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_profiler_headerless_csv_keeps_the_first_record() -> Result<(), DataProfilerError>
+    {
+        let mut temp_file = NamedTempFile::new()?;
+        write!(temp_file, "1,Alice\n2,Bob")?;
+        temp_file.flush()?;
+
+        let report = ArrowProfiler::new()
+            .csv_config(CsvParserConfig::default().has_header(false))
+            .analyze_csv_file(temp_file.path())?;
+
+        assert_eq!(report.execution.rows_processed, 2);
+        assert_eq!(report.execution.ragged_row_count, 0);
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| (column.name.as_str(), column.total_count))
+                .collect::<Vec<_>>(),
+            [("column_0", 2), ("column_1", 2)]
+        );
         Ok(())
     }
 

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -766,7 +766,7 @@ impl ColumnAnalyzer {
                 // fed so numeric stats never fall back to the sample.
                 // decode-audit: no-data — a cell that does not parse is a
                 // non-numeric value, excluded from numeric stats by design.
-                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                if let Some(number) = value.trim().parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }
                 self.cardinality.insert(value);
@@ -787,7 +787,7 @@ impl ColumnAnalyzer {
                 self.update_text_stats(value);
                 // decode-audit: no-data — a cell that does not parse is a
                 // non-numeric value, excluded from numeric stats by design.
-                if let Some(number) = value.parse::<f64>().ok().filter(|n| n.is_finite()) {
+                if let Some(number) = value.trim().parse::<f64>().ok().filter(|n| n.is_finite()) {
                     self.update_numeric_stats(number);
                 }
                 self.cardinality.insert(value);

--- a/crates/dataprof-runtime/src/hint_binding.rs
+++ b/crates/dataprof-runtime/src/hint_binding.rs
@@ -97,7 +97,7 @@ mod tests {
         let hints = SemanticHints::new(vec!["amount".to_string()], vec![])
             .with_temporal_columns(vec!["event".to_string()]);
         let mut accumulator = ValueHintBindingAccumulator::new(&hints);
-        for value in ["1", " 2", "NULL"] {
+        for value in ["1", " 2", " -inf ", "NULL"] {
             accumulator.observe("amount", value);
         }
         for value in ["2020-01-01", "not-a-date", " 2021-01-01"] {
@@ -105,8 +105,8 @@ mod tests {
         }
 
         let bindings = accumulator.bindings(["amount", "event"]);
-        assert_eq!(bindings[0].checked_values, 2);
-        assert_eq!(bindings[0].matched_values, 1);
+        assert_eq!(bindings[0].checked_values, 3);
+        assert_eq!(bindings[0].matched_values, 2);
         assert!(bindings[0].exact);
         assert_eq!(bindings[1].checked_values, 3);
         assert_eq!(bindings[1].matched_values, 1);

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -320,7 +320,12 @@ impl StreamingStatistics {
             self.date_match_count += 1;
         }
 
-        if let Some(number) = value.parse::<f64>().ok().filter(|num| num.is_finite()) {
+        if let Some(number) = value
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|num| num.is_finite())
+        {
             self.welford.update(number);
             self.min = self.min.min(number);
             self.max = self.max.max(number);

--- a/docs/guides/why-dataprof.md
+++ b/docs/guides/why-dataprof.md
@@ -33,12 +33,11 @@ follows from that job.
   CI quality gates fall out of this naturally.
 - **One tool across sources.** CSV, JSON/JSONL, Parquet, Arrow batches,
   pandas/polars DataFrames, dicts, byte buffers, and (opt-in) live database
-  queries — same report shape from all of them. CSV, JSON, and JSONL byte
-  buffers are dependency-free; Parquet byte buffers currently require the
-  pandas extra.
+  queries — same report shape from all of them. CSV, JSON, JSONL, and Parquet
+  byte buffers are dependency-free.
 - **A dependency-free Python wheel.** `pip install dataprof` pulls in no
-  Python dependencies. Profiling local files, dicts, and CSV/JSON/JSONL byte
-  buffers needs neither pandas nor numpy.
+  Python dependencies. Profiling local files, dicts, and byte buffers needs
+  neither pandas nor numpy.
 - **Agent-ready output.** `to_llm_context()` produces a token-bounded summary
   with fail-closed redaction of sensitive values — built for handing a
   dataset's shape to an LLM without handing it the data.

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -189,7 +189,7 @@ Returned by `profile()` and all analysis functions.
 | Property | Type | Description |
 |---|---|---|
 | `source` | `str` | Source identifier (file path, table name, etc.) |
-| `source_type` | `str` | `"file"`, `"query"`, `"dataframe"`, `"stream"` |
+| `source_type` | `str` | `"file"`, `"bytes"`, `"query"`, `"dataframe"`, `"stream"` |
 | `engine` | `str \| None` | Engine or parser that produced the report |
 | `rows` | `int` | Number of rows processed |
 | `columns` | `int` | Number of columns detected |

--- a/python/examples/before_after_cleaning.py
+++ b/python/examples/before_after_cleaning.py
@@ -74,14 +74,14 @@ def main() -> None:
         print(f"| before | {before.rows} | {before_score:.1f} |")
         print(f"| after | {after.rows} | {after_score:.1f} |")
 
-        dropped = before.rows - after.rows
-        gained = after_score - before_score
-        print(f"\n{dropped} row(s) dropped, {gained:+.1f} quality points\n")
-
         # `compare()` does the diffing for you: quality, schema, and per-column
         # deltas. `a` is this report, `b` is the other one, and `abs` is `b - a`
         # (signed, despite the name).
         delta = before.compare(after)
+        dropped = before.rows - after.rows
+        gained = delta["quality_score"]["abs"]
+        print(f"\n{dropped} row(s) dropped, {gained:+.1f} quality points\n")
+
         print("## What changed\n")
         print(f"quality_score: {delta['quality_score']['abs']:+.1f}")
         for dimension, change in sorted(delta["dimensions"].items()):

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -191,6 +191,18 @@ def test_engine_column_order_follows_source(engine, tmp_path):
     assert list(report) == list(COLUMNS)
 
 
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_whitespace_padded_numeric_stats_match_inference(engine, tmp_path):
+    path = tmp_path / "padded_numeric.csv"
+    path.write_bytes(b"name,amount\nAlice, 1 \nBob, 2 \n")
+
+    amount = dataprof.profile(str(path), engine=engine)["amount"]
+
+    assert amount.data_type == "integer", engine
+    assert amount.invalid_count == 0, engine
+    assert (amount.min, amount.max, amount.mean) == pytest.approx((1.0, 2.0, 1.5)), engine
+
+
 # ── High-cardinality regression (issue #386) ──
 #
 # The columnar (Arrow) engine used to stop counting distinct values at an

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -9,9 +9,10 @@ Two promises, checked across the sync and async entry points:
    agree with each other. These four fields are how an agent or quality gate
    tells a complete profile from a bounded one, so they must never contradict.
 
-Units: ``chunk_size`` is **bytes**, everywhere. Row caps are hard caps. Byte
-caps are evaluated at chunk boundaries, so ``bytes_consumed`` may exceed the cap
-by at most one chunk — a bound the caller sets via ``chunk_size``.
+Units: ``chunk_size`` is a **byte target**, everywhere. Row caps are hard caps.
+Byte caps are evaluated at chunk boundaries, so ``bytes_consumed`` may exceed
+the cap by one chunk, and a parser may extend that chunk to keep one logical
+record intact.
 
 Run after building the extension:
     maturin develop --features python,python-async,async-streaming
@@ -109,6 +110,32 @@ def test_chunk_size_never_changes_a_complete_profile(tmp_path, chunk_size):
     assert report.rows == 2_000
     assert report.columns == 5
     _assert_consistent(report, size, f"chunk_size={chunk_size}")
+
+
+def test_chunk_smaller_than_csv_header_keeps_the_schema_and_rows(tmp_path):
+    path = tmp_path / "small_chunks.csv"
+    path.write_bytes(b"alpha,beta\n1,2\n3,4\n")
+
+    report = dp.profile(str(path), engine="incremental", chunk_size=5)
+
+    assert report.rows == 2
+    assert list(report) == ["alpha", "beta"]
+    assert report.ragged_row_count == 0
+    _assert_consistent(report, path.stat().st_size, "header exceeds chunk target")
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental"])
+def test_multiline_record_crossing_chunk_boundary_stays_one_row(tmp_path, engine):
+    path = tmp_path / "multiline.csv"
+    long_value = "x" * 65_490
+    path.write_text(f'id,bio\n1,"{long_value}\ncontinued"\n2,plain\n', encoding="utf-8")
+
+    report = dp.profile(str(path), engine=engine)
+
+    assert report.rows == 2
+    assert list(report) == ["id", "bio"]
+    assert report.ragged_row_count == 0
+    _assert_consistent(report, path.stat().st_size, f"{engine} multiline record")
 
 
 @pytest.mark.parametrize("engine", ["auto", "incremental"])

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -6,10 +6,10 @@
 use std::io::Write;
 use std::path::Path;
 
+use dataprof::{ChunkSize, EngineType, Profiler};
 use dataprof::{
     ColumnStats, CsvParserConfig, DataType, MetricConfidence, QualityDimension, analyze_csv_file,
 };
-use dataprof::{EngineType, Profiler};
 use serde_json::json;
 use tempfile::NamedTempFile;
 
@@ -129,6 +129,136 @@ fn test_empty_csv_quality_presence_matches_across_engines_and_serialization() {
 
         let serialized = serde_json::to_value(&report).expect("report should serialize");
         assert!(serialized["quality"].is_null(), "{engine}");
+    }
+}
+
+/// Numeric inference normalizes surrounding whitespace, so the statistics
+/// parser must consume the same lexical value. Previously every engine typed
+/// these cells as integers but excluded both from its numeric accumulator,
+/// publishing plausible zeroes with `invalid_count == 2`.
+#[test]
+fn whitespace_padded_numeric_stats_match_across_csv_engines() {
+    let mut csv = NamedTempFile::new().unwrap();
+    writeln!(csv, "name,amount").unwrap();
+    writeln!(csv, "Alice, 1 ").unwrap();
+    writeln!(csv, "Bob, 2 ").unwrap();
+    csv.flush().unwrap();
+
+    let reports = [
+        (
+            "standard",
+            analyze_csv_file(csv.path(), &CsvParserConfig::default())
+                .expect("standard CSV analysis should succeed"),
+        ),
+        (
+            "auto",
+            Profiler::new()
+                .engine(EngineType::Auto)
+                .analyze_file(csv.path())
+                .expect("auto analysis should succeed"),
+        ),
+        (
+            "incremental",
+            Profiler::new()
+                .engine(EngineType::Incremental)
+                .analyze_file(csv.path())
+                .expect("incremental analysis should succeed"),
+        ),
+        (
+            "columnar",
+            Profiler::new()
+                .engine(EngineType::Columnar)
+                .analyze_file(csv.path())
+                .expect("columnar analysis should succeed"),
+        ),
+    ];
+
+    for (engine, report) in reports {
+        let amount = report
+            .column_profiles
+            .iter()
+            .find(|column| column.name == "amount")
+            .expect("amount profile");
+        assert_eq!(amount.data_type, DataType::Integer, "{engine}");
+        assert_eq!(amount.invalid_count, Some(0), "{engine}");
+        let ColumnStats::Numeric(stats) = &amount.stats else {
+            panic!("{engine} should produce numeric statistics");
+        };
+        assert_eq!(stats.min, 1.0, "{engine}");
+        assert_eq!(stats.max, 2.0, "{engine}");
+        assert_eq!(stats.mean, 1.5, "{engine}");
+    }
+}
+
+/// A configured chunk is allowed to be smaller than a header or record. It is
+/// a read target, not a license to profile a fragment as the whole schema.
+#[test]
+fn incremental_chunk_smaller_than_header_preserves_the_file() {
+    let mut csv = NamedTempFile::new().unwrap();
+    write!(csv, "alpha,beta\n1,2\n3,4\n").unwrap();
+    csv.flush().unwrap();
+
+    let report = Profiler::new()
+        .engine(EngineType::Incremental)
+        .chunk_size(ChunkSize::Fixed(5))
+        .analyze_file(csv.path())
+        .expect("incremental analysis should succeed");
+
+    assert_eq!(report.execution.rows_processed, 2);
+    assert_eq!(report.execution.ragged_row_count, 0);
+    assert!(report.execution.source_exhausted);
+    assert_eq!(
+        report
+            .column_profiles
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        ["alpha", "beta"]
+    );
+}
+
+/// The default 64 KiB incremental boundary may land inside a quoted multiline
+/// field. Physical newlines inside that field are data, not row boundaries.
+#[test]
+fn multiline_csv_crossing_default_chunk_boundary_matches_columnar() {
+    let mut csv = NamedTempFile::new().unwrap();
+    writeln!(csv, "id,bio").unwrap();
+    writeln!(csv, "0,{}", "x".repeat(65_490)).unwrap();
+    writeln!(csv, "1,\"hello\n{}\"", "w".repeat(100)).unwrap();
+    writeln!(csv, "2,end").unwrap();
+    csv.flush().unwrap();
+
+    let columnar = Profiler::new()
+        .engine(EngineType::Columnar)
+        .analyze_file(csv.path())
+        .expect("columnar analysis should succeed");
+
+    for engine in [EngineType::Auto, EngineType::Incremental] {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(csv.path())
+            .expect("incremental analysis should succeed");
+
+        assert_eq!(
+            report.execution.engine.as_deref(),
+            Some("incremental"),
+            "{engine:?}"
+        );
+        assert_eq!(report.execution.rows_processed, 3, "{engine:?}");
+        assert_eq!(report.execution.ragged_row_count, 0, "{engine:?}");
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|column| (&column.name, &column.data_type, column.total_count))
+                .collect::<Vec<_>>(),
+            columnar
+                .column_profiles
+                .iter()
+                .map(|column| (&column.name, &column.data_type, column.total_count))
+                .collect::<Vec<_>>(),
+            "{engine:?}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- normalize surrounding whitespace before numeric accumulation and positive-column evidence, keeping inferred numeric types, statistics, invalid counts, and quality calculations aligned across engines
- make memory-mapped CSV chunks end on logical record boundaries so long headers and quoted multiline records are never decoded as fragments
- honor headerless CSV configuration in both incremental and Arrow-backed columnar engines, preserving row 1 under generated column names
- add Rust and Python parity regressions, clarify chunk-size target semantics, correct Parquet-byte/source-type docs, and remove the yanked lockfile-only chacha20 release

## Why

Dogfooding the published 0.11.0 wheel found two cases where the report could look plausible while being wrong:

1. whitespace-padded numeric cells inferred as integers but were excluded from numeric accumulators, producing zero-valued statistics and invalid counts
2. the incremental reader split on physical newlines, which could turn a quoted multiline field crossing 64 KiB into a phantom ragged row; a chunk smaller than the header could also erase the schema

The same pass confirmed that the public has_header(false) engine configuration was ignored by incremental and columnar CSV profiling.

## Verification

- cargo test -p dataprof-metrics
- cargo test -p dataprof-csv
- cargo test -p dataprof-engines
- cargo test -p dataprof-parquet --features arrow
- cargo test --test cross_engine_consistency
- cargo test -p dataprof-python
- cargo clippy --all --all-targets -- -D warnings
- cargo fmt --all -- --check
- uv run pytest python/tests/ -q — 1,012 passed, 9 expected skips
- uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
- uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
- uv run ty check python/
- cargo package -p dataprof --allow-dirty --no-verify

Clippy was run with local rustc 1.97.0; CI remains authoritative on the pinned 1.98 toolchain.

## Follow-up

#627 tracks the separate text-length unit decision found during the same dogfood pass. It is deliberately not changed here because choosing UTF-8 bytes, Unicode scalar values, or grapheme clusters changes the serialized numeric contract.
