### PR TITLE
fix(metrics)!: withhold evidence for dimensions that assessed nothing

### DIFF
--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -157,8 +157,13 @@ pub struct PrecisionMetrics {
 /// reported. `None` means "not analyzed"; it is not a score of 100.
 ///
 /// This is the single definition of "assessed" behind the dimension scores,
-/// [`QualityMetrics::assessed_dimensions`], the serialized report and the
-/// Python evidence accessors.
+/// the serialized report and the Python evidence accessors.
+///
+/// [`QualityMetrics::assessed_dimensions`] applies it and then narrows further,
+/// to the dimensions carrying a positive score weight, because it answers what
+/// is behind [`QualityMetrics::overall_score`] rather than what was measured. A
+/// dimension weighted `0.0` is assessed and reported while contributing nothing
+/// to the aggregate.
 pub(crate) trait Assessed {
     fn assessed(&self) -> bool;
 }
@@ -1090,7 +1095,40 @@ mod tests {
     }
 
     #[test]
-    fn serialized_dimensions_are_exactly_the_assessed_ones() {
+    fn a_zero_weighted_dimension_keeps_its_evidence() {
+        // Serialization asks "did this measure anything", which is a wider
+        // question than "is this behind the overall score". A weight of 0.0
+        // removes a dimension from `assessed_dimensions` and from the
+        // aggregate, and removes nothing from what it actually observed.
+        let mut metrics = QualityMetrics::empty();
+        metrics.validity = Some(ValidityMetrics {
+            valid_values_ratio: 80.0,
+            invalid_values: 2,
+            values_checked: 10,
+        });
+        metrics.score_weights = QualityScoreWeights {
+            validity: 0.0,
+            ..QualityScoreWeights::default()
+        };
+
+        assert!(metrics.validity.as_ref().expect("present").is_assessed());
+        assert!(metrics.validity_score().is_some());
+        assert!(
+            !metrics
+                .assessed_dimensions()
+                .contains(&QualityDimension::Validity)
+        );
+        assert_eq!(metrics.overall_score(), None);
+
+        let json = serde_json::to_string(&metrics).unwrap();
+        assert!(
+            json.contains("valid_values_ratio"),
+            "a measured dimension was dropped for carrying no weight: {json}"
+        );
+    }
+
+    #[test]
+    fn serialized_dimensions_are_exactly_the_ones_with_a_denominator() {
         let mut metrics = QualityMetrics::empty();
         metrics.completeness = Some(CompletenessMetrics {
             missing_values_ratio: 10.0,

--- a/crates/dataprof-metrics/src/quality.rs
+++ b/crates/dataprof-metrics/src/quality.rs
@@ -148,22 +148,112 @@ pub struct PrecisionMetrics {
     pub numeric_values_checked: usize,
 }
 
+/// Whether a dimension's metrics were computed against anything.
+///
+/// Every dimension carries the counter it divides by, and a zero there means
+/// the dimension had nothing to assess: no cells, no non-null values, no
+/// numeric values, no dates, no confidently detected pattern. Its ratios are
+/// then defaults rather than measurements, so they are withheld instead of
+/// reported. `None` means "not analyzed"; it is not a score of 100.
+///
+/// This is the single definition of "assessed" behind the dimension scores,
+/// [`QualityMetrics::assessed_dimensions`], the serialized report and the
+/// Python evidence accessors.
+pub(crate) trait Assessed {
+    fn assessed(&self) -> bool;
+}
+
+/// Serde predicate: skip a dimension that assessed nothing.
+fn is_unassessed<T: Assessed>(metrics: &Option<T>) -> bool {
+    metrics.as_ref().is_none_or(|metrics| !metrics.assessed())
+}
+
+impl CompletenessMetrics {
+    /// True when at least one cell was examined.
+    pub fn is_assessed(&self) -> bool {
+        self.total_cells > 0
+    }
+}
+
+impl ConsistencyMetrics {
+    /// True when at least one non-null value was examined.
+    pub fn is_assessed(&self) -> bool {
+        self.values_checked > 0
+    }
+}
+
+impl UniquenessMetrics {
+    /// True when either component had data: rows scanned for duplicates, or an
+    /// identified key column whose uniqueness `key_uniqueness` describes.
+    pub fn is_assessed(&self) -> bool {
+        self.rows_checked > 0 || self.key_column.is_some()
+    }
+}
+
+impl AccuracyMetrics {
+    /// True when at least one finite numeric value was examined.
+    pub fn is_assessed(&self) -> bool {
+        self.numeric_values_checked > 0
+    }
+}
+
+impl TimelinessMetrics {
+    /// True when at least one value in a temporal column was examined.
+    pub fn is_assessed(&self) -> bool {
+        self.date_values_checked > 0
+    }
+}
+
+impl ValidityMetrics {
+    /// True when at least one value was checked against a dominant pattern.
+    pub fn is_assessed(&self) -> bool {
+        self.values_checked > 0
+    }
+}
+
+impl PrecisionMetrics {
+    /// True when at least one parseable float was examined.
+    pub fn is_assessed(&self) -> bool {
+        self.numeric_values_checked > 0
+    }
+}
+
+macro_rules! impl_assessed {
+    ($($metrics:ty),+ $(,)?) => {
+        $(impl Assessed for $metrics {
+            fn assessed(&self) -> bool {
+                self.is_assessed()
+            }
+        })+
+    };
+}
+
+impl_assessed!(
+    CompletenessMetrics,
+    ConsistencyMetrics,
+    UniquenessMetrics,
+    AccuracyMetrics,
+    TimelinessMetrics,
+    ValidityMetrics,
+    PrecisionMetrics,
+);
+
 /// Comprehensive data quality metrics following industry standards.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct QualityMetrics {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub completeness: Option<CompletenessMetrics>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub consistency: Option<ConsistencyMetrics>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub uniqueness: Option<UniquenessMetrics>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub accuracy: Option<AccuracyMetrics>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub timeliness: Option<TimelinessMetrics>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub validity: Option<ValidityMetrics>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "is_unassessed")]
     pub precision: Option<PrecisionMetrics>,
     /// True when the sample used to compute these metrics was below the
     /// minimum recommended size (10 rows). When set, the quality scores and
@@ -248,10 +338,7 @@ impl QualityMetrics {
     /// Mean of cell-level completeness (`100 - missing_values_ratio`) and
     /// row-level completeness (`complete_records_ratio`).
     pub fn completeness_score(&self) -> Option<f64> {
-        let c = self.completeness.as_ref()?;
-        if c.total_cells == 0 {
-            return None;
-        }
+        let c = self.completeness.as_ref().filter(|c| c.is_assessed())?;
         let cell_level = 100.0 - c.missing_values_ratio;
         Some(((cell_level + c.complete_records_ratio) / 2.0).clamp(0.0, 100.0))
     }
@@ -262,10 +349,7 @@ impl QualityMetrics {
     /// Type consistency, penalized by format violations and encoding issues
     /// as a share of the values checked.
     pub fn consistency_score(&self) -> Option<f64> {
-        let c = self.consistency.as_ref()?;
-        if c.values_checked == 0 {
-            return None;
-        }
+        let c = self.consistency.as_ref().filter(|c| c.is_assessed())?;
         let violation_ratio =
             (c.format_violations + c.encoding_issues) as f64 / c.values_checked as f64;
         Some((c.data_type_consistency - violation_ratio * 100.0).clamp(0.0, 100.0))
@@ -280,7 +364,7 @@ impl QualityMetrics {
     /// a row tracker whose samples cannot be proven row-aligned contribute
     /// only the key component.
     pub fn uniqueness_score(&self) -> Option<f64> {
-        let u = self.uniqueness.as_ref()?;
+        let u = self.uniqueness.as_ref().filter(|u| u.is_assessed())?;
         let duplicate_score = (u.rows_checked > 0)
             .then(|| (1.0 - u.duplicate_rows as f64 / u.rows_checked as f64) * 100.0);
         let key_score = u.key_column.is_some().then_some(u.key_uniqueness);
@@ -302,10 +386,7 @@ impl QualityMetrics {
     /// values in positive-only columns as a share of the numeric values
     /// checked.
     pub fn accuracy_score(&self) -> Option<f64> {
-        let a = self.accuracy.as_ref()?;
-        if a.numeric_values_checked == 0 {
-            return None;
-        }
+        let a = self.accuracy.as_ref().filter(|a| a.is_assessed())?;
         let violation_ratio = (a.range_violations + a.negative_values_in_positive) as f64
             / a.numeric_values_checked as f64;
         Some((100.0 - a.outlier_ratio - violation_ratio * 100.0).clamp(0.0, 100.0))
@@ -319,10 +400,7 @@ impl QualityMetrics {
     /// the date values checked and by temporal ordering violations as a
     /// share of the pairs actually compared.
     pub fn timeliness_score(&self) -> Option<f64> {
-        let t = self.timeliness.as_ref()?;
-        if t.date_values_checked == 0 {
-            return None;
-        }
+        let t = self.timeliness.as_ref().filter(|t| t.is_assessed())?;
         let value_violation_ratio =
             (t.future_dates_count + t.invalid_date_values) as f64 / t.date_values_checked as f64;
         let temporal_ratio = if t.temporal_pairs_checked > 0 {
@@ -339,16 +417,15 @@ impl QualityMetrics {
     /// Score for semantic-pattern validity (0-100), or `None` when no column
     /// had a confidently detected pattern to validate.
     pub fn validity_score(&self) -> Option<f64> {
-        let validity = self.validity.as_ref()?;
-        (validity.values_checked > 0).then_some(validity.valid_values_ratio.clamp(0.0, 100.0))
+        let validity = self.validity.as_ref().filter(|v| v.is_assessed())?;
+        Some(validity.valid_values_ratio.clamp(0.0, 100.0))
     }
 
     /// Score for decimal-scale precision consistency (0-100), or `None` when
     /// no floating-point values were available to assess.
     pub fn precision_score(&self) -> Option<f64> {
-        let precision = self.precision.as_ref()?;
-        (precision.numeric_values_checked > 0)
-            .then_some(precision.decimal_places_consistency.clamp(0.0, 100.0))
+        let precision = self.precision.as_ref().filter(|p| p.is_assessed())?;
+        Some(precision.decimal_places_consistency.clamp(0.0, 100.0))
     }
 
     /// Weighted components of the overall score: `(dimension, weight, score)`.
@@ -972,7 +1049,10 @@ mod tests {
     #[test]
     fn test_partial_dimensions_json_skips_none() {
         let metrics = QualityMetrics {
-            completeness: Some(CompletenessMetrics::default()),
+            completeness: Some(CompletenessMetrics {
+                total_cells: 10,
+                ..CompletenessMetrics::default()
+            }),
             ..QualityMetrics::default()
         };
 
@@ -982,6 +1062,94 @@ mod tests {
         assert!(!json.contains("uniqueness"));
         assert!(!json.contains("accuracy"));
         assert!(!json.contains("timeliness"));
+    }
+
+    #[test]
+    fn a_dimension_with_no_denominator_is_not_serialized() {
+        // `empty()` builds every dimension with zero counters, which is what an
+        // engine produces for a header-only file. Serializing those defaults
+        // published `valid_values_ratio: 100.0` from `values_checked: 0` (#622).
+        let metrics = QualityMetrics::empty();
+        assert!(metrics.assessed_dimensions().is_empty());
+
+        let json = serde_json::to_string(&metrics).unwrap();
+        for dimension in [
+            "completeness",
+            "consistency",
+            "uniqueness",
+            "accuracy",
+            "timeliness",
+            "validity",
+            "precision",
+        ] {
+            assert!(
+                !json.contains(dimension),
+                "{dimension} was serialized without having assessed anything: {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn serialized_dimensions_are_exactly_the_assessed_ones() {
+        let mut metrics = QualityMetrics::empty();
+        metrics.completeness = Some(CompletenessMetrics {
+            missing_values_ratio: 10.0,
+            complete_records_ratio: 90.0,
+            null_columns: vec!["a".to_string()],
+            total_cells: 100,
+        });
+        metrics.validity = Some(ValidityMetrics {
+            valid_values_ratio: 80.0,
+            invalid_values: 2,
+            values_checked: 10,
+        });
+
+        let assessed = metrics.assessed_dimensions();
+        assert_eq!(
+            assessed,
+            vec![QualityDimension::Completeness, QualityDimension::Validity]
+        );
+
+        let json = serde_json::to_string(&metrics).unwrap();
+        assert!(json.contains("completeness"));
+        assert!(json.contains("validity"));
+        assert!(!json.contains("consistency"));
+        assert!(!json.contains("precision"));
+    }
+
+    #[test]
+    fn is_assessed_agrees_with_the_dimension_score() {
+        // One definition of "assessed" behind both, so a score can never be
+        // None while its evidence claims to have measured something.
+        let assessed = QualityMetrics {
+            uniqueness: Some(UniquenessMetrics {
+                duplicate_rows: 0,
+                key_uniqueness: 100.0,
+                high_cardinality_warning: false,
+                rows_checked: 0,
+                // No rows scanned, but a key column was identified, so the key
+                // component alone still carries a measurement.
+                key_column: Some("id".to_string()),
+                duplicate_rows_approximate: false,
+            }),
+            ..QualityMetrics::default()
+        };
+        let uniqueness = assessed.uniqueness.as_ref().expect("present");
+        assert!(uniqueness.is_assessed());
+        assert!(assessed.uniqueness_score().is_some());
+
+        let unassessed = QualityMetrics::empty();
+        for metrics in [
+            unassessed.completeness.as_ref().map(|m| m.is_assessed()),
+            unassessed.consistency.as_ref().map(|m| m.is_assessed()),
+            unassessed.uniqueness.as_ref().map(|m| m.is_assessed()),
+            unassessed.accuracy.as_ref().map(|m| m.is_assessed()),
+            unassessed.timeliness.as_ref().map(|m| m.is_assessed()),
+            unassessed.validity.as_ref().map(|m| m.is_assessed()),
+            unassessed.precision.as_ref().map(|m| m.is_assessed()),
+        ] {
+            assert_eq!(metrics, Some(false));
+        }
     }
 
     #[test]

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -447,13 +447,17 @@ impl PyDataQualityMetrics {
 
     // -- Nested dimension accessors (composable API) --
 
-    /// Completeness evidence, or None when the dimension was not assessed.
+    /// Completeness evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn completeness(
         &self,
@@ -496,13 +500,17 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Consistency evidence, or None when the dimension was not assessed.
+    /// Consistency evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn consistency(
         &self,
@@ -538,13 +546,17 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Uniqueness evidence, or None when the dimension was not assessed.
+    /// Uniqueness evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn uniqueness(
         &self,
@@ -597,13 +609,17 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Accuracy evidence, or None when the dimension was not assessed.
+    /// Accuracy evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn accuracy(
         &self,
@@ -642,13 +658,17 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Timeliness evidence, or None when the dimension was not assessed.
+    /// Timeliness evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn timeliness(
         &self,
@@ -692,13 +712,17 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Validity evidence, or None when the dimension was not assessed.
+    /// Validity evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn validity(
         &self,
@@ -727,13 +751,17 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Precision evidence, or None when the dimension was not assessed.
+    /// Precision evidence, or None when the dimension assessed nothing.
     ///
-    /// Absent whenever the dimension is missing from
-    /// `assessed_dimensions()`: either it was not computed, or it had no
-    /// denominator to divide by. Its ratios would be defaults rather than
-    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
-    /// health for something nobody looked at (#622).
+    /// Present exactly when the dimension had a denominator to divide by,
+    /// which is exactly when its `dimension_scores()` entry is a number.
+    /// Otherwise its ratios would be defaults rather than measurements, and
+    /// a 100.0 out of zero checks reads as a clean bill of health for
+    /// something nobody looked at (#622).
+    ///
+    /// `assessed_dimensions()` is that set narrowed to the dimensions
+    /// carrying weight in the overall score, so the two coincide under the
+    /// default weights but not under a custom zero weight.
     #[getter]
     fn precision(
         &self,

--- a/crates/dataprof-python/src/types.rs
+++ b/crates/dataprof-python/src/types.rs
@@ -447,7 +447,13 @@ impl PyDataQualityMetrics {
 
     // -- Nested dimension accessors (composable API) --
 
-    /// Completeness dimension dict, or None if not computed.
+    /// Completeness evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn completeness(
         &self,
@@ -456,6 +462,7 @@ impl PyDataQualityMetrics {
         self.inner
             .completeness
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|c| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(
@@ -489,7 +496,13 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Consistency dimension dict, or None if not computed.
+    /// Consistency evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn consistency(
         &self,
@@ -498,6 +511,7 @@ impl PyDataQualityMetrics {
         self.inner
             .consistency
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|c| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(
@@ -524,7 +538,13 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Uniqueness dimension dict, or None if not computed.
+    /// Uniqueness evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn uniqueness(
         &self,
@@ -533,6 +553,7 @@ impl PyDataQualityMetrics {
         self.inner
             .uniqueness
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|u| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(
@@ -576,7 +597,13 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Accuracy dimension dict, or None if not computed.
+    /// Accuracy evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn accuracy(
         &self,
@@ -585,6 +612,7 @@ impl PyDataQualityMetrics {
         self.inner
             .accuracy
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|a| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(
@@ -614,7 +642,13 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Timeliness dimension dict, or None if not computed.
+    /// Timeliness evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn timeliness(
         &self,
@@ -623,6 +657,7 @@ impl PyDataQualityMetrics {
         self.inner
             .timeliness
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|t| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(
@@ -657,7 +692,13 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Validity dimension dict, or None if not computed.
+    /// Validity evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn validity(
         &self,
@@ -666,6 +707,7 @@ impl PyDataQualityMetrics {
         self.inner
             .validity
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|v| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(
@@ -685,7 +727,13 @@ impl PyDataQualityMetrics {
             .transpose()
     }
 
-    /// Precision dimension dict, or None if not computed.
+    /// Precision evidence, or None when the dimension was not assessed.
+    ///
+    /// Absent whenever the dimension is missing from
+    /// `assessed_dimensions()`: either it was not computed, or it had no
+    /// denominator to divide by. Its ratios would be defaults rather than
+    /// measurements, and a 100.0 out of zero checks reads as a clean bill of
+    /// health for something nobody looked at (#622).
     #[getter]
     fn precision(
         &self,
@@ -694,6 +742,7 @@ impl PyDataQualityMetrics {
         self.inner
             .precision
             .as_ref()
+            .filter(|metrics| metrics.is_assessed())
             .map(|p| -> PyResult<_> {
                 let mut m = std::collections::BTreeMap::new();
                 m.insert(

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -414,7 +414,7 @@ print(q.overall_quality_score())
 print(q.assessed_dimensions())
 print(q.score_weights)  # relative weights used by dataprof's aggregate formula
 
-# Nested dimension accessors (None when not computed)
+# Nested dimension evidence (None when the dimension was not assessed)
 print(q.completeness)    # {"missing_values_ratio": ..., "complete_records_ratio": ..., "null_columns": [...]}
 print(q.consistency)     # {"data_type_consistency": ..., "format_violations": ..., "encoding_issues": ...}
 print(q.uniqueness)      # {"duplicate_rows": ..., "key_uniqueness": ..., "high_cardinality_warning": ...}
@@ -423,6 +423,19 @@ print(q.timeliness)      # {"future_dates_count": ..., "stale_data_ratio": ..., 
 print(q.validity)        # {"valid_values_ratio": ..., "invalid_values": ..., "values_checked": ...}
 print(q.precision)       # {"decimal_places_consistency": ..., "inconsistent_precision_values": ..., "numeric_values_checked": ...}
 ```
+
+A dimension's evidence is present only when it assessed something. `None` covers
+both "not computed" and "computed with nothing to divide by": no cells, no
+non-null values, no numeric values, no dates, no confidently detected pattern.
+The dimensions holding evidence are exactly `assessed_dimensions()`, and exactly
+the ones whose `dimension_scores()` entry is a number.
+
+That distinction is the point rather than a technicality. `validity` reporting
+`valid_values_ratio: 100.0` from `values_checked: 0` reads as a clean bill of
+health for something nobody looked at, and any file without a pattern-bearing
+column used to report exactly that. Serialized reports follow the same rule: an
+unassessed dimension has no key, so a stored report cannot be read as a perfect
+score either.
 
 Flat `DataQualityMetrics` accessors are deprecated in 0.9. Use nested
 dimensions so skipped dimensions are explicit:

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -427,8 +427,15 @@ print(q.precision)       # {"decimal_places_consistency": ..., "inconsistent_pre
 A dimension's evidence is present only when it assessed something. `None` covers
 both "not computed" and "computed with nothing to divide by": no cells, no
 non-null values, no numeric values, no dates, no confidently detected pattern.
-The dimensions holding evidence are exactly `assessed_dimensions()`, and exactly
-the ones whose `dimension_scores()` entry is a number.
+The dimensions holding evidence are exactly the ones whose `dimension_scores()`
+entry is a number.
+
+`assessed_dimensions()` is that set narrowed once more, to the dimensions
+carrying weight in the overall score. The two coincide under the default
+weights; a dimension given a weight of `0.0` still holds evidence and a score
+while sitting outside `assessed_dimensions()`, because it contributes nothing to
+the aggregate. Branch on `dimension_scores()` to ask "was this measured", and on
+`assessed_dimensions()` to ask "is this behind the overall score".
 
 That distinction is the point rather than a technicality. `validity` reporting
 `valid_values_ratio: 100.0` from `values_checked: 0` reads as a clean bill of

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -220,5 +220,12 @@ column published `validity.valid_values_ratio: 100.0` beside
 No property was added, removed or retyped, so the schema document is unchanged
 and stored reports remain valid. What changed is which optional properties
 appear: a consumer that assumed every dimension key was present must read it as
-optional, and the presence of a dimension key now means the same thing as its
-name appearing in `assessed_dimensions`.
+optional. A dimension key is present exactly when that dimension had a positive
+denominator, which is exactly when its `dimension_scores` entry is a number.
+
+That is a slightly wider set than `assessed_dimensions`, which additionally
+filters on a positive score weight. Under the default weights the two agree; a
+dimension configured with a weight of `0.0` is assessed and serialized while
+contributing nothing to `overall_score`, so it is absent from
+`assessed_dimensions`. Read a dimension's presence as "this was measured", not
+as "this is behind the overall score".

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -206,3 +206,19 @@ Both are widenings, so stored v1 reports remain valid. Consumers that read
 `MetricConfidence` must accept `"NotAssessed"`; in both cases the signal is
 "not assessed", never zero. `assessed_dimensions` is empty for exactly these
 reports and is the authority to branch on.
+
+## v1 behaviour change: unassessed dimensions are omitted
+
+The seven quality dimension objects (`completeness`, `consistency`,
+`uniqueness`, `accuracy`, `timeliness`, `validity`, `precision`) were already
+optional in both dialects, and are now genuinely absent when the dimension
+assessed nothing. Previously a dimension was emitted whenever its metric struct
+existed, which is whenever it was requested, so a file with no pattern-bearing
+column published `validity.valid_values_ratio: 100.0` beside
+`values_checked: 0`.
+
+No property was added, removed or retyped, so the schema document is unchanged
+and stored reports remain valid. What changed is which optional properties
+appear: a consumer that assumed every dimension key was present must read it as
+optional, and the presence of a dimension key now means the same thing as its
+name appearing in `assessed_dimensions`.

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -717,12 +717,18 @@ class TestProfileReport:
         q = report.quality
         assert q is not None
         nested = getattr(q, dimension)
-        assert nested is not None
 
         with pytest.warns(DeprecationWarning, match=f"DataQualityMetrics\\.{attr}"):
             value = getattr(q, attr)
 
-        assert value == nested.get(key, default)
+        if nested is None:
+            # The dimension assessed nothing, so there is no evidence to agree
+            # with (#622). The deprecated flat accessor keeps substituting its
+            # documented default until #509 settles its end state, which is the
+            # divergence that made the evidence dicts worth withholding.
+            assert value == default
+        else:
+            assert value == nested.get(key, default)
 
     @pytest.mark.parametrize(
         ("dims", "present", "absent"),

--- a/python/tests/test_unassessed_dimension_evidence.py
+++ b/python/tests/test_unassessed_dimension_evidence.py
@@ -1,0 +1,172 @@
+"""An unassessed dimension reports no evidence, on every accessor.
+
+`assessed_dimensions()` is the authority on what was computed, and the
+interpretation guide tells readers not to report a value for a dimension that is
+missing from it. The per-dimension evidence accessors used to ignore that and
+hand back a populated dict of ratios derived from zero inputs: a header-only file
+reported 100% on five dimensions, and any ordinary file with no pattern-bearing
+column reported `valid_values_ratio: 100.0` from `values_checked: 0` (#622).
+
+Reporting 100% from zero checks is the same error as reporting "0% valid" for an
+unpatterned column, with the opposite sign. Both invent a number where the honest
+answer is "not analyzed", which is what `None` means here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import dataprof
+import pytest
+
+HEADER_ONLY = "id,amount\n"
+# Numeric only, so validity (no confident pattern) and timeliness (no dates)
+# have nothing to assess while the rest of the dimensions do.
+NUMERIC_ROWS = "id,amount\n1,3.5\n2,4.5\n3,5.5\n"
+
+DIMENSIONS = (
+    "completeness",
+    "consistency",
+    "uniqueness",
+    "accuracy",
+    "timeliness",
+    "validity",
+    "precision",
+)
+
+# The counter each dimension divides by. A dimension that reports evidence must
+# have looked at something.
+DENOMINATORS = {
+    "completeness": ("total_cells",),
+    "consistency": ("values_checked",),
+    "uniqueness": ("rows_checked",),
+    "accuracy": ("numeric_values_checked",),
+    "timeliness": ("date_values_checked",),
+    "validity": ("values_checked",),
+    "precision": ("numeric_values_checked",),
+}
+
+
+def write(tmp_path, name: str, contents: str):
+    path = tmp_path / name
+    path.write_text(contents, encoding="utf-8", newline="")
+    return path
+
+
+@pytest.fixture
+def unassessable(tmp_path):
+    return dataprof.profile(write(tmp_path, "empty.csv", HEADER_ONLY))
+
+
+@pytest.fixture
+def partly_assessed(tmp_path):
+    return dataprof.profile(write(tmp_path, "numeric.csv", NUMERIC_ROWS))
+
+
+def test_an_unassessable_report_has_no_evidence_at_all(unassessable) -> None:
+    quality = unassessable.quality
+    assert quality is not None
+    assert quality.assessed_dimensions() == []
+
+    for dimension in DIMENSIONS:
+        assert getattr(quality, dimension) is None, (
+            f"{dimension} reported evidence on a file where nothing was assessed"
+        )
+
+
+def test_only_the_unassessed_dimensions_are_withheld(partly_assessed) -> None:
+    quality = partly_assessed.quality
+    assert quality is not None
+
+    assessed = set(quality.assessed_dimensions())
+    assert assessed, "fixture must assess something"
+    assert {"validity", "timeliness"}.isdisjoint(assessed), (
+        "fixture must leave validity and timeliness unassessed"
+    )
+
+    for dimension in DIMENSIONS:
+        evidence = getattr(quality, dimension)
+        if dimension in assessed:
+            assert isinstance(evidence, dict), f"{dimension} was assessed but reports nothing"
+        else:
+            assert evidence is None, f"{dimension} reports evidence it did not gather"
+
+
+@pytest.mark.parametrize("contents", [HEADER_ONLY, NUMERIC_ROWS])
+def test_evidence_and_dimension_scores_agree(tmp_path, contents: str) -> None:
+    # Two accessors over the same underlying counters. They used to disagree:
+    # a None score beside a populated evidence dict.
+    report = dataprof.profile(write(tmp_path, "agree.csv", contents))
+    quality = report.quality
+    assert quality is not None
+
+    scores = quality.dimension_scores()
+    for dimension in DIMENSIONS:
+        has_evidence = getattr(quality, dimension) is not None
+        assert has_evidence == (scores[dimension] is not None), (
+            f"{dimension}: evidence and score disagree about whether it was assessed"
+        )
+
+
+@pytest.mark.parametrize("contents", [HEADER_ONLY, NUMERIC_ROWS])
+def test_no_reported_ratio_comes_from_zero_inputs(tmp_path, contents: str) -> None:
+    # The acceptance criterion stated directly: every dimension that reports
+    # anything looked at something first.
+    report = dataprof.profile(write(tmp_path, "denominators.csv", contents))
+    quality = report.quality
+    assert quality is not None
+
+    for dimension in DIMENSIONS:
+        evidence = getattr(quality, dimension)
+        if evidence is None:
+            continue
+        counters = [evidence[name] for name in DENOMINATORS[dimension]]
+        if dimension == "uniqueness":
+            # Uniqueness averages whichever of its two components has data, so
+            # a named key column is a denominator of its own.
+            counters.append(1 if evidence.get("key_column") is not None else 0)
+        assert any(counter > 0 for counter in counters), (
+            f"{dimension} reported evidence with every denominator at zero: {evidence}"
+        )
+
+
+def test_the_serialized_report_omits_unassessed_dimensions(partly_assessed) -> None:
+    quality = partly_assessed.to_dict()["quality"]
+    assessed = set(quality["assessed_dimensions"])
+
+    for dimension in DIMENSIONS:
+        assert (dimension in quality) == (dimension in assessed), (
+            f"{dimension} disagrees between the evidence keys and assessed_dimensions"
+        )
+
+    from_json = json.loads(partly_assessed.to_json())["quality"]
+    assert set(from_json) & set(DIMENSIONS) == assessed
+
+
+def test_an_unassessable_report_serializes_no_dimension_keys(unassessable) -> None:
+    quality = unassessable.to_dict()["quality"]
+
+    # The aggregate keys stay, carrying null rather than a fabricated zero.
+    assert quality["overall_score"] is None
+    assert quality["assessed_dimensions"] == []
+    assert set(quality) & set(DIMENSIONS) == set()
+
+
+def test_a_reloaded_report_reads_back_the_same_absence(partly_assessed) -> None:
+    reloaded = dataprof.ProfileReport.from_dict(partly_assessed.to_dict())
+    quality = reloaded.quality
+    assert quality is not None
+
+    assert quality.assessed_dimensions() == partly_assessed.quality.assessed_dimensions()
+    for dimension in DIMENSIONS:
+        original = getattr(partly_assessed.quality, dimension)
+        assert (getattr(quality, dimension) is None) == (original is None), (
+            f"{dimension} changed its assessed state across a round trip"
+        )
+
+
+def test_the_agent_facing_exports_are_unchanged(unassessable, partly_assessed) -> None:
+    # These were already honest, and the fix must not disturb them.
+    assert unassessable.quality_summary()["quality_score"] is None
+    assert "quality: n/a" in unassessable.to_llm_context()
+    assert partly_assessed.quality_summary()["quality_score"] == pytest.approx(100.0)

--- a/tests/fixtures/report_rounding_parity.json
+++ b/tests/fixtures/report_rounding_parity.json
@@ -42,7 +42,7 @@
       "variance": 6.4484
     }
   },
-  "description": "Rounded floats both layers must emit for tests/fixtures/rounding_parity.csv (#513). tests/report_rounding_parity.rs asserts the Rust report against this file and python/tests/test_rounding_parity.py asserts ProfileReport.to_dict() against it, so a precision or tie-breaking change on either side fails.",
+  "description": "Rounded floats both layers must emit for tests/fixtures/rounding_parity.csv (#513). No column in the fixture carries a confident semantic pattern, so validity assesses nothing and is absent from both layers rather than reporting 100% of zero checks (#622). tests/report_rounding_parity.rs asserts the Rust report against this file and python/tests/test_rounding_parity.py asserts ProfileReport.to_dict() against it, so a precision or tie-breaking change on either side fails.",
   "quality": {
     "accuracy": {
       "outlier_ratio": 0.0
@@ -59,9 +59,6 @@
     },
     "uniqueness": {
       "key_uniqueness": 100.0
-    },
-    "validity": {
-      "valid_values_ratio": 100.0
     }
   }
 }


### PR DESCRIPTION
Closes #622.

## The problem

A dimension's metric struct exists whenever the dimension was requested, denominators or not. The evidence accessors read the struct and handed back its defaults as if they were measurements:

```
# id,amount\n  (header only)
assessed_dimensions() -> []
quality.validity      -> {'valid_values_ratio': 100.0, 'invalid_values': 0, 'values_checked': 0}
```

Not confined to degenerate inputs. Any file with no pattern-bearing column reported `valid_values_ratio: 100.0` from `values_checked: 0`, and a three-row numeric CSV reported timeliness evidence with no dates in it. Reporting 100% from zero checks is the same error as reporting "0% valid" for an unpatterned column, with the opposite sign, and the interpretation guide already calls the second one out by name.

## The change

`is_assessed()` on each dimension's metrics struct is now the single definition of "assessed":

- the dimension scores in `QualityMetrics` gate on it instead of each re-testing its own counter;
- serde skips a dimension that assessed nothing (`skip_serializing_if = "is_unassessed"`);
- the Python evidence getters return `None` for it.

Three surfaces that used to test the same idea three ways, or not at all, now cannot drift apart. `to_dict()` already emitted a dimension only when its accessor returned something, so the Python serialization follows without a change there.

Chose option 1 from the issue (withhold the dimension) over option 2 (keep the dict, null the ratios). It matches `dimension_scores()` exactly, and the repo's own language settles it: a column with no detected pattern is *unassessed*, not "analysed, found nothing", so the None-means-not-analyzed contract applies rather than the empty-means-nothing-found one.

## Deliberately not changed

- **The Rust struct fields stay public and stay `Some`.** `is_assessed()` is public so Rust callers have the predicate, but turning the fields into accessors is #509/#516's job, not this one. The examples that read them (`etl_quality_gate`, `messy_csv_inspection`, `before_after_cleaning`) read counters and thresholds, so zero denominators do not make them fire.
- **The deprecated flat accessors keep their documented defaults.** `q.key_uniqueness` still returns 100.0 with a `DeprecationWarning` when uniqueness assessed nothing. That divergence is the reason the evidence dicts were worth withholding, and #509 owns its end state.
- **`assessed_dimensions()` keeps its weight filter.** It answers "what is behind the overall score", so a dimension with a zero weight is correctly absent from it while still holding evidence. The evidence accessors key off "had a denominator", which is what `dimension_scores()` reports. With default weights the two coincide. Copilot caught the docs claiming those two sets were identical; 4aa6477 corrects the seven docstrings and both guides, and `a_zero_weighted_dimension_keeps_its_evidence` now holds the distinction to a test.

## Schema

The seven dimension objects were already optional in both dialects, so `cargo run --example generate_profile_schema` produces no diff and stored v1 reports stay valid. What changed is that the optional properties are now genuinely absent, which `docs/schema/README.md` now records.

## Verification

New `python/tests/test_unassessed_dimension_evidence.py` (10 tests): every accessor withholds on an unassessable report; only the unassessed dimensions are withheld on a partly assessed one; evidence and `dimension_scores()` agree per dimension; every emitted dimension has a positive denominator; the serialized keys equal `assessed_dimensions`; round trip preserves the absence; the agent-facing exports are unchanged.

Reverted each half separately rather than together:

- serde half reverted alone: the two new tests in `quality.rs` fail, Python stays green.
- PyO3 half reverted alone: 8 of the 10 new Python tests fail, Rust stays green.

One gap worth stating rather than implying: after dropping the fabricated `validity` entry from `tests/fixtures/report_rounding_parity.json`, the Python rounding-parity test no longer discriminates a regression of the PyO3 half, because it iterates the fixture's expectations and does not assert the reverse inclusion. The new test file covers that directly.

Two pre-existing tests needed updating, both because they asserted the old behaviour:

- `test_quality_flat_accessors_warn_and_match_nested` asserted `nested is not None` for timeliness on a dateless fixture. It now checks that the flat accessor returns its default when the dimension assessed nothing.
- `tests/fixtures/report_rounding_parity.json` listed `validity.valid_values_ratio: 100.0` for a fixture with no pattern-bearing column, i.e. the bug itself, held identically against both layers.

## Commands run

```
cargo test --workspace                 # 774 passed, 0 failed
uv run pytest python/tests/ -q         # 1032 passed, 9 skipped
cargo run --example generate_profile_schema   # no diff
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
uv run ruff format / ruff check / ty check
```

