### PR TITLE
fix(metrics)!: count text lengths in Unicode scalar values, not UTF-8 bytes

### DIFF
--- a/crates/dataprof-core/src/lib.rs
+++ b/crates/dataprof-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod semantic;
 pub mod serde_helpers;
 pub mod source;
 pub mod stop_condition;
+pub mod text_units;
 pub mod validation;
 
 pub use analysis_options::AnalysisOptions;
@@ -60,4 +61,5 @@ pub use source::{
 pub use stop_condition::{
     SchemaStabilityTracker, StopCondition, StopEvaluator, schema_stable_threshold,
 };
+pub use text_units::char_len;
 pub use validation::{InputValidator, ValidationError, exit_codes, validate_unique_column_names};

--- a/crates/dataprof-core/src/profile.rs
+++ b/crates/dataprof-core/src/profile.rs
@@ -163,12 +163,20 @@ impl NumericStats {
 }
 
 /// Statistics for text/string columns.
+///
+/// Every length here is a count of Unicode scalar values, not UTF-8 bytes and
+/// not grapheme clusters. ASCII text is unaffected by that distinction; a
+/// combining sequence counts each scalar, so the decomposed and precomposed
+/// spellings of the same word report different lengths. The `text_units` module
+/// carries the reasoning.
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct TextStats {
+    /// Shortest value, in Unicode scalar values.
     pub min_length: usize,
+    /// Longest value, in Unicode scalar values.
     pub max_length: usize,
-    // A mean, so it rounds at the statistics precision rather than the
-    // percentage one.
+    /// Mean length in Unicode scalar values. A mean, so it rounds at the
+    /// statistics precision rather than the percentage one.
     #[serde(serialize_with = "crate::serde_helpers::round_4")]
     pub avg_length: f64,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/dataprof-core/src/text_units.rs
+++ b/crates/dataprof-core/src/text_units.rs
@@ -1,0 +1,73 @@
+//! The unit every reported text length is measured in.
+//!
+//! `TextStats::min_length`, `max_length` and `avg_length` count **Unicode
+//! scalar values**, not UTF-8 bytes and not grapheme clusters.
+//!
+//! Bytes were the accidental unit until 0.12: every accumulator reached for
+//! Rust's `str::len()`, so `"東京"` reported a length of 6 and `"🙂"` a length
+//! of 4 under a field named `max_length` (#627). The counts were consistent
+//! across every engine, and consistently surprising for anything but ASCII.
+//!
+//! Scalar values are the least surprising interpretation that costs no
+//! dependency. Grapheme clusters are closer to what a reader would call a
+//! character — `"e\u{0301}"` is one grapheme and two scalars — but segmenting
+//! them correctly needs a Unicode segmentation table and a policy for which
+//! version of it, which is a larger commitment than a profiler's length field
+//! justifies. Encoded size is a property of the encoding rather than the value,
+//! and is available at the source level; it is deliberately not reported under
+//! a name like "length".
+//!
+//! ASCII is unaffected: for ASCII text all three units agree.
+
+/// Number of Unicode scalar values in `value`.
+///
+/// This is the single definition of "length" behind every text statistic, so
+/// the CSV, JSON, Parquet, Arrow and in-memory paths cannot drift apart on what
+/// they are counting.
+#[inline]
+pub fn char_len(value: &str) -> usize {
+    // `Chars::count` counts non-continuation bytes rather than decoding each
+    // scalar, so this stays close to `len()` in cost.
+    value.chars().count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::char_len;
+
+    #[test]
+    fn ascii_is_unchanged() {
+        for value in ["", "a", "hello", "1234567890"] {
+            assert_eq!(char_len(value), value.len(), "{value:?}");
+        }
+    }
+
+    #[test]
+    fn multibyte_scalars_count_once() {
+        // The issue's reproduction: UTF-8 widths are 1, 2, 6, 4.
+        assert_eq!(char_len("a"), 1);
+        assert_eq!(char_len("é"), 1);
+        assert_eq!(char_len("東京"), 2);
+        assert_eq!(char_len("🙂"), 1);
+    }
+
+    #[test]
+    fn a_combining_sequence_counts_each_scalar() {
+        // Two scalars, one grapheme. Documented rather than segmented: the
+        // precomposed and decomposed spellings of the same word differ in
+        // length, which is a property of scalar counting, not a defect.
+        let precomposed = "\u{00e9}";
+        let decomposed = "e\u{0301}";
+        assert_eq!(char_len(precomposed), 1);
+        assert_eq!(char_len(decomposed), 2);
+        // They differ under the old byte unit too, by a different amount, so
+        // neither unit makes the two spellings compare equal.
+        assert_eq!((precomposed.len(), decomposed.len()), (2, 3));
+    }
+
+    #[test]
+    fn an_emoji_sequence_counts_each_scalar() {
+        // A ZWJ family is one grapheme and seven scalars.
+        assert_eq!(char_len("👨‍👩‍👧‍👦"), 7);
+    }
+}

--- a/crates/dataprof-metrics/src/stats/text.rs
+++ b/crates/dataprof-metrics/src/stats/text.rs
@@ -1,4 +1,5 @@
 use crate::types::{ColumnStats, FrequencyItem, TextStats};
+use dataprof_core::char_len;
 use std::collections::HashMap;
 
 const TOP_N_DEFAULT: usize = 10;
@@ -16,8 +17,8 @@ pub fn compute_text_stats(data: &[String]) -> TextStats {
         return TextStats::empty();
     }
 
-    // Existing length calculations
-    let lengths: Vec<usize> = non_empty.iter().map(|s| s.len()).collect();
+    // Unicode scalar values, not UTF-8 bytes: see `dataprof_core::text_units`.
+    let lengths: Vec<usize> = non_empty.iter().map(|s| char_len(s)).collect();
     // decode-audit: impossible — non_empty was checked non-empty above, so
     // lengths always has a min and max.
     let min_length = lengths

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -5,7 +5,7 @@ use arrow::datatypes::*;
 use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
     ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata, FileFormat, Locale,
-    MetricPack, PeakMemorySampler, QualityDimension, SemanticHints, TruncationReason,
+    MetricPack, PeakMemorySampler, QualityDimension, SemanticHints, TruncationReason, char_len,
 };
 use dataprof_csv::CsvParserConfig;
 use dataprof_metrics::CardinalityEstimator;
@@ -875,7 +875,8 @@ impl ColumnAnalyzer {
     }
 
     fn update_text_stats(&mut self, value: &str) {
-        let len = value.len();
+        // Unicode scalar values, not UTF-8 bytes: see `dataprof_core::text_units`.
+        let len = char_len(value);
         self.min_length = self.min_length.min(len);
         self.max_length = self.max_length.max(len);
         self.total_length += len;

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -5,7 +5,7 @@ use arrow::array::*;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
-    ColumnProfile, DataType, Locale, SemanticHintBinding, SemanticHintKind, SemanticHints,
+    ColumnProfile, DataType, Locale, SemanticHintBinding, SemanticHintKind, SemanticHints, char_len,
 };
 use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
@@ -1085,7 +1085,8 @@ impl ColumnAnalyzer {
     }
 
     fn update_text_stats(&mut self, value: &str) {
-        let len = value.len();
+        // Unicode scalar values, not UTF-8 bytes: see `dataprof_core::text_units`.
+        let len = char_len(value);
         self.min_length = self.min_length.min(len);
         self.max_length = self.max_length.max(len);
         self.total_length += len;

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -190,10 +190,16 @@ struct PythonColumnStatsDocument {
     is_approximate: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     outlier_count: Option<usize>,
+    /// Shortest value, in Unicode scalar values. Not UTF-8 bytes and not
+    /// grapheme clusters: ASCII text is unaffected by that distinction, while a
+    /// combining sequence counts each scalar, so the decomposed and precomposed
+    /// spellings of the same word report different lengths.
     #[serde(skip_serializing_if = "Option::is_none")]
     min_length: Option<usize>,
+    /// Longest value, in Unicode scalar values. See `min_length`.
     #[serde(skip_serializing_if = "Option::is_none")]
     max_length: Option<usize>,
+    /// Mean length, in Unicode scalar values. See `min_length`.
     #[serde(skip_serializing_if = "Option::is_none")]
     avg_length: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 use crate::{ValueHintBindingAccumulator, profile_builder::infer_data_type_streaming};
-use dataprof_core::{SemanticHintBinding, SemanticHintKind, SemanticHints};
+use dataprof_core::{SemanticHintBinding, SemanticHintKind, SemanticHints, char_len};
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{
     CardinalityEstimator, HyperLogLog, RowCompletenessSummary, RowDuplicateSummary,
@@ -315,7 +315,8 @@ impl StreamingStatistics {
 
         self.hll.insert(value);
         self.sampler.offer(value.to_string());
-        self.text_length_tracker.update(value.len());
+        // Unicode scalar values, not UTF-8 bytes: see `dataprof_core::text_units`.
+        self.text_length_tracker.update(char_len(value));
         if value_matches_hint(value, SemanticHintKind::Temporal) {
             self.date_match_count += 1;
         }

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -296,18 +296,20 @@ Per-column profiling statistics.
 | `coefficient_of_variation` | `float \| None` | CV |
 | `quartiles` | `dict \| None` | `{"q1", "q2", "q3", "iqr"}` |
 | `is_approximate` | `bool \| None` | Whether stats were estimated from a sample |
-| `min_length` | `int \| None` | Shortest value, in Unicode scalar values |
-| `max_length` | `int \| None` | Longest value, in Unicode scalar values |
-| `avg_length` | `float \| None` | Mean length, in Unicode scalar values |
+| `min_length` | `int \| None` | Shortest value, in Unicode scalar values (0.11: UTF-8 bytes) |
+| `max_length` | `int \| None` | Longest value, in Unicode scalar values (0.11: UTF-8 bytes) |
+| `avg_length` | `float \| None` | Mean length, in Unicode scalar values (0.11: UTF-8 bytes) |
 | `true_count` | `int \| None` | Number of `True` values (boolean columns) |
 | `false_count` | `int \| None` | Number of `False` values (boolean columns) |
 | `true_ratio` | `float \| None` | Ratio of `True` values (0.0--1.0) |
 | `patterns` | `list[Pattern] \| None` | List of detected value patterns |
 
-Text lengths count Unicode scalar values, not UTF-8 bytes and not grapheme
-clusters. `"東京"` has a length of 2 and `"🙂"` a length of 1; through 0.11 those
-reported 6 and 4, because every accumulator used Rust's byte-valued `str::len()`
-under a field named `length` (#627). ASCII text is unaffected.
+**Changed in 0.12.** Text lengths count Unicode scalar values, not UTF-8 bytes
+and not grapheme clusters. `"東京"` has a length of 2 and `"🙂"` a length of 1.
+**In 0.11 and earlier the same values reported 6 and 4**, because every
+accumulator used Rust's byte-valued `str::len()` under a field named `length`
+(#627). ASCII text is unaffected, and reports written by different releases are
+not comparable for non-ASCII text.
 
 A combining sequence counts each scalar, so the decomposed spelling of e-acute
 (`e` followed by U+0301) has a length of 2 while the precomposed spelling

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -296,13 +296,25 @@ Per-column profiling statistics.
 | `coefficient_of_variation` | `float \| None` | CV |
 | `quartiles` | `dict \| None` | `{"q1", "q2", "q3", "iqr"}` |
 | `is_approximate` | `bool \| None` | Whether stats were estimated from a sample |
-| `min_length` | `int \| None` | Minimum character length |
-| `max_length` | `int \| None` | Maximum character length |
-| `avg_length` | `float \| None` | Average character length |
+| `min_length` | `int \| None` | Shortest value, in Unicode scalar values |
+| `max_length` | `int \| None` | Longest value, in Unicode scalar values |
+| `avg_length` | `float \| None` | Mean length, in Unicode scalar values |
 | `true_count` | `int \| None` | Number of `True` values (boolean columns) |
 | `false_count` | `int \| None` | Number of `False` values (boolean columns) |
 | `true_ratio` | `float \| None` | Ratio of `True` values (0.0--1.0) |
 | `patterns` | `list[Pattern] \| None` | List of detected value patterns |
+
+Text lengths count Unicode scalar values, not UTF-8 bytes and not grapheme
+clusters. `"東京"` has a length of 2 and `"🙂"` a length of 1; through 0.11 those
+reported 6 and 4, because every accumulator used Rust's byte-valued `str::len()`
+under a field named `length` (#627). ASCII text is unaffected.
+
+A combining sequence counts each scalar, so the decomposed spelling of e-acute
+(`e` followed by U+0301) has a length of 2 while the precomposed spelling
+(U+00E9) has a length of 1. The two render identically and profile differently.
+Segmenting grapheme clusters instead would need a Unicode segmentation table and
+a policy for which version of it; encoded size is a property of the encoding
+rather than of the value, and is reported at the source level instead.
 
 ## `Pattern`
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -80,6 +80,14 @@ Shipping with these, tracked for 0.12:
   `values_checked: 0` when validity was never assessed. `assessed_dimensions()`,
   `dimension_scores()`, `quality_summary()` and `to_llm_context()` are all
   correct; only the raw evidence dicts fabricate.
+- **Text lengths are UTF-8 byte counts under names that say nothing about
+  encoding** (`#627`). `min_length`, `max_length` and `avg_length` measure
+  encoded bytes on every engine, so `"東京"` reports 6 and `"🙂"` reports 4.
+  0.12 changes the unit to Unicode scalar values, which reports 2 and 1 for the
+  same values. **ASCII is unaffected; a non-ASCII text column profiled under
+  0.11 and under 0.12 is not comparable**, and the report schema version does
+  not move because nothing about validation changes. Re-profile rather than
+  comparing across the boundary.
 - **`std_dev` differs in the last ULP between engines** (`#547`). The
   incremental accumulator and the Arrow path compute it differently. Serialized
   reports round to 4dp and agree; the raw attribute does not.

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -215,10 +215,13 @@ scalar values, so a column of CJK or emoji values reports smaller numbers than a
 stored 0.11 report does for the same data.
 
 No property was added, removed or retyped, and ASCII values are unchanged, so
-the schema document is unchanged and stored reports remain valid. A consumer
-comparing a report across the 0.11/0.12 boundary is comparing two units for
-non-ASCII text, which `schema_version` cannot signal because the schema did not
-change. Compare within a release, or re-profile.
+the schema's validation shape and version are unchanged and stored reports
+remain valid. The document itself does change: both dialects' `min_length`,
+`max_length` and `avg_length` gain `description` annotations naming the unit.
+
+A consumer comparing a report across the 0.11/0.12 boundary is comparing two
+units for non-ASCII text, which `schema_version` cannot signal because nothing
+about validation changed. Compare within a release, or re-profile.
 
 ## v1 behaviour change: unassessed dimensions are omitted
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -207,6 +207,19 @@ Both are widenings, so stored v1 reports remain valid. Consumers that read
 "not assessed", never zero. `assessed_dimensions` is empty for exactly these
 reports and is the authority to branch on.
 
+## v1 behaviour change: text lengths count Unicode scalar values
+
+`min_length`, `max_length` and `avg_length` on a text column counted UTF-8 bytes
+through 0.11, under names that disclose no encoding. They now count Unicode
+scalar values, so a column of CJK or emoji values reports smaller numbers than a
+stored 0.11 report does for the same data.
+
+No property was added, removed or retyped, and ASCII values are unchanged, so
+the schema document is unchanged and stored reports remain valid. A consumer
+comparing a report across the 0.11/0.12 boundary is comparing two units for
+non-ASCII text, which `schema_version` cannot signal because the schema did not
+change. Compare within a release, or re-profile.
+
 ## v1 behaviour change: unassessed dimensions are omitted
 
 The seven quality dimension objects (`completeness`, `consistency`,

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -1242,6 +1242,7 @@
     "PythonColumnStatsDocument": {
       "properties": {
         "avg_length": {
+          "description": "Mean length, in Unicode scalar values. See `min_length`.",
           "format": "double",
           "type": [
             "number",
@@ -1284,6 +1285,7 @@
           ]
         },
         "max_length": {
+          "description": "Longest value, in Unicode scalar values. See `min_length`.",
           "format": "uint",
           "minimum": 0,
           "type": [
@@ -1313,6 +1315,7 @@
           ]
         },
         "min_length": {
+          "description": "Shortest value, in Unicode scalar values. Not UTF-8 bytes and not\ngrapheme clusters: ASCII text is unaffected by that distinction, while a\ncombining sequence counts each scalar, so the decomposed and precomposed\nspellings of the same word report different lengths.",
           "format": "uint",
           "minimum": 0,
           "type": [

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -2059,9 +2059,10 @@
       "description": "Supported stream source systems"
     },
     "TextStats": {
-      "description": "Statistics for text/string columns.",
+      "description": "Statistics for text/string columns.\n\nEvery length here is a count of Unicode scalar values, not UTF-8 bytes and\nnot grapheme clusters. ASCII text is unaffected by that distinction; a\ncombining sequence counts each scalar, so the decomposed and precomposed\nspellings of the same word report different lengths. The `text_units` module\ncarries the reasoning.",
       "properties": {
         "avg_length": {
+          "description": "Mean length in Unicode scalar values. A mean, so it rounds at the\nstatistics precision rather than the percentage one.",
           "format": "double",
           "type": "number"
         },
@@ -2075,11 +2076,13 @@
           ]
         },
         "max_length": {
+          "description": "Longest value, in Unicode scalar values.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"
         },
         "min_length": {
+          "description": "Shortest value, in Unicode scalar values.",
           "format": "uint",
           "minimum": 0,
           "type": "integer"

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -179,8 +179,13 @@ class ColumnProfile:
     quartiles: dict[str, float] | None
     is_approximate: bool | None
     outlier_count: int | None
+    #: Shortest value in Unicode scalar values, not UTF-8 bytes and not
+    #: grapheme clusters. ASCII text is unaffected by that distinction; a
+    #: combining sequence counts each scalar.
     min_length: int | None
+    #: Longest value, in Unicode scalar values. See ``min_length``.
     max_length: int | None
+    #: Mean length, in Unicode scalar values. See ``min_length``.
     avg_length: float | None
     true_count: int | None
     false_count: int | None

--- a/python/tests/test_text_length_units.py
+++ b/python/tests/test_text_length_units.py
@@ -1,0 +1,116 @@
+"""Text lengths count Unicode scalar values, on every input path.
+
+`min_length`, `max_length` and `avg_length` used to report UTF-8 byte counts
+under names that say nothing about encoding, so `"東京"` measured 6 and `"🙂"`
+measured 4 (#627). Every engine agreed, and every engine was surprising for
+anything but ASCII.
+
+Scalar values are the unit; grapheme clusters would need a segmentation policy
+and a dependency, and encoded size is a property of the encoding rather than of
+the value. A combining sequence therefore counts each scalar, which is pinned
+below rather than left to be discovered.
+"""
+
+from __future__ import annotations
+
+import json
+
+import dataprof
+import pytest
+
+# UTF-8 widths are 1, 2, 6, 4; scalar counts are 1, 1, 2, 1.
+SAMPLE = ["a", "é", "東京", "🙂"]
+EXPECTED_MIN = 1
+EXPECTED_MAX = 2
+EXPECTED_AVG = pytest.approx(1.25)
+
+ASCII_SAMPLE = ["a", "bb", "ccc", "dddd"]
+
+
+def lengths(column):
+    return column.min_length, column.max_length, column.avg_length
+
+
+def write_csv(tmp_path, name: str, values: list[str]):
+    path = tmp_path / name
+    path.write_text("text\n" + "\n".join(values) + "\n", encoding="utf-8", newline="")
+    return path
+
+
+def test_in_memory_records_count_scalars() -> None:
+    column = dataprof.profile({"text": SAMPLE})["text"]
+    assert lengths(column) == (EXPECTED_MIN, EXPECTED_MAX, EXPECTED_AVG)
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar", "streaming", "arrow"])
+def test_every_csv_engine_counts_scalars(tmp_path, engine: str) -> None:
+    path = write_csv(tmp_path, f"unicode_{engine}.csv", SAMPLE)
+    column = dataprof.profile(path, engine=engine)["text"]
+    assert lengths(column) == (EXPECTED_MIN, EXPECTED_MAX, EXPECTED_AVG)
+
+
+def test_json_and_jsonl_count_scalars(tmp_path) -> None:
+    records = [{"text": value} for value in SAMPLE]
+
+    array = tmp_path / "unicode.json"
+    array.write_text(json.dumps(records, ensure_ascii=False), encoding="utf-8", newline="")
+
+    lines = tmp_path / "unicode.jsonl"
+    lines.write_text(
+        "\n".join(json.dumps(record, ensure_ascii=False) for record in records) + "\n",
+        encoding="utf-8",
+        newline="",
+    )
+
+    for path in (array, lines):
+        column = dataprof.profile(path)["text"]
+        assert lengths(column) == (EXPECTED_MIN, EXPECTED_MAX, EXPECTED_AVG), path.name
+
+
+def test_parquet_file_and_bytes_count_scalars(tmp_path) -> None:
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    path = tmp_path / "unicode.parquet"
+    pq.write_table(pa.table({"text": SAMPLE}), path)
+
+    from_file = dataprof.profile(path)["text"]
+    assert lengths(from_file) == (EXPECTED_MIN, EXPECTED_MAX, EXPECTED_AVG)
+
+    from_bytes = dataprof.profile(path.read_bytes(), format="parquet")["text"]
+    assert lengths(from_bytes) == (EXPECTED_MIN, EXPECTED_MAX, EXPECTED_AVG)
+
+
+def test_arrow_input_counts_scalars() -> None:
+    pa = pytest.importorskip("pyarrow")
+
+    column = dataprof.profile(pa.table({"text": SAMPLE}))["text"]
+    assert lengths(column) == (EXPECTED_MIN, EXPECTED_MAX, EXPECTED_AVG)
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_ascii_results_are_unchanged(tmp_path, engine: str) -> None:
+    # The unit only moves for non-ASCII text, so an ASCII corpus must report
+    # exactly what it did when lengths were byte counts.
+    path = write_csv(tmp_path, f"ascii_{engine}.csv", ASCII_SAMPLE)
+    column = dataprof.profile(path, engine=engine)["text"]
+    assert lengths(column) == (1, 4, pytest.approx(2.5))
+
+
+def test_a_combining_sequence_counts_each_scalar(tmp_path) -> None:
+    # One grapheme, two scalars. Documented behaviour, not an accident: the
+    # precomposed and decomposed spellings of the same word differ in length.
+    path = write_csv(tmp_path, "combining.csv", ["é", "é"])
+    column = dataprof.profile(path)["text"]
+    assert lengths(column) == (1, 2, pytest.approx(1.5))
+
+
+def test_the_serialized_report_carries_the_same_lengths(tmp_path) -> None:
+    path = write_csv(tmp_path, "serialized.csv", SAMPLE)
+    report = dataprof.profile(path)
+    emitted = report.to_dict()["columns"][0]["stats"]
+
+    assert emitted["min_length"] == EXPECTED_MIN
+    assert emitted["max_length"] == EXPECTED_MAX
+    assert emitted["avg_length"] == EXPECTED_AVG
+    assert json.loads(report.to_json())["columns"][0]["stats"]["max_length"] == EXPECTED_MAX


### PR DESCRIPTION
Closes #627.

## The decision

Text lengths count **Unicode scalar values**. `dataprof_core::text_units` is the one place that says so, and the four accumulators that used to reach for `str::len()` now call `char_len` instead.

The issue left three options open. Scalar values win on the terms the issue itself sets out:

- **Bytes** are defensible only under a byte-named field. `max_length` is not one, and renaming the field to `max_bytes` would break every consumer to preserve a number almost nobody wants.
- **Grapheme clusters** are closest to what a reader calls a character, and cost a Unicode segmentation table plus a policy for which version of it. That is a standing commitment to a Unicode revision cadence, which a profiler's length field does not justify.
- **Scalar values** need no dependency, are stable across Unicode versions for existing text, and are what `str::chars()` already means.

The visible consequence is documented rather than hidden: a combining sequence counts each scalar, so the decomposed spelling of e-acute (`e` + U+0301) has length 2 while the precomposed spelling (U+00E9) has length 1. Those two also differed under the byte unit, by a different amount, so no available unit makes them compare equal.

## No byte-size field was added

The issue allows one ("if retained"). Nothing in the codebase computes anything from these lengths — they are pass-throughs to the report — so a byte metric would be three new fields and a schema change serving no current caller. Encoded size stays available at the source level (`DataSource.size_bytes`). If someone needs per-column byte width later, it can arrive named as bytes, which is the part of the criterion that matters.

## What changed

| Path | Was |
| --- | --- |
| `dataprof-metrics/src/stats/text.rs` | `s.len()` |
| `dataprof-runtime/src/streaming_stats.rs` | `value.len()` |
| `dataprof-parquet/src/arrow_profiler.rs` | `value.len()` |
| `dataprof-parquet/src/record_batch_analyzer.rs` | `value.len()` |

All four now call `dataprof_core::char_len`, so CSV (all engines), JSON/JSONL, Parquet file and bytes, Arrow input and in-memory records cannot drift apart on what they are counting.

## Verification

`python/tests/test_text_length_units.py` (14 tests) covers every input path with the issue's own fixture, and pins the units before the fix rather than after:

- **Reverted, 11 of 14 fail:** in-memory records, all five CSV engines, JSON and JSONL, Parquet file and bytes, Arrow input, the combining sequence, and the serialized report.
- **The 3 that pass either way are the ASCII cases,** which is the point — they encode the "ASCII results remain unchanged" criterion, so they must pass before and after.

`text_units` carries its own unit tests for ASCII, accented Latin, CJK, emoji, a ZWJ family sequence and a combining sequence.

One bad assertion of mine was caught by running these: I had asserted the two spellings of e-acute have equal byte length. They are 2 and 3. Corrected, and the test now states both units explicitly.

## Schema and compatibility

`cargo run --example generate_profile_schema` adds only `description` annotations, no property added, removed or retyped, so the committed schema stays at v1 and stored reports remain valid. `docs/schema/README.md` records the part `schema_version` cannot: a report written by 0.11 and one written by 0.12 use different units for non-ASCII text, and the schema version does not move because the schema did not change. Compare within a release, or re-profile.

## Performance

`char_len` is `chars().count()`, whose std implementation counts non-continuation bytes rather than decoding each scalar. It is still one extra linear pass per text value where `len()` was constant time.

I tried to measure that end to end (200k-row text CSVs, ASCII and CJK, profiled 15 times per build) and **the measurement is inconclusive on this machine**: repeating the same run on the *same* build gave 0.392s and 0.566s for the ASCII case, a 44% spread, which is far wider than any effect this change could have. Minimum-of-N instead of median did not fix it. Quoting a delta from those numbers would be quoting noise.

What can be said structurally: the profiler already does several linear passes over each value's bytes — the HLL hash for cardinality, the reservoir sample's string clone, type inference, and pattern matching — so one more pass is a fraction of existing per-value work, not a new order of cost. If someone wants the real number, this is a good candidate for #401's harness, which exists because reproducible warm/cold timing with variance reporting is not available here yet.

## Commands run

```
cargo test --workspace
uv run pytest python/tests/ -q
cargo run --example generate_profile_schema
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
uv run ruff format / ruff check / ty check
```
