### PR TITLE
fix(database): decode temporal, decimal, UUID and unsigned columns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,12 @@ jobs:
       - name: Run Rust database tests (all DBs)
         run: cargo test --test database_integration --features "all-db"
 
+      # A separate target in a separate package: the command above selects the
+      # root crate's test binary and never builds this one, so the typed-column
+      # regressions would return early and gate nothing (#365).
+      - name: Run dataprof-db typed column decoding tests
+        run: cargo test -p dataprof-db --test typed_column_decoding --features "all-db"
+
   # The Python extension uses a different Cargo profile and feature graph.
   # Build it in parallel so neither cold build blocks the other's cache save.
   python-db-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64 0.22.1",
+ "bigdecimal",
  "bytes",
  "chrono",
  "crc",
@@ -3425,6 +3439,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
+ "bigdecimal",
  "bitflags 2.13.1",
  "byteorder",
  "bytes",
@@ -3469,6 +3484,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
+ "bigdecimal",
  "bitflags 2.13.1",
  "byteorder",
  "chrono",
@@ -3486,6 +3502,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
+ "num-bigint 0.4.8",
  "once_cell",
  "rand 0.8.7",
  "serde",

--- a/crates/dataprof-db/Cargo.toml
+++ b/crates/dataprof-db/Cargo.toml
@@ -11,8 +11,10 @@ readme = "README.md"
 
 [features]
 default = []
-postgres = ["dep:sqlx", "sqlx/postgres"]
-mysql = ["dep:sqlx", "sqlx/mysql"]
+# `sqlx/bigdecimal` rides with the two backends that have a decimal type.
+# SQLite has none, so a sqlite-only build does not pay for it.
+postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/bigdecimal"]
+mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/bigdecimal"]
 sqlite = ["dep:sqlx", "sqlx/sqlite"]
 all-db = ["postgres", "mysql", "sqlite"]
 

--- a/crates/dataprof-db/src/connectors/common.rs
+++ b/crates/dataprof-db/src/connectors/common.rs
@@ -35,13 +35,35 @@ pub fn feature_not_enabled_error(db_name: &str, feature: &str) -> DataProfilerEr
 ///   decode `42` as `true`, so trying `bool` early would render integers as
 ///   "true"/"false".
 /// * Widest integer first, so an INT8/BIGINT is not truncated by a narrower arm.
+/// * The caller's backend-specific arms sit between the signed integers and
+///   `bool`, for the same reason: MySQL's `BIGINT UNSIGNED` fits no signed arm
+///   and used to reach `bool`, where 18446744073709551615 rendered as "true"
+///   (#365).
+/// * Temporal and UUID after the primitives. Neither is compatible with an
+///   earlier arm, so their position is about keeping the common path short
+///   rather than about correctness.
 ///
-/// A value whose type matches none of these arms (NUMERIC/DECIMAL, dates and
-/// times without the corresponding sqlx feature, BLOB) yields `None` and is
-/// recorded as a null, which is the pre-existing behaviour for those types.
+/// Two types cannot live in the shared chain because they have no impl for
+/// every backend, so each connector passes its own: `u64` (MySQL only, no
+/// `Type<Postgres>`) and `BigDecimal` (PostgreSQL and MySQL, no `Type<Sqlite>`
+/// because SQLite has no decimal type).
+///
+/// Temporal values render in the naive ISO form dataprof's date grammar
+/// accepts (`YYYY-MM-DD` and `YYYY-MM-DDTHH:MM:SS`). That grammar rejects a
+/// trailing offset or `Z`, so rendering a timestamp as true RFC 3339 would
+/// profile the column as *text* and leave the Timeliness dimension exactly as
+/// inert as the nulls did. `TIMESTAMPTZ` is converted to UTC and its offset
+/// dropped; the instant survives, the "this is UTC" marker does not.
+///
+/// Still unsupported and still recorded as null: `BLOB`/`BYTEA`, which needs a
+/// binary column type rather than a decode arm, and MySQL `TIME`, which sqlx
+/// decodes as a duration rather than a time of day.
 #[macro_export]
 macro_rules! db_column_to_string {
-    ($row:expr, $index:expr) => {{
+    ($row:expr, $index:expr) => {
+        $crate::db_column_to_string!($row, $index, [])
+    };
+    ($row:expr, $index:expr, [$($backend_ty:ty),* $(,)?]) => {{
         let row = $row;
         let index = $index;
 
@@ -53,7 +75,15 @@ macro_rules! db_column_to_string {
             v.map(|x| x.to_string())
         } else if let Ok(v) = row.try_get::<Option<i16>, _>(index) {
             v.map(|x| x.to_string())
-        } else if let Ok(v) = row.try_get::<Option<f64>, _>(index) {
+        }
+        // Arms the shared chain cannot express because the type has no impl
+        // for one of the backends. `to_string` is exact for both of today's
+        // callers: `u64` prints its digits, and `BigDecimal` keeps the scale
+        // the database stored rather than rounding through f64.
+        $(else if let Ok(v) = row.try_get::<Option<$backend_ty>, _>(index) {
+            v.map(|x| x.to_string())
+        })*
+        else if let Ok(v) = row.try_get::<Option<f64>, _>(index) {
             // `{:?}` keeps the decimal point on integral floats ("100.0", not
             // "100"), so a REAL column of whole numbers is still inferred as a
             // float downstream. It also stays compact at the extremes ("1e300").
@@ -62,16 +92,50 @@ macro_rules! db_column_to_string {
             v.map(|x| format!("{:?}", x))
         } else if let Ok(v) = row.try_get::<Option<bool>, _>(index) {
             v.map(|x| x.to_string())
+        } else if let Ok(v) =
+            row.try_get::<Option<::sqlx::types::chrono::DateTime<::sqlx::types::chrono::Utc>>, _>(
+                index,
+            )
+        {
+            v.map(|x| $crate::render_naive_datetime(x.naive_utc()))
+        } else if let Ok(v) =
+            row.try_get::<Option<::sqlx::types::chrono::NaiveDateTime>, _>(index)
+        {
+            v.map($crate::render_naive_datetime)
+        } else if let Ok(v) = row.try_get::<Option<::sqlx::types::chrono::NaiveDate>, _>(index) {
+            v.map(|x| x.format("%Y-%m-%d").to_string())
+        } else if let Ok(v) = row.try_get::<Option<::sqlx::types::chrono::NaiveTime>, _>(index) {
+            // A time of day carries no date, so it profiles as text. Decoding
+            // it is still better than reporting the column as entirely null.
+            v.map(|x| x.format("%H:%M:%S%.f").to_string())
+        } else if let Ok(v) = row.try_get::<Option<::sqlx::types::Uuid>, _>(index) {
+            v.map(|x| x.to_string())
         } else {
             None
         }
     }};
 }
 
+/// Render a naive datetime in the ISO form dataprof's date grammar accepts.
+///
+/// `%.f` is empty at whole-second precision and prints a fractional part
+/// otherwise, both of which the grammar's `(?:\.\d+)?` allows.
+///
+/// Gated on a backend being enabled: with no feature on, sqlx is not linked at
+/// all and this signature would not resolve.
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
+pub fn render_naive_datetime(value: ::sqlx::types::chrono::NaiveDateTime) -> String {
+    value.format("%Y-%m-%dT%H:%M:%S%.f").to_string()
+}
+
 /// Macro to generate the streaming batch loop for profiling queries.
 #[macro_export]
 macro_rules! streaming_profile_loop {
-    ($pool:expr, $query:expr, $batch_size:expr, $total_rows:expr, $db_name:literal) => {{
+    ($pool:expr, $query:expr, $batch_size:expr, $total_rows:expr, $db_name:literal) => {
+        $crate::streaming_profile_loop!($pool, $query, $batch_size, $total_rows, $db_name, [])
+    };
+    ($pool:expr, $query:expr, $batch_size:expr, $total_rows:expr, $db_name:literal,
+     [$($backend_ty:ty),* $(,)?]) => {{
         use sqlx::{Column, Row};
         use $crate::connectors::common::build_batch_query;
         use $crate::streaming::{StreamingProgress, merge_column_batches};
@@ -109,7 +173,8 @@ macro_rules! streaming_profile_loop {
 
             for row in &rows {
                 for i in 0..columns.len() {
-                    let value: Option<String> = $crate::db_column_to_string!(row, i);
+                    let value: Option<String> =
+                        $crate::db_column_to_string!(row, i, [$($backend_ty),*]);
                     // decode-audit: no-data — None is SQL NULL (or a type
                     // db_column_to_string documents as unsupported); "" is
                     // the profiler's textual null.
@@ -144,7 +209,10 @@ macro_rules! streaming_profile_loop {
 /// Macro to process rows into column-oriented results, in query column order.
 #[macro_export]
 macro_rules! process_rows_to_columns {
-    ($rows:expr) => {{
+    ($rows:expr) => {
+        $crate::process_rows_to_columns!($rows, [])
+    };
+    ($rows:expr, [$($backend_ty:ty),* $(,)?]) => {{
         use sqlx::{Column, Row};
 
         if $rows.is_empty() {
@@ -167,7 +235,8 @@ macro_rules! process_rows_to_columns {
 
                     for row in &$rows {
                         for i in 0..columns.len() {
-                            let value: Option<String> = $crate::db_column_to_string!(row, i);
+                            let value: Option<String> =
+                                $crate::db_column_to_string!(row, i, [$($backend_ty),*]);
                             // decode-audit: no-data — None is SQL NULL (or a type
                             // db_column_to_string documents as unsupported); "" is
                             // the profiler's textual null.

--- a/crates/dataprof-db/src/connectors/mod.rs
+++ b/crates/dataprof-db/src/connectors/mod.rs
@@ -6,6 +6,11 @@
 //! - SQLite (embedded)
 
 mod common;
+
+// The decode macros expand at the call site and reference this by path, so it
+// has to be reachable from the crate root even though `common` stays private.
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
+pub use common::render_naive_datetime;
 pub mod mysql;
 pub mod postgres;
 pub mod sqlite;

--- a/crates/dataprof-db/src/connectors/mysql.rs
+++ b/crates/dataprof-db/src/connectors/mysql.rs
@@ -106,7 +106,11 @@ impl DatabaseConnector for MySqlConnector {
                 DataProfilerError::database_query(&format!("Query execution failed: {}", e))
             })?;
 
-            process_rows_to_columns!(rows)
+            // `u64` first: MySQL is the only backend with an unsigned 64-bit
+            // integer, and without an arm a BIGINT UNSIGNED falls past every
+            // signed arm into `bool` and renders as "true" (#365). DECIMAL
+            // follows for the same reason PostgreSQL needs it.
+            process_rows_to_columns!(rows, [u64, ::sqlx::types::BigDecimal])
         }
 
         #[cfg(not(feature = "mysql"))]
@@ -131,7 +135,14 @@ impl DatabaseConnector for MySqlConnector {
                     DataProfilerError::database_query(&format!("Failed to count rows: {}", e))
                 })?;
 
-            streaming_profile_loop!(pool, query, batch_size, total_rows, "MySQL")
+            streaming_profile_loop!(
+                pool,
+                query,
+                batch_size,
+                total_rows,
+                "MySQL",
+                [u64, ::sqlx::types::BigDecimal]
+            )
         }
 
         #[cfg(not(feature = "mysql"))]

--- a/crates/dataprof-db/src/connectors/postgres.rs
+++ b/crates/dataprof-db/src/connectors/postgres.rs
@@ -107,7 +107,10 @@ impl DatabaseConnector for PostgresConnector {
                 DataProfilerError::database_query(&format!("Query execution failed: {}", e))
             })?;
 
-            process_rows_to_columns!(rows)
+            // NUMERIC has no `Type<Sqlite>` impl, so it cannot sit in the
+            // shared chain. Without this arm it falls past every arm and
+            // records as null (#365).
+            process_rows_to_columns!(rows, [::sqlx::types::BigDecimal])
         }
 
         #[cfg(not(feature = "postgres"))]
@@ -132,7 +135,14 @@ impl DatabaseConnector for PostgresConnector {
                     DataProfilerError::database_query(&format!("Failed to count rows: {}", e))
                 })?;
 
-            streaming_profile_loop!(pool, query, batch_size, total_rows, "PostgreSQL")
+            streaming_profile_loop!(
+                pool,
+                query,
+                batch_size,
+                total_rows,
+                "PostgreSQL",
+                [::sqlx::types::BigDecimal]
+            )
         }
 
         #[cfg(not(feature = "postgres"))]

--- a/crates/dataprof-db/tests/typed_column_decoding.rs
+++ b/crates/dataprof-db/tests/typed_column_decoding.rs
@@ -1,18 +1,24 @@
-//! Types that fall past every arm of `db_column_to_string!` profile as null.
+//! Types that once fell past every arm of `db_column_to_string!` now decode.
 //!
-//! The decode chain tries `String`, the integers, the floats and `bool`, then
-//! gives up and records `None`, which the profiler cannot tell from SQL NULL.
-//! Temporal columns, `NUMERIC`/`DECIMAL` and `UUID` all land there, so a
-//! database source reports them as entirely null (#365).
+//! Until 0.12 the chain tried `String`, the integers, the floats and `bool`,
+//! then gave up and recorded `None`, which the profiler cannot tell from SQL
+//! NULL. Temporal columns, `NUMERIC`/`DECIMAL` and `UUID` all landed there, so
+//! a database source reported them as entirely null. MySQL's `BIGINT UNSIGNED`
+//! was worse: it reached the `bool` arm and reported `true` (#365).
 //!
-//! Temporal columns are the costly case: the Timeliness ISO dimension is
-//! computed from date values, so it assesses nothing at all on any database
-//! source. A dimension that silently measures nothing is exactly the failure
-//! `None`-means-not-analyzed exists to make visible.
+//! Temporal columns were the costly case. The Timeliness ISO dimension is
+//! computed from date values, so it assessed nothing at all on any database
+//! source. A dimension that measures nothing is exactly what
+//! `None`-means-not-analyzed exists to make visible, and it stayed that way
+//! until the values arrived.
+//!
+//! These tests pin the decoded forms: the rendering each type produces, that
+//! SQL NULL still reads as NULL underneath the new arms, and that the batch and
+//! streaming paths of both connectors agree.
 //!
 //! SQLite is absent by design. It has no native temporal, decimal or UUID
-//! types, so those columns arrive as TEXT and the existing `String` arm already
-//! decodes them; the gap is a PostgreSQL and MySQL one.
+//! types, so those columns arrive as TEXT and the `String` arm already decoded
+//! them; the gap was a PostgreSQL and MySQL one.
 
 #![cfg(any(feature = "postgres", feature = "mysql"))]
 
@@ -309,6 +315,35 @@ mod mysql {
         };
 
         assert_eq!(column(columns, "amount"), ["1234.5678", ""]);
+    }
+
+    #[tokio::test]
+    async fn the_streaming_path_decodes_the_same_types() {
+        // MySQL passes its arms at two call sites like PostgreSQL does, and
+        // only the batch one is reached by `decoded()`. Dropping the list from
+        // the streaming site would otherwise leave this suite green while the
+        // two public paths disagree about the same column.
+        let Some(url) = std::env::var("MYSQL_TEST_URL").ok() else {
+            return;
+        };
+        let _ = decoded().await;
+
+        let mut connector = dataprof_db::create_connector(dataprof_db::DatabaseConfig {
+            connection_string: url,
+            load_credentials_from_env: false,
+            ..Default::default()
+        })
+        .expect("connector");
+        connector.connect().await.expect("connect");
+        let columns = connector
+            .profile_query_streaming("SELECT * FROM typed_decoding_my ORDER BY id", 1)
+            .await
+            .expect("streaming profile");
+        connector.disconnect().await.expect("disconnect");
+
+        assert_eq!(column(&columns, "big"), ["18446744073709551615", ""]);
+        assert_eq!(column(&columns, "amount"), ["1234.5678", ""]);
+        assert_eq!(column(&columns, "dt"), ["2024-01-15T10:30:00", ""]);
     }
 
     #[tokio::test]

--- a/crates/dataprof-db/tests/typed_column_decoding.rs
+++ b/crates/dataprof-db/tests/typed_column_decoding.rs
@@ -1,0 +1,324 @@
+//! Types that fall past every arm of `db_column_to_string!` profile as null.
+//!
+//! The decode chain tries `String`, the integers, the floats and `bool`, then
+//! gives up and records `None`, which the profiler cannot tell from SQL NULL.
+//! Temporal columns, `NUMERIC`/`DECIMAL` and `UUID` all land there, so a
+//! database source reports them as entirely null (#365).
+//!
+//! Temporal columns are the costly case: the Timeliness ISO dimension is
+//! computed from date values, so it assesses nothing at all on any database
+//! source. A dimension that silently measures nothing is exactly the failure
+//! `None`-means-not-analyzed exists to make visible.
+//!
+//! SQLite is absent by design. It has no native temporal, decimal or UUID
+//! types, so those columns arrive as TEXT and the existing `String` arm already
+//! decodes them; the gap is a PostgreSQL and MySQL one.
+
+#![cfg(any(feature = "postgres", feature = "mysql"))]
+
+/// Values of one column, in row order, with NULLs rendered as the profiler's
+/// empty-string null.
+fn column<'a>(columns: &'a dataprof_db::QueryColumns, name: &str) -> &'a [String] {
+    columns
+        .get(name)
+        .unwrap_or_else(|| panic!("column {name} missing from the result"))
+}
+
+#[cfg(feature = "postgres")]
+mod postgres {
+    use super::column;
+    use sqlx::postgres::PgPoolOptions;
+
+    const DDL: &str = "CREATE TABLE typed_decoding_pg (
+            id INTEGER,
+            ts TIMESTAMP,
+            tstz TIMESTAMPTZ,
+            d DATE,
+            t TIME,
+            amount NUMERIC(12,4),
+            uid UUID
+        )";
+
+    const ROWS: &str = "INSERT INTO typed_decoding_pg VALUES
+            (1, '2024-01-15 10:30:00', '2024-01-15 10:30:00+00', '2024-01-15',
+             '10:30:00', 1234.5678, '11111111-2222-3333-4444-555555555555'),
+            (2, NULL, NULL, NULL, NULL, NULL, NULL)";
+
+    /// Built once per process: every test reads the same profiled fixture.
+    ///
+    /// Each test dropping and recreating one shared table raced with the
+    /// others under the default parallel runner, so a green run depended on
+    /// `--test-threads=1`.
+    static FIXTURE: tokio::sync::OnceCell<Option<dataprof_db::QueryColumns>> =
+        tokio::sync::OnceCell::const_new();
+
+    /// Profile through the connector, not through the decode macro directly.
+    ///
+    /// The backend-specific arms live at the connector's call site, so a test
+    /// that expanded the macro itself would have to pass those arms in — and
+    /// would then keep passing if a connector dropped them.
+    async fn decoded() -> Option<&'static dataprof_db::QueryColumns> {
+        FIXTURE.get_or_init(build).await.as_ref()
+    }
+
+    async fn build() -> Option<dataprof_db::QueryColumns> {
+        let url = std::env::var("POSTGRES_TEST_URL").ok()?;
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("postgres connection");
+        sqlx::query("DROP TABLE IF EXISTS typed_decoding_pg")
+            .execute(&pool)
+            .await
+            .expect("drop");
+        sqlx::query(DDL).execute(&pool).await.expect("ddl");
+        sqlx::query(ROWS).execute(&pool).await.expect("rows");
+
+        let mut connector = dataprof_db::create_connector(dataprof_db::DatabaseConfig {
+            connection_string: url,
+            load_credentials_from_env: false,
+            ..Default::default()
+        })
+        .expect("connector");
+        connector.connect().await.expect("connect");
+        let columns = connector
+            .profile_query("SELECT * FROM typed_decoding_pg ORDER BY id")
+            .await
+            .expect("profile query");
+        connector.disconnect().await.expect("disconnect");
+        Some(columns)
+    }
+
+    #[tokio::test]
+    async fn timestamps_decode_in_a_form_the_profiler_reads_as_a_date() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        // Naive ISO, not RFC 3339: dataprof's date grammar accepts
+        // `YYYY-MM-DDTHH:MM:SS` and rejects a trailing offset or `Z`, so a
+        // faithful RFC 3339 rendering would profile as text and leave
+        // Timeliness exactly as inert as the nulls do.
+        assert_eq!(column(columns, "ts"), ["2024-01-15T10:30:00", ""]);
+        assert_eq!(column(columns, "tstz"), ["2024-01-15T10:30:00", ""]);
+        assert_eq!(column(columns, "d"), ["2024-01-15", ""]);
+    }
+
+    #[tokio::test]
+    async fn time_of_day_decodes_even_though_it_is_not_a_date() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        // A TIME carries no date, so it profiles as text rather than feeding
+        // Timeliness. Decoding it is still better than reporting it as null.
+        assert_eq!(column(columns, "t"), ["10:30:00", ""]);
+    }
+
+    #[tokio::test]
+    async fn numeric_keeps_its_exact_decimal_string() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        // Not routed through f64: NUMERIC exists precisely because binary
+        // floating point cannot hold these values, and profiling the rounded
+        // form would report statistics about a number the database does not
+        // contain.
+        assert_eq!(column(columns, "amount"), ["1234.5678", ""]);
+    }
+
+    #[tokio::test]
+    async fn uuid_decodes_hyphenated() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        assert_eq!(
+            column(columns, "uid"),
+            ["11111111-2222-3333-4444-555555555555", ""]
+        );
+    }
+
+    #[tokio::test]
+    async fn the_streaming_path_decodes_the_same_types() {
+        // Each connector passes its backend arms at two call sites, the batch
+        // one and the streaming one. Updating only the first is an easy miss
+        // and nothing else would catch it: the two paths would then disagree
+        // about what a NUMERIC column contains.
+        let Some(url) = std::env::var("POSTGRES_TEST_URL").ok() else {
+            return;
+        };
+        let _ = decoded().await;
+
+        let mut connector = dataprof_db::create_connector(dataprof_db::DatabaseConfig {
+            connection_string: url,
+            load_credentials_from_env: false,
+            ..Default::default()
+        })
+        .expect("connector");
+        connector.connect().await.expect("connect");
+        let columns = connector
+            .profile_query_streaming("SELECT * FROM typed_decoding_pg ORDER BY id", 1)
+            .await
+            .expect("streaming profile");
+        connector.disconnect().await.expect("disconnect");
+
+        assert_eq!(column(&columns, "amount"), ["1234.5678", ""]);
+        assert_eq!(column(&columns, "ts"), ["2024-01-15T10:30:00", ""]);
+        assert_eq!(
+            column(&columns, "uid"),
+            ["11111111-2222-3333-4444-555555555555", ""]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_timestamp_column_makes_timeliness_assessable() {
+        // The reason this ticket is worth more than a decode fix. Timeliness is
+        // computed from date values, so while every temporal column arrived as
+        // null the dimension assessed nothing on any database source, and the
+        // report said so honestly: absent, not zero. Decoding the column is what
+        // gives the dimension something to measure.
+        let Some(url) = std::env::var("POSTGRES_TEST_URL").ok() else {
+            return;
+        };
+        // Depends on the fixture table the shared profile built.
+        let _ = decoded().await;
+
+        let report = dataprof_db::analyze_database(
+            dataprof_db::DatabaseConfig {
+                connection_string: url,
+                load_credentials_from_env: false,
+                ..Default::default()
+            },
+            "SELECT ts FROM typed_decoding_pg WHERE ts IS NOT NULL",
+            true,
+            None,
+        )
+        .await
+        .expect("profile");
+
+        let quality = report.quality.as_ref().expect("quality assessed");
+        assert!(
+            quality
+                .metrics
+                .assessed_dimensions()
+                .contains(&dataprof_core::QualityDimension::Timeliness),
+            "timeliness still assesses nothing: {:?}",
+            quality.metrics.assessed_dimensions()
+        );
+        let timeliness = quality
+            .metrics
+            .timeliness
+            .as_ref()
+            .expect("timeliness evidence");
+        assert!(
+            timeliness.date_values_checked > 0,
+            "timeliness reported evidence without checking a date"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_null_row_is_still_null() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        // The new arms must not turn SQL NULL into a rendered zero value. The
+        // `Option<String>` arm is the NULL detector for every type, and adding
+        // arms below it must not disturb that.
+        for name in ["ts", "tstz", "d", "t", "amount", "uid"] {
+            assert_eq!(column(columns, name)[1], "", "{name} lost its NULL");
+        }
+    }
+}
+
+#[cfg(feature = "mysql")]
+mod mysql {
+    use super::column;
+    use sqlx::mysql::MySqlPoolOptions;
+
+    const DDL: &str = "CREATE TABLE typed_decoding_my (
+            id INT,
+            dt DATETIME,
+            ts TIMESTAMP NULL,
+            d DATE,
+            amount DECIMAL(12,4),
+            big BIGINT UNSIGNED
+        )";
+
+    const ROWS: &str = "INSERT INTO typed_decoding_my VALUES
+            (1, '2024-01-15 10:30:00', '2024-01-15 10:30:00', '2024-01-15',
+             1234.5678, 18446744073709551615),
+            (2, NULL, NULL, NULL, NULL, NULL)";
+
+    static FIXTURE: tokio::sync::OnceCell<Option<dataprof_db::QueryColumns>> =
+        tokio::sync::OnceCell::const_new();
+
+    /// See the PostgreSQL note: this profiles through the connector so the
+    /// backend arms under test are the ones the connector actually passes.
+    async fn decoded() -> Option<&'static dataprof_db::QueryColumns> {
+        FIXTURE.get_or_init(build).await.as_ref()
+    }
+
+    async fn build() -> Option<dataprof_db::QueryColumns> {
+        let url = std::env::var("MYSQL_TEST_URL").ok()?;
+        let pool = MySqlPoolOptions::new()
+            .max_connections(1)
+            .connect(&url)
+            .await
+            .expect("mysql connection");
+        sqlx::query("DROP TABLE IF EXISTS typed_decoding_my")
+            .execute(&pool)
+            .await
+            .expect("drop");
+        sqlx::query(DDL).execute(&pool).await.expect("ddl");
+        sqlx::query(ROWS).execute(&pool).await.expect("rows");
+
+        let mut connector = dataprof_db::create_connector(dataprof_db::DatabaseConfig {
+            connection_string: url,
+            load_credentials_from_env: false,
+            ..Default::default()
+        })
+        .expect("connector");
+        connector.connect().await.expect("connect");
+        let columns = connector
+            .profile_query("SELECT * FROM typed_decoding_my ORDER BY id")
+            .await
+            .expect("profile query");
+        connector.disconnect().await.expect("disconnect");
+        Some(columns)
+    }
+
+    #[tokio::test]
+    async fn temporal_columns_decode_in_a_form_the_profiler_reads_as_a_date() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        assert_eq!(column(columns, "dt"), ["2024-01-15T10:30:00", ""]);
+        assert_eq!(column(columns, "ts"), ["2024-01-15T10:30:00", ""]);
+        assert_eq!(column(columns, "d"), ["2024-01-15", ""]);
+    }
+
+    #[tokio::test]
+    async fn decimal_keeps_its_exact_string() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        assert_eq!(column(columns, "amount"), ["1234.5678", ""]);
+    }
+
+    #[tokio::test]
+    async fn unsigned_bigint_survives_above_i64_max() {
+        let Some(columns) = decoded().await else {
+            return;
+        };
+
+        // `u64` has no `Type<Postgres>` impl, so it cannot join the shared
+        // chain; MySQL needs its own arm or the value truncates or nulls.
+        assert_eq!(column(columns, "big"), ["18446744073709551615", ""]);
+    }
+}

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -4,11 +4,21 @@ Profile data directly from PostgreSQL, MySQL, and SQLite databases with quality 
 
 > [!NOTE]
 > Before 0.9.0, every column was read as text and non-text columns profiled as
-> all-null strings. Integer, float, and boolean columns now decode correctly.
-> Types outside that set — `NUMERIC`/`DECIMAL`, dates and times, and `BLOB` —
-> still profile as nulls, because decoding them needs sqlx features this crate
-> does not enable. Profile an exported CSV or Parquet file if you need
-> statistics for those.
+> all-null strings. Integers, floats and booleans decode from 0.9.0; temporal
+> columns, `NUMERIC`/`DECIMAL`, `UUID` and MySQL's `BIGINT UNSIGNED` decode from
+> 0.12.
+>
+> Two types are still unsupported and still profile as null: `BLOB`/`BYTEA`,
+> which needs a binary column type rather than a decode arm, and MySQL `TIME`,
+> which sqlx decodes as a duration rather than a time of day. Profile an
+> exported CSV or Parquet file if you need statistics for those.
+>
+> Timestamps render in dataprof's naive ISO form (`YYYY-MM-DDTHH:MM:SS`) rather
+> than RFC 3339, because the date grammar that decides whether a column is
+> temporal rejects a trailing offset or `Z`. A `TIMESTAMPTZ` is converted to UTC
+> and its offset dropped: the instant survives, the marker saying it is UTC does
+> not. `NUMERIC`/`DECIMAL` keeps the exact digits the database stored rather
+> than routing through `f64`.
 
 ## Feature Requirements
 


### PR DESCRIPTION
Closes #365.

## What was actually broken

Two things, and the second is not in the issue.

**Temporal columns nulled, so an ISO dimension measured nothing.** Timeliness is computed from date values. Every `DATE`/`TIMESTAMP`/`TIMESTAMPTZ` fell past the end of the decode chain and was recorded as `None`, so on any database source the dimension had no denominator and assessed nothing. It reported that honestly — absent, not zero — which is why nobody noticed: the report was correct about having measured nothing.

**MySQL `BIGINT UNSIGNED` did not null. It decoded as `"true"`.** It fits no signed arm, no float arm, and reached `bool`, where `18446744073709551615` came back as `true` and was reported as the column's value. The macro's own doc comment warns about exactly this hazard for SQLite integers; the same trap was live for MySQL and unexamined. The issue describes this case as needing "a backend-specific arm since the generic chain cannot express `u64`" — it does not record that the column currently reports a plausible wrong value rather than a missing one.

## Correction to the issue's proposal

Step 1 says to render temporal values as RFC 3339 "so the existing string-based type inference recognises them". It would not have worked. The grammar is `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$` (`inference.rs`) unioned with a date-only validation set (`metrics/utils.rs`); neither accepts a trailing offset or `Z`. A faithful RFC 3339 rendering would have profiled the column as **text** and left Timeliness exactly as inert as the nulls did, while passing a decode test and failing the issue's own acceptance criterion.

So timestamps render naive ISO instead. `TIMESTAMPTZ` is converted to UTC first: the instant survives, the marker saying it is UTC does not. That is a real loss and it is documented on the macro and in the connectors guide.

This also implies a separate bug, filed rather than folded in here: a **CSV or JSON** column of RFC 3339 timestamps profiles as text today, for the same grammar reason.

## What changed

- Shared chain gains `DateTime<Utc>`, `NaiveDateTime`, `NaiveDate`, `NaiveTime` and `Uuid` arms. `chrono` and `uuid` were already enabled workspace-wide, so these cost no new dependency and the guide's claim that they need features "this crate does not enable" was already stale.
- `u64` and `BigDecimal` cannot live in the shared chain — no `Type<Postgres>` for the first, no `Type<Sqlite>` for the second — so `db_column_to_string!` takes a list of backend arms and each connector passes its own. They sit **before** `bool`, which is what closes the `"true"` path.
- `NUMERIC`/`DECIMAL` keeps its exact digits. Routing through `f64` would report statistics about a number the database does not contain, which is the entire reason the type exists.
- `sqlx/bigdecimal` is attached to the `postgres` and `mysql` features rather than the workspace, so a sqlite-only build does not pay for a decimal type SQLite has no impl for. Verified with `cargo tree`: 0 bigdecimal crates under `--features sqlite`, 2 under `--features postgres`. One new crate total.

## Deliberately still null

Documented on the macro and in the guide rather than left to be discovered:

- `BLOB`/`BYTEA`. Profiling bytes as text is meaningless; this needs a binary column type reporting null count and byte-length distribution, which is a product change rather than a decode arm.
- MySQL `TIME`. sqlx decodes it as a duration, not a time of day.

## Verification

Ten tests in `crates/dataprof-db/tests/typed_column_decoding.rs`, run against real `postgres:16-alpine` and `mysql:8.0` containers matching the CI service definitions.

**Reverted each half separately, not together:**

- Backend arms reverted alone: `numeric`, `decimal` and `unsigned_bigint` fail; the temporal, UUID and Timeliness tests still pass.
- Shared temporal/UUID arms reverted alone: those five fail; the decimal and unsigned tests still pass.

**The acceptance criterion is proved rather than assumed.** `a_timestamp_column_makes_timeliness_assessable` runs a real profile through `analyze_database` and asserts `Timeliness` is in `assessed_dimensions()` with `date_values_checked > 0`.

Three faults in my own tests, found by running them:

1. The first version called the decode macro directly, which meant it supplied the backend arms itself and would have kept passing if a connector dropped them. It now profiles through the connector.
2. The rewrite raced on a shared table and only passed under `--test-threads=1`. The fixture is now built once via `OnceCell`.
3. Each connector has two call sites, batch and streaming, and only the batch one was covered. `the_streaming_path_decodes_the_same_types` closes that; updating one call site and not the other is otherwise an easy and silent miss.

A default no-feature build also broke at first: `render_naive_datetime` is a real function, so its `::sqlx` signature compiled even with sqlx unlinked. Now gated, and every feature combination is checked: `[]`, `[sqlite]`, `[postgres]`, `[mysql]`, `[postgres,mysql,sqlite]`.

## Commands run

```
cargo test --workspace                                    # 842 passed, 0 failed
cargo test -p dataprof-db --features "postgres,mysql,sqlite"   # 49 passed
cargo test --test database_integration --features all-db  # 26 passed
cargo check -p dataprof-db  (each feature combination)
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo clippy -p dataprof-db --all-targets --features "postgres,mysql,sqlite" -- -D warnings
```
