### PR TITLE
feat: add column projection across profiling paths

### DIFF
--- a/crates/dataprof-core/src/analysis_options.rs
+++ b/crates/dataprof-core/src/analysis_options.rs
@@ -8,6 +8,9 @@
 //! [`AnalysisOptions`] bundles them so a path either carries the whole selection
 //! or does not compile.
 
+use std::collections::HashSet;
+
+use crate::errors::DataProfilerError;
 use crate::locale::Locale;
 use crate::quality::{MetricPack, QualityDimension};
 use crate::semantic::SemanticHints;
@@ -18,6 +21,7 @@ use crate::semantic::SemanticHints;
 /// with the builder methods.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AnalysisOptions {
+    columns: Option<Vec<String>>,
     metric_packs: Option<Vec<MetricPack>>,
     quality_dimensions: Option<Vec<QualityDimension>>,
     locale: Option<Locale>,
@@ -25,6 +29,15 @@ pub struct AnalysisOptions {
 }
 
 impl AnalysisOptions {
+    /// Select top-level columns to profile. `None` (the default) means every column.
+    ///
+    /// Selection is by name and reports remain in source-schema order. An empty
+    /// vector requests a schema with no profiled columns.
+    pub fn with_columns(mut self, columns: Option<Vec<String>>) -> Self {
+        self.columns = columns;
+        self
+    }
+
     /// Select the metric packs to compute. `None` (the default) means all.
     pub fn with_metric_packs(mut self, packs: Option<Vec<MetricPack>>) -> Self {
         self.metric_packs = packs;
@@ -100,6 +113,70 @@ impl AnalysisOptions {
     pub fn semantic_hints(&self) -> &SemanticHints {
         &self.semantic_hints
     }
+
+    /// The requested top-level column names, or `None` when every column is selected.
+    pub fn columns(&self) -> Option<&[String]> {
+        self.columns.as_deref()
+    }
+
+    /// Whether the caller selected a subset of the source columns.
+    pub fn has_column_projection(&self) -> bool {
+        self.columns.is_some()
+    }
+
+    /// Resolve the selected columns against a source schema.
+    ///
+    /// Returned indices follow source order, not request order, so every input
+    /// path preserves the same stable report ordering. Unknown and duplicate
+    /// requests fail rather than producing a plausible partial profile.
+    pub fn column_indices(
+        &self,
+        available: &[String],
+    ) -> Result<Option<Vec<usize>>, DataProfilerError> {
+        let Some(requested) = &self.columns else {
+            return Ok(None);
+        };
+
+        let mut seen = HashSet::with_capacity(requested.len());
+        let duplicates = requested
+            .iter()
+            .filter(|name| !seen.insert(name.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !duplicates.is_empty() {
+            return Err(DataProfilerError::invalid_config(
+                &format!(
+                    "column projection contains duplicate name(s): {}",
+                    duplicates.join(", ")
+                ),
+                "List each projected column once.",
+            ));
+        }
+
+        let available_set = available.iter().map(String::as_str).collect::<HashSet<_>>();
+        let missing = requested
+            .iter()
+            .filter(|name| !available_set.contains(name.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            return Err(DataProfilerError::invalid_config(
+                &format!(
+                    "column projection names column(s) absent from the source: {}",
+                    missing.join(", ")
+                ),
+                "Choose column names from the source schema.",
+            ));
+        }
+
+        Ok(Some(
+            available
+                .iter()
+                .enumerate()
+                .filter_map(|(index, name)| seen.contains(name.as_str()).then_some(index))
+                .collect(),
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -114,6 +191,8 @@ mod tests {
         assert!(options.include_quality());
         assert_eq!(options.locale(), None);
         assert_eq!(options.quality_dimensions(), None);
+        assert_eq!(options.columns(), None);
+        assert!(!options.has_column_projection());
     }
 
     #[test]
@@ -156,5 +235,29 @@ mod tests {
             .with_metric_packs(Some(vec![MetricPack::Schema]));
         assert_eq!(options.locale(), Some(Locale::It));
         assert!(!options.include_patterns());
+    }
+
+    #[test]
+    fn column_projection_resolves_in_source_order() {
+        let options = AnalysisOptions::default()
+            .with_columns(Some(vec!["city".to_string(), "id".to_string()]));
+        let available = vec!["id".to_string(), "name".to_string(), "city".to_string()];
+
+        assert_eq!(
+            options.column_indices(&available).unwrap(),
+            Some(vec![0, 2])
+        );
+        assert!(options.has_column_projection());
+    }
+
+    #[test]
+    fn column_projection_rejects_unknown_and_duplicate_names() {
+        let available = vec!["id".to_string(), "city".to_string()];
+        let unknown = AnalysisOptions::default().with_columns(Some(vec!["name".to_string()]));
+        assert!(unknown.column_indices(&available).is_err());
+
+        let duplicate =
+            AnalysisOptions::default().with_columns(Some(vec!["id".to_string(), "id".to_string()]));
+        assert!(duplicate.column_indices(&available).is_err());
     }
 }

--- a/crates/dataprof-db/src/connectors/common.rs
+++ b/crates/dataprof-db/src/connectors/common.rs
@@ -136,12 +136,35 @@ macro_rules! streaming_profile_loop {
     };
     ($pool:expr, $query:expr, $batch_size:expr, $total_rows:expr, $db_name:literal,
      [$($backend_ty:ty),* $(,)?]) => {{
-        use sqlx::{Column, Row};
+        use sqlx::{Column, Executor, Row};
         use $crate::connectors::common::build_batch_query;
         use $crate::streaming::{StreamingProgress, merge_column_batches};
 
         let mut progress = StreamingProgress::new(Some($total_rows as u64));
-        let mut all_batches: Vec<$crate::QueryColumns> = Vec::new();
+        // Describe the query before fetching rows. Row metadata is unavailable
+        // when the first batch is empty, but projection still needs the source
+        // schema to validate duplicate and unknown requested names.
+        let first_batch_query = build_batch_query($query, $batch_size, 0)?;
+        let description = ($pool).describe(&first_batch_query).await.map_err(|e| {
+            $crate::DataProfilerError::DatabaseQueryError {
+                message: format!("Query description failed: {}", e),
+            }
+        })?;
+        let column_names: Vec<String> = description
+            .columns()
+            .iter()
+            .map(|column| column.name().to_string())
+            .collect();
+        dataprof_core::validate_unique_column_names(
+            &column_names,
+            concat!($db_name, " query result"),
+        )?;
+
+        // Seed the merge with the schema so a zero-row query still returns
+        // named empty columns in query order.
+        let mut all_batches: Vec<$crate::QueryColumns> = vec![
+            $crate::QueryColumns::with_names(column_names.clone(), 0),
+        ];
         let mut offset = 0usize;
 
         loop {
@@ -157,22 +180,13 @@ macro_rules! streaming_profile_loop {
                 break;
             }
 
-            let columns = rows[0].columns();
-            let column_names: Vec<String> = columns
-                .iter()
-                .map(|column| column.name().to_string())
-                .collect();
-            dataprof_core::validate_unique_column_names(
-                &column_names,
-                concat!($db_name, " query result"),
-            )?;
             // Built from the driver's column list, so the batch carries the
             // query's column order and values are filed by position.
             let mut batch_result =
                 $crate::QueryColumns::with_names(column_names.clone(), rows.len());
 
             for row in &rows {
-                for i in 0..columns.len() {
+                for i in 0..column_names.len() {
                     let value: Option<String> =
                         $crate::db_column_to_string!(row, i, [$($backend_ty),*]);
                     // decode-audit: no-data — None is SQL NULL (or a type

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -257,7 +257,7 @@ pub async fn analyze_database_with_options(
         (actual_query, None)
     };
 
-    let columns = connector
+    let mut columns = connector
         .profile_query_streaming(&final_query, config.batch_size)
         .await?;
 
@@ -291,6 +291,15 @@ pub async fn analyze_database_with_options(
     // decode-audit: no-data — the empty-columns case returned early above, so
     // this default is only a guard; every column vec has the same length.
     let actual_rows_processed = columns.row_count();
+
+    let available_columns = columns.names().map(str::to_string).collect::<Vec<_>>();
+    if let Some(indices) = options.column_indices(&available_columns)? {
+        let selected = indices
+            .into_iter()
+            .map(|index| available_columns[index].clone())
+            .collect::<Vec<_>>();
+        columns.retain_names(&selected);
+    }
 
     // `columns` keeps the query's column order, so the report reports columns in
     // the order they were selected — the same source-order contract CSV, Parquet

--- a/crates/dataprof-db/src/query_columns.rs
+++ b/crates/dataprof-db/src/query_columns.rs
@@ -100,6 +100,16 @@ impl QueryColumns {
             .map(|(_, data)| data)
     }
 
+    /// Retain selected columns while preserving query order.
+    pub fn retain_names(&mut self, names: &[String]) {
+        let names = names
+            .iter()
+            .map(String::as_str)
+            .collect::<std::collections::HashSet<_>>();
+        self.columns
+            .retain(|(name, _)| names.contains(name.as_str()));
+    }
+
     /// Drop the order and hand back a plain map.
     ///
     /// For consumers keyed purely by name — quality metrics look every column up

--- a/crates/dataprof-db/tests/column_order.rs
+++ b/crates/dataprof-db/tests/column_order.rs
@@ -8,7 +8,11 @@
 
 #![cfg(feature = "sqlite")]
 
-use dataprof_db::{DatabaseConfig, DatabaseConnector, QueryColumns, create_connector};
+use dataprof_core::AnalysisOptions;
+use dataprof_db::{
+    DatabaseConfig, DatabaseConnector, QueryColumns, analyze_database_with_options,
+    create_connector,
+};
 use sqlx::sqlite::SqlitePoolOptions;
 
 /// Four columns whose declaration order differs from alphabetical order in
@@ -106,6 +110,53 @@ async fn streaming_batches_preserve_the_schema_order() {
     assert_eq!(columns["id"], ["0", "1", "2", "3"]);
 
     connector.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn streaming_empty_results_preserve_the_schema_order() {
+    let (_dir, db_path) = fixture(0).await;
+    let mut connector = connect(&db_path).await;
+
+    let columns = connector
+        .profile_query_streaming("SELECT date, id, active, amount FROM t", 2)
+        .await
+        .unwrap();
+
+    assert_eq!(names(&columns), ["date", "id", "active", "amount"]);
+    assert_eq!(columns.row_count(), 0);
+
+    connector.disconnect().await.unwrap();
+}
+
+#[tokio::test]
+async fn empty_results_still_validate_column_projection() {
+    let (_dir, db_path) = fixture(0).await;
+    let database_config = || DatabaseConfig {
+        connection_string: db_path.clone(),
+        load_credentials_from_env: false,
+        ..Default::default()
+    };
+
+    let unknown = AnalysisOptions::default().with_columns(Some(vec!["missing".to_string()]));
+    let error = analyze_database_with_options(database_config(), "SELECT * FROM t", &unknown)
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("absent from the source: missing"),
+        "unexpected unknown-column error: {error}"
+    );
+
+    let duplicate =
+        AnalysisOptions::default().with_columns(Some(vec!["id".to_string(), "id".to_string()]));
+    let error = analyze_database_with_options(database_config(), "SELECT * FROM t", &duplicate)
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("duplicate name(s): id"),
+        "unexpected duplicate-column error: {error}"
+    );
 }
 
 #[tokio::test]

--- a/crates/dataprof-engines/src/adaptive.rs
+++ b/crates/dataprof-engines/src/adaptive.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use dataprof_core::{
-    ChunkSize, DataProfilerError, Locale, MetricPack, QualityDimension, SemanticHints,
+    AnalysisOptions, ChunkSize, DataProfilerError, Locale, MetricPack, QualityDimension,
+    SemanticHints,
 };
 use dataprof_csv::CsvParserConfig;
 use dataprof_runtime::ProfileReport;
@@ -25,6 +26,7 @@ pub(crate) enum InternalEngineType {
 pub struct AdaptiveProfiler {
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
+    columns: Option<Vec<String>>,
     csv_config: Option<CsvParserConfig>,
     locale: Option<Locale>,
     semantic_hints: SemanticHints,
@@ -37,6 +39,7 @@ impl AdaptiveProfiler {
         Self {
             quality_dimensions: None,
             metric_packs: None,
+            columns: None,
             csv_config: None,
             locale: None,
             semantic_hints: SemanticHints::default(),
@@ -67,6 +70,11 @@ impl AdaptiveProfiler {
         self
     }
 
+    pub fn columns(mut self, columns: Vec<String>) -> Self {
+        self.columns = Some(columns);
+        self
+    }
+
     pub fn csv_config(mut self, config: CsvParserConfig) -> Self {
         self.csv_config = Some(config);
         self
@@ -89,10 +97,16 @@ impl AdaptiveProfiler {
         // Parquet has its own parser — short-circuit
         #[cfg(feature = "parquet")]
         if is_parquet(file_path) {
-            return dataprof_parquet::analyze_parquet_with_quality_dims_and_hints(
+            let options = AnalysisOptions::default()
+                .with_columns(self.columns.clone())
+                .with_metric_packs(self.metric_packs.clone())
+                .with_quality_dimensions(self.quality_dimensions.clone())
+                .with_locale(self.locale)
+                .with_semantic_hints(self.semantic_hints.clone());
+            return dataprof_parquet::analyze_parquet_with_options(
                 file_path,
-                self.quality_dimensions.as_deref(),
-                &self.semantic_hints,
+                &dataprof_parquet::ParquetConfig::default(),
+                &options,
             );
         }
 
@@ -122,7 +136,11 @@ impl AdaptiveProfiler {
                 // Duplicate column names are a deterministic property of the file;
                 // no engine can resolve them, so surface the clear, categorized
                 // error instead of burying it under "All engines failed".
-                if matches!(primary_err, DataProfilerError::DuplicateColumnName { .. }) {
+                if matches!(
+                    primary_err,
+                    DataProfilerError::DuplicateColumnName { .. }
+                        | DataProfilerError::InvalidConfiguration { .. }
+                ) {
                     return Err(primary_err);
                 }
                 // Likewise when the caller asked for strict CSV parsing: they
@@ -244,6 +262,9 @@ impl AdaptiveProfiler {
                 if let Some(ref packs) = self.metric_packs {
                     profiler = profiler.metric_packs(packs.clone());
                 }
+                if let Some(ref columns) = self.columns {
+                    profiler = profiler.columns(columns.clone());
+                }
                 if let Some(ref config) = self.csv_config {
                     profiler = profiler.csv_config(config.clone());
                 }
@@ -269,6 +290,9 @@ impl AdaptiveProfiler {
                 }
                 if let Some(ref packs) = self.metric_packs {
                     profiler = profiler.metric_packs(packs.clone());
+                }
+                if let Some(ref columns) = self.columns {
+                    profiler = profiler.columns(columns.clone());
                 }
                 if let Some(ref config) = self.csv_config {
                     profiler = profiler.csv_config(config.clone());

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -423,7 +423,7 @@ impl AsyncStreamingProfiler {
         // a strict-mode malformed record aborts the reader before any data
         // reaches the processor, which would otherwise surface only as a generic
         // "empty input" error and mask the real cause.
-        let (_headers, column_stats, total_rows, sampled_rows, total_bytes, truncation_reason) =
+        let (_headers, mut column_stats, total_rows, sampled_rows, total_bytes, truncation_reason) =
             match process_result {
                 Ok(result) => result,
                 Err(process_err) => {
@@ -433,6 +433,15 @@ impl AsyncStreamingProfiler {
                     };
                 }
             };
+
+        if let Some(indices) = self.options.column_indices(&column_stats.column_names())? {
+            let available = column_stats.column_names();
+            let selected = indices
+                .into_iter()
+                .map(|index| available[index].clone())
+                .collect::<Vec<_>>();
+            column_stats.retain_columns(&selected);
+        }
 
         // Wait for the reader task to finish and propagate any errors
         let reader_outcome = match reader_handle.await {

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -2,9 +2,9 @@ use std::path::Path;
 use std::time::Duration;
 
 use dataprof_core::{
-    ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat, Locale, MetricPack,
-    PeakMemorySampler, ProgressSink, QualityDimension, RowSampler, RowView, SamplingStrategy,
-    SchemaStabilityTracker, SemanticHints, StopCondition, StopEvaluator,
+    AnalysisOptions, ChunkSize, DataProfilerError, DataSource, ExecutionMetadata, FileFormat,
+    Locale, MetricPack, PeakMemorySampler, ProgressSink, QualityDimension, RowSampler, RowView,
+    SamplingStrategy, SchemaStabilityTracker, SemanticHints, StopCondition, StopEvaluator,
 };
 use dataprof_csv::{CsvParserConfig, MemoryMappedCsvReader};
 use dataprof_runtime::{
@@ -25,6 +25,7 @@ pub struct IncrementalProfiler {
     stop_condition: StopCondition,
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
+    columns: Option<Vec<String>>,
     csv_config: Option<CsvParserConfig>,
     locale: Option<Locale>,
     semantic_hints: SemanticHints,
@@ -41,6 +42,7 @@ impl IncrementalProfiler {
             stop_condition: StopCondition::Never,
             quality_dimensions: None,
             metric_packs: None,
+            columns: None,
             csv_config: None,
             locale: None,
             semantic_hints: SemanticHints::default(),
@@ -80,6 +82,11 @@ impl IncrementalProfiler {
 
     pub fn metric_packs(mut self, packs: Vec<MetricPack>) -> Self {
         self.metric_packs = Some(packs);
+        self
+    }
+
+    pub fn columns(mut self, columns: Vec<String>) -> Self {
+        self.columns = Some(columns);
         self
     }
 
@@ -363,16 +370,33 @@ impl IncrementalProfiler {
         memory_sampler.sample();
         progress_tracker.emit_finished(!source_exhausted);
 
+        let options = AnalysisOptions::default()
+            .with_columns(self.columns.clone())
+            .with_metric_packs(self.metric_packs.clone())
+            .with_quality_dimensions(self.quality_dimensions.clone())
+            .with_locale(self.locale)
+            .with_semantic_hints(self.semantic_hints.clone());
+
+        if let Some(indices) = options.column_indices(&column_stats.column_names())? {
+            let available = column_stats.column_names();
+            let selected = indices
+                .into_iter()
+                .map(|index| available[index].clone())
+                .collect::<Vec<_>>();
+            column_stats.retain_columns(&selected);
+        }
+
         // Convert streaming statistics to column profiles
-        let packs = self.metric_packs.as_deref();
+        let effective_packs = options.effective_metric_packs();
+        let packs = effective_packs.as_deref();
         let skip_stats = !MetricPack::include_statistics(packs);
         let skip_patterns = !MetricPack::include_patterns(packs);
         let column_profiles = profile_builder::profiles_from_streaming_with_hints(
             &column_stats,
             skip_stats,
             skip_patterns,
-            self.locale,
-            &self.semantic_hints,
+            options.locale(),
+            options.semantic_hints(),
         );
 
         // Calculate quality metrics from sample data
@@ -438,10 +462,7 @@ impl IncrementalProfiler {
                 .with_row_duplicates(column_stats.row_duplicate_summary())
                 .with_row_completeness(column_stats.row_completeness_summary())
                 .with_exact_value_hint_bindings(column_stats.semantic_hint_bindings())
-                .with_semantic_hints(self.semantic_hints.clone());
-            if let Some(ref dims) = self.quality_dimensions {
-                assembler = assembler.with_requested_dimensions(dims.clone());
-            }
+                .with_analysis_options(&options);
         } else {
             assembler = assembler.skip_quality();
         }

--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -999,6 +999,15 @@ fn analyze_json_from_reader_full<R: BufRead>(
         rows_seen += 1;
     })?;
 
+    if let Some(indices) = options.column_indices(&column_stats.column_names())? {
+        let available = column_stats.column_names();
+        let selected = indices
+            .into_iter()
+            .map(|index| available[index].clone())
+            .collect::<Vec<_>>();
+        column_stats.retain_columns(&selected);
+    }
+
     let profiles = profile_builder::profiles_from_streaming_with_hints(
         &column_stats,
         !options.include_statistics(),

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -4,8 +4,9 @@ use arrow::csv::ReaderBuilder;
 use arrow::datatypes::*;
 use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
-    ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata, FileFormat, Locale,
-    MetricPack, PeakMemorySampler, QualityDimension, SemanticHints, TruncationReason, char_len,
+    AnalysisOptions, ColumnProfile, DataProfilerError, DataSource, DataType, ExecutionMetadata,
+    FileFormat, Locale, MetricPack, PeakMemorySampler, QualityDimension, SemanticHints,
+    TruncationReason, char_len,
 };
 use dataprof_csv::CsvParserConfig;
 use dataprof_metrics::CardinalityEstimator;
@@ -37,6 +38,7 @@ pub struct ArrowProfiler {
     memory_limit_mb: usize,
     quality_dimensions: Option<Vec<QualityDimension>>,
     metric_packs: Option<Vec<MetricPack>>,
+    columns: Option<Vec<String>>,
     csv_config: Option<CsvParserConfig>,
     locale: Option<Locale>,
     semantic_hints: SemanticHints,
@@ -49,6 +51,7 @@ impl ArrowProfiler {
             memory_limit_mb: 512,
             quality_dimensions: None,
             metric_packs: None,
+            columns: None,
             csv_config: None,
             locale: None,
             semantic_hints: SemanticHints::default(),
@@ -72,6 +75,11 @@ impl ArrowProfiler {
 
     pub fn metric_packs(mut self, packs: Vec<MetricPack>) -> Self {
         self.metric_packs = Some(packs);
+        self
+    }
+
+    pub fn columns(mut self, columns: Vec<String>) -> Self {
+        self.columns = Some(columns);
         self
     }
 
@@ -177,6 +185,19 @@ impl ArrowProfiler {
                 .collect()
         };
         let header_width = header_names.len();
+        let options = AnalysisOptions::default()
+            .with_columns(self.columns.clone())
+            .with_metric_packs(self.metric_packs.clone())
+            .with_quality_dimensions(self.quality_dimensions.clone())
+            .with_locale(self.locale)
+            .with_semantic_hints(self.semantic_hints.clone());
+        let projection = options
+            .column_indices(&header_names)?
+            .unwrap_or_else(|| (0..header_width).collect());
+        let projected_header_names = projection
+            .iter()
+            .map(|index| header_names[*index].clone())
+            .collect::<Vec<_>>();
 
         let mut fields = Vec::new();
         for header in &header_names {
@@ -218,7 +239,7 @@ impl ArrowProfiler {
         let mut column_analyzers: std::collections::HashMap<String, ColumnAnalyzer> =
             std::collections::HashMap::new();
 
-        for name in &header_names {
+        for name in &projected_header_names {
             column_analyzers.insert(
                 name.clone(),
                 ColumnAnalyzer::new(&arrow::datatypes::DataType::Utf8),
@@ -240,19 +261,14 @@ impl ArrowProfiler {
         let mut truncated = false;
         let mut memory_sampler = PeakMemorySampler::new();
 
-        let projection: Vec<usize> = (0..header_width).collect();
-
         for batch_result in csv_reader {
             let mut batch = batch_result.map_err(|error| map_arrow_csv_error(file_path, error))?;
 
-            // Drop the overflow columns before anything observes the batch, so
-            // duplicate tracking, hint bindings and the profiles themselves all
-            // see exactly the columns the header declared.
-            if batch.num_columns() > header_width {
-                batch = batch
-                    .project(&projection)
-                    .map_err(DataProfilerError::arrow_error_from)?;
-            }
+            // Drop overflow and unselected columns before anything observes the
+            // batch, so every downstream calculation sees the same projection.
+            batch = batch
+                .project(&projection)
+                .map_err(DataProfilerError::arrow_error_from)?;
 
             if let Some(max) = max_rows {
                 if total_rows >= max {
@@ -294,21 +310,22 @@ impl ArrowProfiler {
 
         // Convert analyzers to column profiles and extract samples
         // Iterate in header order (from schema) to preserve source column ordering
-        let packs = self.metric_packs.as_deref();
+        let effective_packs = options.effective_metric_packs();
+        let packs = effective_packs.as_deref();
         let skip_stats = !MetricPack::include_statistics(packs);
         let skip_patterns = !MetricPack::include_patterns(packs);
 
         let mut column_profiles = Vec::new();
         let mut sample_columns = std::collections::HashMap::new();
 
-        for name in &header_names {
+        for name in &projected_header_names {
             if let Some(analyzer) = column_analyzers.get(name) {
                 let profile = analyzer.to_column_profile(
                     name.clone(),
                     skip_stats,
                     skip_patterns,
-                    self.locale,
-                    &self.semantic_hints,
+                    options.locale(),
+                    options.semantic_hints(),
                 );
                 column_profiles.push(profile);
                 sample_columns.insert(name.clone(), analyzer.get_sample_values());
@@ -348,12 +365,9 @@ impl ArrowProfiler {
             assembler = assembler
                 .with_quality_data(sample_columns)
                 .with_exact_value_hint_bindings(
-                    hint_bindings.bindings(header_names.iter().map(String::as_str)),
+                    hint_bindings.bindings(projected_header_names.iter().map(String::as_str)),
                 )
-                .with_semantic_hints(self.semantic_hints.clone());
-            if let Some(ref dims) = self.quality_dimensions {
-                assembler = assembler.with_requested_dimensions(dims.clone());
-            }
+                .with_analysis_options(&options);
         } else {
             assembler = assembler.skip_quality();
         }

--- a/crates/dataprof-parquet/src/async_http.rs
+++ b/crates/dataprof-parquet/src/async_http.rs
@@ -10,7 +10,7 @@ use parquet::arrow::async_reader::AsyncFileReader;
 use reqwest::{Client, header};
 use std::ops::Range;
 
-use crate::{ParquetConfig, RecordBatchAnalyzer};
+use crate::{ParquetConfig, RecordBatchAnalyzer, parser::projection_mask_for_roots};
 
 /// An asynchronous reader that fetches byte ranges from an HTTP server
 /// using HTTP Range requests. Designed specifically for remote Parquet parsing.
@@ -330,18 +330,24 @@ pub async fn analyze_parquet_async_http_with_options(
         .map(|i| parquet_meta.row_group(i).compressed_size() as u64)
         .sum();
 
-    let arrow_schema = builder.schema().clone();
-    let schema_summary = format!("{arrow_schema}");
+    let source_arrow_schema = builder.schema().clone();
+    let schema_summary = format!("{source_arrow_schema}");
+    let available_columns = source_arrow_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    let projection = options.column_indices(&available_columns)?;
 
-    let mut stream = builder
-        .with_batch_size(config.batch_size)
-        .build()
-        .map_err(|e| {
-            DataProfilerError::parquet_with_source(
-                format!("Failed to build Parquet stream: {}", e),
-                e,
-            )
-        })?;
+    let mut stream_builder = builder.with_batch_size(config.batch_size);
+    if let Some(indices) = projection {
+        let mask = projection_mask_for_roots(stream_builder.parquet_schema(), &indices);
+        stream_builder = stream_builder.with_projection(mask);
+    }
+    let mut stream = stream_builder.build().map_err(|e| {
+        DataProfilerError::parquet_with_source(format!("Failed to build Parquet stream: {}", e), e)
+    })?;
+    let arrow_schema = stream.schema().clone();
 
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
     analyzer.initialize_schema(arrow_schema.as_ref())?;

--- a/crates/dataprof-parquet/src/parser.rs
+++ b/crates/dataprof-parquet/src/parser.rs
@@ -1,6 +1,9 @@
+use arrow::record_batch::RecordBatchReader;
 use bytes::Bytes;
+use parquet::arrow::ProjectionMask;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::reader::ChunkReader;
+use parquet::schema::types::SchemaDescriptor;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
@@ -11,6 +14,21 @@ use dataprof_core::{
     QualityDimension, SemanticHints, TruncationReason,
 };
 use dataprof_runtime::{ProfileReport, ReportAssembler};
+
+/// Expand selected top-level roots to their physical Parquet leaves.
+///
+/// The public report model names top-level Arrow fields, while Parquet performs
+/// projection at leaf granularity. Expanding here keeps every leaf below a
+/// selected nested field and still drives the reader through the leaf-level
+/// projection path that avoids touching unselected column chunks.
+pub(crate) fn projection_mask_for_roots(
+    schema: &SchemaDescriptor,
+    root_indices: &[usize],
+) -> ProjectionMask {
+    let leaves = (0..schema.num_columns())
+        .filter(|leaf_index| root_indices.contains(&schema.get_column_root_idx(*leaf_index)));
+    ProjectionMask::leaves(schema, leaves)
+}
 
 /// Check if a file is a valid Parquet file by examining its magic number.
 ///
@@ -502,10 +520,21 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
         .map(|index| parquet_meta.row_group(index).compressed_size() as u64)
         .sum();
 
-    let arrow_schema = builder.schema().clone();
-    let schema_summary = format!("{arrow_schema}");
+    let source_arrow_schema = builder.schema().clone();
+    let schema_summary = format!("{source_arrow_schema}");
+
+    let available_columns = source_arrow_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    let projection = options.column_indices(&available_columns)?;
 
     let mut reader_builder = builder.with_batch_size(config.batch_size);
+    if let Some(indices) = projection {
+        let mask = projection_mask_for_roots(reader_builder.parquet_schema(), &indices);
+        reader_builder = reader_builder.with_projection(mask);
+    }
     if let Some(max) = config.max_rows {
         reader_builder = reader_builder.with_limit(max);
     }
@@ -515,6 +544,7 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
             error,
         )
     })?;
+    let arrow_schema = reader.schema();
 
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(semantic_hints);
     analyzer.initialize_schema(arrow_schema.as_ref())?;
@@ -591,12 +621,19 @@ fn analyze_parquet_chunks<R: ChunkReader + 'static>(
 mod tests {
     use super::*;
     use anyhow::Result;
-    use arrow::array::{BooleanArray, Date32Array, Float64Array, Int32Array, StringArray};
+    use arrow::array::{
+        Array, ArrayRef, BooleanArray, Date32Array, Float64Array, Int32Array, StringArray,
+        StructArray,
+    };
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use parquet::arrow::ArrowWriter;
+    use parquet::errors::Result as ParquetResult;
     use parquet::file::properties::WriterProperties;
-    use std::sync::Arc;
+    use parquet::file::reader::Length;
+    use std::io::{Cursor, Read};
+    use std::ops::Range;
+    use std::sync::{Arc, Mutex};
     use tempfile::NamedTempFile;
 
     /// Write `batch` to Parquet and return the encoded bytes.
@@ -634,6 +671,167 @@ mod tests {
                 Arc::new(StringArray::from(vec![Some("a"), None, Some("c")])),
             ],
         )?)
+    }
+
+    struct CountingRead {
+        cursor: Cursor<Bytes>,
+        base: u64,
+        ranges: Arc<Mutex<Vec<Range<u64>>>>,
+    }
+
+    impl Read for CountingRead {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let start = self.base + self.cursor.position();
+            let read = self.cursor.read(buffer)?;
+            if read > 0 {
+                self.ranges
+                    .lock()
+                    .expect("read log lock")
+                    .push(start..start + read as u64);
+            }
+            Ok(read)
+        }
+    }
+
+    #[derive(Clone)]
+    struct CountingChunkReader {
+        data: Bytes,
+        ranges: Arc<Mutex<Vec<Range<u64>>>>,
+    }
+
+    impl CountingChunkReader {
+        fn new(data: Bytes) -> Self {
+            Self {
+                data,
+                ranges: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn ranges(&self) -> Vec<Range<u64>> {
+            self.ranges.lock().expect("read log lock").clone()
+        }
+    }
+
+    impl Length for CountingChunkReader {
+        fn len(&self) -> u64 {
+            self.data.len() as u64
+        }
+    }
+
+    impl ChunkReader for CountingChunkReader {
+        type T = CountingRead;
+
+        fn get_read(&self, start: u64) -> ParquetResult<Self::T> {
+            Ok(CountingRead {
+                cursor: Cursor::new(self.data.slice(start as usize..)),
+                base: start,
+                ranges: Arc::clone(&self.ranges),
+            })
+        }
+
+        fn get_bytes(&self, start: u64, length: usize) -> ParquetResult<Bytes> {
+            let end = start + length as u64;
+            self.ranges.lock().expect("read log lock").push(start..end);
+            Ok(self.data.slice(start as usize..end as usize))
+        }
+    }
+
+    #[test]
+    fn projected_reader_never_reads_unselected_column_chunks() -> Result<()> {
+        let encoded = Bytes::from(to_parquet_bytes(&mixed_batch()?)?);
+        let metadata_reader = ParquetRecordBatchReaderBuilder::try_new(encoded.clone())?;
+        let unselected = metadata_reader.metadata().row_group(0).column(4);
+        let (unselected_start, unselected_length) = unselected.byte_range();
+        let unselected_range = unselected_start..unselected_start + unselected_length;
+
+        let counting = CountingChunkReader::new(encoded.clone());
+        let report = analyze_parquet_chunks(
+            counting.clone(),
+            ParquetOrigin::Memory {
+                name: "counted".to_string(),
+                byte_len: encoded.len() as u64,
+            },
+            &ParquetConfig::default(),
+            &AnalysisOptions::default().with_columns(Some(vec!["id".to_string()])),
+        )?;
+
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|profile| profile.name.as_str())
+                .collect::<Vec<_>>(),
+            ["id"]
+        );
+        assert!(
+            counting.ranges().iter().all(|read| {
+                read.end <= unselected_range.start || read.start >= unselected_range.end
+            }),
+            "read log overlapped unselected column chunk {unselected_range:?}: {:?}",
+            counting.ranges()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn top_level_projection_keeps_every_leaf_of_a_nested_column() -> Result<()> {
+        let nested = StructArray::from(vec![
+            (
+                Arc::new(Field::new("city", DataType::Utf8, false)),
+                Arc::new(StringArray::from(vec!["Rome", "Milan"])) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("postcode", DataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![20121, 20122])) as ArrayRef,
+            ),
+        ]);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("address", nested.data_type().clone(), false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(nested) as ArrayRef,
+            ],
+        )?;
+        let encoded = Bytes::from(to_parquet_bytes(&batch)?);
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(encoded.clone())?;
+        let mask = projection_mask_for_roots(builder.parquet_schema(), &[1]);
+        assert!(!mask.leaf_included(0), "unselected id leaf must be pruned");
+        assert!(mask.leaf_included(1), "address.city leaf must be kept");
+        assert!(mask.leaf_included(2), "address.postcode leaf must be kept");
+        let reader = builder.with_projection(mask).build()?;
+        let projected_schema = reader.schema();
+        let projected_field = projected_schema.field(0);
+        let DataType::Struct(children) = projected_field.data_type() else {
+            panic!("address should remain a struct")
+        };
+        assert_eq!(
+            children
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            ["city", "postcode"]
+        );
+
+        let report = analyze_parquet_bytes_with_options(
+            encoded,
+            "nested",
+            &ParquetConfig::default(),
+            &AnalysisOptions::default().with_columns(Some(vec!["address".to_string()])),
+        )?;
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|profile| profile.name.as_str())
+                .collect::<Vec<_>>(),
+            ["address"]
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -365,6 +365,8 @@ pub fn profile_dataframe(
 ) -> PyResult<super::types::PyProfileReport> {
     let start = std::time::Instant::now();
 
+    // decode-audit: no-data — an omitted optional config intentionally uses
+    // the default analysis selection; no decode error is being discarded.
     let options = config
         .map(PyProfilerConfig::analysis_options)
         .unwrap_or_default();
@@ -485,6 +487,8 @@ pub fn profile_arrow(
 ) -> PyResult<super::types::PyProfileReport> {
     let start = std::time::Instant::now();
 
+    // decode-audit: no-data — an omitted optional config intentionally uses
+    // the default analysis selection; no decode error is being discarded.
     let options = config
         .map(PyProfilerConfig::analysis_options)
         .unwrap_or_default();

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -365,8 +365,10 @@ pub fn profile_dataframe(
 ) -> PyResult<super::types::PyProfileReport> {
     let start = std::time::Instant::now();
 
-    // Extract metric packs and quality dimensions from config
-    let resolved_packs = config.and_then(PyProfilerConfig::effective_metric_packs);
+    let options = config
+        .map(PyProfilerConfig::analysis_options)
+        .unwrap_or_default();
+    let resolved_packs = options.effective_metric_packs();
     let packs = resolved_packs.as_deref();
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
@@ -384,17 +386,32 @@ pub fn profile_dataframe(
 
     // Optionally limit rows before analysis
     let (batch, truncated) = limit_batch_rows(batch, effective_max_rows);
+    let available_columns = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    let batch = match options
+        .column_indices(&available_columns)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?
+    {
+        Some(indices) => batch.project(&indices).map_err(|error| {
+            PyRuntimeError::new_err(format!("Arrow projection failed: {error}"))
+        })?,
+        None => batch,
+    };
 
     let num_rows = batch.num_rows();
     let num_cols = batch.num_columns();
     // decode-audit: no-data — absent config simply means no semantic hints.
-    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
+    let semantic_hints = options.semantic_hints().clone();
 
     // Process using existing RecordBatchAnalyzer
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
     analyze_imported_batch(&mut analyzer, &batch)?;
 
-    let locale = config.and_then(|c| c.locale);
+    let locale = options.locale();
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
     let sample_columns = if include_quality {
@@ -430,18 +447,13 @@ pub fn profile_dataframe(
     )
     .columns(column_profiles)
     .with_row_duplicates(analyzer.row_duplicate_summary())
-    .with_row_completeness(analyzer.row_completeness_summary());
+    .with_row_completeness(analyzer.row_completeness_summary())
+    .with_analysis_options(&options);
 
     if include_quality {
         assembler = assembler
             .with_quality_data(sample_columns)
-            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
-            .with_semantic_hints(semantic_hints.clone());
-        if let Some(dims) = config.and_then(|c| c.quality_dimensions.clone()) {
-            assembler = assembler.with_requested_dimensions(dims);
-        }
-    } else {
-        assembler = assembler.skip_quality();
+            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings());
     }
 
     let report = assembler.build();
@@ -473,8 +485,10 @@ pub fn profile_arrow(
 ) -> PyResult<super::types::PyProfileReport> {
     let start = std::time::Instant::now();
 
-    // Extract metric packs and quality dimensions from config
-    let resolved_packs = config.and_then(PyProfilerConfig::effective_metric_packs);
+    let options = config
+        .map(PyProfilerConfig::analysis_options)
+        .unwrap_or_default();
+    let resolved_packs = options.effective_metric_packs();
     let packs = resolved_packs.as_deref();
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
@@ -494,13 +508,33 @@ pub fn profile_arrow(
 
     // Optionally limit rows before analysis
     let (batches, truncated) = limit_batches(batches, effective_max_rows);
+    let available_columns = batches[0]
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect::<Vec<_>>();
+    let batches = match options
+        .column_indices(&available_columns)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?
+    {
+        Some(indices) => batches
+            .into_iter()
+            .map(|batch| {
+                batch.project(&indices).map_err(|error| {
+                    PyRuntimeError::new_err(format!("Arrow projection failed: {error}"))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?,
+        None => batches,
+    };
 
     let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
     // import_batches_from_pyarrow never yields an empty sequence, and
     // limit_batches always keeps one batch for its schema.
     let num_cols = batches[0].num_columns();
     // decode-audit: no-data — absent config simply means no semantic hints.
-    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
+    let semantic_hints = options.semantic_hints().clone();
 
     // Estimate memory from pyarrow's nbytes
     // decode-audit: no-data — memory estimate is best-effort metadata; failure
@@ -516,7 +550,7 @@ pub fn profile_arrow(
         analyze_imported_batch(&mut analyzer, batch)?;
     }
 
-    let locale = config.and_then(|c| c.locale);
+    let locale = options.locale();
     let column_profiles =
         analyzer.to_profiles_with_hints(skip_statistics, skip_patterns, locale, &semantic_hints);
     let sample_columns = analyzer.create_sample_columns();
@@ -544,18 +578,13 @@ pub fn profile_arrow(
     )
     .columns(column_profiles)
     .with_row_duplicates(analyzer.row_duplicate_summary())
-    .with_row_completeness(analyzer.row_completeness_summary());
+    .with_row_completeness(analyzer.row_completeness_summary())
+    .with_analysis_options(&options);
 
     if include_quality {
         assembler = assembler
             .with_quality_data(sample_columns)
-            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings())
-            .with_semantic_hints(semantic_hints.clone());
-        if let Some(dims) = config.and_then(|c| c.quality_dimensions.clone()) {
-            assembler = assembler.with_requested_dimensions(dims);
-        }
-    } else {
-        assembler = assembler.skip_quality();
+            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings());
     }
 
     let report = assembler.build();

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -109,6 +109,17 @@ pub fn profile_columns(
     let column_names: Vec<String> = columns.iter().map(|(n, _)| n.clone()).collect();
     dataprof::validate_unique_column_names(&column_names, "columns")
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    // Source metadata describes the whole materialised input, not just the
+    // columns selected for analysis. Capture it before projection filters the
+    // owned transport vector.
+    let source_memory_bytes: u64 = columns
+        .iter()
+        .flat_map(|(_, cells)| cells.iter())
+        .flatten()
+        .map(|value| value.len() as u64)
+        .sum();
+
     if let Some(indices) = options
         .column_indices(&column_names)
         .map_err(|error| PyValueError::new_err(error.to_string()))?
@@ -217,14 +228,6 @@ pub fn profile_columns(
         ));
     }
 
-    // Rough, but honest: the strings we were handed are the whole materialised input.
-    let memory_bytes: u64 = columns
-        .iter()
-        .flat_map(|(_, cells)| cells.iter())
-        .flatten()
-        .map(|v| v.len() as u64)
-        .sum();
-
     let data_source = if source_type == "bytes" {
         let format = match source_format.as_deref() {
             Some("csv") => FileFormat::Csv,
@@ -253,7 +256,7 @@ pub fn profile_columns(
             source_library: DataFrameLibrary::Custom("python".to_string()),
             row_count: num_rows,
             column_count: num_cols,
-            memory_bytes: Some(memory_bytes),
+            memory_bytes: Some(source_memory_bytes),
         }
     };
 

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -53,7 +53,7 @@ pub type PyColumn = (String, Vec<Option<String>>);
 #[pyo3(signature = (columns, name = "dataframe".to_string(), max_rows = None, config = None, error_count = 0, row_count = None, source_type = "dataframe".to_string(), source_format = None, source_bytes = None))]
 pub fn profile_columns(
     py: Python<'_>,
-    columns: Vec<PyColumn>,
+    mut columns: Vec<PyColumn>,
     name: String,
     max_rows: Option<usize>,
     config: Option<&PyProfilerConfig>,
@@ -65,13 +65,16 @@ pub fn profile_columns(
 ) -> PyResult<PyProfileReport> {
     let start = std::time::Instant::now();
 
-    let resolved_packs = config.and_then(PyProfilerConfig::effective_metric_packs);
+    let options = config
+        .map(PyProfilerConfig::analysis_options)
+        .unwrap_or_default();
+    let resolved_packs = options.effective_metric_packs();
     let packs = resolved_packs.as_deref();
     let skip_statistics = !MetricPack::include_statistics(packs);
     let skip_patterns = !MetricPack::include_patterns(packs);
     let include_quality = MetricPack::include_quality(packs);
-    let locale = config.and_then(|c| c.locale);
-    let semantic_hints = config.map(|c| c.semantic_hints()).unwrap_or_default();
+    let locale = options.locale();
+    let semantic_hints = options.semantic_hints().clone();
 
     let effective_max_rows =
         max_rows.or_else(|| config.and_then(|c| c.max_rows.map(|v| v as usize)));
@@ -106,6 +109,17 @@ pub fn profile_columns(
     let column_names: Vec<String> = columns.iter().map(|(n, _)| n.clone()).collect();
     dataprof::validate_unique_column_names(&column_names, "columns")
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    if let Some(indices) = options
+        .column_indices(&column_names)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?
+    {
+        let selected = indices.into_iter().collect::<HashSet<_>>();
+        columns = columns
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, column)| selected.contains(&index).then_some(column))
+            .collect();
+    }
 
     let num_rows = effective_max_rows
         .map(|cap| cap.min(source_rows))
@@ -246,17 +260,11 @@ pub fn profile_columns(
     let mut assembler = ReportAssembler::new(data_source, exec)
         .columns(column_profiles)
         .with_row_duplicates(row_duplicates)
-        .with_row_completeness(row_completeness);
+        .with_row_completeness(row_completeness)
+        .with_analysis_options(&options);
 
     if include_quality {
-        assembler = assembler
-            .with_quality_data(sample_columns)
-            .with_semantic_hints(semantic_hints.clone());
-        if let Some(dims) = config.and_then(|c| c.quality_dimensions.clone()) {
-            assembler = assembler.with_requested_dimensions(dims);
-        }
-    } else {
-        assembler = assembler.skip_quality();
+        assembler = assembler.with_quality_data(sample_columns);
     }
 
     let report = assembler.build();

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -33,6 +33,7 @@ pub struct PyProfilerConfig {
     pub(crate) progress_interval_ms: Option<u64>,
     pub(crate) quality_dimensions: Option<Vec<QualityDimension>>,
     pub(crate) metric_packs: Option<Vec<MetricPack>>,
+    pub(crate) columns: Option<Vec<String>>,
     pub(crate) locale: Option<Locale>,
     pub(crate) positive_columns: Vec<String>,
     pub(crate) identifier_columns: Vec<String>,
@@ -57,6 +58,7 @@ impl PyProfilerConfig {
         progress_interval_ms = None,
         quality_dimensions = None,
         metrics = None,
+        columns = None,
         locale = None,
         positive_columns = None,
         identifier_columns = None,
@@ -78,6 +80,7 @@ impl PyProfilerConfig {
         progress_interval_ms: Option<u64>,
         quality_dimensions: Option<Vec<String>>,
         metrics: Option<Vec<String>>,
+        columns: Option<Vec<String>>,
         locale: Option<String>,
         positive_columns: Option<Vec<String>>,
         identifier_columns: Option<Vec<String>>,
@@ -157,6 +160,7 @@ impl PyProfilerConfig {
             progress_interval_ms,
             quality_dimensions,
             metric_packs,
+            columns,
             locale,
             positive_columns: positive_columns.unwrap_or_default(),
             identifier_columns: identifier_columns.unwrap_or_default(),
@@ -223,6 +227,12 @@ impl PyProfilerConfig {
     #[getter]
     fn locale(&self) -> Option<&str> {
         self.locale.map(|locale| locale.as_str())
+    }
+
+    /// Columns selected for profiling, or `None` for every column.
+    #[getter]
+    fn columns(&self) -> Option<Vec<String>> {
+        self.columns.clone()
     }
 
     /// Columns expected to contain non-negative numeric values
@@ -305,6 +315,9 @@ impl PyProfilerConfig {
         if let Some(ref packs) = self.metric_packs {
             profiler = profiler.metric_packs(packs.clone());
         }
+        if let Some(ref columns) = self.columns {
+            profiler = profiler.columns(columns.clone());
+        }
         if let Some(l) = self.locale {
             profiler = profiler.locale(l);
         }
@@ -337,20 +350,11 @@ impl PyProfilerConfig {
     /// same `metrics=`, `quality_dimensions=`, and `locale=`.
     pub(crate) fn analysis_options(&self) -> AnalysisOptions {
         AnalysisOptions::default()
+            .with_columns(self.columns.clone())
             .with_metric_packs(self.metric_packs.clone())
             .with_quality_dimensions(self.quality_dimensions.clone())
             .with_locale(self.locale)
             .with_semantic_hints(self.semantic_hints())
-    }
-
-    /// Metric packs with an empty quality-dimension selection folded in.
-    ///
-    /// The in-memory entry points (`profile_columns`, the Arrow exporters) gate
-    /// on packs directly instead of going through `Profiler`, so they resolve
-    /// the same rule here — otherwise `quality_dimensions=[]` would mean one
-    /// thing for a file and another for a DataFrame.
-    pub(crate) fn effective_metric_packs(&self) -> Option<Vec<MetricPack>> {
-        self.analysis_options().effective_metric_packs()
     }
 }
 

--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -58,11 +58,11 @@ impl PyProfilerConfig {
         progress_interval_ms = None,
         quality_dimensions = None,
         metrics = None,
-        columns = None,
         locale = None,
         positive_columns = None,
         identifier_columns = None,
         temporal_columns = None,
+        columns = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -80,11 +80,11 @@ impl PyProfilerConfig {
         progress_interval_ms: Option<u64>,
         quality_dimensions: Option<Vec<String>>,
         metrics: Option<Vec<String>>,
-        columns: Option<Vec<String>>,
         locale: Option<String>,
         positive_columns: Option<Vec<String>>,
         identifier_columns: Option<Vec<String>>,
         temporal_columns: Option<Vec<String>>,
+        columns: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let engine = parse_engine(engine)?;
         let format_override = format.map(parse_format).transpose()?;

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -88,7 +88,7 @@ impl ReportAssembler {
     }
 
     /// Apply the caller's analysis selection: requested dimensions, semantic
-    /// hints, and whether quality is computed at all.
+    /// hints, column projection, and whether quality is computed at all.
     ///
     /// Callers still pass their quality sample with
     /// [`with_quality_data`](Self::with_quality_data); this decides whether it is
@@ -99,6 +99,25 @@ impl ReportAssembler {
         self.skip_quality = !options.include_quality();
         self.semantic_hints = options.semantic_hints().clone();
         self.requested_dimensions = options.quality_dimensions().map(<[_]>::to_vec);
+        if options.has_column_projection() && !self.skip_quality {
+            // Completeness and uniqueness both contain row-level measurements.
+            // Those measurements have a different meaning after projecting a
+            // row, and the current report schema cannot label only the row-level
+            // fields as projected. Withhold the two dimensions instead of
+            // publishing plausible numbers under full-row names.
+            let mut dimensions = self
+                .requested_dimensions
+                .take()
+                .unwrap_or_else(QualityDimension::all);
+            dimensions.retain(|dimension| {
+                !matches!(
+                    dimension,
+                    QualityDimension::Completeness | QualityDimension::Uniqueness
+                )
+            });
+            self.skip_quality = dimensions.is_empty();
+            self.requested_dimensions = Some(dimensions);
+        }
         self
     }
 

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -682,6 +682,20 @@ impl StreamingColumnCollection {
         self.ordered_names.clone()
     }
 
+    /// Retain only the selected columns, preserving their source order.
+    ///
+    /// Parsers call this after validating the selection against the complete
+    /// source schema. Row-level trackers intentionally remain unchanged; a
+    /// projected report withholds the row-level quality dimensions because
+    /// their meaning changes when columns are removed.
+    pub fn retain_columns(&mut self, names: &[String]) {
+        let selected = names.iter().map(String::as_str).collect::<HashSet<_>>();
+        self.columns
+            .retain(|name, _| selected.contains(name.as_str()));
+        self.ordered_names
+            .retain(|name| selected.contains(name.as_str()));
+    }
+
     pub fn memory_usage_bytes(&self) -> usize {
         self.columns
             .values()

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -47,7 +47,9 @@ pub struct ProfilerConfig {
     /// Which metric packs to compute. `None` = all (default).
     /// Controls whether statistics, patterns, and quality are included.
     pub metric_packs: Option<Vec<MetricPack>>,
-    /// Columns to profile. `None` = all columns (default).
+    /// Columns to profile. `None` = all columns (default). Any explicit
+    /// selection withholds row-level completeness and uniqueness because those
+    /// dimensions cannot retain their whole-record meaning after projection.
     pub columns: Option<Vec<String>>,
     /// Locale for pattern detection (e.g. [`Locale::It`]).
     /// When set, locale-matching patterns get a confidence boost and non-matching
@@ -262,7 +264,8 @@ impl Profiler {
     /// whole record but only analyze and report the selected columns. Reports
     /// preserve source-schema order regardless of the order supplied here. A
     /// nested Parquet field is selected as one top-level column, including all
-    /// of its leaves; dotted leaf paths are not report columns today.
+    /// of its leaves; dotted leaf paths are not report columns today. Any
+    /// explicit selection withholds row-level completeness and uniqueness.
     pub fn columns(mut self, columns: Vec<String>) -> Self {
         self.config.columns = Some(columns);
         self

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -47,6 +47,8 @@ pub struct ProfilerConfig {
     /// Which metric packs to compute. `None` = all (default).
     /// Controls whether statistics, patterns, and quality are included.
     pub metric_packs: Option<Vec<MetricPack>>,
+    /// Columns to profile. `None` = all columns (default).
+    pub columns: Option<Vec<String>>,
     /// Locale for pattern detection (e.g. [`Locale::It`]).
     /// When set, locale-matching patterns get a confidence boost and non-matching
     /// locale patterns are suppressed (unless they have a very high match rate).
@@ -83,6 +85,7 @@ impl Default for ProfilerConfig {
             json_error_policy: dataprof_json::JsonErrorPolicy::default(),
             quality_dimensions: None,
             metric_packs: None,
+            columns: None,
             locale: None,
             positive_columns: Vec::new(),
             identifier_columns: Vec::new(),
@@ -250,6 +253,18 @@ impl Profiler {
     /// `Statistics`, `Patterns`, `Quality`. `None` = all (default).
     pub fn metric_packs(mut self, packs: Vec<MetricPack>) -> Self {
         self.config.metric_packs = Some(packs);
+        self
+    }
+
+    /// Select top-level columns to profile by name.
+    ///
+    /// Parquet applies the selection while decoding; CSV and JSON still read the
+    /// whole record but only analyze and report the selected columns. Reports
+    /// preserve source-schema order regardless of the order supplied here. A
+    /// nested Parquet field is selected as one top-level column, including all
+    /// of its leaves; dotted leaf paths are not report columns today.
+    pub fn columns(mut self, columns: Vec<String>) -> Self {
+        self.config.columns = Some(columns);
         self
     }
 
@@ -514,6 +529,7 @@ impl Profiler {
     /// to compute work the caller had deselected.
     fn analysis_options(&self) -> AnalysisOptions {
         AnalysisOptions::default()
+            .with_columns(self.config.columns.clone())
             .with_metric_packs(self.config.metric_packs.clone())
             .with_quality_dimensions(self.config.quality_dimensions.clone())
             .with_locale(self.config.locale)
@@ -690,6 +706,9 @@ impl Profiler {
                     if let Some(l) = self.config.locale {
                         profiler = profiler.locale(l);
                     }
+                    if let Some(columns) = &self.config.columns {
+                        profiler = profiler.columns(columns.clone());
+                    }
                     profiler = profiler.semantic_hints(options.semantic_hints().clone());
                     let csv_config = self.csv_config_for_file(file_path);
                     profiler = profiler.csv_config(csv_config);
@@ -757,6 +776,9 @@ impl Profiler {
         if let Some(l) = self.config.locale {
             profiler = profiler.locale(l);
         }
+        if let Some(columns) = &self.config.columns {
+            profiler = profiler.columns(columns.clone());
+        }
         profiler = profiler.semantic_hints(options.semantic_hints().clone());
         let csv_config = self.csv_config_for_file(file_path);
         profiler = profiler.csv_config(csv_config);
@@ -814,6 +836,9 @@ impl Profiler {
             }
             if let Some(l) = self.config.locale {
                 profiler = profiler.locale(l);
+            }
+            if let Some(columns) = &self.config.columns {
+                profiler = profiler.columns(columns.clone());
             }
             profiler = profiler.semantic_hints(options.semantic_hints().clone());
             // ArrowProfiler reads the row cap off the CSV config; the incremental

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1170,6 +1170,7 @@ def profile_file(
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
+    columns: list[str] | None = None,
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
@@ -1230,6 +1231,9 @@ def profile_file(
         metrics: List of metric packs to compute. Valid values: "schema"
             (always included), "statistics", "patterns", "quality".
             None = all packs (default).
+        columns: Top-level columns to profile. None selects every column;
+            an empty list returns a report with no profiled columns. Reports
+            preserve source order rather than the order supplied here.
         locale: Locale for pattern detection. Supported: "CA", "DE", "FR",
             "GB", "IT", "US"; "it", "ITA" and "it-IT" all mean "IT", and an
             unsupported tag raises ValueError rather than silently suppressing
@@ -1262,6 +1266,7 @@ def profile_file(
         progress_interval_ms=progress_interval_ms,
         quality_dimensions=quality_dimensions,
         metrics=metrics,
+        columns=columns,
         locale=locale,
         positive_columns=positive_columns,
         identifier_columns=identifier_columns,
@@ -1289,6 +1294,7 @@ def profile(
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
+    columns: list[str] | None = None,
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
@@ -1356,6 +1362,9 @@ def profile(
             (always included), "statistics", "patterns", "quality".
             None = all packs (default). Omitting a pack skips that
             category of computation entirely.
+        columns: Top-level columns to profile. None selects every column;
+            an empty list returns a report with no profiled columns. Reports
+            preserve source order rather than the order supplied here.
         locale: Locale for pattern detection. Boosts confidence for
             locale-matching patterns and suppresses non-matching locale
             patterns. None = no preference. Supported: "CA", "DE", "FR", "GB",
@@ -1393,6 +1402,7 @@ def profile(
             progress_interval_ms=progress_interval_ms,
             quality_dimensions=quality_dimensions,
             metrics=metrics,
+            columns=columns,
             locale=locale,
             positive_columns=positive_columns,
             identifier_columns=identifier_columns,
@@ -1408,6 +1418,7 @@ def profile(
                 max_rows,
                 quality_dimensions,
                 metrics,
+                columns,
                 locale,
                 positive_columns,
                 identifier_columns,
@@ -1418,6 +1429,7 @@ def profile(
                 max_rows=max_rows,
                 quality_dimensions=quality_dimensions,
                 metrics=metrics,
+                columns=columns,
                 locale=locale,
                 positive_columns=positive_columns,
                 identifier_columns=identifier_columns,
@@ -1530,11 +1542,11 @@ def profile(
         skipped = 0
         row_count: int | None = None
         if fmt == "csv":
-            columns = _columns_from_csv_bytes(buffer, csv_delimiter)
+            decoded_columns = _columns_from_csv_bytes(buffer, csv_delimiter)
         elif fmt == "jsonl":
             text = buffer.getvalue().decode("utf-8-sig")
             rows, skipped = _scan_jsonl_records(text, jsonl_on_error)
-            columns, row_count = _columns_from_records(rows, max_rows)
+            decoded_columns, row_count = _columns_from_records(rows, max_rows)
         elif fmt == "json":
             text = buffer.getvalue().decode("utf-8-sig")
             try:
@@ -1554,15 +1566,15 @@ def profile(
                 # The file scanner reads a root `{}` as one record instead, so
                 # require at least one column before taking that branch.
                 if rows and all(isinstance(values, (list, tuple)) for values in rows.values()):
-                    columns = _columns_from_dict(rows)
+                    decoded_columns = _columns_from_dict(rows)
                 else:
-                    columns, row_count = _columns_from_records([rows], max_rows)
+                    decoded_columns, row_count = _columns_from_records([rows], max_rows)
             elif isinstance(rows, list):
                 # An array is a document of records: elements that are not
                 # objects follow the same policy the file and async scanners
                 # apply, instead of rejecting the whole array.
                 records, skipped = _scan_json_array_records(rows, jsonl_on_error)
-                columns, row_count = _columns_from_records(records, max_rows)
+                decoded_columns, row_count = _columns_from_records(records, max_rows)
             else:
                 raise ValueError(
                     f"{fmt} bytes must decode to an object of columns or an array of "
@@ -1587,7 +1599,7 @@ def profile(
         # The buffer's own length, not the decoded cells: `size_bytes` on the
         # report is a statement about the input the caller handed over.
         return _profile_python_columns(
-            columns,
+            decoded_columns,
             f"{fmt}_bytes",
             skipped,
             row_count,
@@ -1714,6 +1726,11 @@ class Profiler:
     def quality_dimensions(self, dims: list[str]) -> Profiler:
         """Select quality dimensions to evaluate."""
         self._kwargs["quality_dimensions"] = dims
+        return self
+
+    def columns(self, columns: list[str]) -> Profiler:
+        """Select top-level columns to profile."""
+        self._kwargs["columns"] = columns
         return self
 
     def stop_when(self, condition: StopCondition | str) -> Profiler:

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1233,7 +1233,8 @@ def profile_file(
             None = all packs (default).
         columns: Top-level columns to profile. None selects every column;
             an empty list returns a report with no profiled columns. Reports
-            preserve source order rather than the order supplied here.
+            preserve source order rather than the order supplied here. Any
+            explicit selection withholds row-level completeness and uniqueness.
         locale: Locale for pattern detection. Supported: "CA", "DE", "FR",
             "GB", "IT", "US"; "it", "ITA" and "it-IT" all mean "IT", and an
             unsupported tag raises ValueError rather than silently suppressing
@@ -1364,7 +1365,8 @@ def profile(
             category of computation entirely.
         columns: Top-level columns to profile. None selects every column;
             an empty list returns a report with no profiled columns. Reports
-            preserve source order rather than the order supplied here.
+            preserve source order rather than the order supplied here. Any
+            explicit selection withholds row-level completeness and uniqueness.
         locale: Locale for pattern detection. Boosts confidence for
             locale-matching patterns and suppresses non-matching locale
             patterns. None = no preference. Supported: "CA", "DE", "FR", "GB",
@@ -1729,7 +1731,10 @@ class Profiler:
         return self
 
     def columns(self, columns: list[str]) -> Profiler:
-        """Select top-level columns to profile."""
+        """Select top-level columns to profile.
+
+        Any explicit selection withholds row-level completeness and uniqueness.
+        """
         self._kwargs["columns"] = columns
         return self
 

--- a/python/dataprof/__init__.pyi
+++ b/python/dataprof/__init__.pyi
@@ -73,6 +73,7 @@ def profile(
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
+    columns: list[str] | None = None,
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
@@ -98,6 +99,7 @@ def profile_file(
     progress_interval_ms: int | None = None,
     quality_dimensions: list[str] | None = None,
     metrics: list[str] | None = None,
+    columns: list[str] | None = None,
     locale: str | None = None,
     positive_columns: list[str] | None = None,
     identifier_columns: list[str] | None = None,
@@ -150,6 +152,7 @@ class Profiler:
     def on_progress(self, cb: Callable[[ProgressEvent], None]) -> Profiler: ...
     def progress_interval_ms(self, ms: int) -> Profiler: ...
     def quality_dimensions(self, dims: list[str]) -> Profiler: ...
+    def columns(self, columns: list[str]) -> Profiler: ...
     def stop_when(self, condition: StopCondition | str) -> Profiler: ...
     def metrics(self, packs: list[str]) -> Profiler: ...
     def locale(self, locale: str) -> Profiler: ...

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -34,11 +34,11 @@ class ProfilerConfig:
         progress_interval_ms: int | None = None,
         quality_dimensions: list[str] | None = None,
         metrics: list[str] | None = None,
-        columns: list[str] | None = None,
         locale: str | None = None,
         positive_columns: list[str] | None = None,
         identifier_columns: list[str] | None = None,
         temporal_columns: list[str] | None = None,
+        columns: list[str] | None = None,
     ) -> None: ...
     @property
     def engine(self) -> str: ...

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -34,6 +34,7 @@ class ProfilerConfig:
         progress_interval_ms: int | None = None,
         quality_dimensions: list[str] | None = None,
         metrics: list[str] | None = None,
+        columns: list[str] | None = None,
         locale: str | None = None,
         positive_columns: list[str] | None = None,
         identifier_columns: list[str] | None = None,
@@ -51,6 +52,8 @@ class ProfilerConfig:
     def max_rows(self) -> int | None: ...
     @property
     def locale(self) -> str | None: ...
+    @property
+    def columns(self) -> list[str] | None: ...
     @property
     def positive_columns(self) -> list[str]: ...
     @property

--- a/python/tests/test_analysis_option_parity.py
+++ b/python/tests/test_analysis_option_parity.py
@@ -95,6 +95,39 @@ def _pattern_names(report: dp.ProfileReport, name: str) -> list[str] | None:
 
 
 @pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
+def test_column_projection_applies_to_every_file_format(fixtures, fmt: str) -> None:
+    report = dp.profile(fixtures[fmt], columns=["amount", "id"])
+
+    assert [column.name for column in report.profiles] == ["id", "amount"]
+    assert report.quality is not None
+    assert report.quality.completeness is None
+    assert report.quality.uniqueness is None
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        {name: [record[name] for record in RECORDS] for name in ("id", "cap", "amount")},
+        pa.table({name: [record[name] for record in RECORDS] for name in ("id", "cap", "amount")}),
+    ],
+)
+def test_column_projection_applies_to_in_memory_sources(source) -> None:
+    report = dp.profile(source, columns=["amount", "id"])
+
+    assert [column.name for column in report.profiles] == ["id", "amount"]
+    assert report.quality is not None
+    assert report.quality.completeness is None
+    assert report.quality.uniqueness is None
+
+
+def test_unknown_and_empty_column_projection_are_explicit(fixtures) -> None:
+    with pytest.raises(ValueError, match="missing"):
+        dp.profile(fixtures["csv"], columns=["missing"])
+
+    assert dp.profile(fixtures["json"], columns=[]).profiles == []
+
+
+@pytest.mark.parametrize("fmt", ["csv", "json", "jsonl", "parquet"])
 def test_schema_pack_omits_statistics_patterns_and_quality(fixtures, fmt: str) -> None:
     report = dp.profile(fixtures[fmt], metrics=["schema"])
 
@@ -166,6 +199,9 @@ def test_async_paths_apply_the_same_selection(fixtures, fmt: str) -> None:
         _pattern_names(dp.profile(path, locale="IT"), "cap")
     ), f"{fmt}: sync and async disagree on locale-ranked patterns"
 
+    projected = asyncio.run(profile_file_async(path, columns=["amount", "id"]))
+    assert [column.name for column in projected.profiles] == ["id", "amount"]
+
 
 def test_parquet_byte_buffers_apply_the_same_selection(fixtures) -> None:
     # ``profile(bytes, format="parquet")`` reaches the native reader without
@@ -178,6 +214,9 @@ def test_parquet_byte_buffers_apply_the_same_selection(fixtures) -> None:
         assert column.patterns is None, f"parquet bytes: {column.name} kept patterns"
 
     assert dp.profile(data, format="parquet", quality_dimensions=[]).quality is None
+
+    projected = dp.profile(data, format="parquet", columns=["amount", "id"])
+    assert [column.name for column in projected.profiles] == ["id", "amount"]
 
     assert _pattern_names(dp.profile(data, format="parquet", locale="IT"), "cap") == (
         _pattern_names(dp.profile(fixtures["parquet"], locale="IT"), "cap")

--- a/python/tests/test_analysis_option_parity.py
+++ b/python/tests/test_analysis_option_parity.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any, cast
 
 import dataprof as dp
 import pytest
@@ -118,6 +119,23 @@ def test_column_projection_applies_to_in_memory_sources(source) -> None:
     assert report.quality is not None
     assert report.quality.completeness is None
     assert report.quality.uniqueness is None
+
+
+def test_projection_preserves_python_source_memory_provenance() -> None:
+    source = {
+        "id": ["1", "2"],
+        "payload": ["a much larger value", "another much larger value"],
+    }
+
+    full = dp.profile(source)
+    projected = dp.profile(source, columns=["id"])
+
+    # The native report carries source-memory provenance; the high-level wrapper
+    # intentionally does not duplicate every native metadata accessor.
+    full_native = cast(Any, full)._report
+    projected_native = cast(Any, projected)._report
+    assert full_native.memory_bytes is not None
+    assert projected_native.memory_bytes == full_native.memory_bytes
 
 
 def test_unknown_and_empty_column_projection_are_explicit(fixtures) -> None:

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1917,6 +1917,7 @@ class TestNamespace:
             "progress_interval_ms",
             "quality_dimensions",
             "metrics",
+            "columns",
             "locale",
             "positive_columns",
             "identifier_columns",
@@ -2586,6 +2587,7 @@ class TestProfilerBuilder:
         assert p.max_rows(10) is p
         assert p.csv_delimiter(",") is p
         assert p.quality_dimensions(["completeness"]) is p
+        assert p.columns(["id"]) is p
         assert p.positive_columns(["pressure"]) is p
         assert p.identifier_columns(["order_id"]) is p
         assert p.temporal_columns(["observed_on"]) is p

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1677,6 +1677,37 @@ class TestProfilerConfig:
         assert cfg.identifier_columns == ["order_id", "customer_id"]
         assert cfg.temporal_columns == ["observed_on"]
 
+    def test_positional_order_remains_backward_compatible(self):
+        # `columns` was added after this positional surface already existed.
+        # Keep every established slot stable and append new options at the end.
+        cfg = dataprof.ProfilerConfig(
+            "auto",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "it-IT",
+            ["pressure"],
+            ["order_id"],
+            ["observed_on"],
+            ["amount"],
+        )
+
+        assert cfg.locale == "IT"
+        assert cfg.positive_columns == ["pressure"]
+        assert cfg.identifier_columns == ["order_id"]
+        assert cfg.temporal_columns == ["observed_on"]
+        assert cfg.columns == ["amount"]
+
     def test_max_rows(self):
         if not os.path.exists(CSV_LARGE_FILE):
             pytest.skip("fixture missing")

--- a/tests/analysis_option_parity.rs
+++ b/tests/analysis_option_parity.rs
@@ -11,7 +11,9 @@
 
 use std::io::Write;
 
-use dataprof::{ColumnStats, Locale, MetricPack, ProfileReport, Profiler, QualityDimension};
+use dataprof::{
+    ColumnStats, EngineType, Locale, MetricPack, ProfileReport, Profiler, QualityDimension,
+};
 use tempfile::NamedTempFile;
 
 /// Five records with an Italian postal code column. `cap` is what makes locale
@@ -116,6 +118,110 @@ fn pattern_names(report: &ProfileReport, column: &str) -> Option<Vec<String>> {
         .patterns
         .as_ref()
         .map(|patterns| patterns.iter().map(|p| p.name.clone()).collect())
+}
+
+#[test]
+fn column_projection_matches_full_profiles_on_every_format() {
+    for (label, file) in fixtures() {
+        let full = Profiler::new()
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] full profiling failed: {e}"));
+        let projected = Profiler::new()
+            // Deliberately reverse request order: report order is source order.
+            .columns(vec!["amount".to_string(), "id".to_string()])
+            .analyze_file(file.path())
+            .unwrap_or_else(|e| panic!("[{label}] projected profiling failed: {e}"));
+
+        let names = projected
+            .column_profiles
+            .iter()
+            .map(|profile| profile.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["id", "amount"], "[{label}] projection/order");
+
+        for profile in &projected.column_profiles {
+            let full_profile = full
+                .column_profiles
+                .iter()
+                .find(|candidate| candidate.name == profile.name)
+                .expect("selected column exists in full profile");
+            assert_eq!(
+                serde_json::to_value(profile).unwrap(),
+                serde_json::to_value(full_profile).unwrap(),
+                "[{label}] selected column changed under projection: {}",
+                profile.name
+            );
+        }
+
+        let quality = projected
+            .quality
+            .expect("non-row quality remains available");
+        assert!(
+            quality.metrics.completeness.is_none(),
+            "[{label}] full-row completeness must be withheld under projection"
+        );
+        assert!(
+            quality.metrics.uniqueness.is_none(),
+            "[{label}] full-row duplicates must be withheld under projection"
+        );
+    }
+}
+
+#[test]
+fn both_csv_engines_apply_the_same_projection() {
+    for engine in [EngineType::Incremental, EngineType::Columnar] {
+        let file = csv_fixture();
+        let report = Profiler::new()
+            .engine(engine)
+            .columns(vec!["cap".to_string()])
+            .analyze_file(file.path())
+            .unwrap_or_else(|error| panic!("[{engine:?}] profiling failed: {error}"));
+        assert_eq!(
+            report
+                .column_profiles
+                .iter()
+                .map(|profile| profile.name.as_str())
+                .collect::<Vec<_>>(),
+            ["cap"],
+            "{engine:?} ignored the projection"
+        );
+    }
+}
+
+#[test]
+fn empty_projection_returns_no_columns_on_every_format() {
+    for (label, file) in fixtures() {
+        let report = Profiler::new()
+            .columns(vec![])
+            .analyze_file(file.path())
+            .unwrap_or_else(|error| panic!("[{label}] empty projection failed: {error}"));
+
+        assert!(
+            report.column_profiles.is_empty(),
+            "[{label}] an empty projection must return no profiled columns"
+        );
+    }
+}
+
+#[test]
+fn unknown_projected_columns_fail_on_every_format() {
+    for (label, file) in fixtures() {
+        let error = Profiler::new()
+            .columns(vec!["missing".to_string()])
+            .analyze_file(file.path())
+            .expect_err("unknown selected column must fail");
+        assert!(
+            matches!(
+                error,
+                dataprof::DataProfilerError::InvalidConfiguration { .. }
+            ),
+            "[{label}] unknown projection should remain a typed configuration error: {error}"
+        );
+        assert!(
+            error.to_string().contains("missing"),
+            "[{label}] error should name the unknown column: {error}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Add top-level column selection to `AnalysisOptions`, with duplicate and unknown-name validation, source-schema ordering, and an explicit empty-selection result.
- Apply the same projection contract across the Rust facade, adaptive and streaming engines, CSV, JSON/JSONL, database queries, Parquet file/bytes/HTTP paths, and the Python file/bytes/dict/DataFrame/Arrow APIs.
- Expand selected top-level Parquet fields to physical leaf indices and pass them through `ProjectionMask::leaves`, so unselected column chunks are not read and every leaf under a selected nested field is retained.
- Withhold the row-level completeness and uniqueness dimensions as `None` whenever projection is active, because their row-level report fields are not independently optional.
- Preserve typed `InvalidConfiguration` errors through adaptive fallback and add cross-path, nested-field, and physical byte-range regression coverage.

**Related issue:** Closes #638

## How it was verified

```console
$ cargo +1.98 test --workspace --all-features
all unit, integration, and documentation test suites passed; 0 failed

$ cargo +1.98 test -p dataprof --test analysis_option_parity --all-features
11 passed; 0 failed

$ cargo +1.98 test -p dataprof-engines --all-features
43 passed; 0 failed

$ cargo +1.98 clippy --all --all-targets -- -D warnings
passed

$ cargo +1.98 fmt --all -- --check
passed

$ uv run pytest --basetemp=.pytest-tmp-projection python/tests/test_analysis_option_parity.py python/tests/test_python_api.py -q
353 passed

$ uv run ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/
50 files already formatted

$ uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
All checks passed

$ uv run ty check python/
All checks passed
```

### Follow-up review validation

```console
$ cargo +1.98 test -p dataprof-db --features sqlite --test column_order
7 passed; 0 failed

$ cargo +1.98 check -p dataprof-db --all-features
passed

$ cargo +1.98 clippy --all --all-targets -- -D warnings
passed

$ python -m pytest -o addopts='' --basetemp D:/CodexCaches/pytest-dataprof-followup python/tests/test_analysis_option_parity.py python/tests/test_python_api.py -q
355 passed

$ ruff format --check ... && ruff check ... && ty check python/
passed

$ python .github/scripts/check_decode_audit.py
passed
```

The full workspace suite includes `projected_reader_never_reads_unselected_column_chunks` and `top_level_projection_keeps_every_leaf_of_a_nested_column`.

## Anything reviewers should know

- The public selector intentionally accepts top-level report column names. Dotted nested leaf paths are outside this PR; selecting a top-level struct retains all of its physical leaves.
- Completeness and uniqueness are absent under projection rather than being reported as zero or silently changing meaning.
- The follow-up was pushed as a normal commit without rebasing or rewriting the existing PR history.