### PR TITLE
fix(metrics): count identical JSON records as duplicates across a late key

### DIFF
--- a/crates/dataprof-json/src/lib.rs
+++ b/crates/dataprof-json/src/lib.rs
@@ -1663,6 +1663,44 @@ mod tests {
     }
 
     #[test]
+    fn test_identical_records_count_as_duplicates_across_a_late_key() {
+        // Records 1 and 3 are byte-identical; `b` is only discovered between
+        // them. Signing a row against whatever columns happened to be known at
+        // the time would make the two look different and report no duplicate.
+        let data = b"{\"a\": \"x\"}\n{\"a\": \"x\", \"b\": \"y\"}\n{\"a\": \"x\"}\n";
+        let cursor = Cursor::new(data.as_ref());
+        let config = JsonParserConfig::jsonl();
+
+        let (_profiles, stats, rows, _malformed, _format) =
+            analyze_json_from_reader(cursor, &config).unwrap();
+        assert_eq!(rows, 3);
+
+        let summary = stats
+            .row_duplicate_summary()
+            .expect("three rows were observed");
+        assert_eq!(summary.rows_checked, 3);
+        assert_eq!(summary.duplicate_rows, 1);
+        assert!(!summary.approximate);
+    }
+
+    #[test]
+    fn test_a_late_key_does_not_invent_duplicates() {
+        // The counterpart guard: collapsing the trailing absent field must not
+        // merge rows that differ in the columns they do share.
+        let data = b"{\"a\": \"x\"}\n{\"a\": \"x\", \"b\": \"y\"}\n{\"a\": \"z\"}\n";
+        let cursor = Cursor::new(data.as_ref());
+        let config = JsonParserConfig::jsonl();
+
+        let (_profiles, stats, _rows, _malformed, _format) =
+            analyze_json_from_reader(cursor, &config).unwrap();
+
+        let summary = stats
+            .row_duplicate_summary()
+            .expect("three rows were observed");
+        assert_eq!(summary.duplicate_rows, 0);
+    }
+
+    #[test]
     fn test_analyze_json_file_quality_report() {
         let file = write_file(r#"[{"x":1},{"x":2}]"#);
         let config = JsonParserConfig::default();

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -11,8 +11,8 @@ use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{RowCompletenessSummary, RowDuplicateSummary, infer_type};
 use dataprof_runtime::{
-    ColumnProfileInput, ExactNumericAggregates, RowCompletenessTracker, RowUniquenessTracker,
-    StreamReservoirSampler, TextLengths, build_column_profile,
+    ColumnProfileInput, ExactNumericAggregates, RowCompletenessTracker, RowSignature,
+    RowUniquenessTracker, StreamReservoirSampler, TextLengths, build_column_profile,
 };
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
@@ -81,8 +81,8 @@ fn observe_batch_rows(
     use arrow::datatypes::DataType as ArrowDataType;
     use arrow::util::display::{ArrayFormatter, FormatOptions};
 
-    // Null must render as an empty field ("0:"), matching the incremental
-    // engine — the default formatter would render a visible placeholder.
+    // Null must render as an empty field, matching the incremental engine —
+    // the default formatter would render a visible placeholder.
     let options = FormatOptions::default().with_null("");
     let formatters: Vec<Option<ArrayFormatter>> = batch
         .columns()
@@ -97,7 +97,7 @@ fn observe_batch_rows(
 
     let mut value_buffer = String::new();
     for row_index in 0..batch.num_rows() {
-        let mut row_signature = String::new();
+        let mut row_signature = RowSignature::default();
         let mut row_has_null = false;
         for (column, formatter) in batch.columns().iter().zip(&formatters) {
             value_buffer.clear();
@@ -107,14 +107,13 @@ fn observe_batch_rows(
                 write!(value_buffer, "{}", formatter.value(row_index))
                     .map_err(|error| anyhow::anyhow!("row signature formatting failed: {error}"))?;
             }
-            let _ = write!(row_signature, "{}:", value_buffer.len());
-            row_signature.push_str(&value_buffer);
+            row_signature.push_field(&value_buffer);
             // Arrow nulls already render empty here, and the null-like tokens
             // are the same ones the column analyzers count, so the record
             // count and the cell counts describe one definition of null.
             row_has_null |= is_null_like_token(&value_buffer);
         }
-        tracker.observe(row_signature);
+        tracker.observe(row_signature.finish());
         completeness.observe(row_has_null);
     }
 

--- a/crates/dataprof-python/src/columns.rs
+++ b/crates/dataprof-python/src/columns.rs
@@ -15,8 +15,8 @@ use dataprof::{
     infer_type, is_null_like_token,
 };
 use dataprof_runtime::{
-    ColumnProfileInput, ReportAssembler, RowCompletenessTracker, RowUniquenessTracker,
-    build_column_profile,
+    ColumnProfileInput, ReportAssembler, RowCompletenessTracker, RowSignature,
+    RowUniquenessTracker, build_column_profile,
 };
 
 use super::config::PyProfilerConfig;
@@ -144,26 +144,24 @@ pub fn profile_columns(
         let mut samples = std::collections::HashMap::new();
 
         // Full-stream duplicate-row tracking over the row-aligned input,
-        // using the same length-prefixed signature encoding as the file
-        // engines. Null cells contribute an empty value, so files and
-        // ad-hoc inputs holding the same data agree on duplicate counts.
+        // through the same `RowSignature` encoding the file engines use, so
+        // files and ad-hoc inputs holding the same data agree on duplicate
+        // counts. Null cells contribute an empty value.
         let mut row_tracker = RowUniquenessTracker::default();
         let mut completeness_tracker = RowCompletenessTracker::default();
         if num_cols > 0 {
-            use std::fmt::Write as _;
             for row_index in 0..num_rows {
-                let mut row_signature = String::new();
+                let mut row_signature = RowSignature::default();
                 let mut row_has_null = false;
                 for (_, cells) in &columns {
                     let value = cells[row_index].as_deref().unwrap_or("");
-                    let _ = write!(row_signature, "{}:", value.len());
-                    row_signature.push_str(value);
+                    row_signature.push_field(value);
                     // A missing cell renders empty, which `is_null_like_token`
                     // already treats as null — the same rule that produces
                     // `null_count` below.
                     row_has_null |= is_null_like_token(value);
                 }
-                row_tracker.observe(row_signature);
+                row_tracker.observe(row_signature.finish());
                 completeness_tracker.observe(row_has_null);
             }
         }

--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -24,6 +24,6 @@ pub use profile_report::profile_report_schema_document;
 pub use profile_report::{ProfileReport, REPORT_SCHEMA_VERSION};
 pub use report_assembler::ReportAssembler;
 pub use streaming_stats::{
-    RowCompletenessTracker, RowUniquenessTracker, StreamReservoirSampler,
+    RowCompletenessTracker, RowSignature, RowUniquenessTracker, StreamReservoirSampler,
     StreamingColumnCollection, StreamingStatistics, TextLengthStats, WelfordAccumulator,
 };

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -485,6 +485,46 @@ impl Default for StreamingStatistics {
     }
 }
 
+/// Canonical encoding of one row, for duplicate detection.
+///
+/// Fields are length-prefixed so their boundaries are unambiguous:
+/// `["ab", "c"]` and `["a", "bc"]` must not sign alike. Trailing absent
+/// fields are then dropped, which makes the signature independent of how wide
+/// the schema had grown when the row was read. A JSON key discovered
+/// mid-stream appends a column, and without the trim every row that predates
+/// it signs one field shorter than an identical row read afterwards, so the
+/// two count as distinct and the duplicate total comes up silently short.
+///
+/// The trim is safe because an absent field and an explicitly empty one are
+/// the same null to this profiler: it collapses only rows that already hold
+/// equal values in every column they share. On a fixed schema it applies
+/// uniformly to every row, so it changes no count there.
+#[derive(Debug, Default)]
+pub struct RowSignature {
+    buffer: String,
+    /// Length of `buffer` through the last field that held a value.
+    len_through_last_present: usize,
+}
+
+impl RowSignature {
+    /// Append one field. An absent field is the empty string, the same
+    /// representation [`StreamingColumnCollection::process_record`] gives a
+    /// missing trailing value and an Arrow null.
+    pub fn push_field(&mut self, value: &str) {
+        let _ = write!(self.buffer, "{}:", value.len());
+        self.buffer.push_str(value);
+        if !value.is_empty() {
+            self.len_through_last_present = self.buffer.len();
+        }
+    }
+
+    /// The signature, with trailing absent fields dropped.
+    pub fn finish(mut self) -> String {
+        self.buffer.truncate(self.len_through_last_present);
+        self.buffer
+    }
+}
+
 /// Full-stream row-duplicate tracking with bounded memory.
 ///
 /// Every record's fields are folded into a canonical length-prefixed
@@ -698,9 +738,7 @@ impl StreamingColumnCollection {
     where
         I: IntoIterator<Item = String>,
     {
-        // Length-prefixed so field boundaries are unambiguous:
-        // ["ab", "c"] and ["a", "bc"] must produce different signatures.
-        let mut row_signature = String::new();
+        let mut row_signature = RowSignature::default();
         let mut row_has_null = false;
         let mut values = values.into_iter();
 
@@ -709,8 +747,7 @@ impl StreamingColumnCollection {
         // update every column and hash identically to an explicit empty field.
         for header in headers {
             let value = values.next().unwrap_or_default();
-            let _ = write!(row_signature, "{}:", value.len());
-            row_signature.push_str(&value);
+            row_signature.push_field(&value);
 
             if !self.columns.contains_key(header) {
                 self.ordered_names.push(header.clone());
@@ -724,7 +761,7 @@ impl StreamingColumnCollection {
         }
 
         if !headers.is_empty() {
-            self.row_tracker.observe(row_signature);
+            self.row_tracker.observe(row_signature.finish());
             self.completeness_tracker.observe(row_has_null);
         }
     }
@@ -1060,6 +1097,54 @@ mod row_tracker_tests {
                 .null_count,
             2
         );
+    }
+
+    #[test]
+    fn test_late_column_does_not_split_identical_rows() {
+        // A JSON key discovered mid-stream appends a column. Rows read before
+        // and after that point are signed against header lists of different
+        // lengths, and two identical records must still count as duplicates.
+        let mut collection = StreamingColumnCollection::new();
+        let short = vec!["a".to_string()];
+        let wide = vec!["a".to_string(), "b".to_string()];
+
+        record(&mut collection, &short, &["x"]);
+        collection.init_column_with_missing("b", 1);
+        record(&mut collection, &wide, &["x", "y"]);
+        record(&mut collection, &wide, &["x", ""]);
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert_eq!(summary.rows_checked, 3);
+        assert_eq!(
+            summary.duplicate_rows, 1,
+            "rows 1 and 3 hold the same data; they differ only in how many \
+             columns had been discovered when each was read"
+        );
+    }
+
+    #[test]
+    fn test_late_column_in_the_middle_does_not_split_identical_rows() {
+        // A second late key pushes the first one away from the end, so the
+        // absent field sits in the middle of the later signatures.
+        let mut collection = StreamingColumnCollection::new();
+        let one = vec!["a".to_string()];
+        let two = vec!["a".to_string(), "b".to_string()];
+        let three = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+        record(&mut collection, &one, &["1"]);
+        collection.init_column_with_missing("b", 1);
+        record(&mut collection, &two, &["1", "2"]);
+        collection.init_column_with_missing("c", 2);
+        record(&mut collection, &three, &["1", "", "3"]);
+        record(&mut collection, &three, &["1", "", ""]);
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert_eq!(summary.rows_checked, 4);
+        assert_eq!(summary.duplicate_rows, 1, "row 4 repeats row 1");
     }
 
     #[test]

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -510,6 +510,12 @@ impl RowSignature {
     /// Append one field. An absent field is the empty string, the same
     /// representation [`StreamingColumnCollection::process_record`] gives a
     /// missing trailing value and an Arrow null.
+    ///
+    /// Only an exactly empty value counts as absent here, deliberately: the
+    /// broader `is_null_like_token` rule that decides `null_count` also matches
+    /// `null`, `nan` and whitespace, and trimming on it would collapse a row
+    /// ending in one of those against a row that ends in no field at all,
+    /// inventing a duplicate.
     pub fn push_field(&mut self, value: &str) {
         let _ = write!(self.buffer, "{}:", value.len());
         self.buffer.push_str(value);
@@ -527,12 +533,12 @@ impl RowSignature {
 
 /// Full-stream row-duplicate tracking with bounded memory.
 ///
-/// Every record's fields are folded into a canonical length-prefixed
-/// signature and fed to a [`CardinalityEstimator`]: duplicates are counted
-/// exactly while the distinct-row signatures fit the estimator's exact set,
-/// and estimated (flagged approximate) once it spills to its HLL sketch.
-/// Unlike the per-column reservoirs, this sees whole rows — including
-/// null-like values — so the count is row-aligned by construction.
+/// Every record's fields are folded into a [`RowSignature`] and fed to a
+/// [`CardinalityEstimator`]: duplicates are counted exactly while the
+/// distinct-row signatures fit the estimator's exact set, and estimated
+/// (flagged approximate) once it spills to its HLL sketch. Unlike the
+/// per-column reservoirs, this sees whole rows — including null-like values —
+/// so the count is row-aligned by construction.
 #[derive(Debug, Clone, Default)]
 pub struct RowUniquenessTracker {
     rows_seen: usize,
@@ -1097,6 +1103,24 @@ mod row_tracker_tests {
                 .null_count,
             2
         );
+    }
+
+    #[test]
+    fn test_trailing_null_like_token_is_not_trimmed() {
+        // Only an exactly empty field is absent. A trailing "null" or " " is
+        // a value the row holds, and `is_null_like_token` matches both;
+        // trimming on that broader rule would collapse these rows against the
+        // absent-field one and report duplicates that are not there.
+        let headers = vec!["a".to_string(), "b".to_string()];
+        let mut collection = StreamingColumnCollection::new();
+        record(&mut collection, &headers, &["x", "null"]);
+        record(&mut collection, &headers, &["x", " "]);
+        record(&mut collection, &headers, &["x", ""]);
+
+        let summary = collection
+            .row_duplicate_summary()
+            .expect("rows were observed");
+        assert_eq!(summary.duplicate_rows, 0);
     }
 
     #[test]

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -397,6 +397,30 @@ def test_duplicate_rows_tracked_for_dataframe_and_arrow_inputs(tmp_path):
     assert uniqueness["duplicate_rows"] == 1
 
 
+def test_jsonl_duplicates_survive_a_key_discovered_mid_stream(tmp_path):
+    # JSONL has no header, so a key can appear at any point and widen the
+    # schema. Two identical records must still count as one duplicate whether
+    # or not a new key was discovered between them, and the count must match
+    # the same data written with the key present everywhere.
+    late = tmp_path / "late.jsonl"
+    late.write_text(
+        '{"a": "x"}\n{"a": "x", "b": "y"}\n{"a": "x"}\n',
+        encoding="utf-8",
+    )
+    explicit = tmp_path / "explicit.jsonl"
+    explicit.write_text(
+        '{"a": "x", "b": null}\n{"a": "x", "b": "y"}\n{"a": "x", "b": null}\n',
+        encoding="utf-8",
+    )
+
+    late_uniqueness = dataprof.profile(str(late)).to_dict()["quality"]["uniqueness"]
+    explicit_uniqueness = dataprof.profile(str(explicit)).to_dict()["quality"]["uniqueness"]
+
+    assert late_uniqueness["rows_checked"] == 3
+    assert late_uniqueness["duplicate_rows"] == 1
+    assert late_uniqueness == explicit_uniqueness
+
+
 def test_duplicate_column_names_rejected_across_all_inputs(tmp_path):
     # The same duplicate-header source must be rejected identically regardless of
     # transport, so no path can silently merge or shadow a column (#381).


### PR DESCRIPTION
Closes #656.

## The bug

Row signatures were built positionally over whatever headers were known when
the record was read. JSON/JSONL has no header, so a key can appear at any
point and widen the schema; a record read before that point signed one field
shorter than a byte-identical record read after it.

```
{"a": "x"}              headers [a]     -> 1:x
{"a": "x", "b": "y"}    headers [a, b]  -> 1:x1:y
{"a": "x"}              headers [a, b]  -> 1:x0:
```

Rows 1 and 3 are the same record and hashed differently, so the estimator
counted two distinct rows and `duplicate_rows` reported 0 instead of 1. Short
rather than absent, so it read as a real measurement — and the uniqueness
dimension of the quality score is computed from it.

`init_column_with_missing` already backfilled the column counters for a late
key and `RowCompletenessTracker::invalidate_completed_rows` already corrected
the completeness count; the row signature was the remaining gap.

## The fix

Signatures drop trailing absent fields, which makes them independent of how
wide the schema had grown when the row was read. The trim is safe because an
absent field and an explicitly empty one are already the same null to this
profiler: it collapses only rows that hold equal values in every column they
share. It also handles a key that a later key pushes into the middle of the
schema — a row missing both signs `1:1` `0:` `0:` and trims back to the
one-column form.

On a fixed-schema path (CSV, Parquet, database, Arrow) every signature has the
same arity, so the trim applies uniformly and is injective: no count changes
there.

The length-prefixed encoding moves into a shared `RowSignature` builder that
both the incremental collection and the Arrow batch tracker use, so the two
engines cannot drift apart on how a row is signed.

## Verification

Regression tests confirmed failing before the fix and passing after:

- `dataprof-json`: `test_identical_records_count_as_duplicates_across_a_late_key`
  reproduces the issue byte for byte (0 duplicates before, 1 after), plus a
  counterpart guard that a differing row is still not merged.
- `dataprof-runtime`: two `RowSignature` cases — the late key at the end of the
  schema and a second late key that pushes the first into the middle.
- `python/tests/test_engine_parity.py`: the late-key file must report the same
  uniqueness block as the same data with the key present in every record
  (`0 == 1` before the fix).

The `RowSignature` extraction in `dataprof-parquet` is behaviour-preserving and
is *not* discriminated by the new tests; it is covered by the existing
`test_duplicate_rows_with_nulls_match_across_engines` (Rust) and
`test_duplicate_rows_with_nulls_agree_across_engines` /
`test_duplicate_rows_tracked_for_dataframe_and_arrow_inputs` (Python), which
still pass unchanged.

Cross-path spot check on the same four rows with a trailing null column —
CSV, Parquet and JSONL all report 1 duplicate over 4 rows checked.

The issue's Python repro now prints `duplicate_rows: 1`.

Commands run:

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings
cargo test --workspace
uv run pytest python/tests -q          # 1056 passed, 9 skipped
uv run ruff format / ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```
