### PR TITLE
fix(metrics): accept RFC 3339 offsets, on one date grammar for every engine

### DIFF
--- a/crates/dataprof-db/src/connectors/common.rs
+++ b/crates/dataprof-db/src/connectors/common.rs
@@ -48,12 +48,16 @@ pub fn feature_not_enabled_error(db_name: &str, feature: &str) -> DataProfilerEr
 /// `Type<Postgres>`) and `BigDecimal` (PostgreSQL and MySQL, no `Type<Sqlite>`
 /// because SQLite has no decimal type).
 ///
-/// Temporal values render in the naive ISO form dataprof's date grammar
-/// accepts (`YYYY-MM-DD` and `YYYY-MM-DDTHH:MM:SS`). That grammar rejects a
-/// trailing offset or `Z`, so rendering a timestamp as true RFC 3339 would
-/// profile the column as *text* and leave the Timeliness dimension exactly as
-/// inert as the nulls did. `TIMESTAMPTZ` is converted to UTC and its offset
+/// Temporal values render in the naive ISO form `YYYY-MM-DD` /
+/// `YYYY-MM-DDTHH:MM:SS`. `TIMESTAMPTZ` is converted to UTC and its offset
 /// dropped; the instant survives, the "this is UTC" marker does not.
+///
+/// The grammar now accepts a trailing `Z` or `±HH:MM` (#643), so this is no
+/// longer forced. It stays because it is numerically indistinguishable from the
+/// alternative: dataprof normalizes an offset-bearing value to UTC before any
+/// statistic reads it, so `...T10:30:00` and `...T10:30:00+00:00` produce the
+/// same profile. Rendering the offset would buy fidelity in the raw sample
+/// values and nothing in the numbers.
 ///
 /// Still unsupported and still recorded as null: `BLOB`/`BYTEA`, which needs a
 /// binary column type rather than a decode arm.

--- a/crates/dataprof-db/tests/typed_column_decoding.rs
+++ b/crates/dataprof-db/tests/typed_column_decoding.rs
@@ -102,10 +102,10 @@ mod postgres {
             return;
         };
 
-        // Naive ISO, not RFC 3339: dataprof's date grammar accepts
-        // `YYYY-MM-DDTHH:MM:SS` and rejects a trailing offset or `Z`, so a
-        // faithful RFC 3339 rendering would profile as text and leave
-        // Timeliness exactly as inert as the nulls do.
+        // Naive ISO, not RFC 3339. Since #643 the grammar would accept the
+        // offset too, and an offset-bearing value is normalized to UTC before
+        // any statistic reads it — so the two renderings profile identically
+        // and the connectors keep converting to UTC here instead.
         assert_eq!(column(columns, "ts"), ["2024-01-15T10:30:00", ""]);
         assert_eq!(column(columns, "tstz"), ["2024-01-15T10:30:00", ""]);
         assert_eq!(column(columns, "d"), ["2024-01-15", ""]);

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -27,11 +27,16 @@ static DATE_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         // optional `Z`/`±HH:MM` offset. The offset alternatives are exactly the
         // ones `chrono::DateTime::parse_from_rfc3339` accepts, so a value this
         // pattern calls a date is a value the parser can turn into an instant.
-        // The ISO 8601 basic form (`+0200`) is deliberately absent: chrono
-        // rejects it, and accepting it here would type the column `Date` and
-        // then count every value as `invalid_date_values`.
-        Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$")
-            .expect("BUG: Invalid hardcoded regex pattern for ISO datetime"),
+        //
+        // The offset is range-bound, not `\d{2}:\d{2}`: chrono rejects `+24:00`
+        // and `+00:60` as out of range, so a looser pattern would type the
+        // column `Date` and then count every value as `invalid_date_values` —
+        // the exact mismatch this pattern exists to avoid. The ISO 8601 basic
+        // form (`+0200`) is absent for the same reason.
+        Regex::new(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)?$",
+        )
+        .expect("BUG: Invalid hardcoded regex pattern for ISO datetime"),
         Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
             .expect("BUG: Invalid hardcoded regex pattern for spaced ISO datetime"),
         Regex::new(r"^\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}$")
@@ -571,7 +576,7 @@ mod tests {
         (r"^\d{4}/\d{2}/\d{2}$", "2024/01/15"),
         (r"^\d{2}\.\d{2}\.\d{4}$", "15.01.2024"),
         (
-            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$",
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-](?:[01]\d|2[0-3]):[0-5]\d)?$",
             "2024-01-15T10:30:00",
         ),
         (

--- a/crates/dataprof-metrics/src/analysis/inference.rs
+++ b/crates/dataprof-metrics/src/analysis/inference.rs
@@ -23,7 +23,14 @@ static DATE_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
             .expect("BUG: Invalid hardcoded regex pattern for YYYY/MM/DD date"),
         Regex::new(r"^\d{2}\.\d{2}\.\d{4}$")
             .expect("BUG: Invalid hardcoded regex pattern for DD.MM.YYYY date"),
-        Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$")
+        // RFC 3339: the `T` form with an optional fractional part and an
+        // optional `Z`/`±HH:MM` offset. The offset alternatives are exactly the
+        // ones `chrono::DateTime::parse_from_rfc3339` accepts, so a value this
+        // pattern calls a date is a value the parser can turn into an instant.
+        // The ISO 8601 basic form (`+0200`) is deliberately absent: chrono
+        // rejects it, and accepting it here would type the column `Date` and
+        // then count every value as `invalid_date_values`.
+        Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$")
             .expect("BUG: Invalid hardcoded regex pattern for ISO datetime"),
         Regex::new(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$")
             .expect("BUG: Invalid hardcoded regex pattern for spaced ISO datetime"),
@@ -564,7 +571,7 @@ mod tests {
         (r"^\d{4}/\d{2}/\d{2}$", "2024/01/15"),
         (r"^\d{2}\.\d{2}\.\d{4}$", "15.01.2024"),
         (
-            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$",
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$",
             "2024-01-15T10:30:00",
         ),
         (

--- a/crates/dataprof-metrics/src/analysis/patterns.rs
+++ b/crates/dataprof-metrics/src/analysis/patterns.rs
@@ -408,19 +408,6 @@ static REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new(&patterns).expect("BUG: Failed to compile RegexSet from PATTERN_DEFS")
 });
 
-// Pre-compile date pattern regexes for type inference
-// Previously this was duplicated across 5 engine files without pre-compilation
-static DATE_PATTERN_REGEXES: LazyLock<Vec<Regex>> = LazyLock::new(|| {
-    vec![
-        Regex::new(r"^\d{4}-\d{2}-\d{2}$").expect("BUG: Invalid date pattern YYYY-MM-DD"),
-        Regex::new(r"^\d{2}/\d{2}/\d{4}$").expect("BUG: Invalid date pattern DD/MM/YYYY"),
-        Regex::new(r"^\d{2}-\d{2}-\d{4}$").expect("BUG: Invalid date pattern DD-MM-YYYY"),
-        Regex::new(r"^\d{4}/\d{2}/\d{2}$").expect("BUG: Invalid date pattern YYYY/MM/DD"),
-        Regex::new(r"^\d{2}\.\d{2}\.\d{4}$").expect("BUG: Invalid date pattern DD.MM.YYYY"),
-        Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:").expect("BUG: Invalid date pattern ISO datetime"),
-    ]
-});
-
 /// Intermediate match result used during overlap resolution.
 struct PatternMatch<'a> {
     def: &'a PatternDef,
@@ -676,27 +663,22 @@ pub fn detect_patterns(data: &[String], locale: Option<Locale>) -> Vec<Pattern> 
     results
 }
 
-/// Check if a string value looks like a date
+/// Whether a string value carries one of the date forms that type a column as
+/// [`DataType::Date`](crate::types::DataType).
 ///
-/// Uses pre-compiled regex patterns to detect common date formats.
-/// This function consolidates date detection logic that was previously
-/// duplicated across multiple engine files.
+/// The streaming engines type their columns from sampled strings and reach this
+/// entry point; the buffered paths call
+/// [`infer_type`](crate::analysis::inference::infer_type) directly. Both now
+/// decide "is this a date" on the same set, so a file cannot be a date column
+/// through one engine and a text column through the other.
 ///
-/// # Arguments
-/// * `value` - String value to check
-///
-/// # Returns
-/// `true` if the value matches any common date pattern
-///
-/// # Supported Formats
-/// - YYYY-MM-DD (ISO 8601)
-/// - DD/MM/YYYY (European slash)
-/// - DD-MM-YYYY (European dash)
-/// - YYYY/MM/DD (Asian format)
-/// - DD.MM.YYYY (European dot)
-/// - ISO datetime (YYYY-MM-DDTHH:...)
+/// This used to hold its own list, which had drifted from the inference set in
+/// both directions: it lacked the two space-separated datetime forms, and its
+/// ISO datetime pattern was unanchored (`^\d{4}-\d{2}-\d{2}T\d{2}:`), so it
+/// accepted an RFC 3339 timestamp the inference set rejected — and accepted
+/// truncated values such as `2024-01-15T10:` that no parser can read.
 pub fn looks_like_date(value: &str) -> bool {
-    DATE_PATTERN_REGEXES.iter().any(|re| re.is_match(value))
+    crate::analysis::inference::is_inferred_date_token(value)
 }
 
 #[cfg(test)]
@@ -1403,9 +1385,41 @@ mod tests {
         assert!(!looks_like_date("user@example.com"));
     }
 
+    /// The streaming engines type their columns through `looks_like_date` and
+    /// the buffered ones through `infer_type`. Both read the same set, so the
+    /// forms one accepts are exactly the forms the other accepts.
     #[test]
-    fn test_date_pattern_regexes_precompiled() {
-        assert_eq!(DATE_PATTERN_REGEXES.len(), 6);
+    fn looks_like_date_matches_the_inference_grammar() {
+        for value in [
+            // Forms the old private list missed, so a column of them used to be
+            // a date through the buffered engines and text through streaming.
+            "2024-01-15T10:30:00Z",
+            "2024-01-15T10:30:00+02:00",
+            "2024-01-15T10:30:00.500-05:00",
+            "2024-01-15 10:30:00",
+            "15/01/2024 10:30:00",
+            // Forms both lists always shared.
+            "2024-01-15",
+            "15.01.2024",
+        ] {
+            assert!(looks_like_date(value), "{value:?} should look like a date");
+        }
+
+        for value in [
+            // The old list's ISO datetime pattern was unanchored, so it typed
+            // these as dates and then failed to parse a single one of them.
+            "2024-01-15T10:",
+            "2024-01-15T10:30",
+            "2024-01-15T10:30:00 (UTC)",
+            // The ISO 8601 basic offset, which chrono's RFC 3339 parser rejects.
+            "2024-01-15T10:30:00+0200",
+            "not a date",
+        ] {
+            assert!(
+                !looks_like_date(value),
+                "{value:?} should not look like a date"
+            );
+        }
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/analysis/patterns.rs
+++ b/crates/dataprof-metrics/src/analysis/patterns.rs
@@ -1413,6 +1413,11 @@ mod tests {
             "2024-01-15T10:30:00 (UTC)",
             // The ISO 8601 basic offset, which chrono's RFC 3339 parser rejects.
             "2024-01-15T10:30:00+0200",
+            // Offsets chrono rejects as out of range. A grammar that took these
+            // would type the column `Date` and then fail to parse a value of it.
+            "2024-01-15T10:30:00+24:00",
+            "2024-01-15T10:30:00+99:99",
+            "2024-01-15T10:30:00-00:60",
             "not a date",
         ] {
             assert!(

--- a/crates/dataprof-metrics/src/stats/datetime.rs
+++ b/crates/dataprof-metrics/src/stats/datetime.rs
@@ -14,6 +14,24 @@
 //! - `15.01.2023` → January 15, 2023
 //!
 //! For unambiguous parsing, use ISO 8601 format (YYYY-MM-DD).
+//!
+//! ## UTC Offsets
+//!
+//! A value carrying an RFC 3339 offset (`Z`, `+HH:MM`, `-HH:MM`) designates an
+//! *instant*, and **dataprof normalizes it to UTC** before it reaches any
+//! statistic or quality predicate. `2024-01-15T23:00:00-05:00` therefore counts
+//! as 2024-01-16 at hour 04, not as 2024-01-15 at hour 23.
+//!
+//! The alternative — keeping each value's own wall clock — makes two values that
+//! name the same instant compare as different and two values that name different
+//! instants compare as equal, and it compares an offset-bearing value against a
+//! UTC "now" in the Timeliness dimension. Normalizing costs the local reading of
+//! an hour distribution; it buys min/max, duration, and every comparison being
+//! about one timeline.
+//!
+//! A value with no offset carries no timezone to normalize, so it is read as it
+//! was written. Mixing the two in one column mixes local wall clocks with UTC
+//! instants; that is a property of the data, not something this module can fix.
 
 use crate::types::{ColumnStats, DateTimeStats};
 use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike, Weekday};
@@ -73,10 +91,15 @@ pub fn compute_datetime_stats(data: &[String]) -> DateTimeStats {
 fn parse_flexible_full(s: &str) -> Option<ParsedDateTime> {
     let trimmed = s.trim();
 
+    // An offset-bearing value is an instant, normalized to UTC before anything
+    // else sees it — see the "UTC Offsets" section in the module docs. `Z`
+    // values are unaffected (their offset is already zero); the rule only moves
+    // values written at a non-zero offset.
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(trimmed) {
+        let utc = dt.naive_utc();
         return Some(ParsedDateTime {
-            date: dt.date_naive(),
-            datetime: Some(dt.naive_local()),
+            date: utc.date(),
+            datetime: Some(utc),
         });
     }
 

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -347,10 +347,15 @@ pub fn infer_data_type_streaming(stats: &StreamingStatistics) -> DataType {
             return DataType::Float;
         }
 
+        // `.trim()`, like every sibling predicate in this function and like
+        // `infer_type`. Without it a value that arrived padded — CSV parsing
+        // does not trim by default — was a date to the buffered engines and
+        // text to this one, which is the same cross-engine split the shared
+        // grammar exists to close.
         let date_like_count = non_empty
             .iter()
             .take(100)
-            .filter(|s| looks_like_date(s))
+            .filter(|s| looks_like_date(s.trim()))
             .count();
 
         if date_like_count as f64 / non_empty.len().min(100) as f64 > 0.7 {

--- a/docs/guides/database-connectors.md
+++ b/docs/guides/database-connectors.md
@@ -14,11 +14,13 @@ Profile data directly from PostgreSQL, MySQL, and SQLite databases with quality 
 > exported CSV or Parquet file if you need statistics for those.
 >
 > Timestamps render in dataprof's naive ISO form (`YYYY-MM-DDTHH:MM:SS`) rather
-> than RFC 3339, because the date grammar that decides whether a column is
-> temporal rejects a trailing offset or `Z`. A `TIMESTAMPTZ` is converted to UTC
-> and its offset dropped: the instant survives, the marker saying it is UTC does
-> not. `NUMERIC`/`DECIMAL` keeps the exact digits the database stored rather
-> than routing through `f64`.
+> than RFC 3339. A `TIMESTAMPTZ` is converted to UTC and its offset dropped: the
+> instant survives, the marker saying it is UTC does not. Since 0.12 the date
+> grammar accepts a trailing offset too, but the two renderings profile
+> identically — dataprof normalizes an offset-bearing value to UTC before any
+> statistic reads it — so the connectors keep converting here.
+> `NUMERIC`/`DECIMAL` keeps the exact digits the database stored rather than
+> routing through `f64`.
 
 ## Feature Requirements
 

--- a/python/tests/test_dogfooding_session.py
+++ b/python/tests/test_dogfooding_session.py
@@ -36,7 +36,9 @@ class TestDogfoodingSession:
         assert report["sla_breached"].true_count == 12
         assert report["opened_at"].data_type == "date"
         assert report.quality_score is not None
-        assert report.quality_score < 95
+        # The fixture is imperfect by construction — 5 of its 30 records carry a
+        # null — so completeness has to keep the score off 100.
+        assert report.quality_score < 100
 
         column_repr = repr(report["response_minutes"])
         assert "ColumnProfile" in column_repr
@@ -44,6 +46,14 @@ class TestDogfoodingSession:
 
         quality = report.quality
         assert quality is not None
+
+        # `opened_at` is RFC 3339, and every one of its values is consistent
+        # with the `date` type it was inferred as. Before #643 the date grammar
+        # rejected the trailing `Z`, so all 30 counted against the column they
+        # had just been used to type, and consistency read 91.43% instead.
+        consistency = quality.consistency
+        assert consistency is not None
+        assert consistency["data_type_consistency"] == 100.0
         quality_repr = repr(quality)
         assert "DataQualityMetrics" in quality_repr
         # The repr names the dimensions the score is made of, so it must match

--- a/tests/rfc3339_timestamps.rs
+++ b/tests/rfc3339_timestamps.rs
@@ -138,23 +138,61 @@ fn offsets_are_normalized_to_utc_before_the_statistics() {
 #[test]
 fn a_timestamp_shaped_value_no_parser_accepts_stays_text() {
     // `+0200` is ISO 8601 basic, which chrono's RFC 3339 parser rejects.
-    let csv = write_csv(
-        "moment\n\
-2024-01-15T10:30:00+0200\n\
-2024-01-15T11:30:00+0200\n\
-2024-01-15T12:30:00+0200\n",
-    );
+    // `+24:00` and `-00:60` are well-shaped but out of range, which it also
+    // rejects — so the grammar has to bound the offset, not merely match two
+    // digits on each side of the colon.
+    for value in [
+        "2024-01-15T10:30:00+0200",
+        "2024-01-15T10:30:00+24:00",
+        "2024-01-15T10:30:00+99:99",
+        "2024-01-15T10:30:00-00:60",
+    ] {
+        let csv = write_csv(&format!("moment\n{value}\n{value}\n{value}\n"));
 
-    for engine in EVERY_ENGINE {
-        let report = Profiler::new()
-            .engine(engine)
-            .analyze_file(csv.path())
-            .expect("profile should succeed");
+        for engine in EVERY_ENGINE {
+            let report = Profiler::new()
+                .engine(engine)
+                .analyze_file(csv.path())
+                .expect("profile should succeed");
 
+            assert_eq!(
+                report.column_profiles[0].data_type,
+                DataType::String,
+                "{engine:?} typed {value:?} as a date, but no parser can read it"
+            );
+        }
+    }
+}
+
+/// CSV parsing does not trim by default, so a padded value reaches inference as
+/// it was written. Every engine has to make the same call about it: the
+/// buffered paths trimmed before the date test and the streaming one did not,
+/// so a padded date column was `Date` on one engine and `String` on the other —
+/// the same cross-engine split the shared grammar exists to close.
+#[test]
+fn padding_does_not_change_which_engine_calls_a_column_temporal() {
+    for value in [" 2024-01-15T10:30:00Z ", "  2024-01-15"] {
+        let csv = write_csv(&format!("moment\n{value}\n{value}\n{value}\n"));
+
+        let types: Vec<DataType> = EVERY_ENGINE
+            .iter()
+            .map(|engine| {
+                let report = Profiler::new()
+                    .engine(*engine)
+                    .analyze_file(csv.path())
+                    .expect("profile should succeed");
+                report.column_profiles[0].data_type.clone()
+            })
+            .collect();
+
+        assert!(
+            types.iter().all(|found| *found == types[0]),
+            "engines disagreed on padded {value:?}: {types:?} for {EVERY_ENGINE:?}"
+        );
         assert_eq!(
-            report.column_profiles[0].data_type,
-            DataType::String,
-            "{engine:?} typed a column no parser can read as a date"
+            types[0],
+            DataType::Date,
+            "padding should not stop {value:?} from being temporal"
         );
     }
 }

--- a/tests/rfc3339_timestamps.rs
+++ b/tests/rfc3339_timestamps.rs
@@ -1,0 +1,160 @@
+//! RFC 3339 is the default rendering for a timestamp in JSON APIs, in export
+//! tooling, and in Parquet-to-CSV dumps, so a column of them has to profile as
+//! a date column — identically on every engine (#643).
+
+use std::io::Write;
+
+use dataprof::{ColumnStats, DataType, EngineType, Profiler, QualityDimension};
+use tempfile::NamedTempFile;
+
+/// Mixed `Z` and numeric offsets, which is what a real export looks like once
+/// more than one producer has written to it.
+const RFC3339_CSV: &str = "created_at\n\
+2024-01-15T10:30:00Z\n\
+2024-01-15T11:45:00Z\n\
+2024-01-15T12:00:00+02:00\n\
+2024-01-16T08:15:00-05:00\n\
+2024-01-16T09:00:00Z\n\
+2024-01-17T14:20:00.500Z\n";
+
+const EVERY_ENGINE: [EngineType; 3] = [
+    EngineType::Auto,
+    EngineType::Incremental,
+    EngineType::Columnar,
+];
+
+fn write_csv(content: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".csv").unwrap();
+    write!(file, "{content}").unwrap();
+    file.flush().unwrap();
+    file
+}
+
+#[test]
+fn rfc3339_column_infers_as_a_date_column_on_every_engine() {
+    let csv = write_csv(RFC3339_CSV);
+
+    for engine in EVERY_ENGINE {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(csv.path())
+            .expect("profile should succeed");
+
+        let column = &report.column_profiles[0];
+        assert_eq!(
+            column.data_type,
+            DataType::Date,
+            "{engine:?} profiled an RFC 3339 timestamp column as {:?}",
+            column.data_type
+        );
+        assert_eq!(
+            column.invalid_count,
+            Some(0),
+            "{engine:?} did not read every value as a well-formed instant"
+        );
+        assert!(
+            matches!(column.stats, ColumnStats::DateTime(_)),
+            "{engine:?} reported {:?} instead of temporal statistics",
+            column.stats
+        );
+    }
+}
+
+#[test]
+fn timeliness_assesses_an_rfc3339_column_on_every_engine() {
+    let csv = write_csv(RFC3339_CSV);
+
+    for engine in EVERY_ENGINE {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(csv.path())
+            .expect("profile should succeed");
+
+        let quality = report.quality.as_ref().expect("quality assessed");
+        assert!(
+            quality
+                .metrics
+                .assessed_dimensions()
+                .contains(&QualityDimension::Timeliness),
+            "{engine:?}: timeliness assessed nothing, dimensions were {:?}",
+            quality.metrics.assessed_dimensions()
+        );
+
+        let timeliness = quality
+            .metrics
+            .timeliness
+            .as_ref()
+            .expect("timeliness evidence");
+        assert_eq!(
+            timeliness.date_values_checked, 6,
+            "{engine:?}: date_values_checked should equal the non-null count"
+        );
+        assert_eq!(
+            timeliness.invalid_date_values, 0,
+            "{engine:?}: no RFC 3339 value should count as unparseable"
+        );
+    }
+}
+
+/// An offset-bearing value names an instant, and dataprof normalizes it to UTC
+/// before any statistic sees it. Both values below sit on 2024-03-10 in their
+/// own wall clock and on a *different* UTC day, so a profile that kept the
+/// local reading would report a zero-day span across the two.
+#[test]
+fn offsets_are_normalized_to_utc_before_the_statistics() {
+    let csv = write_csv(
+        "moment\n\
+2024-03-10T23:00:00-05:00\n\
+2024-03-10T01:00:00+02:00\n",
+    );
+
+    for engine in EVERY_ENGINE {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(csv.path())
+            .expect("profile should succeed");
+
+        let ColumnStats::DateTime(stats) = &report.column_profiles[0].stats else {
+            panic!("{engine:?}: expected temporal statistics");
+        };
+
+        // 2024-03-09T23:00:00Z .. 2024-03-11T04:00:00Z
+        assert_eq!(stats.min_datetime, "2024-03-09", "{engine:?}: min");
+        assert_eq!(stats.max_datetime, "2024-03-11", "{engine:?}: max");
+        assert_eq!(stats.duration_days, 2.0, "{engine:?}: duration");
+
+        let hours = stats
+            .hour_distribution
+            .as_ref()
+            .expect("values carry a time of day");
+        assert_eq!(hours.get(&4), Some(&1), "{engine:?}: 23:00-05:00 is 04Z");
+        assert_eq!(hours.get(&23), Some(&1), "{engine:?}: 01:00+02:00 is 23Z");
+    }
+}
+
+/// The grammar must stay narrow enough that a value it calls a date is a value
+/// the parser can read. A form that types the column `Date` and then fails
+/// every parse is worse than leaving it as text.
+#[test]
+fn a_timestamp_shaped_value_no_parser_accepts_stays_text() {
+    // `+0200` is ISO 8601 basic, which chrono's RFC 3339 parser rejects.
+    let csv = write_csv(
+        "moment\n\
+2024-01-15T10:30:00+0200\n\
+2024-01-15T11:30:00+0200\n\
+2024-01-15T12:30:00+0200\n",
+    );
+
+    for engine in EVERY_ENGINE {
+        let report = Profiler::new()
+            .engine(engine)
+            .analyze_file(csv.path())
+            .expect("profile should succeed");
+
+        assert_eq!(
+            report.column_profiles[0].data_type,
+            DataType::String,
+            "{engine:?} typed a column no parser can read as a date"
+        );
+    }
+}


### PR DESCRIPTION
Closes #643.

## What was wrong

A column of RFC 3339 timestamps profiled as text — but only on some engines. Type inference ran on **two different lists of date patterns**, and they disagreed:

| | grammar | `2024-01-15T10:30:00Z` |
| --- | --- | --- |
| `infer_type` (buffered paths, Parquet fallback, Python columns) | `DATE_REGEXES` — `…T\d{2}:\d{2}:\d{2}(?:\.\d+)?$` | rejected |
| `infer_data_type_streaming` | private `DATE_PATTERN_REGEXES` — `^\d{4}-\d{2}-\d{2}T\d{2}:` | accepted by accident (unanchored) |

The same six-row CSV, measured before this change:

```
      Auto: type=Date   invalid=Some(0) timeliness_checked=6  stats=DateTime
Incremental: type=Date   invalid=Some(0) timeliness_checked=6  stats=DateTime
   Columnar: type=String invalid=None    timeliness_checked=0  stats=Text
```

That is the output contract in AGENTS.md failing: profile numbers must be identical regardless of which engine produced them.

## What changed

- **One grammar.** `looks_like_date` now delegates to `is_inferred_date_token`; `DATE_PATTERN_REGEXES` is deleted. Both entry points decide "is this a date" on the same set.
- **RFC 3339 offsets accepted.** The ISO datetime pattern takes an optional `Z`/`z` or `±HH:MM`. Those are exactly the alternatives `chrono::DateTime::parse_from_rfc3339` reads, so a value the grammar calls a date is a value the parser can turn into an instant. The ISO 8601 basic form `+0200` is deliberately excluded — chrono rejects it, and accepting it would type the column `Date` and then count every value as `invalid_date_values`.
- **Offsets normalize to UTC**, decided and documented in the `stats::datetime` module docs. `2024-01-15T23:00:00-05:00` counts as 2024-01-16 hour 04. Keeping each value's own wall clock would make two values naming the same instant compare as different, and would compare an offset-bearing value against a UTC "now" in Timeliness.

## Behavior changes

**Consistency scores rise for columns of offset-bearing timestamps.** Those values used to fail `is_date_token` and count against the column they had just been used to type. Measured on `python/tests/fixtures/dogfood/incidents.csv` (30 RFC 3339 values out of 350 checked):

| | before | after |
| --- | --- | --- |
| `data_type_consistency` | 91.43% | 100.0% |
| `quality_score` | 93.35 | 95.25 |

30/350 = 8.57%, the exact gap — every timestamp was penalized. `test_support_incident_csv_session` asserted `quality_score < 95`, which was encoding the bug; it now asserts the dimension that actually moved.

**Truncated timestamp shapes stop typing as dates.** The old unanchored pattern accepted `2024-01-15T10:` and `2024-01-15T10:30`, typed those columns `Date`, and then failed to parse a single value — empty datetime stats and a full `invalid_count`. They profile as text now, which is what they are.

**The `db_column_to_string!` naive-ISO rendering stays** (#643's follow-up item, and #365's workaround). With offsets normalized to UTC, `…T10:30:00` and `…T10:30:00+00:00` produce identical profiles, so rendering the offset would buy fidelity in the raw sample values and nothing in the numbers. The stale rationale comments saying the grammar *forces* this are corrected in `common.rs`, the connector test, and `docs/guides/database-connectors.md`.

## Acceptance criteria from #643

- [x] A CSV column of RFC 3339 timestamps, mixed `Z` and numeric offsets, infers as a date column — on all three engines
- [x] Timeliness assesses it, with `date_values_checked` matching the non-null count
- [x] The grammars agree; `is_date_token_accepts_every_form_either_regex_set_recognizes` still holds, with its example table updated
- [x] Offset handling decided (normalize to UTC) and documented
- [x] `db_column_to_string!` revisited; decision recorded above and in the code

## Verification

`tests/rfc3339_timestamps.rs` covers all three engines. Each part of the fix was reverted **separately** to confirm the tests discriminate it:

| reverted | failing tests |
| --- | --- |
| `inference.rs` (grammar) | 3 of 4 |
| `patterns.rs` (unification) | `a_timestamp_shaped_value_no_parser_accepts_stays_text` |
| `datetime.rs` (UTC) | `offsets_are_normalized_to_utc_before_the_statistics` |

Commands run:

```
cargo test --workspace                                  # 43 targets, 0 failures
cargo fmt --all --check
cargo +1.98 clippy --all --all-targets --features sqlite -- -D warnings
uv run maturin develop --release
uv run pytest python/tests/ -q                          # 1056 passed, 9 skipped
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
cargo run --example {before_after_cleaning,etl_quality_gate,messy_csv_inspection}
```

The Python surface was checked against the rebuilt extension: all three engines report `date`, `invalid_count=0`, and Timeliness checking all 6 values.