### PR TITLE
fix(parquet): profile a column by its values, not its physical encoding

### DIFF
--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -454,38 +454,25 @@ impl ColumnAnalyzer {
         self.sample_values.offer(value);
     }
 
-    /// Whether this column's sample values are its own values written as text.
+    /// Whether this column's text rendering is an *encoding* of its values
+    /// rather than the values themselves.
     ///
-    /// Kept identical to the parquet analyzer's predicate, which carries the
-    /// full rationale — including why the binary families are excluded.
-    fn samples_are_text_values(&self) -> bool {
+    /// The same predicate as the parquet analyzer's, which carries the full
+    /// rationale. It is deliberately not a list of which types reach the text
+    /// fallback: the match arms above already answer that, and this analyzer's
+    /// arms are not the parquet one's — `Int16`, `UInt*` and `Decimal*` fall
+    /// through to text here and do not there.
+    fn renders_values_as_encoded_bytes(&self) -> bool {
         use arrow::datatypes::DataType as ArrowDataType;
 
-        !matches!(
+        matches!(
             &self.data_type,
-            ArrowDataType::Null
-                | ArrowDataType::Boolean
-                | ArrowDataType::Float64
-                | ArrowDataType::Float32
-                | ArrowDataType::Int64
-                | ArrowDataType::Int32
-                | ArrowDataType::Int16
-                | ArrowDataType::Int8
-                | ArrowDataType::UInt64
-                | ArrowDataType::UInt32
-                | ArrowDataType::UInt16
-                | ArrowDataType::UInt8
-                | ArrowDataType::Decimal128(_, _)
-                | ArrowDataType::Decimal256(_, _)
-                | ArrowDataType::Duration(_)
-                | ArrowDataType::Binary
-                | ArrowDataType::LargeBinary
-                | ArrowDataType::FixedSizeBinary(_)
+            ArrowDataType::Binary | ArrowDataType::LargeBinary | ArrowDataType::FixedSizeBinary(_)
         )
     }
 
     fn should_track_date_matches(&self) -> bool {
-        self.samples_are_text_values()
+        !self.renders_values_as_encoded_bytes()
     }
 
     fn process_array(&mut self, array: &dyn Array) -> Result<(), DataProfilerError> {
@@ -1011,7 +998,9 @@ impl ColumnAnalyzer {
             // same shared inference every other engine types its text columns
             // with. Where the rendering is an encoding rather than the value,
             // the column stays text.
-            _ if self.samples_are_text_values() => infer_type(self.sample_values.samples()),
+            _ if !self.renders_values_as_encoded_bytes() => {
+                infer_type(self.sample_values.samples())
+            }
             _ => DataType::String,
         }
     }

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -423,7 +423,7 @@ struct ColumnAnalyzer {
 impl ColumnAnalyzer {
     fn new(data_type: &arrow::datatypes::DataType) -> Self {
         Self {
-            data_type: data_type.clone(),
+            data_type: crate::record_batch_analyzer::logical_arrow_type(data_type),
             total_count: 0,
             null_count: 0,
             cardinality: CardinalityEstimator::new(),
@@ -454,18 +454,62 @@ impl ColumnAnalyzer {
         self.sample_values.offer(value);
     }
 
-    fn should_track_date_matches(&self) -> bool {
-        matches!(
+    /// Whether this column's sample values are its own values written as text.
+    ///
+    /// Kept identical to the parquet analyzer's predicate, which carries the
+    /// full rationale — including why the binary families are excluded.
+    fn samples_are_text_values(&self) -> bool {
+        use arrow::datatypes::DataType as ArrowDataType;
+
+        !matches!(
             &self.data_type,
-            arrow::datatypes::DataType::Utf8
-                | arrow::datatypes::DataType::LargeUtf8
-                | arrow::datatypes::DataType::Date32
-                | arrow::datatypes::DataType::Date64
-                | arrow::datatypes::DataType::Timestamp(_, _)
+            ArrowDataType::Null
+                | ArrowDataType::Boolean
+                | ArrowDataType::Float64
+                | ArrowDataType::Float32
+                | ArrowDataType::Int64
+                | ArrowDataType::Int32
+                | ArrowDataType::Int16
+                | ArrowDataType::Int8
+                | ArrowDataType::UInt64
+                | ArrowDataType::UInt32
+                | ArrowDataType::UInt16
+                | ArrowDataType::UInt8
+                | ArrowDataType::Decimal128(_, _)
+                | ArrowDataType::Decimal256(_, _)
+                | ArrowDataType::Duration(_)
+                | ArrowDataType::Binary
+                | ArrowDataType::LargeBinary
+                | ArrowDataType::FixedSizeBinary(_)
         )
     }
 
+    fn should_track_date_matches(&self) -> bool {
+        self.samples_are_text_values()
+    }
+
     fn process_array(&mut self, array: &dyn Array) -> Result<(), DataProfilerError> {
+        // Decode the physical encoding first, so a dictionary-encoded or
+        // view-typed column takes the same arm as the plain array holding the
+        // same values. This engine only builds `Utf8` fields today, so the cast
+        // never fires; it is here because the drift this file shares with
+        // `record_batch_analyzer` is what let the two disagree in the first
+        // place (#647).
+        if array.data_type() != &self.data_type {
+            let decoded =
+                arrow::compute::kernels::cast::cast(array, &self.data_type).map_err(|error| {
+                    DataProfilerError::arrow_error(&format!(
+                        "failed to decode {} column as {}: {error}",
+                        array.data_type(),
+                        self.data_type
+                    ))
+                })?;
+            return self.process_decoded_array(decoded.as_ref());
+        }
+        self.process_decoded_array(array)
+    }
+
+    fn process_decoded_array(&mut self, array: &dyn Array) -> Result<(), DataProfilerError> {
         self.total_count += array.len();
         // logical_null_count, not null_count: a NullArray has no validity
         // buffer, so the physical count reports 0 nulls for an all-null array.
@@ -834,8 +878,14 @@ impl ColumnAnalyzer {
         for i in 0..array.len() {
             if !array.is_null(i) {
                 // Use Arrow's built-in conversion to string
-                let value = array_value_to_string(array, i)
-                    .unwrap_or_else(|_| format!("<type:{}>", array.data_type()));
+                // Never `unwrap_or_else` into a placeholder here: a decode
+                // failure that becomes a plausible string is measured as data.
+                let value = array_value_to_string(array, i).map_err(|error| {
+                    DataProfilerError::arrow_error(&format!(
+                        "no text rendering for {} column: {error}",
+                        array.data_type()
+                    ))
+                })?;
                 self.update_text_stats(&value);
 
                 self.offer_sample(value.clone());
@@ -954,11 +1004,14 @@ impl ColumnAnalyzer {
             arrow::datatypes::DataType::Date32
             | arrow::datatypes::DataType::Date64
             | arrow::datatypes::DataType::Timestamp(_, _) => DataType::Date,
-            arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8 => {
-                // Reuse the shared inference logic for consistent type detection
-                // across all engines (dates before numerics, 100% match threshold)
-                infer_type(self.sample_values.samples())
-            }
+            // Everything below reached the profile as text: `Utf8`/`LargeUtf8`
+            // natively, and every type without an arm through the string
+            // fallback. Where those samples are the values themselves, only
+            // they say what the column holds, so they are re-inferred with the
+            // same shared inference every other engine types its text columns
+            // with. Where the rendering is an encoding rather than the value,
+            // the column stays text.
+            _ if self.samples_are_text_values() => infer_type(self.sample_values.samples()),
             _ => DataType::String,
         }
     }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -459,52 +459,35 @@ impl ColumnAnalyzer {
         self.sample_values.offer(value);
     }
 
-    /// Whether this column's sample values are its own values written as text,
-    /// so what the column holds can be read back out of them.
+    /// Whether this column's text rendering is an *encoding* of its values
+    /// rather than the values themselves.
     ///
-    /// This is the one predicate behind both re-inference and date tracking; the
-    /// two used to carry separate lists of Arrow types and had drifted apart.
+    /// This is the only thing re-inference has to know. Which types reach the
+    /// text fallback at all is already answered by the arms above it, per
+    /// analyzer — enumerating them here a second time is exactly the drift this
+    /// change removes, and the two analyzers do not have the same native arms.
     ///
-    /// Stated as what is *excluded*, so a type this build has never seen is
-    /// treated as text — which is what the generic formatter will in fact
-    /// render it as — instead of silently reporting `String` and a date count of
-    /// zero that was never taken.
-    ///
-    /// The exclusions are of two kinds. The numeric, boolean and temporal arms
-    /// have their profile type named by the Arrow type already, and their
-    /// renderings cannot be dates. The **binary** families are excluded for a
-    /// sharper reason: their formatter emits hex, not the value. Re-inferring
-    /// from that reads the three bytes `abc` as the integer 616263 and reports
-    /// a numeric column with that mean — a decode artifact turned into a
-    /// plausible number. What a binary column should report is #645.
-    fn samples_are_text_values(&self) -> bool {
+    /// The binary families are the one case where the samples are not the
+    /// values: their formatter emits hex, so re-inferring reads the three bytes
+    /// `abc` as the integer 616263 and reports a numeric column with that mean.
+    /// What a binary column should report is #645.
+    fn renders_values_as_encoded_bytes(&self) -> bool {
         use arrow::datatypes::DataType as ArrowDataType;
 
-        !matches!(
+        matches!(
             &self.data_type,
-            ArrowDataType::Null
-                | ArrowDataType::Boolean
-                | ArrowDataType::Float64
-                | ArrowDataType::Float32
-                | ArrowDataType::Int64
-                | ArrowDataType::Int32
-                | ArrowDataType::Int16
-                | ArrowDataType::Int8
-                | ArrowDataType::UInt64
-                | ArrowDataType::UInt32
-                | ArrowDataType::UInt16
-                | ArrowDataType::UInt8
-                | ArrowDataType::Decimal128(_, _)
-                | ArrowDataType::Decimal256(_, _)
-                | ArrowDataType::Duration(_)
-                | ArrowDataType::Binary
-                | ArrowDataType::LargeBinary
-                | ArrowDataType::FixedSizeBinary(_)
+            ArrowDataType::Binary | ArrowDataType::LargeBinary | ArrowDataType::FixedSizeBinary(_)
         )
     }
 
+    /// Whether this column's values can be date tokens at all.
+    ///
+    /// Deliberately not a list of Arrow types. A numeric, boolean or duration
+    /// rendering is never a date token, so counting it costs a cheap byte check
+    /// and yields the same zero a skip would have — while a type this build has
+    /// never seen gets an honest count instead of one that was never taken.
     fn should_track_date_matches(&self) -> bool {
-        self.samples_are_text_values()
+        !self.renders_values_as_encoded_bytes()
     }
 
     fn hint_binding(&self, column: &str, kind: SemanticHintKind) -> SemanticHintBinding {
@@ -1262,7 +1245,9 @@ impl ColumnAnalyzer {
             // profiled as integers. Where the rendering is an encoding rather
             // than the value (hex, for binary), re-inference would read the
             // encoding as data, so the column stays text.
-            _ if self.samples_are_text_values() => infer_type(self.sample_values.samples()),
+            _ if !self.renders_values_as_encoded_bytes() => {
+                infer_type(self.sample_values.samples())
+            }
             _ => DataType::String,
         }
     }
@@ -1539,5 +1524,70 @@ mod tests {
         assert_ne!(large, 1_000, "must not expose the old hard cap as exact");
         let error = (large as f64 - 100_000.0).abs() / 100_000.0;
         assert!(error < 0.05, "100k distinct estimated as {large}");
+    }
+
+    /// Profile one column through `RecordBatchAnalyzer` and return everything
+    /// the profile says about it.
+    fn observable(array: ArrayRef) -> String {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "c",
+            array.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        analyzer.process_batch(&batch).unwrap();
+        format!("{:?}", analyzer.to_profiles(false, false, None)[0])
+    }
+
+    /// Run-end encoding never survives a Parquet round trip, so the file-level
+    /// parity suite cannot reach it. It arrives through `RecordBatchAnalyzer`
+    /// directly instead — the entry point the Python Arrow import path feeds —
+    /// which is why the encoding is stripped and why that has to be tested
+    /// here rather than left as an unverified arm.
+    #[test]
+    fn run_end_encoding_profiles_as_the_plain_column_does() {
+        use arrow::array::builder::PrimitiveRunBuilder;
+        use arrow::datatypes::{Float64Type, Int32Type};
+
+        // A *numeric* value type on purpose. A run-end encoded string column
+        // reaches the same answer through the text fallback whether or not the
+        // encoding is stripped, so it would not discriminate this arm. A
+        // numeric one does: without the cast the values never reach
+        // `process_int64_array`, so the exact aggregates behind min, max and
+        // mean are never accumulated.
+        //
+        // Runs, not distinct values: run-end encoding compresses repetition, so
+        // a column with none of it would not exercise the cast either.
+        // A run of NaN on purpose. The native float arm counts NaN as null,
+        // matching every textual path; the generic formatter renders it as the
+        // string "NaN" and the null count never moves. That divergence is what
+        // makes this arm load-bearing — a run of ordinary integers reaches the
+        // same published profile through either path and would not
+        // discriminate it.
+        //
+        // Runs, not distinct values: run-end encoding compresses repetition, so
+        // a column with none of it would not exercise the cast either.
+        let values: Vec<f64> = (0..60)
+            .map(|i| if i < 30 { 7.0 } else { f64::NAN })
+            .collect();
+
+        let mut run_builder = PrimitiveRunBuilder::<Int32Type, Float64Type>::new();
+        for value in &values {
+            run_builder.append_value(*value);
+        }
+        let encoded: ArrayRef = Arc::new(run_builder.finish());
+        assert!(
+            matches!(encoded.data_type(), ArrowDataType::RunEndEncoded(_, _)),
+            "the builder stopped producing run-end encoding"
+        );
+
+        let plain: ArrayRef = Arc::new(Float64Array::from(values));
+        assert_eq!(
+            observable(encoded),
+            observable(plain),
+            "a run-end encoded column profiled differently from the plain one"
+        );
     }
 }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -20,6 +20,43 @@ use std::fmt::Write as _;
 
 const NUMERIC_SAMPLE_CAP: usize = 10_000;
 
+/// Strip the physical encoding a writer chose and return the logical type the
+/// column actually holds.
+///
+/// A `pandas` categorical arrives as `Dictionary(Int8, Utf8)` and a pyarrow
+/// `string_view` as `Utf8View`, but both hold the same values as the plain
+/// `Utf8` a different writer would have produced. Profiling them by their
+/// physical type made the same sixty strings report `integer` with a numeric
+/// block through one writer and `string` with a length block through another —
+/// the output contract failing on a file dataprof reads today.
+///
+/// Every column is normalized through here once, so the dispatch in
+/// [`ColumnAnalyzer::process_array`], the type in
+/// [`ColumnAnalyzer::infer_data_type`] and the date tracking in
+/// [`ColumnAnalyzer::should_track_date_matches`] all see one type. They used to
+/// hold three lists that had drifted apart.
+///
+/// Only encodings are stripped. A type whose *values* need a decision of their
+/// own — nested types (#637), binary (#645) — keeps its identity and is decided
+/// there.
+pub(crate) fn logical_arrow_type(
+    data_type: &arrow::datatypes::DataType,
+) -> arrow::datatypes::DataType {
+    use arrow::datatypes::DataType as ArrowDataType;
+
+    match data_type {
+        // The dictionary is a compression of the value array, not a type.
+        ArrowDataType::Dictionary(_, values) => logical_arrow_type(values),
+        ArrowDataType::RunEndEncoded(_, values) => logical_arrow_type(values.data_type()),
+        // View layouts differ from their contiguous twins in buffer layout only.
+        ArrowDataType::Utf8View => ArrowDataType::Utf8,
+        ArrowDataType::BinaryView => ArrowDataType::Binary,
+        // Half precision has no arm of its own; f32 holds every f16 exactly.
+        ArrowDataType::Float16 => ArrowDataType::Float32,
+        other => other.clone(),
+    }
+}
+
 /// Full-stream duplicate-row tracking over Arrow batches.
 ///
 /// Row signatures use the same length-prefixed encoding as the incremental
@@ -374,7 +411,9 @@ impl ColumnAnalyzer {
         temporal_hint: bool,
     ) -> Self {
         Self {
-            data_type: data_type.clone(),
+            // The physical encoding is stripped once, here, so nothing
+            // downstream has to know about dictionaries or view layouts.
+            data_type: logical_arrow_type(data_type),
             total_count: 0,
             null_count: 0,
             cardinality: CardinalityEstimator::new(),
@@ -420,15 +459,52 @@ impl ColumnAnalyzer {
         self.sample_values.offer(value);
     }
 
-    fn should_track_date_matches(&self) -> bool {
-        matches!(
+    /// Whether this column's sample values are its own values written as text,
+    /// so what the column holds can be read back out of them.
+    ///
+    /// This is the one predicate behind both re-inference and date tracking; the
+    /// two used to carry separate lists of Arrow types and had drifted apart.
+    ///
+    /// Stated as what is *excluded*, so a type this build has never seen is
+    /// treated as text — which is what the generic formatter will in fact
+    /// render it as — instead of silently reporting `String` and a date count of
+    /// zero that was never taken.
+    ///
+    /// The exclusions are of two kinds. The numeric, boolean and temporal arms
+    /// have their profile type named by the Arrow type already, and their
+    /// renderings cannot be dates. The **binary** families are excluded for a
+    /// sharper reason: their formatter emits hex, not the value. Re-inferring
+    /// from that reads the three bytes `abc` as the integer 616263 and reports
+    /// a numeric column with that mean — a decode artifact turned into a
+    /// plausible number. What a binary column should report is #645.
+    fn samples_are_text_values(&self) -> bool {
+        use arrow::datatypes::DataType as ArrowDataType;
+
+        !matches!(
             &self.data_type,
-            arrow::datatypes::DataType::Utf8
-                | arrow::datatypes::DataType::LargeUtf8
-                | arrow::datatypes::DataType::Date32
-                | arrow::datatypes::DataType::Date64
-                | arrow::datatypes::DataType::Timestamp(_, _)
+            ArrowDataType::Null
+                | ArrowDataType::Boolean
+                | ArrowDataType::Float64
+                | ArrowDataType::Float32
+                | ArrowDataType::Int64
+                | ArrowDataType::Int32
+                | ArrowDataType::Int16
+                | ArrowDataType::Int8
+                | ArrowDataType::UInt64
+                | ArrowDataType::UInt32
+                | ArrowDataType::UInt16
+                | ArrowDataType::UInt8
+                | ArrowDataType::Decimal128(_, _)
+                | ArrowDataType::Decimal256(_, _)
+                | ArrowDataType::Duration(_)
+                | ArrowDataType::Binary
+                | ArrowDataType::LargeBinary
+                | ArrowDataType::FixedSizeBinary(_)
         )
+    }
+
+    fn should_track_date_matches(&self) -> bool {
+        self.samples_are_text_values()
     }
 
     fn hint_binding(&self, column: &str, kind: SemanticHintKind) -> SemanticHintBinding {
@@ -447,6 +523,26 @@ impl ColumnAnalyzer {
     }
 
     pub fn process_array(&mut self, array: &dyn Array) -> Result<()> {
+        // Decode the physical encoding before anything measures the values, so
+        // a dictionary-encoded or view-typed column takes the same arm as the
+        // plain array holding the same values. `self.data_type` is already the
+        // logical type; the cast is a no-op for every column that arrived
+        // unencoded.
+        if array.data_type() != &self.data_type {
+            let decoded =
+                arrow::compute::kernels::cast::cast(array, &self.data_type).map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to decode {} column as {}: {error}",
+                        array.data_type(),
+                        self.data_type
+                    )
+                })?;
+            return self.process_decoded_array(decoded.as_ref());
+        }
+        self.process_decoded_array(array)
+    }
+
+    fn process_decoded_array(&mut self, array: &dyn Array) -> Result<()> {
         self.total_count += array.len();
         // logical_null_count, not null_count: a NullArray has no validity
         // buffer, so the physical count reports 0 nulls for an all-null array.
@@ -1026,15 +1122,16 @@ impl ColumnAnalyzer {
                     }
                 }
             }
-            Err(_) => {
-                for index in 0..array.len() {
-                    if !array.is_null(index) {
-                        let value_str = format!("<{}:value_{}>", array.data_type(), index);
-                        self.update_text_stats(&value_str);
-                        self.offer_sample(value_str.clone());
-                        self.cardinality.insert_owned(value_str);
-                    }
-                }
+            // A fabricated `<type:value_N>` per row used to stand in here. It
+            // made every row distinct, so a column dataprof could not read at
+            // all reported full cardinality and a uniqueness ratio of 1.0 — a
+            // decode failure turned into a plausible number, which is the worst
+            // bug class for a profiler.
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "no text rendering for {} column: {error}",
+                    array.data_type()
+                ));
             }
         }
         Ok(())
@@ -1156,9 +1253,16 @@ impl ColumnAnalyzer {
             | arrow::datatypes::DataType::Decimal256(_, _) => DataType::Float,
             arrow::datatypes::DataType::Duration(_) => DataType::Integer,
             arrow::datatypes::DataType::Boolean => DataType::Boolean,
-            arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8 => {
-                infer_type(self.sample_values.samples())
-            }
+            // Everything below reached the profile as text: `Utf8`/`LargeUtf8`
+            // natively, and every type without an arm through the generic
+            // formatter. Where those samples are the values themselves, only
+            // they say what the column holds, so they are re-inferred rather
+            // than declared `String` — which is what made a dictionary of
+            // digits profile as text while the same digits written plain
+            // profiled as integers. Where the rendering is an encoding rather
+            // than the value (hex, for binary), re-inference would read the
+            // encoding as data, so the column stays text.
+            _ if self.samples_are_text_values() => infer_type(self.sample_values.samples()),
             _ => DataType::String,
         }
     }

--- a/tests/parquet_encoding_parity.rs
+++ b/tests/parquet_encoding_parity.rs
@@ -47,18 +47,16 @@ fn profile(array: ArrayRef) -> ColumnProfile {
     report.column_profiles.into_iter().next().unwrap()
 }
 
-/// Everything a profile says about a column, so a divergence anywhere in it
-/// fails rather than only the fields a test remembered to name.
+/// Everything a profile says about a column.
+///
+/// The whole struct, not a hand-picked subset: this change alters the sampled
+/// and rendered values, which drive `patterns`, `type_homogeneity` and
+/// `unique_count_is_approximate` as well as the fields a test would think to
+/// name. A listed subset would let an encoding diverge in the unlisted ones and
+/// still pass. The column is named `c` in every file here, so the name is
+/// common rather than noise.
 fn observable(profile: &ColumnProfile) -> String {
-    format!(
-        "type={:?} total={} null={} invalid={:?} unique={:?} stats={:?}",
-        profile.data_type,
-        profile.total_count,
-        profile.null_count,
-        profile.invalid_count,
-        profile.unique_count,
-        profile.stats,
-    )
+    format!("{profile:?}")
 }
 
 #[track_caller]

--- a/tests/parquet_encoding_parity.rs
+++ b/tests/parquet_encoding_parity.rs
@@ -1,0 +1,200 @@
+//! The physical encoding a writer chose must not change the profile (#647).
+//!
+//! `pandas.DataFrame.to_parquet` on a categorical column writes
+//! `Dictionary(Int8, Utf8)`; pyarrow writes `Utf8View` for `string_view`. Both
+//! hold the values a different writer would have put in a plain `Utf8` column,
+//! and all three have to profile the same way.
+
+#![cfg(feature = "parquet")]
+
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, BinaryArray, BinaryViewArray, FixedSizeBinaryArray, Float32Array, Int32Array,
+    LargeStringArray, StringArray, StringViewArray,
+};
+use arrow::datatypes::{Field, Schema};
+use arrow::record_batch::RecordBatch;
+use dataprof::{ColumnProfile, ColumnStats, DataType, Profiler};
+use parquet::arrow::ArrowWriter;
+use tempfile::NamedTempFile;
+
+/// Sixty values that are digits, so a text encoding has something to be
+/// re-inferred *into* and a failure to re-infer is visible as `String`.
+fn digits() -> Vec<String> {
+    (0..60).map(|i| (i % 9 + 1).to_string()).collect()
+}
+
+fn write(array: ArrayRef) -> NamedTempFile {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "c",
+        array.data_type().clone(),
+        true,
+    )]));
+    let batch = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+    let file = NamedTempFile::with_suffix(".parquet").unwrap();
+    let mut writer = ArrowWriter::try_new(file.reopen().unwrap(), schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    file
+}
+
+fn profile(array: ArrayRef) -> ColumnProfile {
+    let file = write(array);
+    let report = Profiler::new()
+        .analyze_file(file.path())
+        .expect("profile should succeed");
+    report.column_profiles.into_iter().next().unwrap()
+}
+
+/// Everything a profile says about a column, so a divergence anywhere in it
+/// fails rather than only the fields a test remembered to name.
+fn observable(profile: &ColumnProfile) -> String {
+    format!(
+        "type={:?} total={} null={} invalid={:?} unique={:?} stats={:?}",
+        profile.data_type,
+        profile.total_count,
+        profile.null_count,
+        profile.invalid_count,
+        profile.unique_count,
+        profile.stats,
+    )
+}
+
+#[track_caller]
+fn assert_same_profile(baseline_name: &str, baseline: ArrayRef, cases: Vec<(&str, ArrayRef)>) {
+    let expected = profile(baseline);
+    for (name, array) in cases {
+        let actual = profile(array);
+        assert_eq!(
+            observable(&actual),
+            observable(&expected),
+            "{name} profiles differently from {baseline_name}"
+        );
+    }
+}
+
+/// The headline case: the same sixty digit strings, written five ways.
+///
+/// Before the fix `plain` re-inferred as `integer` with a numeric block while
+/// `dictionary` and `string_view` reported `string`, length statistics, and
+/// `invalid_count` absent rather than `0`.
+#[test]
+fn every_string_encoding_profiles_as_the_plain_column_does() {
+    let values = digits();
+    let refs: Vec<&str> = values.iter().map(String::as_str).collect();
+
+    let baseline: ArrayRef = Arc::new(StringArray::from(refs.clone()));
+    assert_eq!(
+        profile(Arc::clone(&baseline)).data_type,
+        DataType::Integer,
+        "the baseline must re-infer, or this test proves nothing"
+    );
+
+    let mut dictionary =
+        arrow::array::builder::StringDictionaryBuilder::<arrow::datatypes::Int8Type>::new();
+    for value in &refs {
+        dictionary.append_value(value);
+    }
+
+    assert_same_profile(
+        "Utf8",
+        baseline,
+        vec![
+            ("LargeUtf8", Arc::new(LargeStringArray::from(refs.clone()))),
+            ("Utf8View", Arc::new(StringViewArray::from(refs.clone()))),
+            ("Dictionary(Int8, Utf8)", Arc::new(dictionary.finish())),
+        ],
+    );
+}
+
+/// A dictionary of a *numeric* value type must profile as that numeric type,
+/// not as its rendering. This one reported `string` with length statistics.
+#[test]
+fn a_dictionary_of_integers_profiles_as_integers() {
+    let values: Vec<i32> = (0..60).map(|i| i % 9 + 1).collect();
+
+    let mut dictionary = arrow::array::builder::PrimitiveDictionaryBuilder::<
+        arrow::datatypes::Int8Type,
+        arrow::datatypes::Int32Type,
+    >::new();
+    for value in &values {
+        dictionary.append_value(*value);
+    }
+
+    assert_same_profile(
+        "Int32",
+        Arc::new(Int32Array::from(values)),
+        vec![("Dictionary(Int8, Int32)", Arc::new(dictionary.finish()))],
+    );
+}
+
+/// `Float16` had no arm, so it fell through to text and reported length
+/// statistics for a numeric column. Every `f16` is exact in `f32`.
+#[test]
+fn half_precision_profiles_as_the_float_it_is() {
+    let values: Vec<f32> = (0..60).map(|i| (i % 9 + 1) as f32).collect();
+    let plain: ArrayRef = Arc::new(Float32Array::from(values));
+    // Cast rather than reach for `half` directly: these values are all exact in
+    // f16, so the round trip changes nothing.
+    let halves =
+        arrow::compute::kernels::cast::cast(&plain, &arrow::datatypes::DataType::Float16).unwrap();
+
+    assert_same_profile("Float32", plain, vec![("Float16", halves)]);
+}
+
+/// The two binary layouts disagreed: the same three bytes reported `max_length`
+/// 6 through the generic fallback and 10 through the `Binary` arm, because the
+/// two paths measured different renderings. What a binary column *should*
+/// report is #645; this asserts only that one answer reaches both.
+#[test]
+fn the_binary_layouts_agree_with_each_other() {
+    let values: Vec<&[u8]> = (0..60).map(|_| b"abc".as_slice()).collect();
+
+    assert_same_profile(
+        "Binary",
+        Arc::new(BinaryArray::from(values.clone())),
+        vec![("BinaryView", Arc::new(BinaryViewArray::from(values)))],
+    );
+}
+
+/// A time of day carries no date, so it stays text — but it must be *re-inferred*
+/// text rather than text by default, and its date-match count must be a real
+/// zero rather than a count that was never taken.
+#[test]
+fn a_time_of_day_is_text_because_it_is_not_a_date() {
+    let times: Vec<i64> = (0..60).map(|i| (i % 24) * 3_600_000_000).collect();
+    let array: ArrayRef = Arc::new(arrow::array::Time64MicrosecondArray::from(times));
+
+    let profile = profile(array);
+    assert_eq!(profile.data_type, DataType::String);
+    assert!(
+        matches!(profile.stats, ColumnStats::Text(_)),
+        "expected text statistics, got {:?}",
+        profile.stats
+    );
+}
+
+/// Re-inferring a column from its rendering is only sound when the rendering is
+/// the value. `FixedSizeBinary` formats as **hex**, so reading the samples back
+/// as data turns the three bytes `abc` into the integer 616263 and reports a
+/// numeric column with that mean — a decode artifact become a plausible number,
+/// which is the one thing a profiler must never do.
+#[test]
+fn a_binary_rendering_is_never_re_inferred_as_the_number_it_spells() {
+    let values: Vec<&[u8]> = (0..60).map(|_| b"abc".as_slice()).collect();
+    let array: ArrayRef =
+        Arc::new(FixedSizeBinaryArray::try_from_iter(values.into_iter()).unwrap());
+
+    let profile = profile(array);
+    assert_eq!(
+        profile.data_type,
+        DataType::String,
+        "a hex rendering was read back as data"
+    );
+    assert!(
+        matches!(profile.stats, ColumnStats::Text(_)),
+        "expected text statistics, got {:?}",
+        profile.stats
+    );
+}


### PR DESCRIPTION
Closes #647.

## What was wrong

The same values profiled differently depending on the physical encoding the writer chose. Measured with pyarrow 25.0.1, forty identical values per file, before this change:

```
       string: type=integer  invalid=0     min=1.0  max=9.0   ← numeric block
 large_string: type=integer  invalid=0     min=1.0  max=9.0
     dict_str: type=string   invalid=None  minlen=1 maxlen=1  ← length block
  string_view: type=string   invalid=None  minlen=1 maxlen=1
     dict_int: type=string   invalid=None  minlen=1 maxlen=1
      float16: type=string   invalid=None  minlen=1 maxlen=1
       binary: type=string   invalid=None  minlen=10 maxlen=10
  binary_view: type=string   invalid=None  minlen=6  maxlen=6  ← disagrees with binary
```

`pandas.DataFrame.to_parquet` on a categorical column is enough to hit it. `RecordBatchAnalyzer` dispatched on the Arrow type in **three** places — `process_array`, `infer_data_type`, `should_track_date_matches` — and the three lists were not the same set.

After:

```
       string: integer  invalid=0  |  dict_str:    integer  invalid=0
 large_string: integer  invalid=0  |  string_view: integer  invalid=0
        int32: integer  invalid=0  |  dict_int:    integer  invalid=0
      float16: float    invalid=0  |  binary/binary_view: both maxlen=10
```

## What changed

- **`logical_arrow_type` strips the encoding once.** `Dictionary(_, v)` → `v`, `RunEndEncoded(_, v)` → `v`, `Utf8View` → `Utf8`, `BinaryView` → `Binary`, `Float16` → `Float32`. The column is normalized at construction and the array cast on entry, so all three matches see one type.
- **The two remaining matches derive their fallback instead of enumerating it.** `infer_data_type` re-infers over the collected samples rather than declaring `String`; date tracking is on by default. The next Arrow type without an arm is right by construction instead of silently text with a date count that was never taken.
- **`process_generic_array` no longer fabricates `<type:value_N>` per row** when a formatter cannot be built. That made every row distinct, so a column dataprof could not read at all reported full cardinality and a uniqueness ratio of 1.0. It is an error now.
- **The columnar CSV engine's copy** of the same three matches gets the same treatment, plus its `array_value_to_string(...).unwrap_or_else(|_| "<type:…>")`, which swallowed a decode error into a plausible value. It only builds `Utf8` fields today, but the duplication is how the sets drifted apart.

## A hazard found while verifying, and guarded

The obvious version of the re-inference fix — `_ => infer_type(samples)` for everything — is **wrong**, and I only caught it by testing a type the issue does not mention. `FixedSizeBinary` formats as hex, so re-inferring reads the three bytes `abc` back as the integer **616263** and reports a numeric column with that mean:

```
FixedSizeBinary -> type=Integer stats=Numeric(min: 616263.0, max: 616263.0, mean: 616263.0, …)
```

That is a decode artifact turned into a plausible number — the failure class AGENTS.md singles out as the worst for a profiler. Both fallbacks are therefore gated on `samples_are_text_values`, which excludes the binary families for exactly this reason, and `a_binary_rendering_is_never_re_inferred_as_the_number_it_spells` pins it.

## Acceptance criteria from #647

- [x] A dictionary-encoded column profiles identically to the same values written undictionaried — data_type, invalid_count, and the stats block
- [x] `Utf8View` agrees with `Utf8`, `BinaryView` with `Binary`
- [x] Temporal and numeric re-inference run for every encoding that can carry them as text — and *only* those, per the hex finding above
- [x] A decode failure in the generic path is an error, not a synthetic value that inflates cardinality
- [x] A regression test writes one file per encoding and asserts profile equality across them

Out of scope, unchanged: what a binary column should report (#645) and nested types (#637). This PR only makes the two paths agree on whatever those decide.

## Verification

`tests/parquet_encoding_parity.rs` compares a full profile string — type, counts, invalid, unique, and the whole stats block — so a divergence anywhere fails, not only in fields a test remembered to name.

Reverting the parts separately:

| reverted | result |
| --- | --- |
| `logical_arrow_type` normalization | `half_precision…` and `the_binary_layouts_agree…` fail |
| re-inference fallback | **no test fails** — see below |

Being explicit, per the repo's own rule about not implying coverage: **the suite does not discriminate the re-inference fallback on its own.** With normalization in place, every encoding in the test is cast to a type that has a native arm, so nothing reaches the fallback. It is kept because it is what makes a *future* Arrow type without an arm correct rather than accidentally correct, and the `FixedSizeBinary` test constrains its shape. The `a_time_of_day_is_text…` case exercises the fallback path but would pass either way.

Commands run:

```
cargo test --workspace --features parquet          # 0 failures
cargo fmt --all
cargo +1.98 clippy --all --all-targets --features parquet,sqlite -- -D warnings
uv run maturin develop --release
uv run pytest python/tests/ -q                     # 1056 passed, 9 skipped
cargo run --example {before_after_cleaning,etl_quality_gate,messy_csv_inspection}
```

Also re-checked end to end against real pyarrow-written files for all ten encodings above.