### PR TITLE
fix(python): profile every chunk of a pandas or polars DataFrame

### DIFF
--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -22,7 +22,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{Array, BooleanArray, Float64Array, RecordBatch, StringArray, UInt64Array};
-use arrow::compute::concat_batches;
 use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema, to_ffi};
 use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
@@ -383,35 +382,47 @@ pub fn profile_dataframe(
     // Detect source library
     let source_library = detect_dataframe_library(py, &df)?;
 
-    // Convert DataFrame to RecordBatch via PyCapsule
-    let batch = convert_dataframe_to_batch(py, &df, &source_library)?;
+    // Import as a batch sequence and keep it that way, exactly as the pyarrow
+    // path does: a chunked frame has more than one batch, and concatenating
+    // them here would both allocate for rows the row limit is about to discard
+    // and peak at roughly twice the input.
+    let batches = convert_dataframe_to_batches(py, &df, &source_library)?;
 
     // Optionally limit rows before analysis
-    let (batch, truncated) = limit_batch_rows(batch, effective_max_rows);
-    let available_columns = batch
+    let (batches, truncated) = limit_batches(batches, effective_max_rows);
+    let available_columns = batches[0]
         .schema()
         .fields()
         .iter()
         .map(|field| field.name().clone())
         .collect::<Vec<_>>();
-    let batch = match options
+    let batches = match options
         .column_indices(&available_columns)
         .map_err(|error| PyValueError::new_err(error.to_string()))?
     {
-        Some(indices) => batch.project(&indices).map_err(|error| {
-            PyRuntimeError::new_err(format!("Arrow projection failed: {error}"))
-        })?,
-        None => batch,
+        Some(indices) => batches
+            .into_iter()
+            .map(|batch| {
+                batch.project(&indices).map_err(|error| {
+                    PyRuntimeError::new_err(format!("Arrow projection failed: {error}"))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?,
+        None => batches,
     };
 
-    let num_rows = batch.num_rows();
-    let num_cols = batch.num_columns();
+    let num_rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
+    // convert_dataframe_to_batches never yields an empty sequence, and
+    // limit_batches always keeps one batch for its schema.
+    let num_cols = batches[0].num_columns();
     // decode-audit: no-data — absent config simply means no semantic hints.
     let semantic_hints = options.semantic_hints().clone();
 
     // Process using existing RecordBatchAnalyzer
     let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(&semantic_hints);
-    analyze_imported_batch(&mut analyzer, &batch)?;
+    for batch in &batches {
+        analyze_imported_batch(&mut analyzer, batch)?;
+    }
 
     let locale = options.locale();
     let column_profiles =
@@ -844,15 +855,6 @@ fn estimate_memory_bytes(
     }
 }
 
-/// Slice a RecordBatch to at most `max_rows` rows. Returns the (possibly
-/// sliced) batch and a boolean indicating whether truncation occurred.
-fn limit_batch_rows(batch: RecordBatch, max_rows: Option<usize>) -> (RecordBatch, bool) {
-    match max_rows {
-        Some(limit) if limit < batch.num_rows() => (batch.slice(0, limit), true),
-        _ => (batch, false),
-    }
-}
-
 /// Apply a row limit across a batch sequence, reporting whether anything was cut.
 ///
 /// Stops before importing rows it would only discard, so a bounded profile of a
@@ -888,22 +890,27 @@ fn limit_batches(batches: Vec<RecordBatch>, max_rows: Option<usize>) -> (Vec<Rec
     (kept, false)
 }
 
-/// Convert DataFrame to Arrow RecordBatch via appropriate method.
-fn convert_dataframe_to_batch(
+/// Convert a DataFrame to the sequence of Arrow batches backing it.
+///
+/// A frame carrying several Arrow chunks yields several batches. Both library
+/// paths below reach the same importer as a pyarrow Table does, because taking
+/// the first batch of a chunked frame reports on a prefix of the data without
+/// saying so.
+fn convert_dataframe_to_batches(
     py: Python<'_>,
     df: &Py<PyAny>,
     source_library: &DataFrameLibrary,
-) -> PyResult<RecordBatch> {
+) -> PyResult<Vec<RecordBatch>> {
     let bound = df.bind(py);
 
     match source_library {
-        DataFrameLibrary::Pandas => convert_pandas_to_batch(py, bound),
-        DataFrameLibrary::Polars => convert_polars_to_batch(py, bound),
-        DataFrameLibrary::PyArrow => import_from_pyarrow(py, bound),
+        DataFrameLibrary::Pandas => convert_pandas_to_batches(py, bound),
+        DataFrameLibrary::Polars => convert_polars_to_batches(py, bound),
+        DataFrameLibrary::PyArrow => import_batches_from_pyarrow(py, bound),
         DataFrameLibrary::Custom(_) => {
             // Try generic PyCapsule import
             if bound.hasattr("__arrow_c_array__")? {
-                import_via_pycapsule(py, bound)
+                Ok(vec![import_via_pycapsule(py, bound)?])
             } else {
                 Err(PyTypeError::new_err(format!(
                     "Unsupported DataFrame type: {}. Must implement Arrow PyCapsule protocol.",
@@ -914,8 +921,11 @@ fn convert_dataframe_to_batch(
     }
 }
 
-/// Convert pandas DataFrame to RecordBatch.
-fn convert_pandas_to_batch(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<RecordBatch> {
+/// Convert a pandas DataFrame to its Arrow batches.
+///
+/// An Arrow-backed frame whose columns are chunked exports as several batches,
+/// which is why this returns the whole sequence rather than `to_batches()[0]`.
+fn convert_pandas_to_batches(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<Vec<RecordBatch>> {
     let pyarrow = py.import("pyarrow").map_err(|_| {
         PyRuntimeError::new_err(
             "pyarrow required for pandas DataFrames. Install with: pip install pyarrow",
@@ -927,33 +937,18 @@ fn convert_pandas_to_batch(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<Re
         .getattr("Table")?
         .call_method1("from_pandas", (df,))?;
 
-    // Get batches and import the first one
-    let batches = pa_table.call_method0("to_batches")?;
-    let batch_list: Vec<Py<PyAny>> = batches.extract()?;
-
-    if batch_list.is_empty() {
-        return Err(PyValueError::new_err("DataFrame is empty"));
-    }
-
-    // Import first batch via PyCapsule
-    import_via_pycapsule(py, batch_list[0].bind(py))
+    import_batches_from_pyarrow(py, &pa_table)
 }
 
-/// Convert polars DataFrame to RecordBatch.
-fn convert_polars_to_batch(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<RecordBatch> {
+/// Convert a polars DataFrame to its Arrow batches.
+///
+/// `pl.concat(..., rechunk=False)` and `vstack` both leave a frame multi-chunk,
+/// so the sequence here routinely has more than one entry.
+fn convert_polars_to_batches(py: Python<'_>, df: &Bound<'_, PyAny>) -> PyResult<Vec<RecordBatch>> {
     // polars DataFrame has to_arrow() method
     if df.hasattr("to_arrow")? {
         let arrow_data = df.call_method0("to_arrow")?;
-
-        // The result is a pyarrow Table, get first batch
-        let batches = arrow_data.call_method0("to_batches")?;
-        let batch_list: Vec<Py<PyAny>> = batches.extract()?;
-
-        if batch_list.is_empty() {
-            return Err(PyValueError::new_err("DataFrame is empty"));
-        }
-
-        import_via_pycapsule(py, batch_list[0].bind(py))
+        import_batches_from_pyarrow(py, &arrow_data)
     } else {
         Err(PyRuntimeError::new_err(
             "polars DataFrame doesn't support Arrow export",
@@ -981,7 +976,12 @@ fn import_batches_from_pyarrow(
         let batch_list: Vec<Py<PyAny>> = batches.extract()?;
 
         if batch_list.is_empty() {
-            return Err(PyValueError::new_err("Table is empty"));
+            // Worded for the source, not for pyarrow: pandas and polars frames
+            // reach this same guard after converting, and "Table is empty" is
+            // not what those callers passed in.
+            return Err(PyValueError::new_err(
+                "Arrow source is empty: it holds no record batches",
+            ));
         }
 
         // Every batch, not just the first. A chunked Table profiled as
@@ -1002,17 +1002,6 @@ fn import_batches_from_pyarrow(
             type_name
         )))
     }
-}
-
-/// Single-RecordBatch form, for callers that cannot consume a sequence.
-fn import_from_pyarrow(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<RecordBatch> {
-    let mut batches = import_batches_from_pyarrow(py, obj)?;
-    if batches.len() == 1 {
-        return Ok(batches.remove(0));
-    }
-    let schema = batches[0].schema();
-    concat_batches(&schema, &batches)
-        .map_err(|e| PyRuntimeError::new_err(format!("Failed to combine Table batches: {}", e)))
 }
 
 /// Import RecordBatch via PyCapsule protocol.

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -908,9 +908,13 @@ fn convert_dataframe_to_batches(
         DataFrameLibrary::Polars => convert_polars_to_batches(py, bound),
         DataFrameLibrary::PyArrow => import_batches_from_pyarrow(py, bound),
         DataFrameLibrary::Custom(_) => {
-            // Try generic PyCapsule import
+            // The same importer as every other arm. A producer that carries its
+            // batches the way a pyarrow Table does is walked in full here too:
+            // reducing it to a single array capsule would leave the
+            // first-batch-only read alive on the one path that has no library
+            // to name in the error below.
             if bound.hasattr("__arrow_c_array__")? {
-                Ok(vec![import_via_pycapsule(py, bound)?])
+                import_batches_from_pyarrow(py, bound)
             } else {
                 Err(PyTypeError::new_err(format!(
                     "Unsupported DataFrame type: {}. Must implement Arrow PyCapsule protocol.",

--- a/python/tests/test_dataframe_chunk_parity.py
+++ b/python/tests/test_dataframe_chunk_parity.py
@@ -160,7 +160,7 @@ def test_empty_frames_are_refused_the_same_way_on_every_path():
     It pins the refusal itself as much as the wording. A zero-row frame with a
     schema is arguably analyzable, and the file paths do analyze it: a
     header-only CSV profiles as 0 rows over its declared columns rather than
-    raising. That divergence is older than this test and is tracked separately;
+    raising. That divergence is older than this test and is tracked in #664;
     changing it here would be a second behaviour change in one commit.
     """
     pd = pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")

--- a/python/tests/test_dataframe_chunk_parity.py
+++ b/python/tests/test_dataframe_chunk_parity.py
@@ -138,15 +138,82 @@ def test_chunked_frames_agree_with_the_arrow_path():
 
     The pyarrow path already walked every batch, so it is the reference the two
     library-specific paths are measured against rather than a third opinion.
+    The comparison is over the whole column section, not a chosen few fields:
+    ``AGENTS.md`` asks for identical numbers, and every field here does agree.
     """
     polars_chunked, _ = _polars_frames()
     pandas_chunked, _ = _pandas_frames()
     arrow_columns = _columns(_chunked_table(), "arrow")
 
-    for frame, label in ((polars_chunked, "polars"), (pandas_chunked, "pandas")):
-        columns = _columns(frame, label)
-        assert len(columns) == len(arrow_columns)
-        for column, expected in zip(columns, arrow_columns):
-            assert column["name"] == expected["name"]
-            assert column["total_count"] == expected["total_count"]
-            assert column["null_count"] == expected["null_count"]
+    assert _columns(polars_chunked, "polars") == arrow_columns
+    assert _columns(pandas_chunked, "pandas") == arrow_columns
+
+
+def test_empty_frames_are_refused_the_same_way_on_every_path():
+    """One error for an empty source, whichever library handed it over.
+
+    The two library paths used to raise "DataFrame is empty" while pyarrow
+    raised "Table is empty", because each had its own copy of the guard. Now
+    that they share an importer they share the message, and this pins that so a
+    later refactor cannot quietly fork it again.
+
+    It pins the refusal itself as much as the wording. A zero-row frame with a
+    schema is arguably analyzable, and the file paths do analyze it: a
+    header-only CSV profiles as 0 rows over its declared columns rather than
+    raising. That divergence is older than this test and is tracked separately;
+    changing it here would be a second behaviour change in one commit.
+    """
+    pd = pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")
+    pl = pytest.importorskip("polars", reason="polars is required for polars interop tests")
+
+    sources = {
+        "pyarrow": pa.table({"a": pa.array([], type=pa.int64())}),
+        "pandas": pd.DataFrame({"a": pd.Series([], dtype="int64")}),
+        "polars": pl.DataFrame({"a": []}),
+    }
+
+    messages = set()
+    for label, source in sources.items():
+        with pytest.raises(ValueError) as raised:
+            dataprof.profile(source, name=label)
+        messages.add(str(raised.value))
+
+    assert len(messages) == 1, f"paths disagree on the empty-source error: {messages}"
+
+
+class Table:
+    """A non-pyarrow batch producer, named ``Table`` because the importer looks.
+
+    ``profile_dataframe`` classifies anything that is not pandas, polars or
+    pyarrow as a custom library, and that arm used to import the array capsule
+    alone. A producer holding several batches was read down to the first one
+    there for the same reason the two library paths were, on the one path with
+    no library to name.
+
+    Reachable through ``dataprof.interop.profile_dataframe``, which is public.
+    ``dataprof.profile()`` sends capsule producers to the Arrow path instead.
+    """
+
+    def __init__(self, batches):
+        self._batches = list(batches)
+
+    def to_batches(self):
+        return list(self._batches)
+
+    def __arrow_c_schema__(self):
+        return self._batches[0].__arrow_c_schema__()
+
+    def __arrow_c_array__(self, requested_schema=None):
+        return self._batches[0].__arrow_c_array__(requested_schema)
+
+
+def test_custom_batch_producer_is_profiled_whole():
+    """The custom arm walks the sequence like every other arm.
+
+    ``interop.profile_dataframe`` returns the unwrapped Rust report, where the
+    row count is ``rows_processed``.
+    """
+    from dataprof.interop import profile_dataframe
+
+    producer = Table(pa.record_batch(chunk) for chunk in CHUNKS)
+    assert profile_dataframe(producer, "custom").rows_processed == TOTAL_ROWS

--- a/python/tests/test_dataframe_chunk_parity.py
+++ b/python/tests/test_dataframe_chunk_parity.py
@@ -1,0 +1,152 @@
+"""Chunked pandas and polars frames must be profiled whole, not first-chunk-only.
+
+``import_batches_from_pyarrow`` was taught to walk every batch of a chunked
+Table, and ``profile_arrow`` was rebuilt around that sequence. The pandas and
+polars paths were not: both converted to a pyarrow Table and then imported
+``to_batches()[0]``, so a frame carrying more than one Arrow chunk was profiled
+over its first chunk alone.
+
+Nothing about that output looks wrong. The row count, the null rates and the
+statistics are all internally consistent; they simply describe a prefix of the
+data. It is the failure mode ``AGENTS.md`` singles out as the worst for a
+profiler, and it sat on the two most common inputs while the path with no
+library-specific code was correct.
+
+Chunking is not exotic on either library: ``pl.concat(..., rechunk=False)`` and
+``vstack`` leave polars frames multi-chunk, and any pandas frame backed by an
+Arrow ``ChunkedArray`` round-trips through ``Table.from_pandas`` as several
+batches.
+
+The row-count assertions are the cheap half. The comparisons against a
+rechunked frame are the half that catches a fix which reads every batch but
+folds only some of them into the statistics.
+"""
+
+from __future__ import annotations
+
+import dataprof
+import pytest
+
+pa = pytest.importorskip("pyarrow", reason="pyarrow is required for Arrow import tests")
+
+# Distinct values per chunk, so every statistic depends on every chunk. Repeating
+# one block would let a first-chunk-only read produce the right answer by luck.
+CHUNKS = [
+    {"n": [1, 2, 3], "s": ["a", "b", "c"]},
+    {"n": [10, 20, 30], "s": ["d", "e", "f"]},
+    {"n": [100, 200, 300], "s": ["g", "h", "i"]},
+]
+TOTAL_ROWS = sum(len(chunk["n"]) for chunk in CHUNKS)
+
+
+def _chunked_table():
+    """A pyarrow Table of three batches. The reference every frame is built from."""
+    return pa.Table.from_batches([pa.record_batch(chunk) for chunk in CHUNKS])
+
+
+def _columns(source, name):
+    return dataprof.profile(source, name=name).to_dict()["columns"]
+
+
+# ---------------------------------------------------------------- polars
+
+
+def _polars_frames():
+    """A multi-chunk frame and its single-chunk twin, same rows in the same order."""
+    pl = pytest.importorskip("polars", reason="polars is required for polars interop tests")
+    chunked = pl.concat([pl.DataFrame(chunk) for chunk in CHUNKS], rechunk=False)
+    assert chunked.n_chunks() > 1, "test needs a multi-chunk frame to be meaningful"
+    return chunked, chunked.rechunk()
+
+
+def test_multi_chunk_polars_profiles_every_row():
+    chunked, _ = _polars_frames()
+    assert dataprof.profile(chunked, name="polars_chunked").rows == TOTAL_ROWS
+
+
+def test_polars_chunking_does_not_change_the_report():
+    """Same rows, different chunking, same column statistics."""
+    chunked, rechunked = _polars_frames()
+    assert _columns(chunked, "chunked") == _columns(rechunked, "rechunked")
+
+
+def test_polars_report_depends_on_every_chunk():
+    """Guards the comparison above against a fix that reads only the first chunk.
+
+    If both frames were profiled first-chunk-only they would still agree with
+    each other. What separates a whole read from a prefix read is disagreeing
+    with the first chunk alone.
+    """
+    pl = pytest.importorskip("polars", reason="polars is required for polars interop tests")
+    chunked, _ = _polars_frames()
+    first_chunk_only = pl.DataFrame(CHUNKS[0])
+    assert _columns(chunked, "chunked") != _columns(first_chunk_only, "first")
+
+
+def test_polars_max_rows_spans_chunks():
+    """A row limit is applied across the sequence, not inside the first chunk."""
+    chunked, _ = _polars_frames()
+    report = dataprof.profile(chunked, name="polars_limited", max_rows=5)
+    assert report.rows == 5
+    assert report.truncation_reason is not None
+
+
+# ---------------------------------------------------------------- pandas
+
+
+def _pandas_frames():
+    """An Arrow-backed frame whose columns are chunked, and its combined twin."""
+    pd = pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")
+    table = _chunked_table()
+    chunked = table.to_pandas(types_mapper=pd.ArrowDtype)
+    assert len(pa.Table.from_pandas(chunked).to_batches()) > 1, (
+        "test needs a frame that exports as several batches to be meaningful"
+    )
+    combined = table.combine_chunks().to_pandas(types_mapper=pd.ArrowDtype)
+    return chunked, combined
+
+
+def test_multi_chunk_pandas_profiles_every_row():
+    chunked, _ = _pandas_frames()
+    assert dataprof.profile(chunked, name="pandas_chunked").rows == TOTAL_ROWS
+
+
+def test_pandas_chunking_does_not_change_the_report():
+    chunked, combined = _pandas_frames()
+    assert _columns(chunked, "chunked") == _columns(combined, "combined")
+
+
+def test_pandas_report_depends_on_every_chunk():
+    pd = pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")
+    chunked, _ = _pandas_frames()
+    first_chunk_only = pa.table(CHUNKS[0]).to_pandas(types_mapper=pd.ArrowDtype)
+    assert _columns(chunked, "chunked") != _columns(first_chunk_only, "first")
+
+
+def test_pandas_max_rows_spans_chunks():
+    chunked, _ = _pandas_frames()
+    report = dataprof.profile(chunked, name="pandas_limited", max_rows=5)
+    assert report.rows == 5
+    assert report.truncation_reason is not None
+
+
+# ---------------------------------------------------------------- across paths
+
+
+def test_chunked_frames_agree_with_the_arrow_path():
+    """The output contract: same data, same numbers, whichever path produced them.
+
+    The pyarrow path already walked every batch, so it is the reference the two
+    library-specific paths are measured against rather than a third opinion.
+    """
+    polars_chunked, _ = _polars_frames()
+    pandas_chunked, _ = _pandas_frames()
+    arrow_columns = _columns(_chunked_table(), "arrow")
+
+    for frame, label in ((polars_chunked, "polars"), (pandas_chunked, "pandas")):
+        columns = _columns(frame, label)
+        assert len(columns) == len(arrow_columns)
+        for column, expected in zip(columns, arrow_columns):
+            assert column["name"] == expected["name"]
+            assert column["total_count"] == expected["total_count"]
+            assert column["null_count"] == expected["null_count"]


### PR DESCRIPTION
## Problem

`dataprof.profile()` on a pandas or polars DataFrame profiled its first Arrow
chunk and reported the result as the whole frame.

```python
import polars as pl, dataprof
df = pl.concat([pl.DataFrame({"x": [1, 2, 3]}),
                pl.DataFrame({"x": [100, 200, 300]})], rechunk=False)
df.height                      # 6
dataprof.profile(df).rows      # 3
```

The same holds for any pandas frame backed by an Arrow `ChunkedArray`, and the
pyarrow path with the same data reports 6. Nothing about the output looks
wrong: the row count, null rates and statistics are all internally consistent,
they simply describe a prefix of the data. `AGENTS.md` singles this out as the
worst failure class for a profiler, and it sat on the two most common inputs.

Chunking is not an edge case on either library. `pl.concat(..., rechunk=False)`
and `vstack` leave a polars frame multi-chunk, and any Arrow-backed pandas
frame round-trips through `Table.from_pandas` as several batches.

## Cause

`import_batches_from_pyarrow` was already taught to walk every batch of a
chunked Table, and `profile_arrow` was rebuilt around that sequence. Neither
adapter picked it up: `convert_pandas_to_batch` and `convert_polars_to_batch`
each converted to a Table and then imported `to_batches()[0]`.

The path with no library-specific code was the correct one, and the two
hand-written branches were both wrong.

## Fix

Both paths now reach `import_batches_from_pyarrow`, and `profile_dataframe`
consumes the batch sequence the way `profile_arrow` does. The row limit is
applied across chunks by the existing `limit_batches`, which also decides the
truncation flag while walking, so stopping exactly on a chunk boundary with
batches still unread is still reported as truncation.

Nothing is concatenated, so a chunked frame no longer peaks at roughly twice
its size the way `concat_batches` did.

`import_from_pyarrow` and `limit_batch_rows` lose their last callers and are
removed (net -11 lines in the module). The empty-source error is reworded from
"Table is empty", since pandas and polars callers reach that guard too.

## Verification

New `python/tests/test_dataframe_chunk_parity.py`, nine tests. Against the
unfixed code all nine fail.

Beyond row counts, each library has a pair that compares the full serialized
column sections of a chunked frame against its rechunked twin, plus one that
asserts the chunked result differs from the first chunk alone. Without the
second assertion, code that reads only the first chunk would satisfy the
comparison, since both sides would be equally wrong.

The two halves were reverted separately. With only the pandas half restored to
`to_batches()[0]`, the four pandas tests and the cross-path test fail while all
four polars tests pass, so neither group is masking the other.

Commands run:

```
cargo fmt --all
cargo clippy -p dataprof-python --all-targets -- -D warnings
cargo test -p dataprof-python
uv run maturin develop
uv run pytest python/tests -q          # 1065 passed, 9 skipped
uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run ty check python/
```

The 9 skips are the pre-existing ones for database features and Windows
symlink privileges.

## Behaviour change

A chunked pandas or polars frame now reports the whole frame instead of its
first chunk, so row counts, null rates and every statistic change for those
inputs. They change towards agreeing with the pyarrow path on the same data.

## Self-review follow-up (second commit)

The custom-producer arm of `convert_dataframe_to_batches` had the same defect
for the same reason: it imported the array capsule alone, so a producer holding
several batches was read down to its first. It is reachable through the public
`dataprof.interop.profile_dataframe`, and now reaches the same importer as every
other arm. A nine-row producer across three batches reports three rows without
the change.

Two test changes came with it. The cross-path comparison went from three chosen
fields to the whole column section, since every field does agree. And the
empty-source error is now pinned as one message across the three Arrow paths,
which it is only because the guard is shared; the paths previously carried two
different wordings.

## Follow-up

Once #505 lands, both conversion functions can be deleted outright: pandas and
polars frames each expose `__arrow_c_stream__` directly, so neither needs a
library-specific branch. Details in a comment there.

#664 covers something the empty-source test surfaced and deliberately does not
fix here: a zero-row Arrow source raises, while a header-only CSV profiles as 0
rows over its declared columns. Same logical input, one path analyzing it and
another refusing, which is the output contract again. Out of scope for this PR
because it is a second behaviour change.
