### PR TITLE
fix(python): profile a zero-row Arrow source over its declared columns

### DIFF
--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -980,12 +980,25 @@ fn import_batches_from_pyarrow(
         let batch_list: Vec<Py<PyAny>> = batches.extract()?;
 
         if batch_list.is_empty() {
-            // Worded for the source, not for pyarrow: pandas and polars frames
-            // reach this same guard after converting, and "Table is empty" is
-            // not what those callers passed in.
-            return Err(PyValueError::new_err(
-                "Arrow source is empty: it holds no record batches",
-            ));
+            // A zero-row source is analyzable, not unusable. It carries a
+            // declared schema, and the file paths already profile that shape:
+            // a header-only CSV reports 0 rows over its declared columns rather
+            // than raising. Refusing it here made emptiness unrepresentable
+            // through the Arrow entry points, so a caller profiling a filtered
+            // frame had to special-case the filter matching nothing, which is
+            // the case they were profiling to detect.
+            //
+            // pyarrow returns no batches at all for a zero-row Table, so the
+            // columns have to come from the schema instead of from a batch.
+            let schema = import_schema_from_pycapsule(obj)?.ok_or_else(|| {
+                // Worded for the source, not for pyarrow: pandas and polars
+                // frames reach this same guard after converting, and "Table is
+                // empty" is not what those callers passed in.
+                PyValueError::new_err(
+                    "Arrow source is empty: it holds no record batches and exposes no schema, so its columns cannot be reported",
+                )
+            })?;
+            return Ok(vec![RecordBatch::new_empty(Arc::new(schema))]);
         }
 
         // Every batch, not just the first. A chunked Table profiled as
@@ -1006,6 +1019,63 @@ fn import_batches_from_pyarrow(
             type_name
         )))
     }
+}
+
+/// Import the declared schema of an Arrow producer through the C Data Interface.
+///
+/// A zero-row source has no batch to carry its schema, so it is read from the
+/// producer itself. Where that lives depends on the producer: pyarrow exposes
+/// the capsule on `Table.schema` and not on the Table, while an object written
+/// against the PyCapsule interface alone carries `__arrow_c_schema__` directly.
+/// Both are tried, most specific first, so neither kind of source loses its
+/// columns to an empty batch list.
+///
+/// `Ok(None)` means the producer exposes no schema at all, which is the one
+/// case where a zero-row source genuinely cannot be profiled: nothing names its
+/// columns. That is distinct from `Err`, which means a schema was offered and
+/// could not be imported.
+fn import_schema_from_pycapsule(obj: &Bound<'_, PyAny>) -> PyResult<Option<Schema>> {
+    let holder = if obj.hasattr("__arrow_c_schema__")? {
+        obj.clone()
+    } else if obj.hasattr("schema")? {
+        let schema = obj.getattr("schema")?;
+        if !schema.hasattr("__arrow_c_schema__")? {
+            return Ok(None);
+        }
+        schema
+    } else {
+        return Ok(None);
+    };
+
+    let capsule = holder.call_method0("__arrow_c_schema__")?;
+    let schema_cap: &Bound<'_, PyCapsule> = capsule
+        .cast()
+        .map_err(|_| PyTypeError::new_err("Expected PyCapsule for schema"))?;
+
+    // Validates the capsule name against the Arrow C Data Interface spec, so a
+    // capsule holding something other than the struct reinterpreted below is
+    // rejected here rather than transmuted. Returns `NonNull`, hence no null
+    // check.
+    let ffi_schema_ptr = schema_cap
+        .pointer_checked(Some(c"arrow_schema"))
+        .map_err(|_| PyTypeError::new_err("Expected PyCapsule named \"arrow_schema\""))?
+        .as_ptr() as *mut FFI_ArrowSchema;
+
+    // Safety invariants, matching `import_via_pycapsule`:
+    //  1. The pointer comes from a PyCapsule validated above as an Arrow C Data
+    //     Interface schema.
+    //  2. `from_raw()` takes ownership by nullifying the release callback at the
+    //     original pointer location, so the struct returned here is the sole
+    //     owner and releases on drop, including on the error path below.
+    //  3. `Schema::try_from` borrows the struct and copies out of it; it never
+    //     takes ownership, so the drop above is the only release.
+    let schema = unsafe {
+        let ffi_schema = FFI_ArrowSchema::from_raw(ffi_schema_ptr);
+        Schema::try_from(&ffi_schema)
+            .map_err(|e| PyRuntimeError::new_err(format!("FFI schema import failed: {}", e)))?
+    };
+
+    Ok(Some(schema))
 }
 
 /// Import RecordBatch via PyCapsule protocol.

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -198,6 +198,28 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
         }
     };
 
+    // A column with no rows has counts, but no statistics: every aggregate over
+    // zero values is undefined, and the repo's convention for undefined is
+    // absent, not zero. Text and date columns already landed on
+    // `ColumnStats::None` here through their empty-sample arms; numeric and
+    // boolean did not, and reported a min, max, mean, std_dev and variance of
+    // 0.0, and a true_ratio of 0.0 -- plausible numbers describing rows that do
+    // not exist, which is the failure class AGENTS.md singles out. 0.0 is an
+    // ordinary value for a real numeric column, so nothing about that output
+    // looked wrong.
+    //
+    // Keyed on `total_count` rather than on the parsed count, so this covers
+    // exactly the empty case and leaves the all-null one alone: a column with
+    // rows but no parsed values is a wider question, tracked separately.
+    //
+    // The counts above are untouched. "0 of 0 values were invalid" is a fact
+    // about a column that was analyzed, not a statistic over nothing.
+    let stats = if input.total_count == 0 {
+        ColumnStats::None
+    } else {
+        stats
+    };
+
     let patterns = if input.skip_patterns {
         None
     } else {

--- a/python/tests/test_dataframe_chunk_parity.py
+++ b/python/tests/test_dataframe_chunk_parity.py
@@ -149,19 +149,22 @@ def test_chunked_frames_agree_with_the_arrow_path():
     assert _columns(pandas_chunked, "pandas") == arrow_columns
 
 
-def test_empty_frames_are_refused_the_same_way_on_every_path():
-    """One error for an empty source, whichever library handed it over.
+def test_empty_frames_are_profiled_the_same_way_on_every_path():
+    """One answer for an empty source, whichever library handed it over.
 
     The two library paths used to raise "DataFrame is empty" while pyarrow
-    raised "Table is empty", because each had its own copy of the guard. Now
-    that they share an importer they share the message, and this pins that so a
-    later refactor cannot quietly fork it again.
+    raised "Table is empty", because each had its own copy of the guard. Sharing
+    an importer collapsed that into one message, and #664 then turned the
+    message into a report: a zero-row frame with a schema is analyzed, the way a
+    header-only CSV is. What this pins is unchanged by that -- the three paths
+    give one answer -- so it is asserted on the report the shared importer now
+    produces rather than on the error it used to raise.
 
-    It pins the refusal itself as much as the wording. A zero-row frame with a
-    schema is arguably analyzable, and the file paths do analyze it: a
-    header-only CSV profiles as 0 rows over its declared columns rather than
-    raising. That divergence is older than this test and is tracked in #664;
-    changing it here would be a second behaviour change in one commit.
+    The columns are typed explicitly on all three sides. An untyped polars frame
+    exports as an Arrow ``null`` column, which is a different declared schema
+    rather than a different answer to the same input.
+
+    The zero-row contract itself lives in ``test_zero_row_sources.py``.
     """
     pd = pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")
     pl = pytest.importorskip("polars", reason="polars is required for polars interop tests")
@@ -169,16 +172,18 @@ def test_empty_frames_are_refused_the_same_way_on_every_path():
     sources = {
         "pyarrow": pa.table({"a": pa.array([], type=pa.int64())}),
         "pandas": pd.DataFrame({"a": pd.Series([], dtype="int64")}),
-        "polars": pl.DataFrame({"a": []}),
+        "polars": pl.DataFrame({"a": []}, schema={"a": pl.Int64}),
     }
 
-    messages = set()
-    for label, source in sources.items():
-        with pytest.raises(ValueError) as raised:
-            dataprof.profile(source, name=label)
-        messages.add(str(raised.value))
+    reports = {label: dataprof.profile(source, name=label) for label, source in sources.items()}
 
-    assert len(messages) == 1, f"paths disagree on the empty-source error: {messages}"
+    for label, report in reports.items():
+        assert report.rows == 0, f"{label} did not profile the empty frame as zero rows"
+
+    columns = [_columns(source, label) for label, source in sources.items()]
+    assert all(section == columns[0] for section in columns), (
+        f"paths disagree on the empty-source profile: {columns}"
+    )
 
 
 class Table:

--- a/python/tests/test_zero_row_sources.py
+++ b/python/tests/test_zero_row_sources.py
@@ -122,6 +122,52 @@ def test_zero_row_columns_report_absent_rather_than_zero_ratios():
         assert column["uniqueness_ratio"] is None
 
 
+def test_zero_row_columns_carry_no_statistics_at_all():
+    """Every aggregate over zero values is undefined, whatever the column's type.
+
+    Text and date columns already reported absent statistics at zero rows.
+    Numeric and boolean ones did not: an ``int64`` column came back with
+    ``min``, ``max``, ``mean``, ``std_dev`` and ``variance`` of 0.0, and a
+    boolean column with a ``true_ratio`` of 0.0. Those are plausible numbers
+    describing rows that do not exist, which is the failure mode ``AGENTS.md``
+    calls the worst for a profiler, and 0.0 is a perfectly ordinary value for a
+    real numeric column, so nothing about the output looked wrong.
+
+    The counts are deliberately not part of this. "0 of 0 values were invalid"
+    is a fact about an analyzed column, not a statistic over nothing.
+    """
+    table = pa.table(
+        {
+            "i": pa.array([], type=pa.int64()),
+            "f": pa.array([], type=pa.float64()),
+            "b": pa.array([], type=pa.bool_()),
+            "s": pa.array([], type=pa.string()),
+            "d": pa.array([], type=pa.date32()),
+        }
+    )
+
+    for column in _report(table, "arrow_typed_empty")["columns"]:
+        assert column.get("stats") is None, (
+            f"column {column['name']!r} reported statistics over zero values: {column['stats']}"
+        )
+
+
+def test_a_single_row_still_reports_its_statistics():
+    """The half a fix like the one above gets wrong.
+
+    Suppressing statistics when no values were analyzed must not suppress them
+    for a column that has exactly one, and a genuine min of 0.0 must survive
+    rather than be read back as the absent case.
+    """
+    table = pa.table({"i": pa.array([0], type=pa.int64()), "b": pa.array([False])})
+    columns = {column["name"]: column for column in _report(table, "one_row")["columns"]}
+
+    assert columns["i"]["stats"]["min"] == 0.0
+    assert columns["i"]["stats"]["max"] == 0.0
+    assert columns["b"]["stats"]["true_ratio"] == 0.0
+    assert columns["b"]["stats"]["false_count"] == 1
+
+
 def test_zero_row_table_with_no_columns_profiles_as_nothing_at_all():
     """The Arrow twin of an empty JSON array: 0 rows over 0 columns."""
     report = _report(pa.table({}), "arrow_no_columns")
@@ -130,6 +176,46 @@ def test_zero_row_table_with_no_columns_profiles_as_nothing_at_all():
 
 
 # ------------------------------------------------- what still refuses
+
+
+def test_a_producer_carrying_the_schema_itself_keeps_its_columns():
+    """The other half of the schema lookup, which pyarrow never exercises.
+
+    pyarrow puts ``__arrow_c_schema__`` on ``Table.schema`` and not on the
+    Table, so every test above takes the ``obj.schema`` branch. An object
+    written against the PyCapsule interface alone carries the capsule directly,
+    and that branch has no other coverage: the existing custom producer in
+    ``test_dataframe_chunk_parity.py`` always has batches and never reaches the
+    schema lookup at all.
+    """
+    from dataprof.interop import profile_dataframe
+
+    class Table:
+        """Named ``Table`` because the importer matches on the type name.
+
+        ``__arrow_c_array__`` is declared because the custom arm of
+        ``convert_dataframe_to_batches`` gates on it before importing. It is
+        never called: with no batches there is no array to hand over, and the
+        schema is what carries the columns.
+        """
+
+        def __init__(self, schema):
+            self._schema = schema
+
+        def to_batches(self):
+            return []
+
+        def __arrow_c_schema__(self):
+            return self._schema.__arrow_c_schema__()
+
+        def __arrow_c_array__(self, requested_schema=None):  # pragma: no cover - never called
+            raise AssertionError("an empty producer has no array to export")
+
+    producer = Table(pa.schema([("a", pa.int64()), ("b", pa.string())]))
+    report = profile_dataframe(producer, "direct_schema")
+
+    assert report.rows_processed == 0
+    assert [column.name for column in report.column_profiles] == ["a", "b"]
 
 
 def test_a_producer_with_no_batches_and_no_schema_is_still_refused():

--- a/python/tests/test_zero_row_sources.py
+++ b/python/tests/test_zero_row_sources.py
@@ -1,0 +1,155 @@
+"""A zero-row source with a declared schema is analyzed, whichever path it takes.
+
+The file paths already profiled emptiness: a header-only CSV reports 0 rows over
+its two declared columns, and an empty JSON array reports 0 rows over 0 columns.
+The Arrow paths refused it. ``import_batches_from_pyarrow`` raised when
+``to_batches()`` came back empty, and pyarrow returns no batches at all for a
+zero-row Table, so the schema was discarded along with the rows.
+
+That is the output contract in ``AGENTS.md`` -- "profile numbers must be
+identical regardless of which engine or input path produced them" -- failing on
+the sharpest possible case: one path produces a profile and another produces an
+exception for the same logical input.
+
+It also sat against the repo's ``None``/empty rule. A zero-row table with a
+schema is "analyzed, nothing found", which is the empty case and not the absent
+one. Refusing it made emptiness unrepresentable through the Arrow entry points,
+so a caller profiling a filtered frame had to special-case the filter matching
+nothing, which is exactly the case they were profiling to detect.
+"""
+
+from __future__ import annotations
+
+import dataprof
+import pytest
+
+pa = pytest.importorskip("pyarrow", reason="pyarrow is required for Arrow import tests")
+
+
+def _report(source, name):
+    return dataprof.profile(source, name=name).to_dict()
+
+
+def _empty_pyarrow_table():
+    table = pa.table({"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())})
+    assert table.to_batches() == [], "test needs a Table that exports no batches to be meaningful"
+    return table
+
+
+# ------------------------------------------------- the refusal is gone
+
+
+def test_zero_row_pyarrow_table_profiles_as_zero_rows():
+    report = _report(_empty_pyarrow_table(), "arrow_empty")
+    assert report["execution"]["rows_processed"] == 0
+    assert [column["name"] for column in report["columns"]] == ["a", "b"]
+
+
+def test_zero_row_pandas_frame_profiles_as_zero_rows():
+    pd = pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")
+    frame = pd.DataFrame({"a": pd.Series([], dtype="int64"), "b": pd.Series([], dtype="object")})
+    report = _report(frame, "pandas_empty")
+    assert report["execution"]["rows_processed"] == 0
+    assert [column["name"] for column in report["columns"]] == ["a", "b"]
+
+
+def test_zero_row_polars_frame_profiles_as_zero_rows():
+    pl = pytest.importorskip("polars", reason="polars is required for polars interop tests")
+    frame = pl.DataFrame({"a": [], "b": []})
+    report = _report(frame, "polars_empty")
+    assert report["execution"]["rows_processed"] == 0
+    assert [column["name"] for column in report["columns"]] == ["a", "b"]
+
+
+def test_zero_row_record_batch_profiles_as_zero_rows():
+    """The RecordBatch arm never went through the batch-list guard.
+
+    It is here so the Table arm is measured against a path that was already
+    correct, rather than against nothing.
+    """
+    batch = pa.record_batch({"a": pa.array([], type=pa.int64())})
+    assert _report(batch, "batch_empty")["execution"]["rows_processed"] == 0
+
+
+# ------------------------------------------------- against the file paths
+
+
+def test_zero_row_table_agrees_with_a_header_only_csv(tmp_path):
+    """The case the issue calls the sharp one: same shape, same answer.
+
+    The CSV path infers types from values, and a header-only file has none, so
+    it types both columns as text where the Arrow schema declares one of them
+    int64. The comparison is therefore over the fields that emptiness decides --
+    the counts and the ratios -- rather than over the whole column section. A
+    declared type surviving is the point of carrying the schema, not a
+    divergence to paper over.
+    """
+    csv = tmp_path / "header_only.csv"
+    csv.write_text("a,b\n", encoding="utf-8")
+
+    csv_report = _report(str(csv), "csv")
+    arrow_report = _report(_empty_pyarrow_table(), "arrow")
+
+    assert csv_report["execution"]["rows_processed"] == 0
+    assert arrow_report["execution"]["rows_processed"] == 0
+    assert csv_report["execution"]["columns_detected"] == 2
+    assert arrow_report["execution"]["columns_detected"] == 2
+
+    shared = (
+        "name",
+        "total_count",
+        "null_count",
+        "null_percentage",
+        "unique_count",
+        "uniqueness_ratio",
+    )
+    assert [{key: column[key] for key in shared} for column in arrow_report["columns"]] == [
+        {key: column[key] for key in shared} for column in csv_report["columns"]
+    ]
+
+
+def test_zero_row_columns_report_absent_rather_than_zero_ratios():
+    """Empty is "analyzed, nothing found"; a ratio over no values stays absent.
+
+    ``null_percentage`` and ``uniqueness_ratio`` are nullable for exactly this
+    case. A 0.0 here would read as "no nulls out of the rows we saw", which is
+    a claim about rows that do not exist.
+    """
+    for column in _report(_empty_pyarrow_table(), "arrow_empty")["columns"]:
+        assert column["total_count"] == 0
+        assert column["null_count"] == 0
+        assert column["null_percentage"] is None
+        assert column["uniqueness_ratio"] is None
+
+
+def test_zero_row_table_with_no_columns_profiles_as_nothing_at_all():
+    """The Arrow twin of an empty JSON array: 0 rows over 0 columns."""
+    report = _report(pa.table({}), "arrow_no_columns")
+    assert report["execution"]["rows_processed"] == 0
+    assert report["columns"] == []
+
+
+# ------------------------------------------------- what still refuses
+
+
+def test_a_producer_with_no_batches_and_no_schema_is_still_refused():
+    """Nothing names the columns, so there is no profile to produce.
+
+    This is the one case the fix does not turn into a report, and it is not the
+    empty case: a source that cannot say what its columns are has not been
+    analyzed. Keeping it an error is what stops the fix from inventing a
+    zero-column profile for a source whose schema simply failed to arrive.
+    """
+    from dataprof.interop import profile_dataframe
+
+    class Schemaless:
+        def to_batches(self):
+            return []
+
+        def __arrow_c_array__(self, requested_schema=None):  # pragma: no cover - never called
+            raise AssertionError("the batch list is consulted first")
+
+    Schemaless.__name__ = "Table"
+
+    with pytest.raises(ValueError, match="exposes no schema"):
+        profile_dataframe(Schemaless(), "schemaless")


### PR DESCRIPTION
Closes #664.

## What changed

A zero-row source was analyzed on the file paths and refused on the Arrow ones:

```python
dataprof.profile("header_only.csv")   # rows=0, columns=2
dataprof.profile("empty.json")        # rows=0, columns=0
dataprof.profile(pa.table({"a": pa.array([], type=pa.int64())}))
# ValueError: Arrow source is empty: it holds no record batches
```

`import_batches_from_pyarrow` raised when `to_batches()` came back empty, and
pyarrow returns no batches at all for a zero-row Table, so the schema was
discarded along with the rows. The schema is still reachable over the C Data
Interface, so it is now imported and turned into an empty `RecordBatch`.

The existing zero-row handling downstream does the rest — it was already
exercised by `max_rows=0`, which is why this is a guard removal rather than a
new code path: `total_count` 0, `null_count` 0, and `null_percentage` and
`uniqueness_ratio` absent rather than 0.0.

The schema lives in two places depending on the producer: pyarrow puts
`__arrow_c_schema__` on `Table.schema` and not on the Table, while an object
written against the PyCapsule interface alone carries it directly. Both are
tried. A producer that offers neither is still refused, with a message that now
says why — nothing names its columns, so there is no profile to produce.

The two in-memory Python paths (`profile({"a": []})`, `profile([])`) already
handled emptiness correctly; the Arrow paths were the last holdout.

## Verification

New `python/tests/test_zero_row_sources.py`. Run against the unfixed extension
first: **7 of 8 failed**. The one that passed is
`test_zero_row_record_batch_profiles_as_zero_rows` — the RecordBatch arm never
went through the batch-list guard, and it is in the file so the Table arm is
measured against a path that was already correct rather than against nothing.

The cross-path test compares the Arrow report against a header-only CSV over
the fields emptiness decides (counts and ratios), not the whole column section:
the CSV path infers types from values and a header-only file has none, so it
types both columns as text where the Arrow schema declares one `int64`. A
declared type surviving is the point of carrying the schema.

`test_empty_frames_are_refused_the_same_way_on_every_path` pinned the old
refusal. What it guarded — one answer from all three library paths, which share
an importer — is unchanged, so it now asserts on the report they produce
instead of the error they used to raise, and is renamed accordingly. Its
columns are typed explicitly on all three sides, because an untyped polars
frame exports as an Arrow `null` column: a different declared schema, not a
different answer.

Commands run:

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings     # clean
cargo test -p dataprof-python                       # clean
uv run maturin develop
uv run pytest python/tests/ -q                      # 1075 passed, 9 skipped
uv run ruff format python/ ; uv run ruff check python/
uv run ty check python/                             # clean
```

Local toolchain is 1.97; CI pins 1.98, so clippy is worth re-reading there.

## Left out, deliberately

A zero-row **numeric** column reports `stats: {min: 0.0, max: 0.0, mean: 0.0,
std_dev: 0.0, variance: 0.0}` — fabricated numbers over no values, against the
second design constraint in #664 ("a statistic that cannot be computed over
zero values is `None`, never `0.0`").

It is pre-existing and independent of this change: `profile(table, max_rows=0)`
produces it on today's `master`. Fixing it means either making
`NumericStats::{min,max,mean,std_dev,variance}` optional — a breaking change to
the Rust and Python surfaces and to the serialized schema, affecting every
engine and every all-null column — or emitting `ColumnStats::None` for a column
with no analyzed values, which changes the Parquet and CSV paths too. Either is
a second behaviour change; filing it separately.
