### PR TITLE
fix(metrics): profile timestamp columns in named time zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.17.1",
  "libc",
@@ -565,6 +566,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -2408,6 +2419,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,6 +3319,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ dataprof-runtime = { version = "0.11.0", path = "crates/dataprof-runtime" }
 
 # External dependencies
 anyhow = "1.0"
-arrow = { version = "59.1.0", features = ["ffi"] }
+arrow = { version = "59.1.0", features = ["ffi", "chrono-tz"] }
 async-trait = "0.1"
 bytes = "1.10"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -1256,11 +1256,73 @@ impl ColumnAnalyzer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Float64Array, Int64Array, StringArray};
+    use arrow::array::{Float64Array, Int64Array, StringArray, TimestampMicrosecondArray};
     use arrow::datatypes::{DataType as ArrowDataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use dataprof_core::ColumnStats;
     use std::sync::Arc;
+
+    #[test]
+    fn named_time_zones_are_resolved_with_their_dst_rules() {
+        // A timestamp column whose zone is a *name* rather than an offset used
+        // to fail the whole report: `ArrayFormatter::try_new` returned "Invalid
+        // timezone \"Europe/Rome\": only offset based timezones supported
+        // without chrono-tz feature", and the error propagated out of
+        // `process_batch`. `UTC` is the spelling pyarrow, pandas and polars all
+        // produce by default, so this hit ordinary inputs rather than exotic
+        // ones.
+        //
+        // The two instants straddle a DST boundary on purpose. Rome is +01:00
+        // in January and +02:00 in June, so the rendered wall-clock times are
+        // 13:00 and 14:00 for instants one hour apart in absolute terms. That
+        // is what makes this a test of the fix rather than of the symptom: a
+        // "fix" that resolved the zone to one fixed offset would stop raising
+        // and start reporting a wrong hour for half the year, and would fail
+        // here on exactly one of the two values.
+        let array = TimestampMicrosecondArray::from(vec![
+            // 2021-01-15T12:00:00Z -> 13:00 CET  (+01:00)
+            1_610_712_000_000_000,
+            // 2021-06-15T12:00:00Z -> 14:00 CEST (+02:00)
+            1_623_758_400_000_000,
+        ])
+        .with_timezone("Europe/Rome");
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "seen_at",
+            array.data_type().clone(),
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap();
+
+        let mut analyzer = RecordBatchAnalyzer::new();
+        analyzer
+            .process_batch(&batch)
+            .expect("a named time zone must not fail the report");
+
+        let samples = analyzer.create_sample_columns();
+        let seen_at = samples.get("seen_at").expect("column must be sampled");
+
+        assert!(
+            seen_at
+                .iter()
+                .any(|value| value.contains("2021-01-15T13:00:00")),
+            "January value should render at +01:00 (CET), got {seen_at:?}"
+        );
+        assert!(
+            seen_at
+                .iter()
+                .any(|value| value.contains("2021-06-15T14:00:00")),
+            "June value should render at +02:00 (CEST), got {seen_at:?}"
+        );
+
+        let profile = analyzer
+            .to_profiles(false, false, None)
+            .into_iter()
+            .find(|p| p.name == "seen_at")
+            .unwrap();
+        assert_eq!(profile.total_count, 2);
+        assert_eq!(profile.null_count, 0);
+    }
 
     #[test]
     fn test_nulls_are_excluded_from_numeric_stats() {

--- a/python/tests/test_named_time_zones.py
+++ b/python/tests/test_named_time_zones.py
@@ -1,0 +1,95 @@
+"""A timestamp column in a named time zone profiles, on every path.
+
+`arrow` was declared with `features = ["ffi"]` alone. Without its `chrono-tz`
+feature, arrow resolves offset-based zones only, so `ArrayFormatter::try_new`
+on a `Timestamp(_, Some("UTC"))` array returned
+
+    Invalid timezone "UTC": only offset based timezones supported without
+    chrono-tz feature
+
+and the error propagated out of the analyzer and failed the whole report. Not a
+wrong number: no report at all.
+
+`UTC` is the spelling pyarrow, pandas and polars all produce by default, and it
+is what `pq.write_table` stores in an ordinary Parquet file, so this hit the
+normal shape of a timestamped dataset rather than an exotic one. Only the
+`+00:00` spelling and naive timestamps worked.
+
+The DST half of the fix -- that `Europe/Rome` renders +01:00 in January and
++02:00 in June rather than one fixed offset -- is pinned in Rust, in
+`record_batch_analyzer::tests::named_time_zones_are_resolved_with_their_dst_rules`.
+It belongs there because the rendered wall-clock string reaches
+`create_sample_columns` but not the Python report surface, so a test here could
+only assert that nothing raised, which a fixed-offset workaround would also
+satisfy while reporting the wrong hour for half the year.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import dataprof
+import pytest
+
+pa = pytest.importorskip("pyarrow", reason="pyarrow is required for Arrow import tests")
+
+INSTANTS = [dt.datetime(2021, 1, 15, 12, 0), dt.datetime(2021, 6, 15, 12, 0)]
+
+
+def _table(tz):
+    return pa.table({"seen_at": pa.array(INSTANTS, type=pa.timestamp("us", tz=tz))})
+
+
+def _columns(source, name):
+    return dataprof.profile(source, name=name).to_dict()["columns"]
+
+
+@pytest.mark.parametrize("tz", ["UTC", "Europe/Rome", "America/New_York", "+00:00", None])
+def test_a_timestamp_column_profiles_whatever_its_zone_is_called(tz):
+    """Named zones, offset zones and naive timestamps all produce a report."""
+    columns = _columns(_table(tz), f"tz_{tz}")
+
+    assert len(columns) == 1
+    assert columns[0]["name"] == "seen_at"
+    assert columns[0]["data_type"] == "date"
+    assert columns[0]["total_count"] == len(INSTANTS)
+    assert columns[0]["null_count"] == 0
+
+
+def test_every_path_agrees_on_a_utc_column(tmp_path):
+    """The output contract, over the spelling that used to fail everywhere.
+
+    A pyarrow Table, the Parquet file written from it, and the pandas and polars
+    frames built from it are the same data by construction, so the whole column
+    section has to agree.
+    """
+    pytest.importorskip("pandas", reason="pandas is required for pandas interop tests")
+    pl = pytest.importorskip("polars", reason="polars is required for polars interop tests")
+    pq = pytest.importorskip("pyarrow.parquet", reason="pyarrow.parquet is required")
+
+    table = _table("UTC")
+    path = tmp_path / "tz.parquet"
+    pq.write_table(table, path)
+
+    reference = _columns(table, "pyarrow")
+    assert _columns(str(path), "parquet") == reference
+    assert _columns(table.to_pandas(), "pandas") == reference
+    assert _columns(pl.from_arrow(table), "polars") == reference
+
+
+def test_a_named_zone_and_its_offset_spelling_describe_the_same_instants():
+    """`UTC` and `+00:00` are two spellings of one zone, so the counts match.
+
+    This is the pair that used to disagree in the sharpest possible way: one
+    raised and the other profiled.
+    """
+    assert _columns(_table("UTC"), "named") == _columns(_table("+00:00"), "offset")
+
+
+def test_a_null_timestamp_in_a_named_zone_is_counted_not_rendered():
+    """Nulls must not be pushed through the formatter that used to fail."""
+    array = pa.array([INSTANTS[0], None], type=pa.timestamp("us", tz="Europe/Rome"))
+    column = _columns(pa.table({"seen_at": array}), "with_null")[0]
+
+    assert column["total_count"] == 2
+    assert column["null_count"] == 1


### PR DESCRIPTION
Closes #668.

## What changed

One line in the workspace `Cargo.toml`:

```diff
-arrow = { version = "59.1.0", features = ["ffi"] }
+arrow = { version = "59.1.0", features = ["ffi", "chrono-tz"] }
```

A timestamp column whose zone is a *name* rather than an offset could not be
profiled on any columnar path. Not a wrong number, no report at all:

```
Analysis failed: Parser error: Invalid timezone "UTC":
only offset based timezones supported without chrono-tz feature
```

Without arrow's `chrono-tz` feature, arrow resolves offset-based zones only.
Every timestamp goes through `ArrayFormatter`, so the error propagated out of
`process_timestamp_array` ([record_batch_analyzer.rs:926](crates/dataprof-parquet/src/record_batch_analyzer.rs#L926))
and failed the whole report.

Measured on `master` before and after, against real builds rather than by
inspection:

| input | before | after |
| --- | --- | --- |
| pyarrow Table, `tz="UTC"` | `RuntimeError` | profiles |
| Parquet file written by pyarrow, `tz="UTC"` | `OSError` | profiles |
| pandas frame, tz-aware | `RuntimeError` | profiles |
| polars frame, tz-aware | `RuntimeError` | profiles |
| `tz="Europe/Rome"` | `RuntimeError` | profiles |
| `tz="+00:00"` (offset) | profiles | profiles |
| naive timestamp | profiles | profiles |

`UTC` is the spelling pyarrow, pandas and polars all produce by default, and it
is what `pq.write_table` stores in an ordinary Parquet file. This was not an
exotic input: a Parquet file with a UTC timestamp column is close to the default
shape of a timestamped dataset.

## The cost, measured

#668 left the wheel-size trade-off open, so I built both release wheels:

| wheel | bytes |
| --- | --- |
| with `chrono-tz` | 7,463,279 |
| without | 7,311,689 |
| **delta** | **+151,590 (+2.1%)** |

148 KB, which settles it in favour of the feature over the alternative in #668
(normalising zones to a fixed offset). That alternative would stop the error and
start reporting a wrong hour for half the year in any zone with DST, which is a
worse outcome than the loud failure it replaced.

## Verification

**The DST half is pinned in Rust**, in
`record_batch_analyzer::tests::named_time_zones_are_resolved_with_their_dst_rules`.
It asserts `Europe/Rome` renders `2021-01-15T13:00:00` (+01:00, CET) and
`2021-06-15T14:00:00` (+02:00, CEST) from two instants exactly one hour apart in
absolute terms.

That location is deliberate. The rendered wall-clock string reaches
`create_sample_columns` but not the Python report surface, so a Python test
could only assert that nothing raised — which the fixed-offset workaround would
*also* satisfy while reporting the wrong hour. The Rust test fails on exactly
one of the two values if a single offset is ever substituted.

Confirmed by reverting the feature and re-running:

```
test named_time_zones_are_resolved_with_their_dst_rules ... FAILED
  panicked at: a named time zone must not fail the report: Parser error:
  Invalid timezone "Europe/Rome": only offset based timezones supported
  without chrono-tz feature
```

New `python/tests/test_named_time_zones.py` covers the cross-path half: eight
tests over `UTC`, `Europe/Rome`, `America/New_York`, `+00:00` and naive; whole
column-section parity between a pyarrow Table, the Parquet file written from it,
and the pandas and polars frames built from it; and a null in a named zone,
since nulls must not reach the formatter that used to fail.

Commands run:

```
cargo fmt --all
cargo clippy --all --all-targets -- -D warnings     # clean
cargo test --workspace                              # clean, no failures
uv run maturin develop
uv run pytest python/tests/ -q                      # 1086 passed, 9 skipped
uv run ruff format / ruff check                     # clean
uv run ty check python/                             # clean
```

Local toolchain is 1.97; CI pins 1.98.

## Notes

Date columns report `stats: null` on the columnar path for every date type,
tz-aware or naive or `date32`. That is pre-existing and uniform, unrelated to
this change, and left alone.

Found while working on #664: a zero-row `timestamp("us", tz="UTC")` column was
the one schema in that PR's sweep that still failed, and it turned out to fail
with rows in it too.
