### PR TITLE
fix: harden numeric statistics and Python input boundaries

### DIFF
--- a/crates/dataprof-core/src/serde_helpers.rs
+++ b/crates/dataprof-core/src/serde_helpers.rs
@@ -34,6 +34,17 @@
 
 use serde::Serializer;
 
+fn round_finite(value: f64, scale: f64) -> f64 {
+    let scaled = value * scale;
+    if scaled.is_finite() {
+        scaled.round() / scale
+    } else {
+        // At this magnitude every representable value is already integral.
+        // Scaling must not turn a finite statistic into a serialized null.
+        value
+    }
+}
+
 /// Round f64 to 2 decimal places (for `0..100` percentages).
 /// Returns null for NaN or infinite values.
 pub fn round_2<S>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
@@ -43,7 +54,7 @@ where
     if !value.is_finite() {
         return serializer.serialize_none();
     }
-    serializer.serialize_f64((value * 100.0).round() / 100.0)
+    serializer.serialize_f64(round_finite(*value, 100.0))
 }
 
 /// Round f64 to 4 decimal places (statistics, data values, and `0..1` ratios).
@@ -55,7 +66,7 @@ where
     if !value.is_finite() {
         return serializer.serialize_none();
     }
-    serializer.serialize_f64((value * 10000.0).round() / 10000.0)
+    serializer.serialize_f64(round_finite(*value, 10000.0))
 }
 
 /// Round `Option<f64>` to 2 decimal places (for `0..100` percentages).
@@ -66,7 +77,7 @@ where
 {
     match value {
         Some(v) if v.is_finite() => {
-            let rounded = (v * 100.0).round() / 100.0;
+            let rounded = round_finite(*v, 100.0);
             serializer.serialize_some(&rounded)
         }
         _ => serializer.serialize_none(),
@@ -81,7 +92,7 @@ where
 {
     match value {
         Some(v) if v.is_finite() => {
-            let rounded = (v * 10000.0).round() / 10000.0;
+            let rounded = round_finite(*v, 10000.0);
             serializer.serialize_some(&rounded)
         }
         _ => serializer.serialize_none(),
@@ -188,6 +199,29 @@ mod tests {
 
         assert_eq!(round_2_json, json!({ "value": null }));
         assert_eq!(round_4_json, json!({ "value": null }));
+    }
+
+    #[test]
+    fn rounding_preserves_large_finite_values() {
+        for value in [f64::MAX, -f64::MAX, 1e308, -1e308] {
+            let expected = json!({ "value": value });
+            assert_eq!(
+                serde_json::to_value(Round2Value { value }).unwrap(),
+                expected
+            );
+            assert_eq!(
+                serde_json::to_value(Round4Value { value }).unwrap(),
+                expected
+            );
+            assert_eq!(
+                serde_json::to_value(Round2OptValue { value: Some(value) }).unwrap(),
+                expected
+            );
+            assert_eq!(
+                serde_json::to_value(Round4OptValue { value: Some(value) }).unwrap(),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/stats/numeric.rs
+++ b/crates/dataprof-metrics/src/stats/numeric.rs
@@ -144,7 +144,7 @@ pub fn calculate_median(sorted_data: &[f64]) -> Option<f64> {
         // Even number of elements - average of two middle values
         let mid1 = sorted_data[len / 2 - 1];
         let mid2 = sorted_data[len / 2];
-        Some((mid1 + mid2) / 2.0)
+        Some(mid1.midpoint(mid2))
     } else {
         // Odd number of elements - middle value
         Some(sorted_data[len / 2])
@@ -198,11 +198,15 @@ pub fn calculate_mode(data: &[f64]) -> Option<f64> {
         return None;
     }
 
-    let mut freq_map: HashMap<String, usize> = HashMap::new();
+    let mut freq_map: HashMap<u64, usize> = HashMap::new();
 
-    // Use string representation to handle floating point comparison
+    // Count the actual values, without rounding distinct small numbers into
+    // the same bucket. Signed zeros compare equal numerically.
     for &value in data {
-        let key = format!("{:.10}", value); // 10 decimal precision
+        if !value.is_finite() {
+            continue;
+        }
+        let key = if value == 0.0 { 0 } else { value.to_bits() };
         *freq_map.entry(key).or_insert(0) += 1;
     }
 
@@ -215,15 +219,11 @@ pub fn calculate_mode(data: &[f64]) -> Option<f64> {
     }
 
     // Find all values with maximum frequency and return the smallest (deterministic)
-    // decode-audit: no-data — non-numeric tokens are excluded from the mode by
-    // design, same as the main numeric pass above.
-    let mut modes: Vec<f64> = freq_map
+    freq_map
         .iter()
         .filter(|(_, count)| **count == max_freq)
-        .filter_map(|(value, _)| value.parse::<f64>().ok())
-        .collect();
-    modes.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    modes.first().copied()
+        .map(|(&bits, _)| f64::from_bits(bits))
+        .min_by(f64::total_cmp)
 }
 
 /// Calculate coefficient of variation (CV)
@@ -318,6 +318,14 @@ mod tests {
     }
 
     #[test]
+    fn median_preserves_finite_extremes_and_subnormals() {
+        assert_eq!(calculate_median(&[f64::MAX, f64::MAX]), Some(f64::MAX));
+        assert_eq!(calculate_median(&[-f64::MAX, f64::MAX]), Some(0.0));
+        let smallest = f64::from_bits(1);
+        assert_eq!(calculate_median(&[smallest, smallest]), Some(smallest));
+    }
+
+    #[test]
     fn test_quartiles() {
         let sorted = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let q = calculate_quartiles(&sorted).unwrap();
@@ -349,6 +357,15 @@ mod tests {
     fn test_mode_empty() {
         let data: Vec<f64> = vec![];
         assert_eq!(calculate_mode(&data), None);
+    }
+
+    #[test]
+    fn mode_counts_exact_values_and_breaks_ties_numerically() {
+        assert_eq!(calculate_mode(&[1e-12, 2e-12, 3e-12]), None);
+        assert_eq!(calculate_mode(&[1e-12, 1e-12, 2e-12]), Some(1e-12));
+        assert_eq!(calculate_mode(&[-0.0, 0.0, 1.0, 1.0]), Some(0.0));
+        assert_eq!(calculate_mode(&[2.0, -3.0, 2.0, -3.0]), Some(-3.0));
+        assert_eq!(calculate_mode(&[f64::NAN, f64::INFINITY]), None);
     }
 
     #[test]

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -484,9 +484,11 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
             delimiter = _csv.Sniffer().sniff(text[:8192], delimiters=",;\t|").delimiter
         except _csv.Error:
             delimiter = ","
-    reader = _csv.reader(_io.StringIO(text), delimiter=delimiter)
+    reader = _csv.reader(_io.StringIO(text, newline=""), delimiter=delimiter)
     try:
-        header = next(reader)
+        # Rust's CSV readers ignore blank physical records, including those
+        # before the header. A quoted empty field is still a real record.
+        header = next(row for row in reader if row)
     except StopIteration:
         return []
 
@@ -508,10 +510,12 @@ def _columns_from_csv_bytes(buffer: _io.BytesIO, delimiter: str | None) -> list[
         )
 
     cells: list[list[str | None]] = [[] for _ in header]
-    for row_num, row in enumerate(reader, start=2):
+    for row in reader:
+        if not row:
+            continue
         if len(row) != len(header):
             raise ValueError(
-                f"csv bytes: row {row_num} has {len(row)} fields, "
+                f"csv bytes: row {reader.line_num} has {len(row)} fields, "
                 f"expected {len(header)}. Write the data to a file to use "
                 f"the flexible CSV engine (csv_flexible=True)."
             )

--- a/python/dataprof/agent.py
+++ b/python/dataprof/agent.py
@@ -23,6 +23,7 @@ is safe to hand back to a model verbatim.
 
 from __future__ import annotations as _annotations
 
+import math as _math
 import os as _os
 import pathlib as _pathlib
 import threading as _threading
@@ -169,8 +170,8 @@ class SandboxPolicy:
         ):
             if value <= 0:
                 raise ValueError(f"{name} must be positive, got {value}")
-        if timeout_seconds <= 0:
-            raise ValueError(f"timeout_seconds must be positive, got {timeout_seconds}")
+        if not _math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError(f"timeout_seconds must be positive and finite, got {timeout_seconds}")
 
         object.__setattr__(self, "roots", _coerce_roots(roots))
         object.__setattr__(self, "max_file_bytes", max_file_bytes)

--- a/python/dataprof/asyncio.py
+++ b/python/dataprof/asyncio.py
@@ -83,12 +83,12 @@ async def profile_bytes(
         ProfileReport with analysis results.
     """
     _check_async()
-    if kwargs.get("engine") == "columnar":
+    config = _ProfilerConfig(**kwargs) if kwargs else None
+    if config is not None and config.engine == "columnar":
         raise ValueError(
             "engine='columnar' is not available for async bytes input; "
             "use engine='auto' or 'incremental'."
         )
-    config = _ProfilerConfig(**kwargs) if kwargs else None
     rust_report = await _profile_bytes_async(data, format, config)
     return _ProfileReport(rust_report)
 

--- a/python/tests/test_agent_guard.py
+++ b/python/tests/test_agent_guard.py
@@ -64,6 +64,12 @@ def test_policy_requires_a_root() -> None:
         SandboxPolicy(roots=[])
 
 
+@pytest.mark.parametrize("timeout", [float("nan"), float("inf"), float("-inf")])
+def test_policy_rejects_nonfinite_timeout(sandbox: Path, timeout: float) -> None:
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        SandboxPolicy(roots=sandbox, timeout_seconds=timeout)
+
+
 def test_policy_rejects_a_root_that_is_not_a_directory(sandbox: Path) -> None:
     with pytest.raises(ValueError, match="not an existing directory"):
         SandboxPolicy(roots=sandbox / "data.csv")

--- a/python/tests/test_csv_blank_lines.py
+++ b/python/tests/test_csv_blank_lines.py
@@ -1,0 +1,32 @@
+"""CSV byte buffers share the file readers' newline and empty-record policy."""
+
+import asyncio
+
+import dataprof
+import pytest
+
+
+@pytest.mark.parametrize("newline", [b"\n", b"\r", b"\r\n"])
+@pytest.mark.parametrize("blank_lines", [False, True])
+def test_csv_bytes_match_file_readers(tmp_path, newline, blank_lines):
+    lines = [b"x,y", b"1,a", b"2,b"]
+    if blank_lines:
+        lines = [b"", lines[0], b"", lines[1], b"", lines[2], b""]
+    data = newline.join(lines) + newline
+    path = tmp_path / "records.csv"
+    path.write_bytes(data)
+
+    reference = dataprof.profile(path, engine="incremental").to_dict()["columns"]
+    assert dataprof.profile(path, engine="columnar").to_dict()["columns"] == reference
+    assert dataprof.profile(data, format="csv").to_dict()["columns"] == reference
+    if dataprof.capabilities().async_streaming:
+        from dataprof.asyncio import profile_bytes
+
+        report = asyncio.run(profile_bytes(data, format="csv"))
+        assert report.to_dict()["columns"] == reference
+
+
+def test_quoted_empty_csv_record_is_a_null_row():
+    report = dataprof.profile(b'x\n\n""\n1\n', format="csv")
+    assert report.rows == 2
+    assert report["x"].null_count == 1

--- a/python/tests/test_execution_controls.py
+++ b/python/tests/test_execution_controls.py
@@ -314,9 +314,10 @@ def test_async_json_row_cap_keeps_partial_byte_accounting(fmt, data):
 
 
 @requires_async
-def test_async_bytes_reject_columnar_engine():
+@pytest.mark.parametrize("engine", ["columnar", "COLUMNAR", "arrow", "ARROW"])
+def test_async_bytes_reject_columnar_engine(engine):
     with pytest.raises(ValueError, match="columnar"):
-        _async_bytes(_csv_bytes(3), engine="columnar")
+        _async_bytes(_csv_bytes(3), engine=engine)
 
 
 @requires_async

--- a/python/tests/test_numeric_extremes.py
+++ b/python/tests/test_numeric_extremes.py
@@ -1,0 +1,54 @@
+"""Numeric distributions must retain actual values at floating-point extremes."""
+
+from __future__ import annotations
+
+import json
+
+import dataprof
+import pytest
+
+
+@pytest.mark.parametrize("route", ["dict", "csv", "columnar", "json", "arrow", "parquet"])
+@pytest.mark.parametrize(
+    ("values", "field", "expected"),
+    [
+        ([1e-12, 2e-12, 3e-12, 4e-12], "mode", None),
+        ([1e-12, 1e-12, 2e-12], "mode", 1e-12),
+        ([-0.0, 0.0, 1.0, 1.0], "mode", 0.0),
+        ([1e308, 1e308], "median", 1e308),
+        ([-1e308, 1e308], "median", 0.0),
+    ],
+)
+def test_extreme_distribution_values(tmp_path, route, values, field, expected):
+    source = {"x": values}
+    engine = "auto"
+    if route in ("csv", "columnar"):
+        source = tmp_path / "values.csv"
+        source.write_text("x\n" + "\n".join(map(str, values)), encoding="utf-8")
+        engine = "columnar" if route == "columnar" else "incremental"
+    elif route == "json":
+        source = tmp_path / "values.json"
+        source.write_text(json.dumps([{"x": v} for v in values]), encoding="utf-8")
+    elif route in ("arrow", "parquet"):
+        pa = pytest.importorskip("pyarrow")
+        source = pa.table(source)
+        if route == "parquet":
+            pq = pytest.importorskip("pyarrow.parquet")
+            path = tmp_path / "values.parquet"
+            pq.write_table(source, path)
+            source = path
+
+    column = dataprof.profile(source, engine=engine)["x"]
+    # Exact equality matters: an absolute tolerance would accept a fabricated
+    # zero as the mode of a column containing only tiny nonzero numbers.
+    assert getattr(column, field) == expected
+
+
+@pytest.mark.parametrize("value", [1e308, -1e308])
+def test_large_finite_values_survive_native_serialization(value):
+    report = dataprof.profile({"x": [value]})
+    native_report = getattr(report, "_report")
+    native = json.loads(native_report.to_json())["column_profiles"][0]["stats"]["Numeric"]
+    public = report.to_dict()["columns"][0]["stats"]
+    for field in ("min", "max", "mean", "median"):
+        assert native[field] == public[field] == value


### PR DESCRIPTION
## What changed

Fix seven edge cases confirmed by profiling real inputs across the Rust/Python paths:

- Count numeric modes by exact value, preserving tiny distinct numbers and treating signed zeros equally.
- Compute even-length medians without overflowing finite values.
- Preserve large finite statistics when Rust serializers round them.
- Accept carriage-return CSV buffers and ignore blank physical records consistently with file/async readers; quoted empty fields remain null rows.
- Reject every columnar engine spelling for async bytes, including aliases and case variants.
- Reject NaN/infinite sandbox timeouts when constructing the policy.

Regression tests reproduced 36 failing cases before their fixes. Numeric distribution tests cover dict, CSV engines, JSON, Arrow and Parquet; CSV tests compare synchronous buffers with both file engines and async bytes.

Related findings: #670 and #671 track the larger variance and mean accumulation defects discovered in the same audit. This PR does not close them.

## How it was verified

On Windows x64, Rust 1.98.1 and CPython 3.12.13:

- `uv run maturin develop` — rebuilt the shipped feature set.
- `uv run pytest python/tests -q --tb=short` — 1,131 passed, 9 skipped (database features and Windows symlink privileges).
- `cargo test --profile dev -p dataprof-core -p dataprof-metrics` — 425 unit tests and 2 doctests passed.
- `cargo test --profile dev -p dataprof --tests` — 148 tests passed across 21 test binaries.
- `cargo clippy --all --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/` — passed.
- `uv run ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/` — passed.
- `uv run ty check python/` — passed.
- `uv run python .github/scripts/check_decode_audit.py` — passed.
- An additional 221-profile matrix over 17 adversarial fixtures and 13 input routes found only the variance discrepancy tracked in #670.

## Anything reviewers should know

The report schema and feature set are unchanged. Corrected statistics can change existing results at floating-point extremes. Mean accumulation and cancellation remain tracked separately; preserving serialization does not repair an already nonfinite computed mean.
