### PR TITLE
refactor(metrics): compute numeric aggregates with a stable accumulator

### DIFF
--- a/crates/dataprof-metrics/src/acceleration/simd.rs
+++ b/crates/dataprof-metrics/src/acceleration/simd.rs
@@ -1,115 +1,68 @@
 /// SIMD-accelerated numerical computations for data profiling
 /// Uses the `wide` crate for portable SIMD operations
+use crate::stats::NumericAccumulator;
 use wide::*;
 
-/// SIMD-accelerated statistical computations
-pub struct SimdStats {
-    pub count: usize,
-    pub sum: f64,
-    pub sum_squares: f64,
-    pub min: f64,
-    pub max: f64,
-}
+/// Values processed per SIMD step, one per `f64x4` lane.
+const LANES: usize = 4;
 
-impl Default for SimdStats {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+/// Accumulate stable numeric aggregates over `values`, four lanes at a time.
+///
+/// Each lane runs the same Welford and compensated-sum recurrences as
+/// [`NumericAccumulator::update`] over every fourth value, and the four lane
+/// accumulators are merged at the end. Accumulating a naive `sum` and
+/// `sum_squares` here would vectorize just as well and lose the small spread of
+/// a large-offset column entirely, which is what this path used to do.
+pub fn compute_stats_simd(values: &[f64]) -> NumericAccumulator {
+    let (chunks, remainder) = values.as_chunks::<LANES>();
 
-impl SimdStats {
-    pub fn new() -> Self {
-        Self {
-            count: 0,
-            sum: 0.0,
-            sum_squares: 0.0,
-            min: f64::INFINITY,
-            max: f64::NEG_INFINITY,
-        }
-    }
+    // One count for all four lanes: every step feeds every lane, and the tail
+    // goes through the scalar path below.
+    let mut count = 0u64;
+    let mut mean = f64x4::splat(0.0);
+    let mut m2 = f64x4::splat(0.0);
+    let mut sum = f64x4::splat(0.0);
+    let mut compensation = f64x4::splat(0.0);
+    let mut min = f64x4::splat(f64::INFINITY);
+    let mut max = f64x4::splat(f64::NEG_INFINITY);
 
-    pub fn mean(&self) -> f64 {
-        if self.count > 0 {
-            self.sum / self.count as f64
-        } else {
-            0.0
-        }
-    }
-
-    pub fn variance(&self) -> f64 {
-        if self.count <= 1 {
-            return 0.0;
-        }
-
-        let n = self.count as f64;
-        let mean = self.mean();
-        (self.sum_squares - n * mean * mean) / n
-    }
-
-    pub fn std_dev(&self) -> f64 {
-        self.variance().sqrt()
-    }
-}
-
-/// Compute basic statistics using SIMD operations
-pub fn compute_stats_simd(values: &[f64]) -> SimdStats {
-    if values.is_empty() {
-        return SimdStats::new();
-    }
-
-    let mut stats = SimdStats::new();
-    stats.count = values.len();
-
-    // Process in SIMD chunks of 4 f64 values
-    let chunk_size = 4;
-    let chunks = values.chunks_exact(chunk_size);
-    let remainder = chunks.remainder();
-
-    // SIMD variables for accumulation
-    let mut sum_vec = f64x4::splat(0.0);
-    let mut sum_squares_vec = f64x4::splat(0.0);
-    let mut min_vec = f64x4::splat(f64::INFINITY);
-    let mut max_vec = f64x4::splat(f64::NEG_INFINITY);
-
-    // Process SIMD chunks
     for chunk in chunks {
-        let vec = f64x4::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let value = f64x4::new(*chunk);
+        count += 1;
 
-        // Accumulate sum
-        sum_vec += vec;
+        let delta = value - mean;
+        mean += delta / f64x4::splat(count as f64);
+        m2 += delta * (value - mean);
 
-        // Accumulate sum of squares
-        sum_squares_vec += vec * vec;
+        // Knuth's two-sum, lane-wise.
+        let total = sum + value;
+        let value_virtual = total - sum;
+        compensation += (sum - (total - value_virtual)) + (value - value_virtual);
+        sum = total;
 
-        // Update min/max
-        min_vec = min_vec.min(vec);
-        max_vec = max_vec.max(vec);
+        min = min.min(value);
+        max = max.max(value);
     }
 
-    // Reduce SIMD vectors to scalar values
-    let sum_array: [f64; 4] = sum_vec.to_array();
-    let sum_squares_array: [f64; 4] = sum_squares_vec.to_array();
-    let min_array: [f64; 4] = min_vec.to_array();
-    let max_array: [f64; 4] = max_vec.to_array();
+    let (mean, m2) = (mean.to_array(), m2.to_array());
+    let (sum, compensation) = (sum.to_array(), compensation.to_array());
+    let (min, max) = (min.to_array(), max.to_array());
 
-    stats.sum = sum_array[0] + sum_array[1] + sum_array[2] + sum_array[3];
-    stats.sum_squares =
-        sum_squares_array[0] + sum_squares_array[1] + sum_squares_array[2] + sum_squares_array[3];
-    stats.min = min_array[0]
-        .min(min_array[1])
-        .min(min_array[2])
-        .min(min_array[3]);
-    stats.max = max_array[0]
-        .max(max_array[1])
-        .max(max_array[2])
-        .max(max_array[3]);
+    let mut stats = NumericAccumulator::new();
+    for lane in 0..LANES {
+        stats.merge(&NumericAccumulator::from_lane_state(
+            count,
+            mean[lane],
+            m2[lane],
+            sum[lane],
+            compensation[lane],
+            min[lane],
+            max[lane],
+        ));
+    }
 
-    // Process remainder values (non-SIMD)
     for &value in remainder {
-        stats.sum += value;
-        stats.sum_squares += value * value;
-        stats.min = stats.min.min(value);
-        stats.max = stats.max.max(value);
+        stats.update(value);
     }
 
     stats
@@ -228,7 +181,7 @@ pub fn should_use_simd(data_size: usize) -> bool {
 }
 
 /// Auto-choose between SIMD and regular computation
-pub fn compute_stats_auto(values: &[f64]) -> SimdStats {
+pub fn compute_stats_auto(values: &[f64]) -> NumericAccumulator {
     if should_use_simd(values.len()) && is_simd_available() {
         compute_stats_simd(values)
     } else {
@@ -244,25 +197,8 @@ pub fn is_simd_available() -> bool {
 }
 
 /// Fallback non-SIMD implementation
-fn compute_stats_fallback(values: &[f64]) -> SimdStats {
-    let mut stats = SimdStats::new();
-    stats.count = values.len();
-
-    if values.is_empty() {
-        return stats;
-    }
-
-    stats.min = values[0];
-    stats.max = values[0];
-
-    for &value in values {
-        stats.sum += value;
-        stats.sum_squares += value * value;
-        stats.min = stats.min.min(value);
-        stats.max = stats.max.max(value);
-    }
-
-    stats
+fn compute_stats_fallback(values: &[f64]) -> NumericAccumulator {
+    values.iter().copied().collect()
 }
 
 #[cfg(test)]
@@ -274,11 +210,11 @@ mod tests {
         let values = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let stats = compute_stats_simd(&values);
 
-        assert_eq!(stats.count, 8);
-        assert!((stats.sum - 36.0).abs() < 1e-10);
-        assert_eq!(stats.min, 1.0);
-        assert_eq!(stats.max, 8.0);
+        assert_eq!(stats.count(), 8);
+        assert_eq!(stats.min(), Some(1.0));
+        assert_eq!(stats.max(), Some(8.0));
         assert!((stats.mean() - 4.5).abs() < 1e-10);
+        assert!((stats.sample_variance() - 6.0).abs() < 1e-10);
     }
 
     #[test]
@@ -288,10 +224,31 @@ mod tests {
         let simd_stats = compute_stats_simd(&values);
         let fallback_stats = compute_stats_fallback(&values);
 
-        assert!((simd_stats.sum - fallback_stats.sum).abs() < 1e-10);
-        assert!((simd_stats.min - fallback_stats.min).abs() < 1e-10);
-        assert!((simd_stats.max - fallback_stats.max).abs() < 1e-10);
+        assert_eq!(simd_stats.count(), fallback_stats.count());
+        assert_eq!(simd_stats.min(), fallback_stats.min());
+        assert_eq!(simd_stats.max(), fallback_stats.max());
         assert!((simd_stats.mean() - fallback_stats.mean()).abs() < 1e-10);
+        assert!((simd_stats.sample_variance() - fallback_stats.sample_variance()).abs() < 1e-10);
+    }
+
+    /// The lane accumulation has to be as stable as the scalar one: a column
+    /// large enough to reach SIMD is exactly where a naive sum does its damage.
+    #[test]
+    fn simd_lanes_stay_stable_on_hard_inputs() {
+        // A small spread on a large offset, and a tail that is not a whole
+        // number of lanes, so both halves of the routine are exercised.
+        let offset: Vec<f64> = (0..102).map(|i| 1e9 + (i % 4) as f64).collect();
+        let expected = compute_stats_fallback(&offset);
+        let actual = compute_stats_simd(&offset);
+        assert!(expected.sample_variance() > 1.0);
+        assert!((actual.sample_variance() - expected.sample_variance()).abs() < 1e-6);
+
+        // Large values that cancel, leaving a mean far smaller than any of them.
+        let mut cancelling = [1e16, -1e16].repeat(50);
+        cancelling.push(1.0);
+        let stats = compute_stats_simd(&cancelling);
+        assert_eq!(stats.count(), 101);
+        assert!((stats.mean() - 1.0 / 101.0).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/acceleration/simd.rs
+++ b/crates/dataprof-metrics/src/acceleration/simd.rs
@@ -68,112 +68,6 @@ pub fn compute_stats_simd(values: &[f64]) -> NumericAccumulator {
     stats
 }
 
-/// Fast parallel sum using SIMD
-pub fn sum_simd(values: &[f64]) -> f64 {
-    if values.is_empty() {
-        return 0.0;
-    }
-
-    let chunk_size = 4;
-    let chunks = values.chunks_exact(chunk_size);
-    let remainder = chunks.remainder();
-
-    let mut sum_vec = f64x4::splat(0.0);
-
-    for chunk in chunks {
-        let vec = f64x4::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
-        sum_vec += vec;
-    }
-
-    let sum_array: [f64; 4] = sum_vec.to_array();
-    let mut total = sum_array[0] + sum_array[1] + sum_array[2] + sum_array[3];
-
-    // Add remainder
-    for &value in remainder {
-        total += value;
-    }
-
-    total
-}
-
-/// Fast min/max finding using SIMD
-pub fn min_max_simd(values: &[f64]) -> (f64, f64) {
-    if values.is_empty() {
-        return (0.0, 0.0);
-    }
-
-    if values.len() == 1 {
-        return (values[0], values[0]);
-    }
-
-    let chunk_size = 4;
-    let chunks = values.chunks_exact(chunk_size);
-    let remainder = chunks.remainder();
-
-    let mut min_vec = f64x4::splat(f64::INFINITY);
-    let mut max_vec = f64x4::splat(f64::NEG_INFINITY);
-
-    for chunk in chunks {
-        let vec = f64x4::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
-        min_vec = min_vec.min(vec);
-        max_vec = max_vec.max(vec);
-    }
-
-    let min_array: [f64; 4] = min_vec.to_array();
-    let max_array: [f64; 4] = max_vec.to_array();
-
-    let mut min_val = min_array[0]
-        .min(min_array[1])
-        .min(min_array[2])
-        .min(min_array[3]);
-    let mut max_val = max_array[0]
-        .max(max_array[1])
-        .max(max_array[2])
-        .max(max_array[3]);
-
-    // Process remainder
-    for &value in remainder {
-        min_val = min_val.min(value);
-        max_val = max_val.max(value);
-    }
-
-    (min_val, max_val)
-}
-
-/// SIMD-accelerated dot product (useful for correlation computations)
-pub fn dot_product_simd(a: &[f64], b: &[f64]) -> f64 {
-    assert_eq!(a.len(), b.len());
-
-    if a.is_empty() {
-        return 0.0;
-    }
-
-    let chunk_size = 4;
-    let chunks_a = a.chunks_exact(chunk_size);
-    let chunks_b = b.chunks_exact(chunk_size);
-    let remainder_a = chunks_a.remainder();
-    let remainder_b = chunks_b.remainder();
-
-    let mut dot_vec = f64x4::splat(0.0);
-
-    for (chunk_a, chunk_b) in chunks_a.zip(chunks_b) {
-        let vec_a = f64x4::new([chunk_a[0], chunk_a[1], chunk_a[2], chunk_a[3]]);
-        let vec_b = f64x4::new([chunk_b[0], chunk_b[1], chunk_b[2], chunk_b[3]]);
-
-        dot_vec += vec_a * vec_b;
-    }
-
-    let dot_array: [f64; 4] = dot_vec.to_array();
-    let mut result = dot_array[0] + dot_array[1] + dot_array[2] + dot_array[3];
-
-    // Process remainder
-    for (&val_a, &val_b) in remainder_a.iter().zip(remainder_b.iter()) {
-        result += val_a * val_b;
-    }
-
-    result
-}
-
 /// Check if SIMD is beneficial for the given data size
 pub fn should_use_simd(data_size: usize) -> bool {
     // SIMD is beneficial for larger datasets due to setup overhead
@@ -249,25 +143,6 @@ mod tests {
         let stats = compute_stats_simd(&cancelling);
         assert_eq!(stats.count(), 101);
         assert!((stats.mean() - 1.0 / 101.0).abs() < 1e-12);
-    }
-
-    #[test]
-    fn test_min_max_simd() {
-        let values = vec![3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0];
-        let (min, max) = min_max_simd(&values);
-
-        assert_eq!(min, 1.0);
-        assert_eq!(max, 9.0);
-    }
-
-    #[test]
-    fn test_dot_product_simd() {
-        let a = vec![1.0, 2.0, 3.0, 4.0];
-        let b = vec![5.0, 6.0, 7.0, 8.0];
-        let dot = dot_product_simd(&a, &b);
-
-        // 1*5 + 2*6 + 3*7 + 4*8 = 5 + 12 + 21 + 32 = 70
-        assert!((dot - 70.0).abs() < 1e-10);
     }
 
     #[test]

--- a/crates/dataprof-metrics/src/lib.rs
+++ b/crates/dataprof-metrics/src/lib.rs
@@ -18,6 +18,6 @@ pub use quality::{
     TimelinessMetrics, UniquenessMetrics, ValidityMetrics,
 };
 pub use stats::{
-    CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog, calculate_datetime_stats,
-    calculate_numeric_stats, calculate_text_stats,
+    CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog, NumericAccumulator,
+    calculate_datetime_stats, calculate_numeric_stats, calculate_text_stats,
 };

--- a/crates/dataprof-metrics/src/stats/accumulator.rs
+++ b/crates/dataprof-metrics/src/stats/accumulator.rs
@@ -1,0 +1,325 @@
+//! Numerically stable accumulation of the aggregates a numeric column reports.
+
+/// Running count, min, max, mean and sample variance over a stream of finite
+/// `f64` values.
+///
+/// Two accumulations run side by side because neither alone is enough:
+///
+/// - **Welford's online mean and M2** give a translation-invariant variance.
+///   `sum_squares - n * mean²` loses every significant digit of a small spread
+///   sitting on a large offset: four consecutive integers near 1e9 came back
+///   with a variance of exactly 0.0, describing a varying column as constant.
+/// - **A compensated (Knuth two-sum) running sum** gives a mean that survives
+///   cancellation. Welford's running mean rounds `[1e16, 1.0, -1e16]` to 0.0
+///   because the unit contribution disappears into the intermediate mean; the
+///   compensated sum keeps it and returns 1/3.
+///
+/// The compensated sum can still overflow where the mean itself is
+/// representable (`[1e308, 1e308]`), so [`mean`](Self::mean) falls back to
+/// Welford's running mean — which cannot overflow — whenever the sum is not
+/// finite.
+///
+/// [`merge`](Self::merge) combines accumulators computed over disjoint parts of
+/// a column, so chunked, batched and SIMD-lane accumulation report what a
+/// single pass would.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NumericAccumulator {
+    count: u64,
+    /// Welford's running mean: overflow-proof, used when `sum` is not finite.
+    running_mean: f64,
+    /// Welford's sum of squared deviations from the running mean.
+    m2: f64,
+    /// Running sum, with `compensation` carrying the bits it rounded away.
+    sum: f64,
+    compensation: f64,
+    min: f64,
+    max: f64,
+}
+
+impl Default for NumericAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Knuth's two-sum: the rounded sum of `a + b` and the exact rounding error,
+/// with no branch and no wider type. `err` is exact whenever `a + b` is finite.
+#[inline]
+fn two_sum(a: f64, b: f64) -> (f64, f64) {
+    let sum = a + b;
+    let b_virtual = sum - a;
+    let err = (a - (sum - b_virtual)) + (b - b_virtual);
+    (sum, err)
+}
+
+impl NumericAccumulator {
+    pub fn new() -> Self {
+        Self {
+            count: 0,
+            running_mean: 0.0,
+            m2: 0.0,
+            sum: 0.0,
+            compensation: 0.0,
+            min: f64::INFINITY,
+            max: f64::NEG_INFINITY,
+        }
+    }
+
+    /// Fold one value in. Callers pass finite values only; non-finite input is
+    /// filtered out at parse time so it can never reach the aggregates.
+    #[inline]
+    pub fn update(&mut self, value: f64) {
+        debug_assert!(value.is_finite());
+        self.count += 1;
+
+        let delta = value - self.running_mean;
+        self.running_mean += delta / self.count as f64;
+        self.m2 += delta * (value - self.running_mean);
+
+        let (sum, err) = two_sum(self.sum, value);
+        self.sum = sum;
+        self.compensation += err;
+
+        self.min = self.min.min(value);
+        self.max = self.max.max(value);
+    }
+
+    /// Rebuild an accumulator from state computed elsewhere.
+    ///
+    /// Used by the SIMD accumulation in [`crate::acceleration::simd`], which
+    /// runs these same recurrences over four lanes at once and then merges the
+    /// lanes back together. Nothing else should reach past [`Self::update`].
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn from_lane_state(
+        count: u64,
+        running_mean: f64,
+        m2: f64,
+        sum: f64,
+        compensation: f64,
+        min: f64,
+        max: f64,
+    ) -> Self {
+        Self {
+            count,
+            running_mean,
+            m2,
+            sum,
+            compensation,
+            min,
+            max,
+        }
+    }
+
+    /// Fold in an accumulator built over a disjoint set of values.
+    pub fn merge(&mut self, other: &Self) {
+        if other.count == 0 {
+            return;
+        }
+        if self.count == 0 {
+            *self = *other;
+            return;
+        }
+
+        // Chan's parallel form of Welford's update.
+        let (a, b) = (self.count as f64, other.count as f64);
+        let combined = a + b;
+        let delta = other.running_mean - self.running_mean;
+        self.running_mean += delta * (b / combined);
+        self.m2 += other.m2 + delta * delta * (a * b / combined);
+        self.count += other.count;
+
+        let (sum, err) = two_sum(self.sum, other.sum);
+        self.sum = sum;
+        self.compensation += err + other.compensation;
+
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
+    }
+
+    #[inline]
+    pub fn count(&self) -> u64 {
+        self.count
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Smallest value seen, or `None` when nothing was accumulated.
+    #[inline]
+    pub fn min(&self) -> Option<f64> {
+        (self.count > 0).then_some(self.min)
+    }
+
+    /// Largest value seen, or `None` when nothing was accumulated.
+    #[inline]
+    pub fn max(&self) -> Option<f64> {
+        (self.count > 0).then_some(self.max)
+    }
+
+    /// Arithmetic mean. Zero for an empty accumulator, matching the callers
+    /// that report absent statistics separately.
+    pub fn mean(&self) -> f64 {
+        if self.count == 0 {
+            return 0.0;
+        }
+        // `compensation` is NaN once the sum overflows, which fails this test
+        // just as an infinite sum does.
+        let total = self.sum + self.compensation;
+        if total.is_finite() {
+            total / self.count as f64
+        } else {
+            self.running_mean
+        }
+    }
+
+    /// Unbiased sample variance (n-1 denominator).
+    pub fn sample_variance(&self) -> f64 {
+        if self.count < 2 {
+            return 0.0;
+        }
+        (self.m2 / (self.count - 1) as f64).max(0.0)
+    }
+
+    /// Standard deviation derived from [`sample_variance`](Self::sample_variance).
+    pub fn sample_std_dev(&self) -> f64 {
+        self.sample_variance().sqrt()
+    }
+
+    /// Population variance (n denominator).
+    pub fn population_variance(&self) -> f64 {
+        if self.count < 2 {
+            return 0.0;
+        }
+        (self.m2 / self.count as f64).max(0.0)
+    }
+
+    /// Standard deviation derived from [`population_variance`](Self::population_variance).
+    pub fn population_std_dev(&self) -> f64 {
+        self.population_variance().sqrt()
+    }
+}
+
+impl FromIterator<f64> for NumericAccumulator {
+    fn from_iter<I: IntoIterator<Item = f64>>(values: I) -> Self {
+        let mut accumulator = Self::new();
+        for value in values {
+            accumulator.update(value);
+        }
+        accumulator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accumulate(values: &[f64]) -> NumericAccumulator {
+        values.iter().copied().collect()
+    }
+
+    #[test]
+    fn empty_accumulator_reports_no_values() {
+        let accumulator = NumericAccumulator::new();
+        assert_eq!(accumulator.count(), 0);
+        assert!(accumulator.is_empty());
+        assert_eq!(accumulator.min(), None);
+        assert_eq!(accumulator.max(), None);
+        assert_eq!(accumulator.mean(), 0.0);
+        assert_eq!(accumulator.sample_variance(), 0.0);
+    }
+
+    #[test]
+    fn reports_textbook_statistics() {
+        let accumulator = accumulate(&[2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]);
+        assert_eq!(accumulator.count(), 8);
+        assert_eq!(accumulator.min(), Some(2.0));
+        assert_eq!(accumulator.max(), Some(9.0));
+        assert_eq!(accumulator.mean(), 5.0);
+        // Sample variance of the classic 8-value set is 32/7.
+        assert!((accumulator.sample_variance() - 32.0 / 7.0).abs() < 1e-12);
+        assert!((accumulator.population_variance() - 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn variance_is_translation_invariant() {
+        for offset in [0.0, 1e6, 1e8, 1e9, 1e12] {
+            let accumulator = accumulate(&[offset, offset + 1.0, offset + 2.0, offset + 3.0]);
+            assert!(
+                (accumulator.sample_variance() - 5.0 / 3.0).abs() < 1e-9,
+                "offset {offset} reported variance {}",
+                accumulator.sample_variance()
+            );
+        }
+    }
+
+    #[test]
+    fn mean_survives_cancellation_in_any_order() {
+        for values in [
+            [1e16, 1.0, -1e16],
+            [1e16, -1e16, 1.0],
+            [-1e16, 1e16, 1.0],
+            [1.0, 1e16, -1e16],
+        ] {
+            let accumulator = accumulate(&values);
+            assert!(
+                (accumulator.mean() - 1.0 / 3.0).abs() < 1e-12,
+                "{values:?} reported mean {}",
+                accumulator.mean()
+            );
+        }
+    }
+
+    #[test]
+    fn mean_stays_finite_when_the_sum_overflows() {
+        let accumulator = accumulate(&[1e308, 1e308]);
+        assert_eq!(accumulator.mean(), 1e308);
+        assert_eq!(accumulator.sample_variance(), 0.0);
+    }
+
+    #[test]
+    fn merge_matches_a_single_pass() {
+        let values: Vec<f64> = (0..97).map(|i| 1e9 + (i % 7) as f64).collect();
+        let single = accumulate(&values);
+
+        for split in [1, 13, 48, 96] {
+            let mut merged = accumulate(&values[..split]);
+            merged.merge(&accumulate(&values[split..]));
+
+            assert_eq!(merged.count(), single.count());
+            assert_eq!(merged.min(), single.min());
+            assert_eq!(merged.max(), single.max());
+            // Relative, not exact: combining two means near 1e9 rounds, so a
+            // merge is never bit-identical to a single pass. It is still three
+            // orders tighter than the error this fix is about — the naive
+            // sum-of-squares reported 0.0 for this column.
+            assert!(
+                (merged.mean() - single.mean()).abs() <= single.mean().abs() * 1e-12,
+                "split {split} mean {} vs {}",
+                merged.mean(),
+                single.mean()
+            );
+            assert!(
+                (merged.sample_variance() - single.sample_variance()).abs()
+                    <= single.sample_variance() * 1e-7,
+                "split {split} variance {} vs {}",
+                merged.sample_variance(),
+                single.sample_variance()
+            );
+        }
+    }
+
+    #[test]
+    fn merging_an_empty_accumulator_changes_nothing() {
+        let single = accumulate(&[1.0, 2.0, 3.0]);
+
+        let mut with_empty = single;
+        with_empty.merge(&NumericAccumulator::new());
+        assert_eq!(with_empty, single);
+
+        let mut from_empty = NumericAccumulator::new();
+        from_empty.merge(&single);
+        assert_eq!(from_empty, single);
+    }
+}

--- a/crates/dataprof-metrics/src/stats/accumulator.rs
+++ b/crates/dataprof-metrics/src/stats/accumulator.rs
@@ -141,11 +141,6 @@ impl NumericAccumulator {
         self.count
     }
 
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.count == 0
-    }
-
     /// Smallest value seen, or `None` when nothing was accumulated.
     #[inline]
     pub fn min(&self) -> Option<f64> {
@@ -223,7 +218,6 @@ mod tests {
     fn empty_accumulator_reports_no_values() {
         let accumulator = NumericAccumulator::new();
         assert_eq!(accumulator.count(), 0);
-        assert!(accumulator.is_empty());
         assert_eq!(accumulator.min(), None);
         assert_eq!(accumulator.max(), None);
         assert_eq!(accumulator.mean(), 0.0);

--- a/crates/dataprof-metrics/src/stats/mod.rs
+++ b/crates/dataprof-metrics/src/stats/mod.rs
@@ -1,8 +1,10 @@
+pub mod accumulator;
 pub mod cardinality;
 pub mod datetime;
 pub mod numeric;
 pub mod text;
 
+pub use accumulator::NumericAccumulator;
 pub use cardinality::{CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog};
 pub use datetime::calculate_datetime_stats;
 pub use numeric::calculate_numeric_stats;

--- a/crates/dataprof-metrics/src/stats/numeric.rs
+++ b/crates/dataprof-metrics/src/stats/numeric.rs
@@ -30,34 +30,16 @@ pub fn compute_numeric_stats_with_parsed_count(data: &[String]) -> (NumericStats
         return (NumericStats::empty(), 0);
     }
 
-    // Single SIMD-accelerated pass for base statistics (min, max, sum, sum_squares)
-    // Automatically falls back to scalar for small datasets (<64 elements)
+    // Single stable pass for the base statistics. `NumericAccumulator` carries
+    // Welford's mean and M2 alongside a compensated sum, so the variance of a
+    // small spread on a large offset survives and the mean survives both
+    // cancellation and an overflowing sum.
     let base = compute_stats_auto(&numbers);
-    let min = base.min;
-    let max = base.max;
+    let min = base.min().expect("accumulator covers a non-empty column");
+    let max = base.max().expect("accumulator covers a non-empty column");
     let mean = base.mean();
-    let mut variance = calculate_variance(base.sum_squares, base.sum, numbers.len());
-
-    // Fallback if variance is invalid or sum_squares overflowed
-    // Tiny negative variances can happen due to floating point catastrophic cancellation
-    if (!variance.is_finite() || variance < 0.0 || base.sum_squares.is_infinite())
-        && numbers.len() > 1
-    {
-        let mut welford_mean = 0.0;
-        let mut welford_m2 = 0.0;
-        for (i, &x) in numbers.iter().enumerate() {
-            let n = (i + 1) as f64;
-            let delta = x - welford_mean;
-            welford_mean += delta / n;
-            let delta2 = x - welford_mean;
-            welford_m2 += delta * delta2;
-        }
-        variance = welford_m2 / (numbers.len() - 1) as f64;
-    }
-
-    // Ensure variance doesn't become slightly negative before taking sqrt
-    let safe_variance = variance.max(0.0);
-    let std_dev = safe_variance.sqrt();
+    let variance = base.sample_variance();
+    let std_dev = base.sample_std_dev();
 
     // Determine if we need sampling for large datasets
     let (sample_data, is_approximate) = if numbers.len() > SAMPLE_THRESHOLD {
@@ -118,18 +100,6 @@ fn count_outliers_iqr(
     let lower = q.q1 - 1.5 * q.iqr;
     let upper = q.q3 + 1.5 * q.iqr;
     Some(values.iter().filter(|&&v| v < lower || v > upper).count())
-}
-
-/// Calculate variance using sum of squares
-/// Uses sample variance (n-1) for unbiased estimation
-pub fn calculate_variance(sum_squares: f64, sum: f64, count: usize) -> f64 {
-    let n = count as f64;
-    if n <= 1.0 {
-        return 0.0;
-    }
-
-    let mean = sum / n;
-    (sum_squares - n * mean * mean) / (n - 1.0)
 }
 
 /// Calculate median from sorted data
@@ -398,14 +368,58 @@ mod tests {
         assert!(kurt.is_some());
     }
 
+    /// The batch path is what an in-memory source (a dict, a DataFrame) is
+    /// profiled with. No engine supplies exact stream aggregates to override
+    /// these numbers there, so this is the whole answer (#670, #671).
     #[test]
-    fn test_variance() {
-        let sum_squares = 55.0; // 1² + 2² + 3² + 4² + 5²
-        let sum = 15.0; // 1 + 2 + 3 + 4 + 5
-        let count = 5;
-        let var = calculate_variance(sum_squares, sum, count);
-        // Sample variance (n-1): 2.5
-        assert!((var - 2.5).abs() < 0.01);
+    fn batch_stats_are_numerically_stable() {
+        fn column(values: &[f64]) -> NumericStats {
+            let cells: Vec<String> = values.iter().map(|value| value.to_string()).collect();
+            compute_numeric_stats(&cells)
+        }
+
+        // A small spread on a large offset: `sum_squares - n * mean²` cancels
+        // it away entirely, reporting a varying column as constant.
+        for base in [1e6, 1e8, 1e9, 1e12] {
+            let stats = column(&[base, base + 1.0, base + 2.0, base + 3.0]);
+            // Equality, not a tolerance: four values accumulate to the
+            // correctly rounded answer at every offset here.
+            assert_eq!(stats.variance, 5.0 / 3.0, "offset {base}");
+            assert_eq!(stats.std_dev, (5.0f64 / 3.0).sqrt(), "offset {base}");
+            assert_eq!(stats.mean, base + 1.5, "offset {base}");
+        }
+
+        // Past the SIMD threshold, where the lanes accumulate independently.
+        let many: Vec<f64> = (0..500).map(|i| 1e9 + (i % 4) as f64).collect();
+        let expected_variance = (0..4)
+            .map(|i| 125.0 * (i as f64 - 1.5).powi(2))
+            .sum::<f64>()
+            / (many.len() as f64 - 1.0);
+        let stats = column(&many);
+        assert!(
+            (stats.variance - expected_variance).abs() < 1e-6,
+            "500 values reported variance {}",
+            stats.variance
+        );
+
+        // Large values that cancel: the unit contribution is the whole mean.
+        for values in [[1e16, 1.0, -1e16], [1e16, -1e16, 1.0]] {
+            let stats = column(&values);
+            assert!(
+                (stats.mean - 1.0 / 3.0).abs() < 1e-9,
+                "{values:?} reported mean {}",
+                stats.mean
+            );
+        }
+
+        // A representable mean whose naive sum is not representable.
+        assert_eq!(column(&[1e308, 1e308]).mean, 1e308);
+
+        // And a genuinely constant column still reports no spread at all.
+        let constant = column(&[1e9; 4]);
+        assert_eq!(constant.variance, 0.0);
+        assert_eq!(constant.std_dev, 0.0);
+        assert_eq!(constant.mean, 1e9);
     }
 
     #[test]

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -9,8 +9,8 @@ use dataprof_core::{
     TruncationReason, char_len,
 };
 use dataprof_csv::CsvParserConfig;
-use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::{infer_type, is_null_like_token};
+use dataprof_metrics::{CardinalityEstimator, NumericAccumulator};
 use dataprof_runtime::{
     ColumnProfileInput, ExactNumericAggregates, ProfileReport, ReportAssembler,
     StreamReservoirSampler, TextLengths, ValueHintBindingAccumulator, build_column_profile,
@@ -403,11 +403,7 @@ struct ColumnAnalyzer {
     null_count: usize,
     cardinality: CardinalityEstimator,
     // Numeric statistics
-    min_value: Option<f64>,
-    max_value: Option<f64>,
-    sum: f64,
-    sum_squares: f64,
-    numeric_count: usize,
+    numeric: NumericAccumulator,
     // Text statistics
     min_length: usize,
     max_length: usize,
@@ -427,11 +423,7 @@ impl ColumnAnalyzer {
             total_count: 0,
             null_count: 0,
             cardinality: CardinalityEstimator::new(),
-            min_value: None,
-            max_value: None,
-            sum: 0.0,
-            sum_squares: 0.0,
-            numeric_count: 0,
+            numeric: NumericAccumulator::new(),
             min_length: usize::MAX,
             max_length: 0,
             total_length: 0,
@@ -884,44 +876,20 @@ impl ColumnAnalyzer {
     }
 
     fn update_numeric_stats(&mut self, value: f64) {
-        self.sum += value;
-        self.sum_squares += value * value;
-        self.numeric_count += 1;
-
-        self.min_value = Some(match self.min_value {
-            Some(min) => min.min(value),
-            None => value,
-        });
-
-        self.max_value = Some(match self.max_value {
-            Some(max) => max.max(value),
-            None => value,
-        });
+        self.numeric.update(value);
     }
 
     /// Exact aggregates over every numeric value processed, independent of the
     /// bounded reservoir sample. `None` when the column saw no numeric values.
     fn exact_numeric_aggregates(&self) -> Option<ExactNumericAggregates> {
-        let (min, max) = (self.min_value?, self.max_value?);
-        if self.numeric_count == 0 {
-            return None;
-        }
-        let mean = self.sum / self.numeric_count as f64;
-        // Clamp: sum-of-squares variance can go slightly negative from
-        // floating-point cancellation.
-        let variance = dataprof_metrics::stats::numeric::calculate_variance(
-            self.sum_squares,
-            self.sum,
-            self.numeric_count,
-        )
-        .max(0.0);
+        let (min, max) = (self.numeric.min()?, self.numeric.max()?);
         Some(ExactNumericAggregates {
             min,
             max,
-            mean,
-            std_dev: variance.sqrt(),
-            variance,
-            count: self.numeric_count,
+            mean: self.numeric.mean(),
+            std_dev: self.numeric.sample_std_dev(),
+            variance: self.numeric.sample_variance(),
+            count: self.numeric.count() as usize,
         })
     }
 

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -7,8 +7,8 @@ use arrow::util::display::ArrayFormatter;
 use dataprof_core::{
     ColumnProfile, DataType, Locale, SemanticHintBinding, SemanticHintKind, SemanticHints, char_len,
 };
-use dataprof_metrics::CardinalityEstimator;
 use dataprof_metrics::analysis::inference::is_null_like_token;
+use dataprof_metrics::{CardinalityEstimator, NumericAccumulator};
 use dataprof_metrics::{RowCompletenessSummary, RowDuplicateSummary, infer_type};
 use dataprof_runtime::{
     ColumnProfileInput, ExactNumericAggregates, RowCompletenessTracker, RowSignature,
@@ -381,11 +381,7 @@ pub struct ColumnAnalyzer {
     total_count: usize,
     null_count: usize,
     cardinality: CardinalityEstimator,
-    min_value: Option<f64>,
-    max_value: Option<f64>,
-    sum: f64,
-    sum_squares: f64,
-    numeric_count: usize,
+    numeric: NumericAccumulator,
     min_length: usize,
     max_length: usize,
     total_length: usize,
@@ -417,11 +413,7 @@ impl ColumnAnalyzer {
             total_count: 0,
             null_count: 0,
             cardinality: CardinalityEstimator::new(),
-            min_value: None,
-            max_value: None,
-            sum: 0.0,
-            sum_squares: 0.0,
-            numeric_count: 0,
+            numeric: NumericAccumulator::new(),
             min_length: usize::MAX,
             max_length: 0,
             total_length: 0,
@@ -691,7 +683,7 @@ impl ColumnAnalyzer {
                 // Match the textual/ad-hoc paths: NaN is a null-like value,
                 // while infinities are present but invalid numeric values.
                 // Neither may enter the exact accumulators — one non-finite
-                // value would otherwise poison sum/sum_squares and serialize
+                // value would otherwise poison the running sum and serialize
                 // as plausible zero variance with a missing mean.
                 if value.is_nan() {
                     self.null_count += 1;
@@ -1122,44 +1114,20 @@ impl ColumnAnalyzer {
 
     fn update_numeric_stats(&mut self, value: f64) {
         debug_assert!(value.is_finite());
-        self.sum += value;
-        self.sum_squares += value * value;
-        self.numeric_count += 1;
-
-        self.min_value = Some(match self.min_value {
-            Some(min_value) => min_value.min(value),
-            None => value,
-        });
-
-        self.max_value = Some(match self.max_value {
-            Some(max_value) => max_value.max(value),
-            None => value,
-        });
+        self.numeric.update(value);
     }
 
     /// Exact aggregates over every numeric value processed, independent of the
     /// bounded reservoir sample. `None` when the column saw no numeric values.
     fn exact_numeric_aggregates(&self) -> Option<ExactNumericAggregates> {
-        let (min, max) = (self.min_value?, self.max_value?);
-        if self.numeric_count == 0 {
-            return None;
-        }
-        let mean = self.sum / self.numeric_count as f64;
-        // Clamp: sum-of-squares variance can go slightly negative from
-        // floating-point cancellation.
-        let variance = dataprof_metrics::stats::numeric::calculate_variance(
-            self.sum_squares,
-            self.sum,
-            self.numeric_count,
-        )
-        .max(0.0);
+        let (min, max) = (self.numeric.min()?, self.numeric.max()?);
         Some(ExactNumericAggregates {
             min,
             max,
-            mean,
-            std_dev: variance.sqrt(),
-            variance,
-            count: self.numeric_count,
+            mean: self.numeric.mean(),
+            std_dev: self.numeric.sample_std_dev(),
+            variance: self.numeric.sample_variance(),
+            count: self.numeric.count() as usize,
         })
     }
 

--- a/crates/dataprof-runtime/src/lib.rs
+++ b/crates/dataprof-runtime/src/lib.rs
@@ -25,5 +25,5 @@ pub use profile_report::{ProfileReport, REPORT_SCHEMA_VERSION};
 pub use report_assembler::ReportAssembler;
 pub use streaming_stats::{
     RowCompletenessTracker, RowSignature, RowUniquenessTracker, StreamReservoirSampler,
-    StreamingColumnCollection, StreamingStatistics, TextLengthStats, WelfordAccumulator,
+    StreamingColumnCollection, StreamingStatistics, TextLengthStats,
 };

--- a/crates/dataprof-runtime/src/streaming_stats.rs
+++ b/crates/dataprof-runtime/src/streaming_stats.rs
@@ -7,109 +7,20 @@ use crate::{ValueHintBindingAccumulator, profile_builder::infer_data_type_stream
 use dataprof_core::{SemanticHintBinding, SemanticHintKind, SemanticHints, char_len};
 use dataprof_metrics::analysis::inference::is_null_like_token;
 use dataprof_metrics::{
-    CardinalityEstimator, HyperLogLog, RowCompletenessSummary, RowDuplicateSummary,
-    value_matches_hint,
+    CardinalityEstimator, HyperLogLog, NumericAccumulator, RowCompletenessSummary,
+    RowDuplicateSummary, value_matches_hint,
 };
 
 /// Incremental statistics computation for streaming data processing.
 ///
 /// This module provides bounded-memory statistical computation using:
-/// - **Welford's algorithm** for numerically stable variance/stddev (O(1) memory)
+/// - **[`NumericAccumulator`]** for numerically stable mean/variance/stddev
+///   (O(1) memory), shared with the batch paths so every engine reports the
+///   same numbers
 /// - **HyperLogLog** for approximate distinct counts (~16 KB fixed registers)
 /// - **Reservoir sampling** for unbiased samples (fixed capacity; total memory
 ///   depends on the capacity and the length of sampled strings)
 /// - **Streaming text-length tracking** with min/max/mean/histogram (O(1) memory)
-
-#[derive(Debug, Clone)]
-pub struct WelfordAccumulator {
-    count: u64,
-    mean: f64,
-    m2: f64,
-}
-
-impl WelfordAccumulator {
-    pub fn new() -> Self {
-        Self {
-            count: 0,
-            mean: 0.0,
-            m2: 0.0,
-        }
-    }
-
-    #[inline]
-    pub fn update(&mut self, value: f64) {
-        self.count += 1;
-        let delta = value - self.mean;
-        self.mean += delta / self.count as f64;
-        let delta2 = value - self.mean;
-        self.m2 += delta * delta2;
-    }
-
-    #[inline]
-    pub fn mean(&self) -> f64 {
-        if self.count == 0 { 0.0 } else { self.mean }
-    }
-
-    /// Number of values folded into this accumulator.
-    #[inline]
-    pub fn count(&self) -> u64 {
-        self.count
-    }
-
-    pub fn variance(&self) -> f64 {
-        if self.count < 2 {
-            0.0
-        } else {
-            self.m2 / self.count as f64
-        }
-    }
-
-    pub fn std_dev(&self) -> f64 {
-        self.variance().sqrt()
-    }
-
-    /// Unbiased sample variance (n-1 denominator), matching the convention of
-    /// the batch numeric stats in `dataprof-metrics`.
-    pub fn sample_variance(&self) -> f64 {
-        if self.count < 2 {
-            0.0
-        } else {
-            (self.m2 / (self.count - 1) as f64).max(0.0)
-        }
-    }
-
-    /// Standard deviation derived from [`Self::sample_variance`].
-    pub fn sample_std_dev(&self) -> f64 {
-        self.sample_variance().sqrt()
-    }
-
-    pub fn merge(&mut self, other: &WelfordAccumulator) {
-        if other.count == 0 {
-            return;
-        }
-        if self.count == 0 {
-            *self = other.clone();
-            return;
-        }
-
-        let combined_count = self.count + other.count;
-        let delta = other.mean - self.mean;
-        let new_mean = self.mean + delta * (other.count as f64 / combined_count as f64);
-        let new_m2 = self.m2
-            + other.m2
-            + delta * delta * (self.count as f64 * other.count as f64 / combined_count as f64);
-
-        self.count = combined_count;
-        self.mean = new_mean;
-        self.m2 = new_m2;
-    }
-}
-
-impl Default for WelfordAccumulator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct StreamReservoirSampler {
@@ -258,7 +169,7 @@ pub struct TextLengthStats {
     pub min_length: usize,
     pub max_length: usize,
     pub avg_length: f64,
-    welford: WelfordAccumulator,
+    welford: NumericAccumulator,
     histogram: [u64; 32],
 }
 
@@ -268,7 +179,7 @@ impl TextLengthStats {
             min_length: usize::MAX,
             max_length: 0,
             avg_length: 0.0,
-            welford: WelfordAccumulator::new(),
+            welford: NumericAccumulator::new(),
             histogram: [0u64; 32],
         }
     }
@@ -288,10 +199,10 @@ impl TextLengthStats {
     }
 
     pub fn merge(&mut self, other: &TextLengthStats) {
-        if other.welford.count == 0 {
+        if other.welford.count() == 0 {
             return;
         }
-        if self.welford.count == 0 {
+        if self.welford.count() == 0 {
             *self = other.clone();
             return;
         }
@@ -311,7 +222,7 @@ impl TextLengthStats {
             min_length: 0,
             max_length: 0,
             avg_length: 0.0,
-            welford: WelfordAccumulator::new(),
+            welford: NumericAccumulator::new(),
             histogram: [0u64; 32],
         }
     }
@@ -329,7 +240,7 @@ pub struct StreamingStatistics {
     pub null_count: usize,
     pub min: f64,
     pub max: f64,
-    welford: WelfordAccumulator,
+    welford: NumericAccumulator,
     hll: HyperLogLog,
     sampler: StreamReservoirSampler,
     text_length_tracker: TextLengthStats,
@@ -343,7 +254,7 @@ impl StreamingStatistics {
             null_count: 0,
             min: f64::INFINITY,
             max: f64::NEG_INFINITY,
-            welford: WelfordAccumulator::new(),
+            welford: NumericAccumulator::new(),
             hll: HyperLogLog::new(),
             sampler: StreamReservoirSampler::new(10_000),
             text_length_tracker: TextLengthStats::new(),
@@ -409,11 +320,11 @@ impl StreamingStatistics {
     }
 
     pub fn variance(&self) -> f64 {
-        self.welford.variance()
+        self.welford.population_variance()
     }
 
     pub fn std_dev(&self) -> f64 {
-        self.welford.std_dev()
+        self.welford.population_std_dev()
     }
 
     pub fn unique_count(&self) -> usize {
@@ -460,7 +371,7 @@ impl StreamingStatistics {
     }
 
     pub fn text_length_stats(&self) -> TextLengthStats {
-        if self.text_length_tracker.welford.count == 0 {
+        if self.text_length_tracker.welford.count() == 0 {
             return TextLengthStats::empty();
         }
         self.text_length_tracker.clone()
@@ -1561,21 +1472,21 @@ mod tests {
 
     #[test]
     fn test_welford_accuracy() {
-        let mut accumulator = WelfordAccumulator::new();
+        let mut accumulator = NumericAccumulator::new();
         for value in 1..=1000 {
             accumulator.update(value as f64);
         }
         let expected_mean = 500.5;
         let expected_variance = (1000.0 * 1000.0 - 1.0) / 12.0;
         assert!((accumulator.mean() - expected_mean).abs() < 1e-6);
-        assert!((accumulator.variance() - expected_variance).abs() < 1.0);
+        assert!((accumulator.population_variance() - expected_variance).abs() < 1.0);
     }
 
     #[test]
     fn test_welford_merge() {
-        let mut left = WelfordAccumulator::new();
-        let mut right = WelfordAccumulator::new();
-        let mut full = WelfordAccumulator::new();
+        let mut left = NumericAccumulator::new();
+        let mut right = NumericAccumulator::new();
+        let mut full = NumericAccumulator::new();
 
         for value in 1..=500 {
             left.update(value as f64);
@@ -1588,7 +1499,7 @@ mod tests {
 
         left.merge(&right);
         assert!((left.mean() - full.mean()).abs() < 1e-10);
-        assert!((left.variance() - full.variance()).abs() < 1e-6);
+        assert!((left.population_variance() - full.population_variance()).abs() < 1e-6);
     }
 
     #[test]

--- a/python/tests/test_numeric_stability.py
+++ b/python/tests/test_numeric_stability.py
@@ -1,0 +1,159 @@
+"""Numeric aggregates must be numerically stable on every route (#670, #671).
+
+Two failures found in a 221-profile dogfooding matrix, both of which survive
+report rounding and read as ordinary numbers:
+
+* a variance computed as ``sum_squares - n * mean**2`` cancels away the spread
+  of a column sitting on a large offset — four consecutive integers near 1e9
+  came back with a variance of exactly 0.0, describing a varying column as
+  constant, and near 1e8 with a variance 60% too large;
+* a naive running sum drops a small contribution between large values that
+  cancel (the mean of ``[1e16, 1.0, -1e16]`` came back 0.0 instead of 1/3) and
+  overflows where the mean itself is representable.
+
+Six routes disagreed with the batch reference, so every case runs over all of
+them and over the serialized report as well as the attribute.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+
+import pytest
+
+try:
+    import dataprof as dp
+except ImportError:
+    pytest.skip(
+        "dataprof native extension not built. Run: maturin develop --features python",
+        allow_module_level=True,
+    )
+
+from dataprof.asyncio import _HAS_ASYNC
+
+ROUTES = ("dict", "csv", "columnar", "json", "jsonl", "bytes", "async", "arrow", "parquet")
+
+
+def _profile(route, values, tmp_path):
+    """Profile a one-column dataset of ``values`` through one input route."""
+    text = "\n".join(repr(value) for value in values)
+
+    if route == "dict":
+        return dp.profile({"x": list(values)})
+    if route in ("csv", "columnar"):
+        path = tmp_path / "values.csv"
+        path.write_text(f"x\n{text}\n", encoding="utf-8")
+        return dp.profile(path, engine="columnar" if route == "columnar" else "incremental")
+    if route == "json":
+        path = tmp_path / "values.json"
+        path.write_text(json.dumps([{"x": value} for value in values]), encoding="utf-8")
+        return dp.profile(path)
+    if route == "jsonl":
+        path = tmp_path / "values.jsonl"
+        path.write_text(
+            "\n".join(json.dumps({"x": value}) for value in values) + "\n", encoding="utf-8"
+        )
+        return dp.profile(path)
+    if route == "bytes":
+        return dp.profile(f"x\n{text}\n".encode(), format="csv")
+    if route == "async":
+        if not _HAS_ASYNC:
+            pytest.skip(
+                "async streaming not compiled: build with --features "
+                "'python,python-async,async-streaming'"
+            )
+        return asyncio.run(dp.asyncio.profile_bytes(f"x\n{text}\n".encode(), format="csv"))
+
+    pa = pytest.importorskip("pyarrow")
+    table = pa.table({"x": [float(value) for value in values]})
+    if route == "arrow":
+        return dp.profile(table)
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "values.parquet"
+    pq.write_table(table, path)
+    return dp.profile(path)
+
+
+def _stats(report):
+    """The column as an attribute and as the report serializes it."""
+    return report["x"], report.to_dict()["columns"][0]["stats"]
+
+
+@pytest.mark.parametrize("route", ROUTES)
+@pytest.mark.parametrize("base", [1e6, 1e8, 1e9, 1e12])
+def test_variance_survives_a_large_offset(tmp_path, route, base):
+    values = [base + offset for offset in range(4)]
+    expected = statistics.variance(values)
+    assert expected == pytest.approx(5 / 3)
+
+    column, serialized = _stats(_profile(route, values, tmp_path))
+
+    # Equality, not a tolerance: a stable accumulation of four values reaches
+    # the correctly rounded answer, and every route here does.
+    assert column.variance == expected
+    assert column.std_dev == expected**0.5
+    assert column.mean == base + 1.5
+    # Rounding does not rescue this: 0.0 and 2.6667 round to themselves.
+    assert serialized["variance"] == 1.6667
+    assert serialized["std_dev"] == round(expected**0.5, 4)
+
+
+@pytest.mark.parametrize("route", ROUTES)
+def test_a_constant_column_still_reports_no_spread(tmp_path, route):
+    """The half a stability fix can get wrong: inventing spread out of noise."""
+    column, serialized = _stats(_profile(route, [1e9] * 4, tmp_path))
+
+    assert column.variance == 0.0
+    assert column.std_dev == 0.0
+    assert column.mean == 1e9
+    assert serialized["variance"] == 0.0
+    assert serialized["std_dev"] == 0.0
+
+
+@pytest.mark.parametrize("route", ROUTES)
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1e16, 1.0, -1e16],
+        [1e16, -1e16, 1.0],
+        [-1e16, 1.0, 1e16],
+    ],
+)
+def test_mean_survives_cancelling_values(tmp_path, route, values):
+    """Permutations matter: which value is dropped depends on the order."""
+    expected = statistics.mean(values)
+    assert expected == pytest.approx(1 / 3)
+
+    column, serialized = _stats(_profile(route, values, tmp_path))
+
+    assert column.mean == expected
+    assert serialized["mean"] == 0.3333
+
+
+@pytest.mark.parametrize("route", ROUTES)
+def test_mean_stays_finite_when_the_naive_sum_overflows(tmp_path, route):
+    """The mean of two 1e308 values is representable; their sum is not."""
+    column, serialized = _stats(_profile(route, [1e308, 1e308], tmp_path))
+
+    assert column.mean == 1e308
+    # An infinite mean did not serialize at all, so the field went missing.
+    assert serialized["mean"] == 1e308
+
+
+@pytest.mark.parametrize("route", ROUTES)
+def test_stability_holds_past_the_simd_threshold(tmp_path, route):
+    """Long enough to reach the four-lane accumulation, on a large offset."""
+    values = [1e9 + (index % 4) for index in range(1000)]
+    expected = statistics.variance(values)
+
+    column, serialized = _stats(_profile(route, values, tmp_path))
+
+    # Relative here, not exact: over a thousand values a running accumulation
+    # drifts about 1e-10 relative at this offset. That is still five orders
+    # tighter than the failure — the columnar engine reported 4985.7 for this
+    # column, and the batch path 0.0 at a slightly larger offset.
+    assert column.variance == pytest.approx(expected, rel=1e-9)
+    assert column.mean == pytest.approx(1e9 + 1.5, rel=1e-15)
+    assert serialized["variance"] == pytest.approx(round(expected, 4), abs=1e-4)

--- a/tests/numeric_stability.rs
+++ b/tests/numeric_stability.rs
@@ -1,0 +1,285 @@
+//! Numeric aggregates stay stable on every engine (#670, #671).
+//!
+//! Two failures found in a dogfooding matrix. Both survive report rounding and
+//! both read as ordinary numbers, which is what makes them dangerous:
+//!
+//! * `sum_squares - n * mean²` cancels away the spread of a column sitting on
+//!   a large offset. Four consecutive integers near 1e9 were reported with a
+//!   variance of exactly 0.0 — a varying column described as constant — and
+//!   near 1e8 with a variance 60% too large.
+//! * A naive running sum drops a small contribution between large values that
+//!   cancel (the mean of `[1e16, 1.0, -1e16]` came back as 0.0 instead of 1/3)
+//!   and overflows where the mean itself is representable (`[1e308, 1e308]`
+//!   gave `inf`, which then vanished from the serialized report).
+//!
+//! The engines disagreed with each other on these inputs, so every assertion
+//! runs over all of them plus the serialized report.
+
+use std::io::Write;
+
+use dataprof::{
+    ColumnStats, CsvParserConfig, EngineType, NumericStats, Profiler, analyze_csv_file,
+};
+use serde_json::Value;
+use tempfile::NamedTempFile;
+
+/// Sample variance of four consecutive integers, at any offset.
+const CONSECUTIVE_FOUR_VARIANCE: f64 = 5.0 / 3.0;
+
+fn csv_with(values: &[f64]) -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".csv").unwrap();
+    writeln!(file, "x").unwrap();
+    for value in values {
+        writeln!(file, "{value}").unwrap();
+    }
+    file.flush().unwrap();
+    file
+}
+
+/// The numeric stats every CSV engine reports for `values`, each paired with
+/// the same column as the report serializes it.
+fn stats_per_engine(values: &[f64]) -> Vec<(&'static str, NumericStats, Value)> {
+    let file = csv_with(values);
+    let path = file.path();
+
+    let reports = vec![
+        (
+            "standard",
+            analyze_csv_file(path, &CsvParserConfig::default()).expect("standard analysis"),
+        ),
+        (
+            "auto",
+            Profiler::new()
+                .engine(EngineType::Auto)
+                .analyze_file(path)
+                .expect("auto analysis"),
+        ),
+        (
+            "incremental",
+            Profiler::new()
+                .engine(EngineType::Incremental)
+                .analyze_file(path)
+                .expect("incremental analysis"),
+        ),
+        (
+            "columnar",
+            Profiler::new()
+                .engine(EngineType::Columnar)
+                .analyze_file(path)
+                .expect("columnar analysis"),
+        ),
+    ];
+
+    reports
+        .into_iter()
+        .map(|(engine, report)| {
+            let serialized = serde_json::to_value(&report).expect("report serializes");
+            let column = serialized["column_profiles"][0]["stats"]["Numeric"].clone();
+            let profile = report
+                .column_profiles
+                .into_iter()
+                .next()
+                .expect("one column");
+            match profile.stats {
+                ColumnStats::Numeric(stats) => (engine, stats, column),
+                other => panic!("{engine} reported {other:?} for a numeric column"),
+            }
+        })
+        .collect()
+}
+
+#[track_caller]
+fn assert_close(engine: &str, field: &str, actual: f64, expected: f64, tolerance: f64) {
+    assert!(
+        (actual - expected).abs() <= tolerance,
+        "{engine} reported {field} {actual}, expected {expected} (tolerance {tolerance})"
+    );
+}
+
+/// Equality, not a tolerance: a stable accumulation of four values reaches the
+/// correctly rounded answer, and every engine here does. A tolerance would let
+/// a path drift without saying so.
+#[track_caller]
+fn assert_exact(engine: &str, field: &str, actual: f64, expected: f64) {
+    assert_eq!(actual, expected, "{engine} reported {field} {actual}");
+}
+
+/// The serialized value, which is rounded and therefore what a quality gate
+/// reading a report actually sees.
+#[track_caller]
+fn serialized(column: &Value, field: &str, engine: &str) -> f64 {
+    column[field]
+        .as_f64()
+        .unwrap_or_else(|| panic!("{engine} serialized {field} as {}", column[field]))
+}
+
+#[test]
+fn variance_survives_a_large_offset_on_every_engine() {
+    for base in [1e6, 1e8, 1e9, 1e12] {
+        let values: Vec<f64> = (0..4).map(|i| base + i as f64).collect();
+        for (engine, stats, column) in stats_per_engine(&values) {
+            let engine = &format!("{engine} at offset {base}");
+            assert_exact(engine, "mean", stats.mean, base + 1.5);
+            assert_exact(
+                engine,
+                "variance",
+                stats.variance,
+                CONSECUTIVE_FOUR_VARIANCE,
+            );
+            assert_exact(
+                engine,
+                "std_dev",
+                stats.std_dev,
+                CONSECUTIVE_FOUR_VARIANCE.sqrt(),
+            );
+            // Rounding cannot rescue this: 0.0 and 2.6667 round to themselves.
+            assert_exact(
+                engine,
+                "serialized variance",
+                serialized(&column, "variance", engine),
+                1.6667,
+            );
+        }
+    }
+}
+
+/// A genuinely constant column must still report zero variance — the half a
+/// stability fix could get wrong by inventing spread out of rounding noise.
+#[test]
+fn a_constant_column_still_reports_zero_variance() {
+    for value in [0.0, 1.0, 1e9] {
+        for (engine, stats, column) in stats_per_engine(&[value; 4]) {
+            assert_eq!(stats.variance, 0.0, "{engine} at value {value}");
+            assert_eq!(stats.std_dev, 0.0, "{engine} at value {value}");
+            assert_eq!(stats.mean, value, "{engine} at value {value}");
+            assert_eq!(
+                serialized(&column, "variance", engine),
+                0.0,
+                "{engine} at value {value}"
+            );
+        }
+    }
+}
+
+#[test]
+fn mean_survives_cancelling_values_in_any_order() {
+    // The unit contribution is what a naive sum drops; the order decides
+    // whether it is dropped, so both permutations run.
+    for values in [[1e16, 1.0, -1e16], [1e16, -1e16, 1.0]] {
+        for (engine, stats, column) in stats_per_engine(&values) {
+            let engine = &format!("{engine} on {values:?}");
+            assert_exact(engine, "mean", stats.mean, 1.0 / 3.0);
+            assert_exact(
+                engine,
+                "serialized mean",
+                serialized(&column, "mean", engine),
+                0.3333,
+            );
+        }
+    }
+}
+
+#[test]
+fn mean_stays_finite_when_the_naive_sum_overflows() {
+    for (engine, stats, column) in stats_per_engine(&[1e308, 1e308]) {
+        assert_eq!(stats.mean, 1e308, "{engine}");
+        assert_eq!(serialized(&column, "mean", engine), 1e308, "{engine}");
+    }
+}
+
+/// A column long enough to reach the SIMD accumulation, whose spread only
+/// survives if the lanes are as stable as the scalar path.
+#[test]
+fn stability_holds_past_the_simd_threshold() {
+    let values: Vec<f64> = (0..1_000).map(|i| 1e9 + (i % 4) as f64).collect();
+    let expected_variance = {
+        // Sample variance of 250 copies each of 0, 1, 2, 3.
+        let n = values.len() as f64;
+        let squared_deviation: f64 = (0..4).map(|i| 250.0 * (i as f64 - 1.5).powi(2)).sum();
+        squared_deviation / (n - 1.0)
+    };
+
+    for (engine, stats, column) in stats_per_engine(&values) {
+        assert_close(engine, "mean", stats.mean, 1e9 + 1.5, 1e-6);
+        assert_close(engine, "variance", stats.variance, expected_variance, 1e-6);
+        assert_close(
+            engine,
+            "serialized variance",
+            serialized(&column, "variance", engine),
+            expected_variance,
+            1e-4,
+        );
+    }
+}
+
+#[cfg(feature = "parquet")]
+mod parquet_path {
+    use std::sync::Arc;
+
+    use arrow::array::Float64Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use dataprof::{ColumnStats, NumericStats, Profiler};
+    use parquet::arrow::ArrowWriter;
+    use tempfile::NamedTempFile;
+
+    /// One batch per chunk: the accumulators are merged across batches, so a
+    /// merge that loses stability shows up here and not in a single-batch file.
+    fn parquet_stats(values: &[f64], batch_size: usize) -> NumericStats {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Float64, false)]));
+        let file = NamedTempFile::with_suffix(".parquet").unwrap();
+        let mut writer =
+            ArrowWriter::try_new(file.reopen().unwrap(), schema.clone(), None).unwrap();
+        for batch in values.chunks(batch_size) {
+            let array = Float64Array::from(batch.to_vec());
+            writer
+                .write(&RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap())
+                .unwrap();
+        }
+        writer.close().unwrap();
+
+        let report = Profiler::new()
+            .analyze_file(file.path())
+            .expect("parquet analysis");
+        match report.column_profiles.into_iter().next().unwrap().stats {
+            ColumnStats::Numeric(stats) => stats,
+            other => panic!("parquet reported {other:?} for a numeric column"),
+        }
+    }
+
+    #[test]
+    fn parquet_aggregates_are_stable_across_row_groups() {
+        let values: Vec<f64> = (0..400).map(|i| 1e9 + (i % 4) as f64).collect();
+        let expected_variance = {
+            let squared_deviation: f64 = (0..4).map(|i| 100.0 * (i as f64 - 1.5).powi(2)).sum();
+            squared_deviation / (values.len() as f64 - 1.0)
+        };
+
+        for batch_size in [400, 64, 7] {
+            let stats = parquet_stats(&values, batch_size);
+            assert!(
+                (stats.mean - (1e9 + 1.5)).abs() < 1e-6,
+                "batch size {batch_size} reported mean {}",
+                stats.mean
+            );
+            assert!(
+                (stats.variance - expected_variance).abs() < 1e-6,
+                "batch size {batch_size} reported variance {}",
+                stats.variance
+            );
+        }
+    }
+
+    #[test]
+    fn parquet_mean_survives_cancellation_and_overflow() {
+        let cancelling = parquet_stats(&[1e16, 1.0, -1e16], 3);
+        assert!(
+            (cancelling.mean - 1.0 / 3.0).abs() < 1e-9,
+            "reported mean {}",
+            cancelling.mean
+        );
+
+        let overflowing = parquet_stats(&[1e308, 1e308], 1);
+        assert_eq!(overflowing.mean, 1e308);
+    }
+}


### PR DESCRIPTION
## What changed

Numeric aggregates are computed with one shared, numerically stable accumulator
instead of a naive `sum` / `sum_squares` pair, so a column's variance and mean
are right on data that is perfectly ordinary — values sitting on a large offset,
or large values that cancel.

Both failures survived report rounding and read as plausible numbers, which is
the worst bug class for a profiler: a quality gate reading `variance` got 0.0
for a varying column, and a missing `mean` where the mean was representable.

| Input | Expected | Before | After |
| --- | --- | --- | --- |
| `[1e9, 1e9+1, 1e9+2, 1e9+3]` | variance `1.6667` | `0.0` | `1.6667` |
| `[1e8, 1e8+1, 1e8+2, 1e8+3]` | variance `1.6667` | `2.6667` | `1.6667` |
| `[1e16, 1.0, -1e16]` | mean `1/3` | `0.0` | `1/3` |
| `[1e308, 1e308]` | mean `1e308` | `inf`, omitted from the report | `1e308` |

`NumericAccumulator` (`crates/dataprof-metrics/src/stats/accumulator.rs`) carries
two accumulations because neither alone is enough:

- **Welford's mean and M2** for a translation-invariant variance.
  `sum_squares - n * mean²` loses every digit of a small spread on a large
  offset.
- **A Knuth two-sum compensated running sum** for a mean that survives
  cancellation. Welford's running mean rounds `[1e16, 1.0, -1e16]` to 0.0 on its
  own, so the previous "fall back to Welford when the variance looks wrong"
  guard could not have fixed the mean either.

The compensated sum can still overflow where the mean is representable, so
`mean()` falls back to the running mean whenever the sum is not finite. `merge()`
combines accumulators over disjoint parts of a column, so chunked, batched and
SIMD-lane accumulation report what a single pass would.

Every path shares it now — the batch path used by in-memory sources, the SIMD
lanes (which accumulate four independent lane accumulators and merge them, in
place of a vectorized naive sum), both Arrow analyzers, and the streaming
statistics, whose separate Welford implementation this replaces. The naive
`calculate_variance` helper is deleted rather than left in place as a trap.

**Related issues:** Closes #670, closes #671.

## How it was verified

New tests, in three layers because the paths diverge:

- `crates/dataprof-metrics/src/stats/accumulator.rs` — unit tests for the
  accumulator itself, including merge-versus-single-pass.
- `crates/dataprof-metrics/src/stats/numeric.rs::batch_stats_are_numerically_stable`
  — the batch path, which is the whole answer for an in-memory source (no engine
  supplies exact stream aggregates to override it).
- `tests/numeric_stability.rs` — the four CSV engines and Parquet across row
  groups, asserting the serialized report as well as the attribute.
- `python/tests/test_numeric_stability.py` — 90 cases over nine input routes:
  dict, CSV (incremental), columnar, JSON, JSONL, bytes, async bytes, Arrow and
  Parquet.

Each asserts equality rather than a tolerance wherever the data allows it: four
values accumulate to the correctly rounded answer on every route, so a tolerance
would let a path drift silently. The one exception is the 1000-value case, where
a running accumulation drifts ~1e-10 relative and the test says so.

Every case also has its opposite: `a_constant_column_still_reports_zero_variance`
pins that a genuinely constant column still reports exactly 0.0, which is the
half a stability fix can get wrong by inventing spread out of rounding noise.

```console
$ cargo test --workspace --all-features
test result: ok. 271 passed; 0 failed   # dataprof-metrics lib
test result: ok. 7 passed; 0 failed     # tests/numeric_stability.rs
... 43 further suites, all ok (45 "test result: ok", none failed)

$ uv run maturin develop --features "python,python-async,async-streaming"
$ uv run pytest python/tests/test_numeric_stability.py -q
90 passed in 1.17s

$ cargo fmt --all
$ cargo clippy --all --all-targets --all-features -- -D warnings
   Finished (no warnings)
$ uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
56 files left unchanged
$ uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
All checks passed!
$ uv run ty check python/
All checks passed!
```

### Reverting each part separately

The fix touches three accumulation sites, and reverting them together would only
prove the tests catch *something*. Each was reverted on its own, against the
final assertions:

**1. The batch path** (`compute_numeric_stats` back to `sum_squares`):

```console
$ cargo test -p dataprof-metrics --lib batch_stats_are_numerically_stable
assertion `left == right` failed: offset 100000000
  left: 2.6666666666666665
 right: 1.6666666666666667
test result: FAILED. 0 passed; 1 failed
```

**2. The Arrow analyzers** (both files back to their pre-fix versions):

```console
$ cargo test --test numeric_stability --all-features
assertion `left == right` failed: columnar at offset 100000000 reported variance 2.6666666666666665
  left: 2.6666666666666665
 right: 1.6666666666666667
assertion `left == right` failed: columnar on [1e16, 1.0, -1e16] reported mean 0
  left: 0.0
 right: 0.3333333333333333
assertion `left == right` failed: columnar
  left: inf
 right: 1e308
test result: FAILED. 1 passed; 6 failed
```

**3. The streaming accumulator** (`WelfordAccumulator` restored):

```console
$ cargo test --test numeric_stability --all-features
assertion `left == right` failed: standard on [1e16, 1.0, -1e16] reported mean 0
  left: 0.0
 right: 0.3333333333333333
test result: FAILED. 6 passed; 1 failed
```

**4. The whole tree at once, for the Python suite.** The Rust reverts above run
in-tree; the Python routes need a rebuilt extension, so the pre-fix commit was
built in a separate worktree with only the new test file copied in:

```console
$ git worktree add <tmp> HEAD~1   # 148fbaf, before this branch
$ uv run maturin develop --features "python,python-async,async-streaming"
$ uv run pytest python/tests/test_numeric_stability.py -q
E       AssertionError: assert 2.6666666666666665 == 1.6666666666666667
E       AssertionError: assert 0.0 == 1.6666666666666667
E       AssertionError: assert 0.0 == 0.3333333333333333
39 failed, 51 passed in 10.34s
```

All nine routes fail at least twice: parquet, columnar and arrow 7 each, dict
and bytes 5, csv/json/jsonl/async 2 each. The 51 that pass are the constant-column
guard on every route plus the low-offset cases, where the naive sum of squares
stays under 2^53 and happens to be exact — which is why the parametrization
sweeps four offsets rather than picking one.

Note what part 3 does *not* discriminate: the streaming path already used
Welford, so its variance was correct before and after. Only its mean changes,
and only under cancellation. The `a_constant_column_still_reports_zero_variance`
guard passes in all three reverted states by design — it exists to catch the
opposite failure.

## What the review pass changed

A self-review of the same diff before it was committed, and two follow-up
commits after Copilot's review:

- A `debug_assert!(value.is_finite())` added to the Arrow profiler asserted an
  invariant the caller does not enforce — unlike the Parquet analyzer, its
  float arms do not filter non-finite values — so it was removed rather than
  left as a new debug-build panic path. Probes with `inf`, `1e400`, `NaN` and
  null slots through the columnar engine all return correct numbers today, so
  this is an inconsistency between the two analyzers, not a reachable defect.
- The assertions were weaker than the data allows. Four values reach the
  correctly rounded answer on every route, so the tolerances became equality;
  only the 1000-value case keeps a relative one.
- `is_empty` on the accumulator, and `sum_simd` / `min_max_simd` /
  `dot_product_simd` in the acceleration module, had no callers left. The three
  SIMD helpers each accumulated a naive sum, so keeping them would leave exactly
  the shape of this bug available to reach for.

## Anything reviewers should know

- **Breaking change (internal crates only):** `dataprof_metrics::stats::numeric::calculate_variance`,
  the `SimdStats` struct and the three unused SIMD helpers are gone, and
  `dataprof_runtime::WelfordAccumulator` is replaced by
  `dataprof_metrics::NumericAccumulator`. None is re-exported from the `dataprof`
  facade or reachable from Python, so the public surface is unchanged, and
  0.11 -> 0.12 is a breaking-allowed bump for a 0.x crate. Shims were considered
  and rejected: `calculate_variance(sum_squares, sum, count)` has no stable
  implementation to forward to — its parameters *are* the unstable algorithm —
  and a `WelfordAccumulator` alias would not be source-compatible, since
  `variance()` returned the population value that is now named
  `population_variance()`.
- **No schema change:** the same fields with the same types; only the values are
  now correct. `docs/schema/` needs no regeneration.
- The SIMD path keeps its acceleration: four `f64x4` lanes each run the same
  recurrences and are merged with Chan's parallel form, rather than dropping to
  a scalar loop.
