### PR TITLE
fix(python): document supported engine aliases

### DIFF
--- a/crates/dataprof-python/src/config.rs
+++ b/crates/dataprof-python/src/config.rs
@@ -364,7 +364,7 @@ fn parse_engine(s: &str) -> PyResult<EngineType> {
         "incremental" | "streaming" => Ok(EngineType::Incremental),
         "columnar" | "arrow" => Ok(EngineType::Columnar),
         _ => Err(PyValueError::new_err(format!(
-            "Unknown engine '{}'. Valid: auto, incremental, columnar",
+            "Unknown engine '{}'. Valid: auto, incremental (alias: streaming), columnar (alias: arrow)",
             s
         ))),
     }

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -109,6 +109,14 @@ dp.profile(
 ) -> ProfileReport
 ```
 
+For file profiling, `engine` accepts the case-insensitive names `auto`,
+`incremental` (compatibility alias: `streaming`), and `columnar` (compatibility
+alias: `arrow`). This applies to `dp.profile(..., engine=...)`,
+`dp.profile_file(..., engine=...)`, and `dp.Profiler().engine(...).profile(...)`.
+CSV reports use the selected canonical name, `incremental` or `columnar`, in
+`report.engine` and `report.to_dict()["execution"]["engine"]`; aliases are never
+emitted, and `auto` reports the engine it selected.
+
 **Source types:**
 
 | Type | Description |

--- a/python/dataprof/__init__.py
+++ b/python/dataprof/__init__.py
@@ -1187,7 +1187,10 @@ def profile_file(
 
     Args:
         path: File path to profile.
-        engine: Engine to use ("auto", "incremental", "columnar").
+        engine: File profiling engine ("auto", "incremental", "columnar").
+            "streaming" aliases "incremental"; "arrow" aliases "columnar".
+            Names are case-insensitive. CSV execution metadata reports the
+            selected canonical engine ("incremental" or "columnar").
         chunk_size: Bytes to read per streaming chunk (None = adaptive).
             Bounds the working set and the granularity at which progress
             and stop conditions are evaluated; it never changes the
@@ -1316,7 +1319,10 @@ def profile(
 
     Args:
         source: Data source to profile.
-        engine: Engine to use ("auto", "incremental", "columnar").
+        engine: File profiling engine ("auto", "incremental", "columnar").
+            "streaming" aliases "incremental"; "arrow" aliases "columnar".
+            Names are case-insensitive. CSV execution metadata reports the
+            selected canonical engine ("incremental" or "columnar").
         chunk_size: Bytes to read per streaming chunk (None = adaptive).
             Bounds the working set and the granularity at which progress
             and stop conditions are evaluated; it never changes the
@@ -1666,7 +1672,12 @@ class Profiler:
         self._kwargs: dict[str, _Any] = {}
 
     def engine(self, engine: str) -> Profiler:
-        """Set profiling engine ("auto", "incremental", "columnar")."""
+        """Set file profiling engine ("auto", "incremental", "columnar").
+
+        "streaming" aliases "incremental"; "arrow" aliases "columnar".
+        Names are case-insensitive. CSV execution metadata reports the selected
+        canonical engine ("incremental" or "columnar").
+        """
         self._kwargs["engine"] = engine
         return self
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1680,13 +1680,15 @@ class TestProfilerConfig:
 
     @pytest.mark.parametrize("entry_point", ["profile", "profile_file", "builder"])
     @pytest.mark.parametrize("engine", ["auto", "incremental", "streaming", "columnar", "arrow"])
-    def test_engine_spellings_profile_csv(self, tmp_path, entry_point, engine):
+    @pytest.mark.parametrize("uppercase", [False, True], ids=["lowercase", "uppercase"])
+    def test_engine_spellings_profile_csv(self, tmp_path, entry_point, engine, uppercase):
         path = tmp_path / "values.csv"
         path.write_text("value\n1\n2\n3\n", encoding="utf-8")
+        spelling = engine.upper() if uppercase else engine
         if entry_point == "builder":
-            report = dataprof.Profiler().engine(engine).profile(path)
+            report = dataprof.Profiler().engine(spelling).profile(path)
         else:
-            report = getattr(dataprof, entry_point)(path, engine=engine)
+            report = getattr(dataprof, entry_point)(path, engine=spelling)
 
         assert report.rows == 3
         canonical = {"streaming": "incremental", "arrow": "columnar"}.get(engine, engine)

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1663,9 +1663,38 @@ class TestProfilerConfig:
         assert cfg.chunk_size is None
         assert cfg.max_rows is None
 
-    def test_engine_override(self):
-        cfg = dataprof.ProfilerConfig(engine="incremental")
-        assert cfg.engine == "incremental"
+    @pytest.mark.parametrize(
+        ("engine", "canonical"),
+        [
+            ("auto", "auto"),
+            ("incremental", "incremental"),
+            ("streaming", "incremental"),
+            ("columnar", "columnar"),
+            ("arrow", "columnar"),
+        ],
+    )
+    def test_engine_override(self, engine, canonical):
+        for spelling in (engine, engine.upper()):
+            cfg = dataprof.ProfilerConfig(engine=spelling)
+            assert cfg.engine == canonical
+
+    @pytest.mark.parametrize("entry_point", ["profile", "profile_file", "builder"])
+    @pytest.mark.parametrize("engine", ["auto", "incremental", "streaming", "columnar", "arrow"])
+    def test_engine_spellings_profile_csv(self, tmp_path, entry_point, engine):
+        path = tmp_path / "values.csv"
+        path.write_text("value\n1\n2\n3\n", encoding="utf-8")
+        if entry_point == "builder":
+            report = dataprof.Profiler().engine(engine).profile(path)
+        else:
+            report = getattr(dataprof, entry_point)(path, engine=engine)
+
+        assert report.rows == 3
+        canonical = {"streaming": "incremental", "arrow": "columnar"}.get(engine, engine)
+        if canonical == "auto":
+            assert report.engine in {"incremental", "columnar"}
+        else:
+            assert report.engine == canonical
+        assert report.to_dict()["execution"]["engine"] == report.engine
 
     def test_semantic_hint_config(self):
         cfg = dataprof.ProfilerConfig(
@@ -1728,9 +1757,21 @@ class TestProfilerConfig:
         r = dataprof.profile(CSV_FILE, format="csv")
         assert r.rows > 0
 
-    def test_invalid_engine_raises(self):
-        with pytest.raises(ValueError):
-            dataprof.ProfilerConfig(engine="invalid")
+    @pytest.mark.parametrize("entry_point", ["config", "profile", "profile_file", "builder"])
+    def test_invalid_engine_raises(self, tmp_path, entry_point):
+        path = tmp_path / "values.csv"
+        path.write_text("value\n1\n", encoding="utf-8")
+        with pytest.raises(ValueError) as excinfo:
+            if entry_point == "config":
+                dataprof.ProfilerConfig(engine="invalid")
+            elif entry_point == "builder":
+                dataprof.Profiler().engine("invalid").profile(path)
+            else:
+                getattr(dataprof, entry_point)(path, engine="invalid")
+        assert str(excinfo.value) == (
+            "Unknown engine 'invalid'. Valid: auto, incremental (alias: streaming), "
+            "columnar (alias: arrow)"
+        )
 
     def test_max_rows_and_stop_condition_conflict(self):
         with pytest.raises(ValueError, match="Cannot specify both"):


### PR DESCRIPTION
## What changed

Python accepts `streaming` and `arrow` as compatibility aliases, but its invalid-engine error and API docs omitted them. List aliases beside their canonical engines in the diagnostic and document case-insensitive spellings and canonical CSV execution metadata for `profile()`, `profile_file()`, and the profiler builder.

Tests cover all five spellings in lowercase and uppercase through the public file-profiling entry points, configuration normalization, canonical report metadata, and the exact invalid-engine diagnostic.

**Related issue:** Closes #623

## How it was verified

- `uv run maturin develop` — rebuilt and installed the extension.
- `uv run pytest python/tests/ -q` — 1,243 passed, 9 skipped (database features and Windows symlink privileges).
- `uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/` — unchanged.
- `uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/` — passed.
- `uv run ty check python/` — passed.
- `cargo clippy --all --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

- `uv run pytest python/tests/test_python_api.py::TestProfilerConfig -q` — 46 passed, including uppercase names through all three entry points.

