### PR TITLE
fix: omit statistics when no values parsed

### DIFF
--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -117,7 +117,11 @@ fn analyze_column_with_options(
                         .saturating_sub(null_count)
                         .saturating_sub(parsed),
                 );
-                ColumnStats::Numeric(numeric)
+                if parsed == 0 {
+                    ColumnStats::None
+                } else {
+                    ColumnStats::Numeric(numeric)
+                }
             }
             DataType::Date => {
                 let parsed = data
@@ -146,16 +150,15 @@ fn analyze_column_with_options(
                     .filter(|v| parse_strict_boolean_token(v.trim()) == Some(false))
                     .count();
                 let total = tc + fc;
-                let true_ratio = if total > 0 {
-                    tc as f64 / total as f64
+                if total > 0 {
+                    ColumnStats::Boolean(crate::types::BooleanStats {
+                        true_count: tc,
+                        false_count: fc,
+                        true_ratio: tc as f64 / total as f64,
+                    })
                 } else {
-                    0.0
-                };
-                ColumnStats::Boolean(crate::types::BooleanStats {
-                    true_count: tc,
-                    false_count: fc,
-                    true_ratio,
-                })
+                    ColumnStats::None
+                }
             }
             DataType::String | DataType::Identifier => calculate_text_stats(data),
         }
@@ -202,6 +205,36 @@ fn analyze_column_with_options(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn non_finite_numeric_column_has_no_statistics() {
+        let data = ["Infinity", "-inf"].map(String::from);
+        let profile = analyze_column("v", &data);
+        assert_eq!(profile.data_type, DataType::Float);
+        assert_eq!(profile.total_count, 2);
+        assert_eq!(profile.null_count, 0);
+        assert_eq!(profile.invalid_count, Some(2));
+        assert!(matches!(profile.stats, ColumnStats::None));
+    }
+
+    #[test]
+    fn measured_zeros_survive_in_memory_analysis() {
+        let numeric = ["", "0", "0"].map(String::from);
+        let profile = analyze_column("n", &numeric);
+        let ColumnStats::Numeric(stats) = profile.stats else {
+            panic!("expected numeric statistics over real zeros");
+        };
+        assert_eq!(stats.min, 0.0);
+        assert_eq!(stats.mean, 0.0);
+        assert_eq!(profile.invalid_count, Some(0));
+
+        let boolean = ["", "false", "false"].map(String::from);
+        let ColumnStats::Boolean(stats) = analyze_column("b", &boolean).stats else {
+            panic!("expected boolean statistics over real false values");
+        };
+        assert_eq!(stats.true_ratio, 0.0);
+        assert_eq!(stats.false_count, 2);
+    }
 
     #[test]
     fn test_analyze_column_basic() {

--- a/crates/dataprof-runtime/src/profile_builder.rs
+++ b/crates/dataprof-runtime/src/profile_builder.rs
@@ -125,7 +125,11 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
                         numeric.is_approximate = Some(true);
                     }
                 }
-                ColumnStats::Numeric(numeric)
+                if parsed_total == 0 {
+                    ColumnStats::None
+                } else {
+                    ColumnStats::Numeric(numeric)
+                }
             }
             DataType::Date => {
                 let parsed_dates = input.exact_date_matches.unwrap_or_else(|| {
@@ -173,16 +177,15 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
                     (tc, fc)
                 });
                 let total = true_count + false_count;
-                let true_ratio = if total > 0 {
-                    true_count as f64 / total as f64
+                if total > 0 {
+                    ColumnStats::Boolean(BooleanStats {
+                        true_count,
+                        false_count,
+                        true_ratio: true_count as f64 / total as f64,
+                    })
                 } else {
-                    0.0
-                };
-                ColumnStats::Boolean(BooleanStats {
-                    true_count,
-                    false_count,
-                    true_ratio,
-                })
+                    ColumnStats::None
+                }
             }
             DataType::String | DataType::Identifier => {
                 if let Some(tl) = &input.text_lengths {
@@ -208,9 +211,8 @@ pub fn build_column_profile(input: ColumnProfileInput<'_>) -> ColumnProfile {
     // ordinary value for a real numeric column, so nothing about that output
     // looked wrong.
     //
-    // Keyed on `total_count` rather than on the parsed count, so this covers
-    // exactly the empty case and leaves the all-null one alone: a column with
-    // rows but no parsed values is a wider question, tracked separately.
+    // Numeric and boolean columns also suppress statistics above when rows
+    // exist but no values parsed. This guard covers zero rows for every type.
     //
     // The counts above are untouched. "0 of 0 values were invalid" is a fact
     // about a column that was analyzed, not a statistic over nothing.
@@ -452,7 +454,7 @@ mod tests {
 
         assert_eq!(value.data_type, DataType::Float);
         assert_eq!(value.invalid_count, Some(2));
-        assert!(matches!(value.stats, ColumnStats::Numeric(_)));
+        assert!(matches!(value.stats, ColumnStats::None));
     }
 
     #[test]
@@ -503,6 +505,87 @@ mod tests {
         let samples = quality_check_samples(&collection);
         assert!(samples.contains_key("col"));
         assert_eq!(samples["col"].len(), 2);
+    }
+
+    #[test]
+    fn typed_columns_without_parsed_values_have_no_statistics() {
+        for data_type in [DataType::Integer, DataType::Float, DataType::Boolean] {
+            for values in [["", ""], ["junk", "Infinity"]] {
+                let samples = values.map(String::from);
+                let null_count = if values[0].is_empty() { 2 } else { 0 };
+                let profile = build_column_profile(ColumnProfileInput {
+                    name: "v".to_string(),
+                    data_type: data_type.clone(),
+                    total_count: 2,
+                    null_count,
+                    unique_count: None,
+                    unique_count_is_approximate: None,
+                    sample_values: &samples,
+                    text_lengths: None,
+                    boolean_counts: None,
+                    skip_statistics: false,
+                    skip_patterns: false,
+                    locale: None,
+                    exact_numeric: None,
+                    exact_date_matches: None,
+                });
+
+                assert!(matches!(profile.stats, ColumnStats::None));
+                assert_eq!(profile.data_type, data_type);
+                assert_eq!(profile.total_count, 2);
+                assert_eq!(profile.null_count, null_count);
+                if matches!(data_type, DataType::Integer | DataType::Float) {
+                    assert_eq!(profile.invalid_count, Some(2 - null_count));
+                }
+                assert!(profile.patterns.is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn exact_zero_statistics_survive_a_sample_without_parsed_values() {
+        // A bounded sample can miss every usable value. The full-stream
+        // count, not the sample count or the aggregate's value, governs absence.
+        for data_type in [DataType::Integer, DataType::Boolean] {
+            let samples = [String::new()];
+            let profile = build_column_profile(ColumnProfileInput {
+                name: "v".to_string(),
+                data_type: data_type.clone(),
+                total_count: 3,
+                null_count: 1,
+                unique_count: None,
+                unique_count_is_approximate: None,
+                sample_values: &samples,
+                text_lengths: None,
+                boolean_counts: Some((0, 2)),
+                skip_statistics: false,
+                skip_patterns: true,
+                locale: None,
+                exact_numeric: Some(ExactNumericAggregates {
+                    min: 0.0,
+                    max: 0.0,
+                    mean: 0.0,
+                    std_dev: 0.0,
+                    variance: 0.0,
+                    count: 2,
+                }),
+                exact_date_matches: None,
+            });
+
+            match profile.stats {
+                ColumnStats::Numeric(stats) => {
+                    assert_eq!(stats.min, 0.0);
+                    assert_eq!(stats.mean, 0.0);
+                    assert_eq!(stats.is_approximate, Some(true));
+                    assert_eq!(profile.invalid_count, Some(0));
+                }
+                ColumnStats::Boolean(stats) => {
+                    assert_eq!(stats.true_ratio, 0.0);
+                    assert_eq!(stats.false_count, 2);
+                }
+                other => panic!("expected measured zero statistics, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -312,6 +312,19 @@ Per-column profiling statistics.
 | `true_ratio` | `float \| None` | Ratio of `True` values (0.0--1.0) |
 | `patterns` | `list[Pattern] \| None` | List of detected value patterns |
 
+**Changed in 0.12 (#667).** Numeric columns with no finite parsed values and
+boolean columns with no parsed booleans have no statistics block. Their statistic
+accessors return `None`, including boolean counts and `true_ratio`. The declared
+column type, row/null counts, and numeric `invalid_count` remain available. A
+measured numeric zero or an all-false column still reports `0.0`. CSV columns
+containing only nulls infer as text because CSV carries no declared type.
+
+This uses the existing absent-statistics representation (`ColumnStats::None` in
+Rust); numeric fields do not become optional within `NumericStats`, and the report
+schema version is unchanged. Saved reports remain readable as written: loading an
+older report does not replace its recorded zeros. Re-profile the source to obtain
+the corrected absence semantics.
+
 **Changed in 0.12.** Text lengths count Unicode scalar values, not UTF-8 bytes
 and not grapheme clusters. `"東京"` has a length of 2 and `"🙂"` a length of 1.
 **In 0.11 and earlier the same values reported 6 and 4**, because every

--- a/python/tests/test_undefined_statistics.py
+++ b/python/tests/test_undefined_statistics.py
@@ -1,0 +1,82 @@
+"""Undefined aggregates stay absent, while measured zeros survive every path (#667)."""
+
+import dataprof
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+
+
+@pytest.fixture(params=["auto", "incremental", "columnar", "arrow", "parquet"])
+def profile_values(request, tmp_path):
+    def profile(integer, number, boolean):
+        table = pa.table(
+            {
+                "i": pa.array(integer, type=pa.int64()),
+                "f": pa.array(number, type=pa.float64()),
+                "b": pa.array(boolean, type=pa.bool_()),
+            }
+        )
+        if request.param == "arrow":
+            return dataprof.profile(table)
+        if request.param == "parquet":
+            path = tmp_path / "values.parquet"
+            pq.write_table(table, path)
+            return dataprof.profile(path)
+        path = tmp_path / "values.csv"
+        rows = [
+            ",".join("" if value is None else str(value) for value in row)
+            for row in zip(integer, number, boolean)
+        ]
+        path.write_text("i,f,b\n" + "\n".join(rows) + "\n", encoding="utf-8")
+        return dataprof.profile(path, engine=request.param)
+
+    return profile
+
+
+def test_all_null_columns_have_no_statistics(profile_values):
+    report = profile_values([None, None], [None, None], [None, None])
+    for column in report.to_dict()["columns"]:
+        assert column["total_count"] == 2
+        assert column["null_count"] == 2
+        # CSV has no declared types: an all-null column infers as string.
+        # Arrow and Parquet retain the numeric/boolean schema and must omit stats.
+        if column["data_type"] != "string":
+            assert column.get("stats") is None
+        for field in ("min", "max", "mean", "std_dev", "variance", "true_ratio"):
+            assert getattr(report[column["name"]], field) is None
+
+
+def test_non_finite_numbers_have_no_statistics(profile_values):
+    report = profile_values([None, None], [float("inf"), float("-inf")], [None, None])
+    column = report["f"]
+    assert column.data_type == "float"
+    assert column.total_count == 2
+    assert column.null_count == 0
+    assert column.invalid_count == 2
+    assert column.min is None
+    assert report.to_dict()["columns"][1].get("stats") is None
+
+
+def test_measured_zeros_survive_null_and_invalid_values(profile_values):
+    report = profile_values([None, 0, 0], [float("inf"), 0.0, 0.0], [None, False, False])
+    for name in ("i", "f"):
+        for field in ("min", "max", "mean", "std_dev", "variance"):
+            assert getattr(report[name], field) == 0.0
+    assert report["f"].invalid_count == 1
+    assert report["b"].true_ratio == 0.0
+    assert report["b"].true_count == 0
+    assert report["b"].false_count == 2
+
+
+def test_declared_types_and_absence_survive_report_roundtrip():
+    table = pa.table(
+        {"i": pa.array([None], type=pa.int64()), "b": pa.array([None], type=pa.bool_())}
+    )
+    report = dataprof.profile(table)
+    restored = dataprof.ProfileReport.from_dict(report.to_dict())
+    assert restored["i"].data_type == "integer"
+    assert restored["b"].data_type == "boolean"
+    assert restored["i"].min is None
+    assert restored["b"].true_ratio is None
+    assert restored.to_dict()["columns"] == report.to_dict()["columns"]


### PR DESCRIPTION
## What changed

Numeric columns with rows but no finite parsed values, and boolean columns with no parsed booleans, now report absent statistics instead of plausible zero aggregates. The shared engine profile builder and the in-memory analyzer preserve column types and row/null/invalid counts; measured numeric zeros and all-false columns still report their statistics.

Implements option 2 from the issue using the existing `ColumnStats::None` representation. Regression coverage includes CSV engines, Arrow, Parquet, report round-tripping, and exact aggregates whose usable values are absent from the retained sample.

**Related issue:** Closes #667

## How it was verified

On Windows with Rust 1.98.1 and Python 3.12:

- `uv run maturin develop` — rebuilt the local extension.
- `uv run pytest python/tests/test_undefined_statistics.py python/tests/test_zero_row_sources.py python/tests/test_engine_parity.py python/tests/test_dataframe_chunk_parity.py -q --tb=short` — 82 passed, 1 database-only test skipped because database features are not compiled.
- `uv run pytest python/tests/test_python_api.py -q --tb=short` — 362 passed.
- `cargo test -p dataprof-runtime -p dataprof-metrics -p dataprof-parquet --quiet` — 347 tests passed; Parquet's default feature set has no tests.
- `cargo test -p dataprof-parquet --features parquet --quiet` — 37 unit tests and 6 doctests passed.
- `cargo test --test profile_report_schema --quiet` — 7 passed, including the committed-schema comparison.
- `cargo clippy --all --all-targets -- -D warnings` — passed.
- `cargo fmt --all --check` — passed.
- `uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/` — 57 files unchanged.
- `uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/` — passed.
- `uv run ty check python/` — passed.
- `uv run python .github/scripts/check_decode_audit.py` — passed.

The new Python tests reproduced misleading zero aggregates before the implementation; all 16 pass after it.

## Anything reviewers should know

- The whole numeric/boolean statistics block becomes absent, including boolean counts. Consumers should handle absent statistics while using the column-level counts for evidence.
- No Rust struct or serialized schema shape changes; the existing schema version remains valid. Older saved reports remain readable with their recorded values. Re-profile the source to obtain corrected absence semantics.
- CSV carries no declared types, so entirely null CSV columns infer as text. Typed all-null numeric/boolean coverage uses Arrow and Parquet; all-non-finite CSV columns exercise the numeric absence case on every CSV engine.
