### PR TITLE
ci: run omitted database regression suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,11 +493,10 @@ jobs:
       - name: Run Rust database tests (all DBs)
         run: cargo test --test database_integration --features "all-db"
 
-      # A separate target in a separate package: the command above selects the
-      # root crate's test binary and never builds this one, so the typed-column
-      # regressions would return early and gate nothing (#365).
-      - name: Run dataprof-db typed column decoding tests
-        run: cargo test -p dataprof-db --test typed_column_decoding --features "all-db"
+      # The facade command above does not select member-crate tests. Run the
+      # whole database package, including unit, decoding and column-order tests.
+      - name: Run all dataprof-db tests
+        run: cargo test -p dataprof-db --all-features
 
   # The Python extension uses a different Cargo profile and feature graph.
   # Build it in parallel so neither cold build blocks the other's cache save.
@@ -534,9 +533,27 @@ jobs:
       - name: Build Python bindings with database support
         run: uv run maturin develop --features "python,python-async,sqlite"
 
+      - name: Require SQLite database support
+        run: |
+          uv run --no-sync python - <<'PY'
+          import dataprof
+          from dataprof._dataprof import (
+              analyze_database_async,
+              count_table_rows_async,
+              get_table_schema_async,
+              test_connection_async,
+          )
+
+          caps = dataprof.capabilities()
+          assert caps.database and "sqlite" in caps.database_connectors, caps
+          print(caps)
+          PY
+
       - name: Run Python database tests
         run: >-
-          uv run pytest
+          uv run --no-sync pytest
           python/tests/test_database_api.py
+          python/tests/test_database_option_parity.py
+          python/tests/test_column_order.py
           python/tests/test_engine_parity.py::test_sqlite_parity
           -v -ra

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -77,6 +77,53 @@ You do not need to run every expensive workspace check for a small docs or
 Python-only PR. Prefer a focused test command that matches your change, and
 list exactly what you ran in the PR body.
 
+### Database regression tests
+
+CI runs both the facade integration target and every test target in the database
+crate, including unit tests, column decoding, query column order, and typed
+PostgreSQL/MySQL decoding:
+
+```bash
+cargo test --test database_integration --features "all-db"
+cargo test -p dataprof-db --all-features
+```
+
+Set `POSTGRES_TEST_URL` and `MYSQL_TEST_URL` to disposable test databases to run
+the service-backed cases, as the CI database job does. Without these variables,
+those cases return early; SQLite cases need no external service.
+
+The separate Python database job builds SQLite support and runs the API, option
+parity, and column-order suites plus the SQLite engine-parity case. Check both
+the native exports and the compiled connector before pytest so a missing feature
+cannot turn these regressions into skipped tests:
+
+```bash
+uv run maturin develop --features "python,python-async,sqlite"
+uv run --no-sync python - <<'PY'
+import dataprof
+from dataprof._dataprof import (
+    analyze_database_async,
+    count_table_rows_async,
+    get_table_schema_async,
+    test_connection_async,
+)
+
+caps = dataprof.capabilities()
+assert caps.database and "sqlite" in caps.database_connectors, caps
+print(caps)
+PY
+uv run --no-sync pytest \
+    python/tests/test_database_api.py \
+    python/tests/test_database_option_parity.py \
+    python/tests/test_column_order.py \
+    python/tests/test_engine_parity.py::test_sqlite_parity -v -ra
+```
+
+`--no-sync` keeps the SQLite-enabled extension built by `maturin develop` in use.
+This feature set intentionally skips the three async file-transport cases in
+`test_column_order.py`; the ordinary Python job covers them. Every database case
+runs here. The ordinary wheel build omits database support.
+
 ## Development Workflow
 
 ### Create a Feature Branch


### PR DESCRIPTION
## What changed

Database CI selected only one dataprof-db integration target and omitted Python option-parity and query-order regressions. Run every database crate test target and add the missing Python suites to the existing SQLite job.

A preflight checks native database exports and the compiled SQLite capability before pytest. Test commands use `--no-sync` to retain that build, and contributor guidance documents the same commands and intentional skips. Existing PostgreSQL/MySQL services and environment variables are preserved.

**Related issue:** Closes #673

## How it was verified

- `cargo test -p dataprof-db --all-features`: 29 unit tests, 6 column-decoding tests and 7 column-order tests passed. The 13 PostgreSQL/MySQL cases compiled but returned early without service URLs locally; their execution remains covered by the existing CI services.
- `uv run maturin develop --features "python,python-async,sqlite"`: succeeded on Windows, Rust 1.98.1 / Python 3.12. The linker emitted its library-creation message as a warning.
- SQLite preflight: failed against the ordinary build without database support, then passed against the SQLite-enabled build.
- `uv run --no-sync pytest python/tests/test_database_api.py python/tests/test_database_option_parity.py python/tests/test_column_order.py python/tests/test_engine_parity.py::test_sqlite_parity -v -ra`: 46 passed, 3 skipped. Only async file-transport cases skipped; every selected database case executed.
- Parsed workflow YAML, compiled the embedded preflight Python, and checked the documented preflight matches CI.
- `uv run --no-sync python .github/scripts/check_decode_audit.py` and `git diff --check`: passed.
