### PR TITLE
ci: compile the advertised MSRV feature graphs on 1.96

### DIFF
--- a/.github/scripts/msrv_check.py
+++ b/.github/scripts/msrv_check.py
@@ -1,0 +1,170 @@
+"""Compile the advertised MSRV feature graphs on the MSRV toolchain (issue #674).
+
+`rust-version` in the root `Cargo.toml` is the single source of truth for the
+minimum supported Rust version. Before this gate existed nothing compiled
+against it: ordinary CI installs the pinned 1.98 toolchain, and the one 1.96 job
+in `release.yml` ran `cargo metadata --no-deps`, which parses manifests without
+touching a line of source. A newer standard-library API, language feature or
+dependency MSRV could pass every gate and still break a downstream build on the
+promised minimum compiler.
+
+What this script asserts:
+
+1. Every workspace package declares the same `rust-version` (nothing drifts off
+   the shared value inherited from `[workspace.package]`).
+2. The *active* toolchain is that version. Running the gate on a newer compiler
+   proves nothing, so a workflow pin that drifts away from `rust-version` fails
+   loudly here instead of passing quietly.
+3. Each declared feature graph in `FEATURE_GRAPHS` compiles under
+   `cargo check --locked --lib`.
+
+Scope, and why:
+
+- `--lib` only. The MSRV promise is that the published *libraries* build for a
+  downstream consumer. Dev-dependencies (criterion, jsonschema, proptest),
+  examples and benches are development tooling and build on the pinned
+  toolchain, not this one.
+- `--locked`. The gate checks the dependency set a release actually ships,
+  the one in `Cargo.lock`. It is not a minimal-version check: a dependency
+  raising its own MSRV surfaces here when the lockfile is updated, which is
+  exactly when a dependency-update PR runs this job.
+
+Run it locally against the MSRV toolchain (rustup honours `RUSTUP_TOOLCHAIN`):
+
+    rustup toolchain install 1.96
+    RUSTUP_TOOLCHAIN=1.96 python3 .github/scripts/msrv_check.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The feature graphs the MSRV promise covers. Every published surface a
+# downstream crate can turn on is listed: leaving one out means the promise is
+# unverified for whoever enables it. Keep this in step with the release-surface
+# list in `.github/workflows/release.yml`.
+FEATURE_GRAPHS: list[tuple[str, list[str]]] = [
+    ("facade, no default features", ["-p", "dataprof", "--no-default-features"]),
+    ("facade, default features (parquet)", ["-p", "dataprof"]),
+    (
+        "facade, async-streaming",
+        ["-p", "dataprof", "--no-default-features", "--features", "async-streaming"],
+    ),
+    ("facade, parquet-async", ["-p", "dataprof", "--features", "parquet-async"]),
+    # Covers `database` and the postgres/mysql/sqlite connectors.
+    ("facade, all features", ["-p", "dataprof", "--all-features"]),
+    # docs/python/README.md tells users a source build needs Rust 1.96 or later,
+    # so the extension crate is part of the promise, not just the pure-Rust
+    # facade. Release wheels are built on the pinned toolchain; an sdist build
+    # on a user's machine is what this arm stands for.
+    ("python extension crate, all features", ["-p", "dataprof-python", "--all-features"]),
+]
+
+RUSTC_VERSION = re.compile(r"^rustc (\d+)\.(\d+)\.(\d+)")
+
+
+def run(command: list[str], root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command, cwd=root, capture_output=True, text=True, encoding="utf-8", check=False
+    )
+
+
+def declared_msrv(root: Path) -> str:
+    """The `rust-version` every workspace package agrees on."""
+    result = run(["cargo", "metadata", "--no-deps", "--format-version", "1"], root)
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit("error: cargo metadata failed")
+
+    packages = json.loads(result.stdout)["packages"]
+    missing = sorted(p["name"] for p in packages if not p.get("rust_version"))
+    if missing:
+        raise SystemExit(
+            "error: workspace package(s) declare no rust-version: "
+            + ", ".join(missing)
+            + "\nAdd `rust-version.workspace = true` so the MSRV covers them."
+        )
+
+    declared = sorted({p["rust_version"] for p in packages})
+    if len(declared) != 1:
+        raise SystemExit(
+            "error: workspace packages declare different rust-versions: " + ", ".join(declared)
+        )
+    return declared[0]
+
+
+def active_toolchain_version() -> tuple[int, int, str]:
+    result = subprocess.run(
+        ["rustc", "--version"], capture_output=True, text=True, encoding="utf-8", check=False
+    )
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        raise SystemExit("error: rustc --version failed")
+
+    reported = result.stdout.strip()
+    match = RUSTC_VERSION.match(reported)
+    if match is None:
+        raise SystemExit(f"error: cannot parse rustc version from {reported!r}")
+    return int(match.group(1)), int(match.group(2)), reported
+
+
+def assert_running_on_msrv(declared: str, reported: str, active: tuple[int, int]) -> None:
+    parts = declared.split(".")
+    wanted = (int(parts[0]), int(parts[1]))
+    if active == wanted:
+        return
+    raise SystemExit(
+        f"error: this gate must run on the declared MSRV {declared}, "
+        f"but the active toolchain is {reported}.\n"
+        "A newer compiler accepts code the MSRV rejects, so a mismatched run "
+        "proves nothing.\n"
+        "Bump the `dtolnay/rust-toolchain@` pin on the MSRV jobs and "
+        "`rust-version` in Cargo.toml together, or run locally with "
+        f"RUSTUP_TOOLCHAIN={declared}."
+    )
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[2]
+    declared = declared_msrv(root)
+    major, minor, reported = active_toolchain_version()
+    assert_running_on_msrv(declared, reported, (major, minor))
+
+    print(f"MSRV gate: {reported} against declared rust-version {declared}\n")
+
+    failures: list[str] = []
+    for label, arguments in FEATURE_GRAPHS:
+        command = ["cargo", "check", "--locked", "--lib", *arguments]
+        print(f"==> {label}\n    {' '.join(command)}", flush=True)
+        result = subprocess.run(command, cwd=root, check=False)
+        if result.returncode != 0:
+            failures.append(label)
+            print(f"    FAILED on Rust {declared}", flush=True)
+
+    if failures:
+        print(
+            f"\nerror: {len(failures)} feature graph(s) do not compile on the "
+            f"declared MSRV {declared}:",
+            file=sys.stderr,
+        )
+        for label in failures:
+            print(f"  - {label}", file=sys.stderr)
+        print(
+            "\nEither keep the code within Rust "
+            f"{declared}, or raise `rust-version` in Cargo.toml (and the pins "
+            "in README.md, AGENTS.md, docs/CONTRIBUTING.md and the MSRV jobs) "
+            "deliberately.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nMSRV gate passed: {len(FEATURE_GRAPHS)} feature graphs compile on {declared}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,46 @@ jobs:
       - name: Run feature checks
         run: ${{ matrix.commands }}
 
+  # The workspace advertises Rust 1.96 in Cargo.toml, README.md and AGENTS.md,
+  # and until this job nothing compiled against it: every other Rust job here
+  # runs the pinned 1.98, and the 1.96 job in release.yml only ran
+  # `cargo metadata`, which parses manifests without touching source. #674.
+  msrv:
+    name: MSRV Compile Gate
+    runs-on: ubuntu-latest
+    # Six feature graphs back to back, so the cold-cache reasoning under
+    # feature-checks applies here too.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          token: ${{ github.token }}
+
+      # Deliberately not ./.github/actions/setup-rust: that pins 1.98, the lint
+      # and test toolchain. This job's whole point is the *minimum* one, and a
+      # `uses:` ref cannot be templated, so the version is written out here.
+      # msrv_check.py fails if this pin and `rust-version` ever disagree.
+      - name: Install Rust 1.96 (workspace MSRV)
+        uses: dtolnay/rust-toolchain@1.96
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: rust-msrv
+          shared-key: "v4"
+
+      # pyo3's build script needs an interpreter to configure the extension
+      # crate arm of the matrix.
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+
+      - name: Compile MSRV feature graphs
+        run: python3 .github/scripts/msrv_check.py
+
   python-quality:
     name: Python Lint & Format
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,13 +189,36 @@ jobs:
         cargo check --locked -p dataprof-python --all-features
       shell: bash
 
+  # Step 2b: the same published surfaces, compiled on the *minimum* supported
+  # compiler rather than the pinned one. The job above proves the release builds
+  # for us; this one proves it builds for a downstream crate that took the MSRV
+  # in Cargo.toml at its word. #674.
+  msrv:
+    name: Validate MSRV Compile Gate
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+    - uses: actions/checkout@v7.0.1
+
+    - name: Install Rust 1.96 (workspace MSRV)
+      uses: dtolnay/rust-toolchain@1.96
+
+    - name: Setup Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.10'
+
+    - name: Compile MSRV feature graphs
+      run: python3 .github/scripts/msrv_check.py
+      shell: bash
+
   # Step 3: Verify every crate's packaged contents before the first real publish.
   # Full `cargo publish --dry-run` is not viable for interdependent workspace crates
   # because crates.io cannot resolve unpublished internal versions yet.
   rust-package-checks:
     name: Check Rust Package Contents
     runs-on: ubuntu-latest
-    needs: rust-release-checks
+    needs: [rust-release-checks, msrv]
     steps:
     - uses: actions/checkout@v7.0.1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,13 @@ differs from 1.98 can pass here and still fail CI, or the reverse. When clippy
 disagrees with CI, check `rustc --version` first and reproduce with
 `cargo +1.98 clippy`.
 
+The MSRV itself is enforced by compilation, not by the declaration: the `MSRV
+Compile Gate` job runs `cargo check --locked --lib` over every published feature
+graph on 1.96. Reproduce it with
+`RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py`. If a change needs
+a newer standard-library API, raising the MSRV is a deliberate separate change —
+see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#rust-toolchains-msrv-vs-pinned).
+
 ```bash
 uv sync                     # install the Python dev environment
 uv run maturin develop      # build + install the local Python extension

--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ dataprof = "0.11"
 # or: dataprof = { version = "0.11", default-features = false }
 ```
 
-Minimum supported Rust version: 1.96.
+Minimum supported Rust version: 1.96. Every published feature graph — the
+default build, `no-default-features`, the async and database features, and the
+Python extension crate — is compiled on 1.96 in CI and before each release, so
+this is a verified floor rather than a declared one. Development itself pins a
+newer toolchain for linting and testing; see
+[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#rust-toolchains-msrv-vs-pinned).
 
 ```rust
 use dataprof::Profiler;

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -77,6 +77,50 @@ You do not need to run every expensive workspace check for a small docs or
 Python-only PR. Prefer a focused test command that matches your change, and
 list exactly what you ran in the PR body.
 
+### Rust toolchains: MSRV vs pinned
+
+Two Rust versions are in play and they do different jobs.
+
+- **1.96 is the MSRV**, declared once as `rust-version` in the root
+  `Cargo.toml` and inherited by every workspace package. It is a promise to
+  downstream crates: the published libraries compile on it.
+- **1.98 is the pinned development toolchain** (`.github/actions/setup-rust`,
+  and the release build). Formatting, clippy and the test suites run there.
+  Clippy gains lints with every release, so an older compiler must not decide
+  what the lint gate accepts.
+
+The MSRV is verified by compilation, not by declaration:
+
+```bash
+rustup toolchain install 1.96
+RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py
+```
+
+That script is the `MSRV Compile Gate` job in CI and a release gate in
+`release.yml`. It asserts every workspace package declares the same
+`rust-version`, asserts the running toolchain *is* that version — a gate run on
+a newer compiler proves nothing — and then runs `cargo check --locked --lib`
+over each published feature graph: the facade with no default features, with
+defaults, with `async-streaming`, with `parquet-async`, with all features
+(which covers `database` and the three connectors), and the
+`dataprof-python` extension crate, since a source install builds that from an
+sdist on the user's own toolchain.
+
+Two scope choices worth knowing:
+
+- **`--lib`.** The promise covers the libraries a consumer depends on.
+  Dev-dependencies, examples and benches are development tooling and build on
+  the pinned toolchain instead.
+- **`--locked`.** The gate compiles the dependency set a release actually
+  ships. It is not a minimal-version check; a dependency raising its own MSRV
+  shows up when `Cargo.lock` changes, which is when a dependency-update PR runs
+  the job.
+
+Raising the MSRV is a deliberate, separate change: bump `rust-version` in
+`Cargo.toml`, the `dtolnay/rust-toolchain@` pins on the two MSRV jobs, and the
+version stated in `README.md`, `AGENTS.md` and this file. The script fails
+loudly if the toolchain pin and `rust-version` drift apart.
+
 ### Database regression tests
 
 CI runs both the facade integration target and every test target in the database

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -781,8 +781,10 @@ features, which is why they are long.
 `database` on its own is also not enough: the connectors are reported only when
 `python-async` is compiled in as well.
 
-A source build needs a Rust toolchain (1.96 or later). `postgres` and `mysql`
-are pure Rust; `sqlite` compiles `libsqlite3-sys`, which is C.
+A source build needs a Rust toolchain (1.96 or later; CI compiles the extension
+crate on exactly 1.96, so that floor is tested rather than assumed).
+`postgres` and `mysql` are pure Rust; `sqlite` compiles `libsqlite3-sys`, which
+is C.
 
 Check what you actually got before relying on it:
 


### PR DESCRIPTION
## What changed

Guard before any future bump of msrv

Rust 1.96 is advertised as the MSRV in `Cargo.toml`, `README.md` and `AGENTS.md`, and nothing compiled against it. Every Rust job in CI installs the pinned 1.98 toolchain, and the one 1.96 job in `release.yml` ran `cargo metadata --no-deps`, which parses manifests without touching a line of source. A newer standard-library API, language feature or dependency MSRV could pass every existing gate and still break a downstream crate that took the promise at its word.

`.github/scripts/msrv_check.py` is now that gate, run as the `MSRV Compile Gate` job on every PR and as a release gate before `rust-package-checks`. It:

1. reads `rust-version` from `cargo metadata` and asserts every workspace package declares the same one;
2. asserts the **running** toolchain is that version — a gate run on a newer compiler proves nothing, so a `dtolnay/rust-toolchain@` pin that drifts away from `rust-version` fails loudly instead of passing quietly;
3. runs `cargo check --locked --lib` over each published feature graph.

The matrix, and why each arm is in it:

| graph | why |
| --- | --- |
| `-p dataprof --no-default-features` | the minimal facade a downstream crate can depend on |
| `-p dataprof` | default features (`parquet`) |
| `-p dataprof --no-default-features --features async-streaming` | async surface |
| `-p dataprof --features parquet-async` | async + parquet interaction |
| `-p dataprof --all-features` | covers `database` and the postgres/mysql/sqlite connectors |
| `-p dataprof-python --all-features` | `docs/python/README.md` tells users a source build needs 1.96, so an sdist build on a user's toolchain is part of the promise |

Two scope decisions, documented in the script and in `docs/CONTRIBUTING.md`:

- **`--lib`.** The MSRV promise is that the published *libraries* compile for a consumer. Dev-dependencies (criterion, jsonschema, proptest), examples and benches are development tooling and stay on the pinned toolchain — this is the "avoid relying solely on dev-dependency tests" point in the issue.
- **`--locked`.** The gate compiles the dependency set a release actually ships. It is not a minimal-version check; a dependency raising its own MSRV surfaces when `Cargo.lock` changes, which is exactly when a dependency-update PR runs the job.

**No 1.96 incompatibility was found.** All six graphs compile on 1.96 today, and every workspace package already declares the same `rust-version`, so no narrower guarantee for optional features is needed — the promise as written holds, it just was not checked.

**Related issue:** Closes #674

## How it was verified

The toolchain assertion, run on the default (pinned) toolchain:

```console
$ python .github/scripts/msrv_check.py
error: this gate must run on the declared MSRV 1.96, but the active toolchain is rustc 1.98.1 (48a229cea 2026-09-01).
A newer compiler accepts code the MSRV rejects, so a mismatched run proves nothing.
Bump the `dtolnay/rust-toolchain@` pin on the MSRV jobs and `rust-version` in Cargo.toml together, or run locally with RUSTUP_TOOLCHAIN=1.96.
$ echo $?
1
```

The gate itself, on 1.96:

```console
$ rustup toolchain install 1.96
1.96-x86_64-pc-windows-msvc installed - rustc 1.96.1 (31fca3adb 2026-06-26)

$ RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py
MSRV gate: rustc 1.96.1 (31fca3adb 2026-06-26) against declared rust-version 1.96

==> facade, no default features
    cargo check --locked --lib -p dataprof --no-default-features
==> facade, default features (parquet)
    cargo check --locked --lib -p dataprof
==> facade, async-streaming
    cargo check --locked --lib -p dataprof --no-default-features --features async-streaming
==> facade, parquet-async
    cargo check --locked --lib -p dataprof --features parquet-async
==> facade, all features
    cargo check --locked --lib -p dataprof --all-features
==> python extension crate, all features
    cargo check --locked --lib -p dataprof-python --all-features

MSRV gate passed: 6 feature graphs compile on 1.96
```

### The gate is proven to fail, not just to pass

The issue's acceptance asks to verify the check reaches compilation rather than metadata. A gate that has only ever passed guards nothing, so it was run against code that a 1.96 compiler must reject.

`u64::bit_width()` stabilised in Rust 1.97.0 (`#[stable(feature = "uint_bit_width", since = "1.97.0")]` in the 1.98 `rust-src`), which makes it exactly the innocent-looking line this job exists to catch. Temporarily appended to `crates/dataprof-core/src/classification.rs`:

```rust
pub fn msrv_probe(value: u64) -> u32 {
    value.bit_width()
}
```

```console
$ RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py
MSRV gate: rustc 1.96.1 (31fca3adb 2026-06-26) against declared rust-version 1.96

==> facade, no default features
    cargo check --locked --lib -p dataprof --no-default-features
error[E0658]: use of unstable library feature `uint_bit_width`
   --> crates\dataprof-core\src\classification.rs:301:11
    |
301 |     value.bit_width()
    |           ^^^^^^^^^
    |
    = note: see issue #142326 <https://github.com/rust-lang/rust/issues/142326> for more information

error: could not compile `dataprof-core` (lib) due to 1 previous error
    FAILED on Rust 1.96
...
$ echo $?
1
```

The same probe compiles clean on the pinned toolchain, which is the point — every gate on `master` today would have let it through:

```console
$ RUSTUP_TOOLCHAIN=1.98 cargo check --locked --lib -p dataprof --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 04s
```

The probe was reverted; `git diff` against the pre-probe file is empty.

Other checks:

```console
$ uv run ruff format .github/scripts/
1 file reformatted, 4 files left unchanged

$ uv run ruff check .github/scripts/
All checks passed!

$ python -c "yaml.safe_load(...)"  # both workflows
.github/workflows/ci.yml -> [..., 'feature-checks', 'msrv', 'python-quality', ...]
.github/workflows/release.yml -> [..., 'rust-release-checks', 'msrv', 'rust-package-checks', ...]
release rust-package-checks needs: ['rust-release-checks', 'msrv']
```

No Rust source changed, so the workspace test suites were not re-run.

## Anything reviewers should know

- **Not a behaviour change.** CI and docs only; no library code is touched and the serialized schema is unaffected.
- **Toolchain pin duplication is deliberate.** `uses:` cannot template a version ref, so `dtolnay/rust-toolchain@1.96` is written out in both MSRV jobs rather than going through `.github/actions/setup-rust` (which pins 1.98, the lint and test toolchain). The script's toolchain assertion is what keeps those pins honest: if `rust-version` moves and a pin does not, the job fails with a message naming both places.
- **Release gating changed.** `rust-package-checks` now needs `[rust-release-checks, msrv]`, so a release cannot publish with a broken MSRV.
- **Required status checks.** If `MSRV Compile Gate` should block merges, it needs adding to the branch protection rules — that is a repo setting, not something in this PR.
- **Acceptance item deliberately left as-is:** "dependency-update PRs run the gate" needs no change. `ci.yml` runs on every PR to `master`, and its `paths-ignore` list does not cover `Cargo.toml` or `Cargo.lock`, so dependabot's cargo PRs already trigger the job.
- **Unrelated observation, not fixed here:** `cargo check --no-default-features` emits a pre-existing `unused import: AnalysisOptions` warning from `crates/dataprof-engines/src/adaptive.rs:4`. Clippy only runs `--all-features`, where the import is used, so nothing catches it. The MSRV job does not use `-D warnings` — an older compiler should not decide the lint gate — so it stays green. Happy to file it separately.
