### PR TITLE
fix(streaming): preserve EOF metadata for async stops

### DIFF
--- a/crates/dataprof-core/src/stop_condition.rs
+++ b/crates/dataprof-core/src/stop_condition.rs
@@ -8,13 +8,17 @@ use crate::execution::TruncationReason;
 
 /// A composable condition that can trigger early termination of profiling.
 ///
-/// Conditions are checked per-chunk (not per-row) for performance.
-/// The actual row count at termination may slightly exceed the limit.
+/// Conditions other than [`StopCondition::MaxRows`] are checked per chunk for
+/// performance. Their observed boundary can therefore vary with chunk size.
 #[derive(Debug, Clone, Default)]
 pub enum StopCondition {
     /// Stop after processing this many rows.
     MaxRows(u64),
     /// Stop after consuming this many bytes from the source.
+    ///
+    /// The budget is evaluated after whole data chunks. `bytes_consumed`
+    /// reports every source byte read, including headers, so it can exceed the
+    /// requested value; configure smaller chunks for a tighter bound.
     MaxBytes(u64),
     /// Stop when column types have not changed for approximately N rows
     /// (accumulated across chunks).

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -1257,9 +1257,12 @@ impl AsyncStreamingProfiler {
             } else {
                 0.0
             };
+            let reached_eof = size_hint.is_some_and(|size| total_bytes >= size);
 
             if stop_eval.update(chunk_rows as u64, chunk_bytes, memory_fraction) {
-                truncation_reason = stop_eval.truncation_reason();
+                if !reached_eof {
+                    truncation_reason = stop_eval.truncation_reason();
+                }
                 drop(rx); // signal reader task to stop
                 break;
             }
@@ -1268,7 +1271,9 @@ impl AsyncStreamingProfiler {
             if let Some(ref mut tracker) = schema_tracker {
                 let fingerprint = column_stats.column_type_fingerprint();
                 if tracker.update(fingerprint, chunk_rows as u64) {
-                    truncation_reason = Some(tracker.truncation_reason());
+                    if !reached_eof {
+                        truncation_reason = Some(tracker.truncation_reason());
+                    }
                     drop(rx);
                     break;
                 }

--- a/crates/dataprof-python/src/stop_condition.rs
+++ b/crates/dataprof-python/src/stop_condition.rs
@@ -37,6 +37,10 @@ impl PyStopCondition {
     }
 
     /// Stop after consuming this many bytes.
+    ///
+    /// The budget is checked after whole data chunks. Reported bytes include
+    /// headers, so consumption can exceed the requested value; use smaller
+    /// chunks for a tighter bound.
     #[staticmethod]
     fn max_bytes(n: u64) -> PyResult<Self> {
         if n == 0 {

--- a/tests/execution_controls.rs
+++ b/tests/execution_controls.rs
@@ -426,6 +426,59 @@ mod async_controls {
     }
 
     #[tokio::test]
+    async fn async_conditions_met_on_the_final_chunk_are_complete() {
+        for condition in [
+            StopCondition::MaxBytes(1),
+            StopCondition::SchemaStable {
+                consecutive_stable_rows: 1,
+            },
+        ] {
+            let data = csv_bytes(123);
+            let size = data.len() as u64;
+            let report = Profiler::new()
+                .chunk_size(ChunkSize::Fixed((size as usize) * 2))
+                .stop_when(condition.clone())
+                .profile_stream(source(data, FileFormat::Csv))
+                .await
+                .unwrap();
+
+            assert_eq!(report.execution.rows_processed, 123, "{condition:?}");
+            assert!(
+                report.execution.source_exhausted,
+                "{condition:?}: a final-chunk stop leaves nothing unread"
+            );
+            assert!(
+                report.execution.truncation_reason.is_none(),
+                "{condition:?}"
+            );
+            assert_provenance_consistent(&report, size, &format!("async {condition:?}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn async_byte_caps_are_chunk_granular() {
+        let data = csv_bytes(500);
+        let size = data.len() as u64;
+        let cap = 1u64;
+        let report = Profiler::new()
+            .chunk_size(ChunkSize::Fixed(1_024))
+            .stop_when(StopCondition::MaxBytes(cap))
+            .profile_stream(source(data, FileFormat::Csv))
+            .await
+            .unwrap();
+
+        assert!(!report.execution.source_exhausted);
+        assert!(matches!(
+            report.execution.truncation_reason,
+            Some(dataprof::TruncationReason::MaxBytes(1))
+        ));
+        let consumed = report.execution.bytes_consumed.unwrap_or(0);
+        assert!(consumed > cap);
+        assert!(consumed < size);
+        assert_provenance_consistent(&report, size, "async byte cap");
+    }
+
+    #[tokio::test]
     async fn async_chunk_size_never_changes_a_complete_profile() {
         let mut baseline: Option<(usize, usize)> = None;
         for chunk in [


### PR DESCRIPTION
## What changed

Async stop conditions now preserve complete-source metadata when they fire on the final chunk of a known-size stream. The async path keeps `source_exhausted=true`, leaves `truncation_reason` empty, and reports the full source size in that case.

`max_bytes` documentation now describes its chunk-granular behavior: reported consumption includes headers and can exceed the requested budget, while smaller chunks tighten the boundary.

**Related issue:** Fixes #692

## How it was verified

```console
$ cargo test --test execution_controls --features async-streaming
test result: ok. 15 passed; 0 failed

$ cargo clippy --all --all-targets --features async-streaming -- -D warnings
```

The regression coverage checks `MaxBytes` and `SchemaStable` at EOF, plus a below-chunk byte budget that remains observable as a bounded async scan.
