### PR TITLE
fix(partial): type Parquet text columns from their values, not the metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,6 +981,7 @@ dependencies = [
  "dataprof-core",
  "dataprof-csv",
  "dataprof-json",
+ "dataprof-parquet",
  "dataprof-runtime",
  "parquet",
  "serde",

--- a/crates/dataprof-core/src/partial.rs
+++ b/crates/dataprof-core/src/partial.rs
@@ -7,13 +7,15 @@ pub struct SchemaResult {
     /// the header/schema, JSON/JSONL follow the first record's field order with
     /// later-only fields appended in first-seen order.
     pub columns: Vec<ColumnSchema>,
-    /// How many rows were sampled to infer the schema (0 for Parquet metadata).
+    /// How many rows were sampled to infer the schema. 0 when nothing had to
+    /// be read: a Parquet file whose every column is typed by its encoding
+    /// is answered from the metadata alone.
     pub rows_sampled: usize,
     /// Time taken for inference in milliseconds.
     pub inference_time_ms: u128,
-    /// `true` when the entire file was consumed or schema was read from
-    /// metadata; `false` when inference stopped at the sample-size cap and
-    /// the schema may not have fully stabilized.
+    /// `true` when the entire file was consumed or the schema was read from
+    /// metadata alone; `false` when inference stopped at the sample-size cap
+    /// and the schema may not have fully stabilized.
     pub schema_stable: bool,
 }
 
@@ -64,7 +66,10 @@ pub struct StructureColumnSummary {
     pub unique_count: Option<usize>,
     pub uniqueness_ratio: Option<f64>,
     pub distinct_count_approximate: Option<bool>,
-    /// `"sample"` for CSV/JSON/JSONL, `"metadata"` for Parquet.
+    /// `"sample"` when the column's type came from reading values,
+    /// `"metadata"` when the declared schema decided it. CSV/JSON/JSONL are
+    /// always `"sample"`; a Parquet file carries both, since only its text
+    /// columns need values read to be typed (#693).
     pub provenance: String,
 }
 

--- a/crates/dataprof-parquet/src/lib.rs
+++ b/crates/dataprof-parquet/src/lib.rs
@@ -50,7 +50,9 @@ pub use async_http::{
 };
 
 #[cfg(feature = "arrow")]
-pub use record_batch_analyzer::RecordBatchAnalyzer;
+pub use record_batch_analyzer::{
+    RecordBatchAnalyzer, data_type_from_arrow_type, logical_arrow_type,
+};
 
 #[cfg(feature = "parquet")]
 pub use parser::{

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -39,9 +39,7 @@ const NUMERIC_SAMPLE_CAP: usize = 10_000;
 /// Only encodings are stripped. A type whose *values* need a decision of their
 /// own — nested types (#637), binary (#645) — keeps its identity and is decided
 /// there.
-pub(crate) fn logical_arrow_type(
-    data_type: &arrow::datatypes::DataType,
-) -> arrow::datatypes::DataType {
+pub fn logical_arrow_type(data_type: &arrow::datatypes::DataType) -> arrow::datatypes::DataType {
     use arrow::datatypes::DataType as ArrowDataType;
 
     match data_type {
@@ -54,6 +52,45 @@ pub(crate) fn logical_arrow_type(
         // Half precision has no arm of its own; f32 holds every f16 exactly.
         ArrowDataType::Float16 => ArrowDataType::Float32,
         other => other.clone(),
+    }
+}
+
+/// The type a column profiles as when its Arrow type alone decides it, or
+/// `None` when only the values can say.
+///
+/// `None` is the answer for text (`Utf8`/`LargeUtf8`), where the same column
+/// holds `"2026-01-02"` in one file and `"ORD-7"` in another, and for every
+/// Arrow type without a native arm below, which reaches the profile through a
+/// formatter and is re-inferred from its rendering.
+///
+/// Callers that hold the values pass them through [`infer_type`]; callers that
+/// hold only the schema — `infer_schema()` on a Parquet file — decide from this
+/// whether reading a sample can change the answer. Both read one list, so the
+/// fast schema path and the full profiler cannot name a column's type
+/// differently (#693).
+///
+/// Pass a type that has been through [`logical_arrow_type`]: this maps the
+/// logical type, not the physical encoding.
+pub fn data_type_from_arrow_type(arrow_type: &arrow::datatypes::DataType) -> Option<DataType> {
+    use arrow::datatypes::DataType as ArrowDataType;
+
+    match arrow_type {
+        ArrowDataType::Float64 | ArrowDataType::Float32 => Some(DataType::Float),
+        ArrowDataType::Int64
+        | ArrowDataType::Int32
+        | ArrowDataType::Int16
+        | ArrowDataType::Int8
+        | ArrowDataType::UInt64
+        | ArrowDataType::UInt32
+        | ArrowDataType::UInt16
+        | ArrowDataType::UInt8 => Some(DataType::Integer),
+        ArrowDataType::Date32 | ArrowDataType::Date64 | ArrowDataType::Timestamp(_, _) => {
+            Some(DataType::Date)
+        }
+        ArrowDataType::Decimal128(_, _) | ArrowDataType::Decimal256(_, _) => Some(DataType::Float),
+        ArrowDataType::Duration(_) => Some(DataType::Integer),
+        ArrowDataType::Boolean => Some(DataType::Boolean),
+        _ => None,
     }
 }
 
@@ -1185,38 +1222,23 @@ impl ColumnAnalyzer {
     }
 
     fn infer_data_type(&self) -> DataType {
-        match &self.data_type {
-            arrow::datatypes::DataType::Float64 | arrow::datatypes::DataType::Float32 => {
-                DataType::Float
-            }
-            arrow::datatypes::DataType::Int64
-            | arrow::datatypes::DataType::Int32
-            | arrow::datatypes::DataType::Int16
-            | arrow::datatypes::DataType::Int8
-            | arrow::datatypes::DataType::UInt64
-            | arrow::datatypes::DataType::UInt32
-            | arrow::datatypes::DataType::UInt16
-            | arrow::datatypes::DataType::UInt8 => DataType::Integer,
-            arrow::datatypes::DataType::Date32
-            | arrow::datatypes::DataType::Date64
-            | arrow::datatypes::DataType::Timestamp(_, _) => DataType::Date,
-            arrow::datatypes::DataType::Decimal128(_, _)
-            | arrow::datatypes::DataType::Decimal256(_, _) => DataType::Float,
-            arrow::datatypes::DataType::Duration(_) => DataType::Integer,
-            arrow::datatypes::DataType::Boolean => DataType::Boolean,
-            // Everything below reached the profile as text: `Utf8`/`LargeUtf8`
-            // natively, and every type without an arm through the generic
-            // formatter. Where those samples are the values themselves, only
-            // they say what the column holds, so they are re-inferred rather
-            // than declared `String` — which is what made a dictionary of
-            // digits profile as text while the same digits written plain
-            // profiled as integers. Where the rendering is an encoding rather
-            // than the value (hex, for binary), re-inference would read the
-            // encoding as data, so the column stays text.
-            _ if !self.renders_values_as_encoded_bytes() => {
-                infer_type(self.sample_values.samples())
-            }
-            _ => DataType::String,
+        if let Some(decided) = data_type_from_arrow_type(&self.data_type) {
+            return decided;
+        }
+
+        // Everything left reached the profile as text: `Utf8`/`LargeUtf8`
+        // natively, and every type without an arm through the generic
+        // formatter. Where those samples are the values themselves, only they
+        // say what the column holds, so they are re-inferred rather than
+        // declared `String` — which is what made a dictionary of digits profile
+        // as text while the same digits written plain profiled as integers.
+        // Where the rendering is an encoding rather than the value (hex, for
+        // binary), re-inference would read the encoding as data, so the column
+        // stays text.
+        if self.renders_values_as_encoded_bytes() {
+            DataType::String
+        } else {
+            infer_type(self.sample_values.samples())
         }
     }
 }

--- a/crates/dataprof-partial/Cargo.toml
+++ b/crates/dataprof-partial/Cargo.toml
@@ -11,7 +11,13 @@ readme = "README.md"
 
 [features]
 default = []
-parquet = ["dep:arrow", "dep:parquet", "dataprof-core/arrow"]
+parquet = [
+    "dep:arrow",
+    "dep:parquet",
+    "dep:dataprof-parquet",
+    "dataprof-parquet/parquet",
+    "dataprof-core/arrow",
+]
 async-streaming = [
     "dep:bytes",
     "dep:tokio",
@@ -27,6 +33,7 @@ csv = { workspace = true }
 dataprof-core = { workspace = true }
 dataprof-csv = { workspace = true }
 dataprof-json = { workspace = true }
+dataprof-parquet = { workspace = true, optional = true }
 dataprof-runtime = { workspace = true }
 parquet = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -10,6 +10,8 @@ use std::path::Path;
 use std::time::Instant;
 
 #[cfg(feature = "parquet")]
+use parquet::arrow::ProjectionMask;
+#[cfg(feature = "parquet")]
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::Deserialize;
 
@@ -21,6 +23,8 @@ use dataprof_core::{
 };
 use dataprof_csv::CsvParserConfig;
 use dataprof_json::JsonParserConfig;
+#[cfg(feature = "parquet")]
+use dataprof_parquet::{RecordBatchAnalyzer, data_type_from_arrow_type, logical_arrow_type};
 use dataprof_runtime::StreamingColumnCollection;
 
 /// Schema inference sample size (rows to read for CSV/JSON).
@@ -44,6 +48,12 @@ const ROW_SAMPLE_LINES_PER_WINDOW: usize = ROW_SAMPLE_LINES / ROW_SAMPLE_WINDOWS
 /// Default row cap for `analyze_structure()`.
 const STRUCTURE_SAMPLE_ROWS: usize = 1000;
 
+/// Batch size for the Parquet value sample. Caps the decode buffer when a
+/// caller asks `analyze_structure()` for a row limit far above the sample
+/// budget; the reader is stopped by its row limit, not by this.
+#[cfg(feature = "parquet")]
+const PARQUET_SAMPLE_BATCH_ROWS: usize = 8192;
+
 // ---------------------------------------------------------------------------
 // Public free functions
 // ---------------------------------------------------------------------------
@@ -51,7 +61,10 @@ const STRUCTURE_SAMPLE_ROWS: usize = 1000;
 /// Infer the schema (column names + data types) of a file.
 ///
 /// This is much faster than a full `Profiler::analyze_file` because it reads
-/// only a small sample of rows (or just the metadata for Parquet files).
+/// only a small sample of rows. A Parquet file is answered from its
+/// metadata wherever the metadata decides the type; its text columns are
+/// sampled, because only their values say whether they hold dates,
+/// integers or text (#693).
 ///
 /// # Example
 /// ```no_run
@@ -125,7 +138,7 @@ pub fn infer_schema_with_format(
         FileFormat::Parquet => {
             #[cfg(feature = "parquet")]
             {
-                infer_schema_parquet(path, start)
+                infer_schema_parquet(path, start, SCHEMA_SAMPLE_ROWS)
             }
             #[cfg(not(feature = "parquet"))]
             {
@@ -185,7 +198,7 @@ pub fn analyze_structure_with_format(
     match format {
         FileFormat::Csv => analyze_structure_csv(path, limit),
         FileFormat::Json | FileFormat::Jsonl => analyze_structure_json(path, format, limit),
-        FileFormat::Parquet => analyze_structure_parquet(path),
+        FileFormat::Parquet => analyze_structure_parquet(path, limit),
         FileFormat::Unknown(ref ext) => Err(DataProfilerError::UnsupportedFormat {
             format: ext.clone(),
         }),
@@ -196,8 +209,41 @@ pub fn analyze_structure_with_format(
 // Schema inference — per format
 // ---------------------------------------------------------------------------
 
+/// Infer a Parquet schema, reading values only for the columns whose type the
+/// file's metadata cannot decide.
+///
+/// A Parquet writer that did not type its input leaves dates, integers and
+/// booleans in `Utf8` columns — the shape any CSV-to-Parquet export produces.
+/// `profile()` re-infers those from the values, so a metadata-only schema
+/// disagreed with the full profiler about the same column of the same file, and
+/// with `infer_schema()` on the identical data as CSV (#693).
+///
+/// The metadata fast path is kept where it is authoritative: a column whose
+/// Arrow type decides its profiled type costs no read, so a fully typed file
+/// still reports `rows_sampled: 0`. Only text columns are projected, and only
+/// up to `sample_rows` of them, so the cost is bounded by the sample rather
+/// than the file.
+///
+/// The sample is the file prefix, as the profiling row cap is; spreading it
+/// across row groups is #639.
 #[cfg(feature = "parquet")]
-fn infer_schema_parquet(path: &Path, start: Instant) -> Result<SchemaResult, DataProfilerError> {
+fn infer_schema_parquet(
+    path: &Path,
+    start: Instant,
+    sample_rows: usize,
+) -> Result<SchemaResult, DataProfilerError> {
+    parquet_schema(path, start, sample_rows).map(|(schema, _)| schema)
+}
+
+/// [`infer_schema_parquet`], plus the names of the columns whose type came from
+/// the value sample rather than the metadata. `analyze_structure()` reports
+/// that split as per-column provenance.
+#[cfg(feature = "parquet")]
+fn parquet_schema(
+    path: &Path,
+    start: Instant,
+    sample_rows: usize,
+) -> Result<(SchemaResult, Vec<String>), DataProfilerError> {
     let file = fs::File::open(path).map_err(|_| DataProfilerError::FileNotFound {
         path: path.display().to_string(),
     })?;
@@ -206,22 +252,118 @@ fn infer_schema_parquet(path: &Path, start: Instant) -> Result<SchemaResult, Dat
         DataProfilerError::parquet_with_source(format!("Failed to read Parquet metadata: {}", e), e)
     })?;
 
-    let arrow_schema = builder.schema();
-    let columns = arrow_schema
-        .fields()
-        .iter()
-        .map(|field| ColumnSchema {
-            name: field.name().clone(),
-            data_type: arrow_type_to_dataprof(field.data_type()),
-        })
-        .collect();
+    let arrow_schema = builder.schema().clone();
+    let mut columns: Vec<ColumnSchema> = Vec::with_capacity(arrow_schema.fields().len());
+    let mut text_columns: Vec<usize> = Vec::new();
 
-    Ok(SchemaResult {
-        columns,
-        rows_sampled: 0,
-        inference_time_ms: start.elapsed().as_millis(),
-        schema_stable: true,
-    })
+    for (index, field) in arrow_schema.fields().iter().enumerate() {
+        let logical = logical_arrow_type(field.data_type());
+        let data_type = match data_type_from_arrow_type(&logical) {
+            // The Arrow type decides this column on its own, and the profiler
+            // reads the same list.
+            Some(decided) => decided,
+            // No arm: the profiler types this column from its values. Where the
+            // values *are* their rendering the sample below settles it; where
+            // the rendering is an encoding or a container serialisation the
+            // profiler reports `String`, which is what stands here (binary is
+            // #645, nested containers #637).
+            None => {
+                if values_decide_type(&logical) {
+                    text_columns.push(index);
+                }
+                DataType::String
+            }
+        };
+
+        columns.push(ColumnSchema {
+            name: field.name().clone(),
+            data_type,
+        });
+    }
+
+    if text_columns.is_empty() || sample_rows == 0 {
+        return Ok((
+            SchemaResult {
+                columns,
+                rows_sampled: 0,
+                inference_time_ms: start.elapsed().as_millis(),
+                schema_stable: true,
+            },
+            Vec::new(),
+        ));
+    }
+
+    let total_rows = builder.metadata().file_metadata().num_rows().max(0) as usize;
+    let projection = ProjectionMask::roots(builder.parquet_schema(), text_columns.iter().copied());
+    let reader = builder
+        .with_projection(projection)
+        .with_batch_size(sample_rows.min(PARQUET_SAMPLE_BATCH_ROWS))
+        .with_limit(sample_rows)
+        .build()
+        .map_err(|e| {
+            DataProfilerError::parquet_with_source(
+                format!("Failed to read Parquet sample: {}", e),
+                e,
+            )
+        })?;
+
+    // The profiler's own analyzer, so the type comes off a `ColumnProfile`
+    // exactly as it does for CSV and JSON in `schema_from_profiles`. Statistics
+    // and patterns are skipped: only the type is read.
+    let mut analyzer = RecordBatchAnalyzer::new();
+    let mut rows_sampled = 0usize;
+    for batch in reader {
+        let batch = batch.map_err(|e| {
+            DataProfilerError::parquet_with_source(
+                format!("Failed to read Parquet sample: {}", e),
+                e,
+            )
+        })?;
+        rows_sampled += batch.num_rows();
+        analyzer.process_batch(&batch).map_err(|e| {
+            DataProfilerError::parquet_error(&format!("Failed to analyze Parquet sample: {}", e))
+        })?;
+    }
+
+    let mut sampled_columns = Vec::with_capacity(text_columns.len());
+    for profile in analyzer.to_profiles(true, true, None) {
+        if let Some(column) = columns
+            .iter_mut()
+            .find(|column| column.name == profile.name)
+        {
+            column.data_type = profile.data_type;
+            sampled_columns.push(profile.name);
+        }
+    }
+
+    Ok((
+        SchemaResult {
+            columns,
+            rows_sampled,
+            inference_time_ms: start.elapsed().as_millis(),
+            // Every row of the sampled columns was read, so no further row can
+            // change a type. A truncated sample can: the same clause the CSV
+            // and JSON paths report.
+            schema_stable: rows_sampled >= total_rows,
+        },
+        sampled_columns,
+    ))
+}
+
+/// Whether a column's values, rather than its Arrow type, decide the type the
+/// profiler reports — and reading a sample can therefore change the answer.
+///
+/// Text is the one case worth a read. Every other type without a decided answer
+/// reaches the profile through a formatter, so a sample would type the
+/// rendering rather than the data: hex for binary (#645), a container
+/// serialisation for nested columns (#637). Both report `String` today, which
+/// the metadata path names without reading anything.
+#[cfg(feature = "parquet")]
+fn values_decide_type(logical: &arrow::datatypes::DataType) -> bool {
+    matches!(
+        logical,
+        arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8
+    )
 }
 
 fn infer_schema_csv(path: &Path, start: Instant) -> Result<SchemaResult, DataProfilerError> {
@@ -868,44 +1010,63 @@ fn analyze_structure_json(
     })
 }
 
-fn analyze_structure_parquet(path: &Path) -> Result<StructureReport, DataProfilerError> {
+fn analyze_structure_parquet(
+    path: &Path,
+    max_rows: usize,
+) -> Result<StructureReport, DataProfilerError> {
     #[cfg(feature = "parquet")]
     {
-        let schema = infer_schema_with_format(path, FileFormat::Parquet)?;
+        let (schema, sampled_columns) = parquet_schema(path, Instant::now(), max_rows)?;
         let row_count = quick_row_count_with_format(path, FileFormat::Parquet)?;
+        // Provenance is per column, because a Parquet file is now typed from
+        // both sources: the encoding answers for an already-typed column, a
+        // bounded value sample for a text one. Labelling a sampled column
+        // "metadata" would claim a stability the sample does not have.
         let columns = schema
             .columns
             .into_iter()
-            .map(|column| StructureColumnSummary {
-                name: column.name,
-                data_type: column.data_type,
-                total_count: None,
-                null_count: None,
-                null_ratio: None,
-                unique_count: None,
-                uniqueness_ratio: None,
-                distinct_count_approximate: None,
-                provenance: "metadata".to_string(),
+            .map(|column| {
+                let provenance = if sampled_columns.contains(&column.name) {
+                    "sample"
+                } else {
+                    "metadata"
+                };
+                StructureColumnSummary {
+                    name: column.name,
+                    data_type: column.data_type,
+                    total_count: None,
+                    null_count: None,
+                    null_ratio: None,
+                    unique_count: None,
+                    uniqueness_ratio: None,
+                    distinct_count_approximate: None,
+                    provenance: provenance.to_string(),
+                }
             })
             .collect();
+
+        // Only the sampled columns can be truncated; a file with nothing to
+        // sample is exhausted by its metadata, as it was before (#693).
+        let truncated = !schema.schema_stable;
+        let warnings = structure_warnings(&row_count, truncated, None);
 
         Ok(StructureReport {
             source: path.display().to_string(),
             format: FileFormat::Parquet,
             row_count,
-            rows_sampled: 0,
-            source_exhausted: true,
-            truncated: false,
-            truncation_reason: None,
+            rows_sampled: schema.rows_sampled,
+            source_exhausted: !truncated,
+            truncated,
+            truncation_reason: truncated.then(|| format!("max_rows({max_rows})")),
             delimiter: None,
             columns,
-            warnings: Vec::new(),
+            warnings,
         })
     }
 
     #[cfg(not(feature = "parquet"))]
     {
-        let _ = path;
+        let _ = (path, max_rows);
         Err(DataProfilerError::UnsupportedFormat {
             format: "parquet (enable the `parquet` feature)".to_string(),
         })
@@ -1029,7 +1190,7 @@ fn schema_from_profiles(
         .collect();
 
     // schema_stable is true when the sample scan reached EOF — the whole
-    // source was consumed — or for Parquet (metadata-only). The parsers probe
+    // source was consumed. The parsers probe
     // one record past SCHEMA_SAMPLE_ROWS so a file with exactly `cap` rows is
     // not mistaken for a truncated one (gh #553).
     let schema_stable = !truncated;
@@ -1039,35 +1200,6 @@ fn schema_from_profiles(
         rows_sampled,
         inference_time_ms: elapsed_ms,
         schema_stable,
-    }
-}
-
-/// Map Arrow data types to dataprof's simplified 4-variant DataType.
-#[cfg(feature = "parquet")]
-fn arrow_type_to_dataprof(arrow_type: &arrow::datatypes::DataType) -> DataType {
-    use arrow::datatypes::DataType as AT;
-    match arrow_type {
-        AT::Int8
-        | AT::Int16
-        | AT::Int32
-        | AT::Int64
-        | AT::UInt8
-        | AT::UInt16
-        | AT::UInt32
-        | AT::UInt64 => DataType::Integer,
-
-        AT::Float16 | AT::Float32 | AT::Float64 | AT::Decimal128(_, _) | AT::Decimal256(_, _) => {
-            DataType::Float
-        }
-
-        AT::Date32 | AT::Date64 | AT::Timestamp(_, _) | AT::Time32(_) | AT::Time64(_) => {
-            DataType::Date
-        }
-
-        // Everything else (Utf8, LargeUtf8, Binary, List, Struct, etc.)
-        // Boolean gets its own type
-        AT::Boolean => DataType::Boolean,
-        _ => DataType::String,
     }
 }
 
@@ -1384,7 +1516,10 @@ mod tests {
         }
 
         let result = infer_schema(f.path()).unwrap();
-        assert_eq!(result.rows_sampled, 0); // Parquet reads metadata only
+        // Two rows read: the `label` column is `Utf8`, so only its values say
+        // what it holds. The typed columns cost no read (#693).
+        assert_eq!(result.rows_sampled, 2);
+        assert!(result.schema_stable);
         assert_eq!(result.columns.len(), 3);
         assert_eq!(result.columns[0].name, "id");
         assert_eq!(result.columns[0].data_type, DataType::Integer);
@@ -1827,28 +1962,48 @@ mod tests {
         assert!(matches!(err, DataProfilerError::FileNotFound { .. }));
     }
 
+    /// The schema path reads the profiler's own type map, so the two cannot
+    /// name a column's type differently (#693). `None` is the profiler's "only
+    /// the values say", and is what sends a text column to the value sample.
     #[cfg(feature = "parquet")]
     #[test]
     fn test_arrow_type_mapping() {
         use arrow::datatypes::DataType as AT;
 
-        assert_eq!(arrow_type_to_dataprof(&AT::Int32), DataType::Integer);
-        assert_eq!(arrow_type_to_dataprof(&AT::UInt64), DataType::Integer);
-        assert_eq!(arrow_type_to_dataprof(&AT::Float64), DataType::Float);
+        let mapped = |arrow_type: &AT| data_type_from_arrow_type(&logical_arrow_type(arrow_type));
+
+        assert_eq!(mapped(&AT::Int32), Some(DataType::Integer));
+        assert_eq!(mapped(&AT::UInt64), Some(DataType::Integer));
+        assert_eq!(mapped(&AT::Float64), Some(DataType::Float));
+        assert_eq!(mapped(&AT::Decimal128(10, 2)), Some(DataType::Float));
+        assert_eq!(mapped(&AT::Date32), Some(DataType::Date));
         assert_eq!(
-            arrow_type_to_dataprof(&AT::Decimal128(10, 2)),
-            DataType::Float
-        );
-        assert_eq!(arrow_type_to_dataprof(&AT::Date32), DataType::Date);
-        assert_eq!(
-            arrow_type_to_dataprof(&AT::Timestamp(
+            mapped(&AT::Timestamp(
                 arrow::datatypes::TimeUnit::Millisecond,
                 None
             )),
-            DataType::Date
+            Some(DataType::Date)
         );
-        assert_eq!(arrow_type_to_dataprof(&AT::Utf8), DataType::String);
-        assert_eq!(arrow_type_to_dataprof(&AT::Boolean), DataType::Boolean);
+        assert_eq!(mapped(&AT::Boolean), Some(DataType::Boolean));
+
+        // A dictionary is an encoding, not a type: the values it compresses
+        // decide, exactly as they do for the plain column.
+        assert_eq!(
+            mapped(&AT::Dictionary(Box::new(AT::Int8), Box::new(AT::Int64))),
+            Some(DataType::Integer)
+        );
+
+        // Text: no answer from the type, and the one case worth reading rows
+        // for.
+        assert_eq!(mapped(&AT::Utf8), None);
+        assert_eq!(mapped(&AT::LargeUtf8), None);
+        assert!(values_decide_type(&logical_arrow_type(&AT::Utf8)));
+        assert!(values_decide_type(&logical_arrow_type(&AT::Utf8View)));
+
+        // No answer from the type either, but the rendering is not the value,
+        // so a sample would type the rendering. Left to #637 and #645.
+        assert_eq!(mapped(&AT::Binary), None);
+        assert!(!values_decide_type(&logical_arrow_type(&AT::Binary)));
     }
 
     #[cfg(feature = "parquet")]
@@ -1880,20 +2035,71 @@ mod tests {
             writer.close().unwrap();
         }
 
+        // max_rows(1) against two rows: the text column is typed from the
+        // first row only, so the pass is truncated and says so.
         let report = analyze_structure(f.path(), Some(1)).unwrap();
         assert_eq!(report.format, FileFormat::Parquet);
         assert_eq!(report.row_count.count, 2);
+        assert_eq!(report.rows_sampled, 1);
+        assert!(!report.source_exhausted);
+        assert!(report.truncated);
+        assert_eq!(report.truncation_reason.as_deref(), Some("max_rows(1)"));
+        assert_eq!(report.columns.len(), 2);
+        // Provenance is per column: the encoding types `id`, the value sample
+        // types `label`.
+        let provenance: Vec<_> = report
+            .columns
+            .iter()
+            .map(|col| (col.name.as_str(), col.provenance.as_str()))
+            .collect();
+        assert_eq!(provenance, vec![("id", "metadata"), ("label", "sample")]);
+        assert!(report.columns.iter().all(|col| col.total_count.is_none()));
+    }
+
+    /// A file whose columns are all typed by their encoding keeps the
+    /// metadata-only fast path: nothing to re-infer, so nothing is read (#693).
+    #[cfg(feature = "parquet")]
+    #[test]
+    fn test_parquet_without_text_columns_reads_no_rows() {
+        use arrow::array::{Float64Array, Int32Array};
+        use arrow::datatypes::{DataType as ArrowDT, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use parquet::arrow::ArrowWriter;
+
+        let schema = Schema::new(vec![
+            Field::new("id", ArrowDT::Int32, false),
+            Field::new("score", ArrowDT::Float64, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            std::sync::Arc::new(schema),
+            vec![
+                std::sync::Arc::new(Int32Array::from(vec![1, 2])),
+                std::sync::Arc::new(Float64Array::from(vec![1.5, 2.5])),
+            ],
+        )
+        .unwrap();
+
+        let mut f = NamedTempFile::with_suffix(".parquet").unwrap();
+        {
+            let mut writer = ArrowWriter::try_new(&mut f, batch.schema(), None).unwrap();
+            writer.write(&batch).unwrap();
+            writer.close().unwrap();
+        }
+
+        let schema = infer_schema(f.path()).unwrap();
+        assert_eq!(schema.rows_sampled, 0);
+        assert!(schema.schema_stable);
+
+        let report = analyze_structure(f.path(), Some(1)).unwrap();
         assert_eq!(report.rows_sampled, 0);
         assert!(report.source_exhausted);
         assert!(!report.truncated);
-        assert_eq!(report.columns.len(), 2);
         assert!(
             report
                 .columns
                 .iter()
                 .all(|col| col.provenance == "metadata")
         );
-        assert!(report.columns.iter().all(|col| col.total_count.is_none()));
     }
 }
 

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -281,19 +281,25 @@ fn parquet_schema(
         });
     }
 
+    let total_rows = builder.metadata().file_metadata().num_rows().max(0) as usize;
+
     if text_columns.is_empty() || sample_rows == 0 {
         return Ok((
             SchemaResult {
                 columns,
                 rows_sampled: 0,
                 inference_time_ms: start.elapsed().as_millis(),
-                schema_stable: true,
+                // Stable only because nothing was left to read: either the
+                // metadata typed every column, or the file has no rows. A
+                // caller who asked for a zero-row sample of a file that does
+                // have text columns is told the schema is not settled, as the
+                // CSV and JSON paths tell them.
+                schema_stable: text_columns.is_empty() || total_rows == 0,
             },
             Vec::new(),
         ));
     }
 
-    let total_rows = builder.metadata().file_metadata().num_rows().max(0) as usize;
     let projection = ProjectionMask::roots(builder.parquet_schema(), text_columns.iter().copied());
     let reader = builder
         .with_projection(projection)
@@ -1022,6 +1028,11 @@ fn analyze_structure_parquet(
         // both sources: the encoding answers for an already-typed column, a
         // bounded value sample for a text one. Labelling a sampled column
         // "metadata" would claim a stability the sample does not have.
+        //
+        // The counters stay `None` even for the sampled columns: the rows read
+        // here type the column and are not counted. Whether a Parquet
+        // structural report should carry counters, and over which row set, is
+        // #700.
         let columns = schema
             .columns
             .into_iter()

--- a/crates/dataprof-python/src/partial.rs
+++ b/crates/dataprof-python/src/partial.rs
@@ -320,8 +320,12 @@ impl PyRowCountEstimate {
 ///
 /// Much faster than full profiling — reads only a small sample of rows.
 /// A Parquet file is answered from its metadata except for text columns,
-/// whose type only their values decide; those are sampled, so the schema
-/// names the same type `profile()` will (#693).
+/// whose type only their values decide; those are sampled through the same
+/// inference the profiler runs (#693).
+///
+/// The sample is bounded, so it names the type `profile()` reports whenever
+/// `schema_stable` is true — the scan reached the end of the source. Once it
+/// stops at the cap, a later row can still move the type, in any format.
 #[pyfunction]
 pub fn infer_schema(path: &str) -> PyResult<PySchemaResult> {
     let result = dataprof::infer_schema(Path::new(path)).map_err(|e| analysis_error_to_py(&e))?;

--- a/crates/dataprof-python/src/partial.rs
+++ b/crates/dataprof-python/src/partial.rs
@@ -50,7 +50,10 @@ impl PySchemaResult {
             .collect()
     }
 
-    /// Number of rows sampled to infer the schema (0 for Parquet metadata)
+    /// Number of rows sampled to infer the schema.
+    ///
+    /// 0 when nothing had to be read: a Parquet file whose every column is
+    /// typed by its encoding is answered from the metadata alone.
     #[getter]
     fn rows_sampled(&self) -> usize {
         self.inner.rows_sampled
@@ -315,8 +318,10 @@ impl PyRowCountEstimate {
 
 /// Infer the schema (column names + data types) of a file.
 ///
-/// Much faster than full profiling — reads only a small sample
-/// (or just metadata for Parquet).
+/// Much faster than full profiling — reads only a small sample of rows.
+/// A Parquet file is answered from its metadata except for text columns,
+/// whose type only their values decide; those are sampled, so the schema
+/// names the same type `profile()` will (#693).
 #[pyfunction]
 pub fn infer_schema(path: &str) -> PyResult<PySchemaResult> {
     let result = dataprof::infer_schema(Path::new(path)).map_err(|e| analysis_error_to_py(&e))?;

--- a/crates/dataprof/src/profiler.rs
+++ b/crates/dataprof/src/profiler.rs
@@ -425,7 +425,9 @@ impl Profiler {
     /// Infer the schema (column names + data types) of a file.
     ///
     /// Respects the builder's format override. This is much faster than a full
-    /// `analyze_file` — it reads only a small sample (or just metadata for Parquet).
+    /// `analyze_file` — it reads only a small sample of rows. A Parquet file is
+    /// answered from its metadata except for text columns, whose type only
+    /// their values decide (#693).
     pub fn infer_schema<P: AsRef<Path>>(&self, path: P) -> Result<SchemaResult, DataProfilerError> {
         let path = path.as_ref();
         let format = self

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -241,10 +241,10 @@ entry points all agree on what a record is.
 
 ### Parquet
 
-Parquet is the most efficient format to profile. Schema inference and row counting read only the file metadata -- zero row scanning required.
+Parquet is the most efficient format to profile. Row counting reads only the file metadata, and so does schema inference for every column the metadata types. Text columns are the exception: a writer that did not type its input leaves dates, integers and booleans in string columns, so `infer_schema()` reads a bounded sample of those columns and reports the same type `profile()` will. `rows_sampled` says how many rows that cost.
 
 ```python
-schema = dp.infer_schema("data.parquet")      # instant schema from metadata
+schema = dp.infer_schema("data.parquet")      # metadata, plus a bounded sample of text columns
 rows = dp.quick_row_count("data.parquet")     # instant row count from metadata
 report = dp.profile("data.parquet")           # full profiling reads row groups
 ```

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -241,7 +241,7 @@ entry points all agree on what a record is.
 
 ### Parquet
 
-Parquet is the most efficient format to profile. Row counting reads only the file metadata, and so does schema inference for every column the metadata types. Text columns are the exception: a writer that did not type its input leaves dates, integers and booleans in string columns, so `infer_schema()` reads a bounded sample of those columns and reports the same type `profile()` will. `rows_sampled` says how many rows that cost.
+Parquet is the most efficient format to profile. Row counting reads only the file metadata, and so does schema inference for every column the metadata types. Text columns are the exception: a writer that did not type its input leaves dates, integers and booleans in string columns, so `infer_schema()` reads a bounded sample of those columns and types them through the same inference `profile()` runs. `rows_sampled` says how many rows that cost, and `schema_stable` says whether the sample reached the end of the file -- once it stops at the cap, a later row can still move a type, exactly as for CSV and JSON.
 
 ```python
 schema = dp.infer_schema("data.parquet")      # metadata, plus a bounded sample of text columns

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -760,6 +760,12 @@ for col in result.columns:
     print(f"  {col['name']}: {col['data_type']}")
 ```
 
+The type is the one `profile()` will report, in every format. On a Parquet file
+that means the metadata answers for every column it types, and text columns are
+sampled: only their values say whether they hold dates, integers or booleans,
+which is what a writer that did not type its input leaves behind.
+`rows_sampled` reports what that cost -- `0` for a fully typed file.
+
 ### `quick_row_count()`
 
 ```python

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -760,11 +760,15 @@ for col in result.columns:
     print(f"  {col['name']}: {col['data_type']}")
 ```
 
-The type is the one `profile()` will report, in every format. On a Parquet file
-that means the metadata answers for every column it types, and text columns are
+Every format runs the same inference `profile()` does. On a Parquet file that
+means the metadata answers for every column it types, and text columns are
 sampled: only their values say whether they hold dates, integers or booleans,
 which is what a writer that did not type its input leaves behind.
 `rows_sampled` reports what that cost -- `0` for a fully typed file.
+
+The sample is bounded in every format, so the type matches a full `profile()`
+whenever `schema_stable` is true; once inference stops at the cap, a later row
+can still move it.
 
 ### `quick_row_count()`
 

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1699,6 +1699,9 @@ class TestPartialAnalysis:
         # every row of it was read.
         assert structure.rows_sampled == 3
         assert structure.source_exhausted is True
+        # The sampled rows type the column; they are not counted. #700 decides
+        # whether a Parquet structural report should carry counters at all.
+        assert all(column.null_count is None for column in structure.columns)
         assert dataprof.infer_schema(path).schema_stable is True
 
     def test_fully_typed_parquet_still_reads_no_rows(self, tmp_path):

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1638,6 +1638,82 @@ class TestPartialAnalysis:
         assert age.uniqueness_ratio is not None
         assert age.distinct_count_approximate is False
 
+    def test_parquet_schema_agrees_with_profile_and_with_csv(self, tmp_path):
+        """One dataset, two formats, one answer (#693).
+
+        A Parquet writer that did not type its input leaves dates, integers and
+        booleans in string columns. The schema used to be read from the file
+        metadata alone, so ``infer_schema`` reported ``string`` for three of
+        these five columns while ``profile`` on the same file reported the
+        types the values carry.
+        """
+        pa = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+
+        rows = 50
+        columns = {
+            "when": ["2026-01-02T03:04:05Z"] * rows,
+            "ident": [f"ORD-{i}" for i in range(rows)],
+            "numish": [str(i * 3) for i in range(rows)],
+            "boolish": ["true", "false"] * (rows // 2),
+            "real_int": [str(i) for i in range(rows)],
+        }
+        parquet_path = tmp_path / "typed.parquet"
+        pq.write_table(pa.table({**columns, "real_int": list(range(rows))}), parquet_path)
+
+        # The identical data as CSV. No value needs quoting, so a plain join is
+        # the whole writer.
+        csv_path = tmp_path / "typed.csv"
+        lines = [",".join(columns)]
+        lines += [",".join(values[row] for values in columns.values()) for row in range(rows)]
+        csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        expected = {
+            "when": "date",
+            "ident": "string",
+            "numish": "integer",
+            "boolish": "boolean",
+            "real_int": "integer",
+        }
+        for path in (parquet_path, csv_path):
+            profile = dataprof.profile(path)
+            schema = dataprof.infer_schema(path)
+            structure = dataprof.analyze_structure(path)
+
+            assert {name: profile[name].data_type for name in expected} == expected, path
+            assert {c["name"]: c["data_type"] for c in schema.columns} == expected, path
+            assert {c.name: c.data_type for c in structure.columns} == expected, path
+
+    def test_parquet_structure_provenance_separates_metadata_from_sample(self, tmp_path):
+        """A Parquet file is typed from two sources, and says which is which."""
+        pa = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+
+        path = tmp_path / "mixed.parquet"
+        pq.write_table(pa.table({"id": [1, 2, 3], "label": ["a", "b", "c"]}), path)
+
+        structure = dataprof.analyze_structure(path)
+        provenance = {column.name: column.provenance for column in structure.columns}
+        assert provenance == {"id": "metadata", "label": "sample"}
+        # Only the text column needed values, and the file is short enough that
+        # every row of it was read.
+        assert structure.rows_sampled == 3
+        assert structure.source_exhausted is True
+        assert dataprof.infer_schema(path).schema_stable is True
+
+    def test_fully_typed_parquet_still_reads_no_rows(self, tmp_path):
+        """The metadata fast path survives where the metadata is the answer."""
+        pa = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+
+        path = tmp_path / "typed_only.parquet"
+        pq.write_table(pa.table({"id": [1, 2, 3], "score": [1.5, 2.5, 3.5]}), path)
+
+        schema = dataprof.infer_schema(path)
+        assert schema.rows_sampled == 0
+        assert schema.schema_stable is True
+        assert [c["data_type"] for c in schema.columns] == ["integer", "float"]
+
     def test_missing_file_raises_file_not_found(self):
         missing = str(FIXTURES / "does_not_exist.csv")
         with pytest.raises(FileNotFoundError, match="does_not_exist.csv") as excinfo:

--- a/tests/partial_schema_parity.rs
+++ b/tests/partial_schema_parity.rs
@@ -227,6 +227,48 @@ fn infer_schema_agrees_with_profile_on_a_time_column() {
     assert_eq!(infer_schema(file.path()).unwrap().rows_sampled, 0);
 }
 
+/// A zero-row sample of a file that does have text columns is not a settled
+/// schema, and must not claim to be. The CSV and JSON paths report the same
+/// clause for the same reason.
+#[test]
+fn a_zero_row_sample_is_not_a_stable_schema() {
+    let parquet = parquet_fixture();
+
+    let report = analyze_structure(parquet.path(), Some(0)).unwrap();
+    assert_eq!(report.rows_sampled, 0);
+    assert!(report.truncated);
+    assert!(!report.source_exhausted);
+}
+
+/// An empty file is settled, though: there is no row left that could change a
+/// type, so nothing is truncated and the text column keeps the type an empty
+/// profile reports.
+#[test]
+fn an_empty_parquet_file_is_stable_without_reading_rows() {
+    let empty = write_parquet(vec![
+        (
+            "id",
+            Arc::new(Int64Array::from(Vec::<i64>::new())) as ArrayRef,
+        ),
+        (
+            "label",
+            Arc::new(StringArray::from(Vec::<String>::new())) as ArrayRef,
+        ),
+    ]);
+
+    let schema = infer_schema(empty.path()).unwrap();
+    assert_eq!(schema.rows_sampled, 0);
+    assert!(schema.schema_stable);
+    assert_eq!(
+        schema
+            .columns
+            .into_iter()
+            .map(|column| (column.name, column.data_type))
+            .collect::<Vec<_>>(),
+        profile_types(&empty)
+    );
+}
+
 /// The physical encoding a Parquet writer chose must not reach the schema
 /// either: a dictionary is a compression of the values, not a type.
 #[test]

--- a/tests/partial_schema_parity.rs
+++ b/tests/partial_schema_parity.rs
@@ -1,0 +1,275 @@
+//! `infer_schema()` and `profile()` must name the same type for the same
+//! column, in every format (#693).
+//!
+//! A Parquet writer that did not type its input leaves dates, integers and
+//! booleans in `Utf8` columns — what any CSV-to-Parquet export produces.
+//! `profile()` re-infers those from the values (#661), so a schema read from
+//! the file metadata alone disagreed with the full profiler about three of the
+//! five columns below, and with `infer_schema()` on the identical data as CSV.
+
+#![cfg(feature = "parquet")]
+
+use std::io::Write;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, DictionaryArray, Int64Array, StringArray, Time32MillisecondArray};
+use arrow::datatypes::{Field, Int8Type, Schema};
+use arrow::record_batch::RecordBatch;
+use dataprof::{DataType, Profiler, analyze_structure, infer_schema};
+use parquet::arrow::ArrowWriter;
+use tempfile::NamedTempFile;
+
+/// Fifty rows, wide enough for the sample to be representative and short enough
+/// to stay under every row cap in the partial paths.
+const ROWS: usize = 50;
+
+const COLUMNS: [&str; 5] = ["when", "ident", "numish", "boolish", "real_int"];
+
+fn when(row: usize) -> String {
+    format!("2026-01-{:02}T03:04:05Z", row % 28 + 1)
+}
+
+fn ident(row: usize) -> String {
+    format!("ORD-{row}")
+}
+
+fn numish(row: usize) -> String {
+    (row * 3).to_string()
+}
+
+fn boolish(row: usize) -> String {
+    if row.is_multiple_of(2) {
+        "true"
+    } else {
+        "false"
+    }
+    .to_string()
+}
+
+fn real_int(row: usize) -> i64 {
+    row as i64
+}
+
+fn csv_fixture() -> NamedTempFile {
+    let mut file = NamedTempFile::with_suffix(".csv").unwrap();
+    writeln!(file, "{}", COLUMNS.join(",")).unwrap();
+    for row in 0..ROWS {
+        writeln!(
+            file,
+            "{},{},{},{},{}",
+            when(row),
+            ident(row),
+            numish(row),
+            boolish(row),
+            real_int(row)
+        )
+        .unwrap();
+    }
+    file.flush().unwrap();
+    file
+}
+
+/// The same data as Parquet, with every text column written `Utf8` — the shape
+/// a writer produces when its input was untyped.
+fn parquet_fixture() -> NamedTempFile {
+    let text = |value: fn(usize) -> String| -> ArrayRef {
+        Arc::new(StringArray::from(
+            (0..ROWS).map(value).collect::<Vec<String>>(),
+        ))
+    };
+
+    write_parquet(vec![
+        ("when", text(when)),
+        ("ident", text(ident)),
+        ("numish", text(numish)),
+        ("boolish", text(boolish)),
+        (
+            "real_int",
+            Arc::new(Int64Array::from(
+                (0..ROWS).map(real_int).collect::<Vec<i64>>(),
+            )),
+        ),
+    ])
+}
+
+/// The same data again, with the text columns dictionary-encoded — what
+/// `pandas.DataFrame.to_parquet` writes for a categorical column. The encoding
+/// is not the type, so the schema must not change (#661).
+fn dictionary_parquet_fixture() -> NamedTempFile {
+    let text = |value: fn(usize) -> String| -> ArrayRef {
+        let values: DictionaryArray<Int8Type> = (0..ROWS)
+            .map(value)
+            .collect::<Vec<String>>()
+            .iter()
+            .map(|value| Some(value.as_str()))
+            .collect();
+        Arc::new(values)
+    };
+
+    write_parquet(vec![
+        ("when", text(when)),
+        ("ident", text(ident)),
+        ("numish", text(numish)),
+        ("boolish", text(boolish)),
+        (
+            "real_int",
+            Arc::new(Int64Array::from(
+                (0..ROWS).map(real_int).collect::<Vec<i64>>(),
+            )),
+        ),
+    ])
+}
+
+fn write_parquet(columns: Vec<(&str, ArrayRef)>) -> NamedTempFile {
+    let schema = Arc::new(Schema::new(
+        columns
+            .iter()
+            .map(|(name, array)| Field::new(*name, array.data_type().clone(), true))
+            .collect::<Vec<Field>>(),
+    ));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        columns.into_iter().map(|(_, array)| array).collect(),
+    )
+    .unwrap();
+
+    let file = NamedTempFile::with_suffix(".parquet").unwrap();
+    let mut writer = ArrowWriter::try_new(file.reopen().unwrap(), schema, None).unwrap();
+    writer.write(&batch).unwrap();
+    writer.close().unwrap();
+    file
+}
+
+fn schema_types(file: &NamedTempFile) -> Vec<(String, DataType)> {
+    infer_schema(file.path())
+        .unwrap()
+        .columns
+        .into_iter()
+        .map(|column| (column.name, column.data_type))
+        .collect()
+}
+
+fn profile_types(file: &NamedTempFile) -> Vec<(String, DataType)> {
+    Profiler::new()
+        .analyze_file(file.path())
+        .unwrap()
+        .column_profiles
+        .into_iter()
+        .map(|profile| (profile.name, profile.data_type))
+        .collect()
+}
+
+fn structure_types(file: &NamedTempFile) -> Vec<(String, DataType)> {
+    analyze_structure(file.path(), None)
+        .unwrap()
+        .columns
+        .into_iter()
+        .map(|column| (column.name, column.data_type))
+        .collect()
+}
+
+/// What the values say, which is what CSV already reported and what `profile()`
+/// reports for every format.
+fn expected() -> Vec<(String, DataType)> {
+    vec![
+        ("when".to_string(), DataType::Date),
+        ("ident".to_string(), DataType::String),
+        ("numish".to_string(), DataType::Integer),
+        ("boolish".to_string(), DataType::Boolean),
+        ("real_int".to_string(), DataType::Integer),
+    ]
+}
+
+/// The headline case: one dataset, two formats, four surfaces, one answer.
+///
+/// Before the fix the three string-encoded columns reported `string` from
+/// `infer_schema()` and `analyze_structure()` on the Parquet file, while
+/// `profile()` on the same file and all four surfaces on the CSV reported
+/// `date`, `integer` and `boolean`.
+#[test]
+fn infer_schema_agrees_with_profile_across_csv_and_parquet() {
+    let csv = csv_fixture();
+    let parquet = parquet_fixture();
+
+    for (label, file) in [("csv", &csv), ("parquet", &parquet)] {
+        assert_eq!(schema_types(file), expected(), "infer_schema on {label}");
+        assert_eq!(profile_types(file), expected(), "profile on {label}");
+        assert_eq!(
+            structure_types(file),
+            expected(),
+            "analyze_structure on {label}"
+        );
+    }
+}
+
+/// A type the schema path answered on its own, differently from the profiler.
+///
+/// `Time32`/`Time64` had an arm in the schema path's Arrow map (`date`) and
+/// none in the profiler's, which renders the values and re-infers them as
+/// `string`. Both surfaces read one map now, so the arm cannot exist on one
+/// side only — and no row is read to establish it, since the values are not
+/// what decided it.
+#[test]
+fn infer_schema_agrees_with_profile_on_a_time_column() {
+    let file = write_parquet(vec![(
+        "clock",
+        Arc::new(Time32MillisecondArray::from(
+            (0..ROWS)
+                .map(|row| (row * 1_000) as i32)
+                .collect::<Vec<i32>>(),
+        )) as ArrayRef,
+    )]);
+
+    let expected = vec![("clock".to_string(), DataType::String)];
+    assert_eq!(profile_types(&file), expected);
+    assert_eq!(schema_types(&file), expected);
+    assert_eq!(structure_types(&file), expected);
+    assert_eq!(infer_schema(file.path()).unwrap().rows_sampled, 0);
+}
+
+/// The physical encoding a Parquet writer chose must not reach the schema
+/// either: a dictionary is a compression of the values, not a type.
+#[test]
+fn infer_schema_ignores_dictionary_encoding() {
+    let dictionary = dictionary_parquet_fixture();
+
+    assert_eq!(schema_types(&dictionary), expected());
+    assert_eq!(profile_types(&dictionary), expected());
+}
+
+/// The value sample is bounded, and its cost is disclosed: `rows_sampled`
+/// reports the rows read, and `schema_stable` is false once the sample stopped
+/// short of the file.
+#[test]
+fn parquet_schema_reports_the_rows_it_read() {
+    let parquet = parquet_fixture();
+
+    let schema = infer_schema(parquet.path()).unwrap();
+    assert_eq!(schema.rows_sampled, ROWS);
+    assert!(schema.schema_stable, "the whole file was read");
+
+    // The structural pass takes its own cap, and says so rather than reporting
+    // a type as if the whole file had backed it.
+    let capped = analyze_structure(parquet.path(), Some(10)).unwrap();
+    assert_eq!(capped.rows_sampled, 10);
+    assert!(capped.truncated);
+    assert_eq!(capped.truncation_reason.as_deref(), Some("max_rows(10)"));
+    assert!(!capped.source_exhausted);
+
+    // Provenance separates the two sources the file is typed from.
+    let provenance: Vec<(String, String)> = capped
+        .columns
+        .into_iter()
+        .map(|column| (column.name, column.provenance))
+        .collect();
+    assert_eq!(
+        provenance,
+        vec![
+            ("when".to_string(), "sample".to_string()),
+            ("ident".to_string(), "sample".to_string()),
+            ("numish".to_string(), "sample".to_string()),
+            ("boolish".to_string(), "sample".to_string()),
+            ("real_int".to_string(), "metadata".to_string()),
+        ]
+    );
+}


### PR DESCRIPTION
## What changed

`infer_schema()` and `analyze_structure()` reported a Parquet column's physical
Arrow type while `profile()` reported the type inferred from its values. On the
issue's fixture three of five columns disagreed, and `infer_schema()` on a
Parquet file disagreed with `infer_schema()` on the identical data as CSV:

| column | profile(pq) | infer(pq) before | infer(pq) after | infer(csv) |
| --- | --- | --- | --- | --- |
| `when` (RFC 3339 strings) | date | **string** | date | date |
| `numish` (digit strings) | integer | **string** | integer | integer |
| `boolish` ("true"/"false") | boolean | **string** | boolean | boolean |
| `ident`, `real_int` | string, integer | string, integer | string, integer | string, integer |

Resolution 2 from the issue: sample values only where inference can change the
answer. A column whose Arrow type decides its profiled type still costs no
read, so a fully typed Parquet file reports `rows_sampled: 0` exactly as
before; text columns are projected and read up to the sample cap, and the
type comes off a `ColumnProfile` produced by the profiler's own
`RecordBatchAnalyzer` -- the same way `schema_from_profiles` reads it for CSV
and JSON.

The two surfaces now read **one** type map. The non-text arms of
`ColumnAnalyzer::infer_data_type` move into `data_type_from_arrow_type`, which
returns `None` where only the values decide; the schema path consumes that and
`logical_arrow_type` instead of keeping its own list. That removes a second
class of disagreement the issue did not name, because the two lists had
drifted:

- `Time32`/`Time64`: `date` from the schema path, `string` from the profiler.
- `Dictionary(_, Int64)`: `string` from the schema path, `integer` from the
  profiler.

`analyze_structure()` reports the split rather than hiding it: per-column
provenance (`"metadata"` for an encoding-typed column, `"sample"` for a
value-typed one), the rows actually read, and truncation when the sample
stopped short of the file. It also honors its `max_rows` argument on Parquet,
which it previously ignored.

**Related issue:** Closes #693

## How it was verified

The new `tests/partial_schema_parity.rs` reverted against each half of the fix
separately, since one half can mask the other.

Part 1 -- the value sample (`values_decide_type` forced to `false`):

```console
$ cargo test --test partial_schema_parity
test infer_schema_agrees_with_profile_on_a_time_column ... ok
test parquet_schema_reports_the_rows_it_read ... FAILED
test infer_schema_ignores_dictionary_encoding ... FAILED
test infer_schema_agrees_with_profile_across_csv_and_parquet ... FAILED

---- infer_schema_agrees_with_profile_across_csv_and_parquet stdout ----
assertion `left == right` failed: infer_schema on parquet
  left: [("when", String), ("ident", String), ("numish", String), ("boolish", String), ("real_int", Integer)]
 right: [("when", Date), ("ident", String), ("numish", Integer), ("boolish", Boolean), ("real_int", Integer)]

test result: FAILED. 1 passed; 3 failed
```

Part 2 -- the shared type map (the pre-fix Arrow map restored for the
metadata branch, value sampling left in place):

```console
$ cargo test --test partial_schema_parity
test infer_schema_agrees_with_profile_on_a_time_column ... FAILED

---- infer_schema_agrees_with_profile_on_a_time_column stdout ----
assertion `left == right` failed
  left: [("clock", Date)]
 right: [("clock", String)]

test result: FAILED. 3 passed; 1 failed
```

Part 1 also discriminates the `analyze_structure()` reporting, via the crate's
own tests:

```console
$ cargo test -p dataprof-partial --features parquet   # part 1 reverted
---- tests::test_analyze_structure_parquet_metadata stdout ----
assertion `left == right` failed
  left: 0
 right: 1
test result: FAILED. 34 passed; 3 failed
```

With both halves in place:

```console
$ cargo test --test partial_schema_parity
test result: ok. 4 passed; 0 failed

$ cargo test -p dataprof-partial --features parquet
test result: ok. 37 passed; 0 failed

$ cargo test -p dataprof-parquet --features parquet
test result: ok. 37 passed; 0 failed
test result: ok. 6 passed; 0 failed

$ cargo test -p dataprof-engines --features parquet
test result: ok. 13 passed; 0 failed

$ cargo test          # root package, default features, 24 binaries
test result: ok. 28 passed; 0 failed
... (all green)

$ cargo fmt --all
$ cargo clippy --all --all-targets -- -D warnings
    Finished `dev` profile

$ RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py
MSRV gate passed: 6 feature graphs compile on 1.96

$ uv run maturin develop
$ uv run pytest python/tests -q
1277 passed, 9 skipped in 50.93s

$ uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
1 file reformatted, 57 files left unchanged
$ uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
All checks passed!
$ uv run ty check python/
All checks passed!
```

## Anything reviewers should know

- **Behavior change, deliberate:** `infer_schema()` on a Parquet file with text
  columns now reads rows. `rows_sampled` stops being `0` there, `schema_stable`
  can be `false`, and `analyze_structure()` can report `truncated: true` with
  the `structure_sample_truncated` warning. The docstrings and the two guides
  that promised "metadata only" are updated. `docs/release-notes.md` is left
  alone.
- **Cost:** bounded by the sample, not the file -- at most 1000 rows of the
  text columns only, and nothing at all for a fully typed file. A wide file of
  text columns pays for all of them; that is the trade the issue's resolution 2
  names.
- **Provenance values are unchanged in kind** (`"sample"` / `"metadata"`), but
  a Parquet report can now carry both, where it previously carried only
  `"metadata"`. The per-column counters stay `None`: only the type is sampled.
- **New crate dependency:** `dataprof-partial` now depends on
  `dataprof-parquet`, gated on its existing `parquet` feature. Without the
  feature nothing changes. No cycle -- `dataprof-parquet` does not depend on
  `dataprof-partial`.
- **Noted side effect:** a Parquet file with duplicate column names among its
  *text* columns now errors from `infer_schema()` instead of returning a
  schema, because the sample runs through the analyzer's name validation.
  `profile()` already rejects that file, so the two agree; flagging it since it
  is the one input whose error surface moved.
- The sample is the file prefix, like the profiling row cap. Spreading it
  across row groups is #639 and applies to both.
- Nested (#637) and binary (#645) columns keep their current answer (`string`)
  and are still not read: their rendering is not their value, so a sample would
  type the rendering. The comments say so at each site.

## Review pass

**Self-review** (`7543c6e`) found one behavior bug and one follow-up:

- `infer_schema()` with a zero-row sample budget returned early with
  `schema_stable: true` even for a file with text columns nothing had typed, so
  `analyze_structure(path, Some(0))` reported `truncated: false` and
  `source_exhausted: true` for a pass that read nothing. Fixed, with
  `a_zero_row_sample_is_not_a_stable_schema` pinning it -- it fails against the
  branch as first written.
- The per-column counters a Parquet structural report still does not carry, now
  that the path decodes rows for the text columns, are filed as **#700** rather
  than folded in. The code comment and the Python test point there.

**Copilot** (🟡 changes recommended) raised the same zero-row branch
independently, plus three documentation claims that promised more than a
bounded sample can give: "reports the same type `profile()` will" holds while
`schema_stable` is true and not after. Reworded in `541e8c8` to promise what is
actually shared -- one inference, one type map -- and to name the flag that
upgrades it to equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
