### PR TITLE
fix(partial): refuse duplicate Parquet column names, and name the type's source

### DIFF
--- a/crates/dataprof-core/src/partial.rs
+++ b/crates/dataprof-core/src/partial.rs
@@ -66,10 +66,14 @@ pub struct StructureColumnSummary {
     pub unique_count: Option<usize>,
     pub uniqueness_ratio: Option<f64>,
     pub distinct_count_approximate: Option<bool>,
-    /// `"sample"` when the column's type came from reading values,
-    /// `"metadata"` when the declared schema decided it. CSV/JSON/JSONL are
-    /// always `"sample"`; a Parquet file carries both, since only its text
-    /// columns need values read to be typed (#693).
+    /// Which source governs this column's type: `"metadata"` when the declared
+    /// schema decided it, `"sample"` when only the column's values can. It
+    /// names the source, not the read — a `"sample"` column is one the metadata
+    /// could not type, whether or not the caller's row budget allowed any row
+    /// to be read for it. `rows_sampled` and `truncated` report the read.
+    ///
+    /// CSV/JSON/JSONL are always `"sample"`; a Parquet file carries both, since
+    /// only its text columns need values to be typed (#693).
     pub provenance: String,
 }
 

--- a/crates/dataprof-parquet/src/lib.rs
+++ b/crates/dataprof-parquet/src/lib.rs
@@ -51,7 +51,7 @@ pub use async_http::{
 
 #[cfg(feature = "arrow")]
 pub use record_batch_analyzer::{
-    RecordBatchAnalyzer, data_type_from_arrow_type, logical_arrow_type,
+    RecordBatchAnalyzer, data_type_from_arrow_type, logical_arrow_type, sampling_can_decide_type,
 };
 
 #[cfg(feature = "parquet")]

--- a/crates/dataprof-parquet/src/record_batch_analyzer.rs
+++ b/crates/dataprof-parquet/src/record_batch_analyzer.rs
@@ -56,18 +56,24 @@ pub fn logical_arrow_type(data_type: &arrow::datatypes::DataType) -> arrow::data
 }
 
 /// The type a column profiles as when its Arrow type alone decides it, or
-/// `None` when only the values can say.
+/// `None` when it has no native arm here and the profile types it from
+/// whatever text reaches the accumulator.
 ///
-/// `None` is the answer for text (`Utf8`/`LargeUtf8`), where the same column
-/// holds `"2026-01-02"` in one file and `"ORD-7"` in another, and for every
-/// Arrow type without a native arm below, which reaches the profile through a
-/// formatter and is re-inferred from its rendering.
+/// `None` is not the same claim as "the values decide". It covers three cases
+/// that behave differently, and a caller who cannot read values needs
+/// [`sampling_can_decide_type`] to tell them apart:
 ///
-/// Callers that hold the values pass them through [`infer_type`]; callers that
-/// hold only the schema — `infer_schema()` on a Parquet file — decide from this
-/// whether reading a sample can change the answer. Both read one list, so the
-/// fast schema path and the full profiler cannot name a column's type
-/// differently (#693).
+/// - text (`Utf8`/`LargeUtf8`), where the rendering *is* the value, so
+///   re-inference answers and reading a sample can change the answer;
+/// - binary, where the rendering is hex and re-inference is refused outright —
+///   the profile declares `String` (#645);
+/// - nested containers, where the rendering is a bracketed serialisation, so
+///   re-inference reads the serialisation rather than the data and lands on
+///   `String` for every container shape (#637).
+///
+/// Both the profiler and `infer_schema()` read this one list, so the fast
+/// schema path and the full profiler cannot name a column's type differently
+/// (#693).
 ///
 /// Pass a type that has been through [`logical_arrow_type`]: this maps the
 /// logical type, not the physical encoding.
@@ -92,6 +98,25 @@ pub fn data_type_from_arrow_type(arrow_type: &arrow::datatypes::DataType) -> Opt
         ArrowDataType::Boolean => Some(DataType::Boolean),
         _ => None,
     }
+}
+
+/// Whether reading a sample of this column's values can decide its type.
+///
+/// The question `infer_schema()` asks before it pays for a read, kept next to
+/// the map it refines rather than restated by each caller — the same list in
+/// two places is what #661 removed from the profiler itself.
+///
+/// True only for text. A native arm needs no values, and the two families
+/// without one reach the profile as a *rendering* of their values — hex for
+/// binary, a bracketed serialisation for a container — which re-inference reads
+/// as text either way, so a read cannot move the answer off `String`.
+///
+/// Pass a type that has been through [`logical_arrow_type`].
+pub fn sampling_can_decide_type(arrow_type: &arrow::datatypes::DataType) -> bool {
+    use arrow::datatypes::DataType as ArrowDataType;
+
+    data_type_from_arrow_type(arrow_type).is_none()
+        && matches!(arrow_type, ArrowDataType::Utf8 | ArrowDataType::LargeUtf8)
 }
 
 /// Full-stream duplicate-row tracking over Arrow batches.

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -24,7 +24,9 @@ use dataprof_core::{
 use dataprof_csv::CsvParserConfig;
 use dataprof_json::JsonParserConfig;
 #[cfg(feature = "parquet")]
-use dataprof_parquet::{RecordBatchAnalyzer, data_type_from_arrow_type, logical_arrow_type};
+use dataprof_parquet::{
+    RecordBatchAnalyzer, data_type_from_arrow_type, logical_arrow_type, sampling_can_decide_type,
+};
 use dataprof_runtime::StreamingColumnCollection;
 
 /// Schema inference sample size (rows to read for CSV/JSON).
@@ -235,9 +237,15 @@ fn infer_schema_parquet(
     parquet_schema(path, start, sample_rows).map(|(schema, _)| schema)
 }
 
-/// [`infer_schema_parquet`], plus the names of the columns whose type came from
-/// the value sample rather than the metadata. `analyze_structure()` reports
-/// that split as per-column provenance.
+/// [`infer_schema_parquet`], plus the names of the columns whose type the
+/// metadata could not decide. `analyze_structure()` reports that split as
+/// per-column provenance.
+///
+/// The split is the schema decision, not a report of what the read produced: a
+/// text column is governed by its values whether or not the caller's row budget
+/// let them be read. `rows_sampled` and `truncated` say what was read, and the
+/// CSV path draws the same line — it labels every column `"sample"` at
+/// `max_rows(0)`.
 #[cfg(feature = "parquet")]
 fn parquet_schema(
     path: &Path,
@@ -253,6 +261,25 @@ fn parquet_schema(
     })?;
 
     let arrow_schema = builder.schema().clone();
+
+    // Reject duplicate names up front, on the *whole* schema.
+    //
+    // Two reasons, and either alone is enough. The full profiler refuses this
+    // file, and so does `infer_schema()` on a CSV with a duplicated header, so
+    // answering here made Parquet the one surface that accepted a file nothing
+    // else would read. And the sample below is projected: with `x: Int64` and
+    // `x: Utf8` the projection hides the collision from the analyzer's own
+    // validation, and the sampled type then lands on whichever `x` comes first
+    // — reporting the integer column as a date and leaving the text column at
+    // its fallback. Validating here also makes the name lookup after the scan
+    // unambiguous by construction.
+    let names: Vec<String> = arrow_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().to_string())
+        .collect();
+    dataprof_core::validate_unique_column_names(&names, "Arrow/Parquet schema")?;
+
     let mut columns: Vec<ColumnSchema> = Vec::with_capacity(arrow_schema.fields().len());
     let mut text_columns: Vec<usize> = Vec::new();
 
@@ -268,7 +295,7 @@ fn parquet_schema(
             // profiler reports `String`, which is what stands here (binary is
             // #645, nested containers #637).
             None => {
-                if values_decide_type(&logical) {
+                if sampling_can_decide_type(&logical) {
                     text_columns.push(index);
                 }
                 DataType::String
@@ -284,6 +311,7 @@ fn parquet_schema(
     let total_rows = builder.metadata().file_metadata().num_rows().max(0) as usize;
 
     if text_columns.is_empty() || sample_rows == 0 {
+        let value_typed = value_typed_names(&columns, &text_columns);
         return Ok((
             SchemaResult {
                 columns,
@@ -296,7 +324,7 @@ fn parquet_schema(
                 // CSV and JSON paths tell them.
                 schema_stable: text_columns.is_empty() || total_rows == 0,
             },
-            Vec::new(),
+            value_typed,
         ));
     }
 
@@ -331,16 +359,17 @@ fn parquet_schema(
         })?;
     }
 
-    let mut sampled_columns = Vec::with_capacity(text_columns.len());
+    // Names are unique — validated above — so this lookup names one column.
     for profile in analyzer.to_profiles(true, true, None) {
         if let Some(column) = columns
             .iter_mut()
             .find(|column| column.name == profile.name)
         {
             column.data_type = profile.data_type;
-            sampled_columns.push(profile.name);
         }
     }
+
+    let value_typed = value_typed_names(&columns, &text_columns);
 
     Ok((
         SchemaResult {
@@ -352,24 +381,17 @@ fn parquet_schema(
             // and JSON paths report.
             schema_stable: rows_sampled >= total_rows,
         },
-        sampled_columns,
+        value_typed,
     ))
 }
 
-/// Whether a column's values, rather than its Arrow type, decide the type the
-/// profiler reports — and reading a sample can therefore change the answer.
-///
-/// Text is the one case worth a read. Every other type without a decided answer
-/// reaches the profile through a formatter, so a sample would type the
-/// rendering rather than the data: hex for binary (#645), a container
-/// serialisation for nested columns (#637). Both report `String` today, which
-/// the metadata path names without reading anything.
+/// The names of the columns whose type the metadata could not decide.
 #[cfg(feature = "parquet")]
-fn values_decide_type(logical: &arrow::datatypes::DataType) -> bool {
-    matches!(
-        logical,
-        arrow::datatypes::DataType::Utf8 | arrow::datatypes::DataType::LargeUtf8
-    )
+fn value_typed_names(columns: &[ColumnSchema], text_columns: &[usize]) -> Vec<String> {
+    text_columns
+        .iter()
+        .map(|index| columns[*index].name.clone())
+        .collect()
 }
 
 fn infer_schema_csv(path: &Path, start: Instant) -> Result<SchemaResult, DataProfilerError> {
@@ -1022,7 +1044,7 @@ fn analyze_structure_parquet(
 ) -> Result<StructureReport, DataProfilerError> {
     #[cfg(feature = "parquet")]
     {
-        let (schema, sampled_columns) = parquet_schema(path, Instant::now(), max_rows)?;
+        let (schema, value_typed) = parquet_schema(path, Instant::now(), max_rows)?;
         let row_count = quick_row_count_with_format(path, FileFormat::Parquet)?;
         // Provenance is per column, because a Parquet file is now typed from
         // both sources: the encoding answers for an already-typed column, a
@@ -1037,7 +1059,7 @@ fn analyze_structure_parquet(
             .columns
             .into_iter()
             .map(|column| {
-                let provenance = if sampled_columns.contains(&column.name) {
+                let provenance = if value_typed.contains(&column.name) {
                     "sample"
                 } else {
                     "metadata"
@@ -2008,13 +2030,13 @@ mod tests {
         // for.
         assert_eq!(mapped(&AT::Utf8), None);
         assert_eq!(mapped(&AT::LargeUtf8), None);
-        assert!(values_decide_type(&logical_arrow_type(&AT::Utf8)));
-        assert!(values_decide_type(&logical_arrow_type(&AT::Utf8View)));
+        assert!(sampling_can_decide_type(&logical_arrow_type(&AT::Utf8)));
+        assert!(sampling_can_decide_type(&logical_arrow_type(&AT::Utf8View)));
 
         // No answer from the type either, but the rendering is not the value,
         // so a sample would type the rendering. Left to #637 and #645.
         assert_eq!(mapped(&AT::Binary), None);
-        assert!(!values_decide_type(&logical_arrow_type(&AT::Binary)));
+        assert!(!sampling_can_decide_type(&logical_arrow_type(&AT::Binary)));
     }
 
     #[cfg(feature = "parquet")]

--- a/crates/dataprof-python/src/partial.rs
+++ b/crates/dataprof-python/src/partial.rs
@@ -53,7 +53,8 @@ impl PySchemaResult {
     /// Number of rows sampled to infer the schema.
     ///
     /// 0 when nothing had to be read: a Parquet file whose every column is
-    /// typed by its encoding is answered from the metadata alone.
+    /// typed by its encoding is answered from the metadata alone, and reports
+    /// `schema_stable` true on that basis rather than on a scan.
     #[getter]
     fn rows_sampled(&self) -> usize {
         self.inner.rows_sampled
@@ -324,8 +325,10 @@ impl PyRowCountEstimate {
 /// inference the profiler runs (#693).
 ///
 /// The sample is bounded, so it names the type `profile()` reports whenever
-/// `schema_stable` is true — the scan reached the end of the source. Once it
-/// stops at the cap, a later row can still move the type, in any format.
+/// `schema_stable` is true — nothing was left unread that could move a type,
+/// because the scan reached the end of the source or, for Parquet, because the
+/// metadata typed every column and no scan was needed. Once inference stops at
+/// the cap, a later row can still move the type, in any format.
 #[pyfunction]
 pub fn infer_schema(path: &str) -> PyResult<PySchemaResult> {
     let result = dataprof::infer_schema(Path::new(path)).map_err(|e| analysis_error_to_py(&e))?;

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -767,8 +767,10 @@ which is what a writer that did not type its input leaves behind.
 `rows_sampled` reports what that cost -- `0` for a fully typed file.
 
 The sample is bounded in every format, so the type matches a full `profile()`
-whenever `schema_stable` is true; once inference stops at the cap, a later row
-can still move it.
+whenever `schema_stable` is true -- nothing was left unread that could move it,
+either because the scan reached the end of the file or because the Parquet
+metadata typed every column and no scan was needed. Once inference stops at the
+cap, a later row can still move it.
 
 ### `quick_row_count()`
 

--- a/tests/partial_schema_parity.rs
+++ b/tests/partial_schema_parity.rs
@@ -227,6 +227,97 @@ fn infer_schema_agrees_with_profile_on_a_time_column() {
     assert_eq!(infer_schema(file.path()).unwrap().rows_sampled, 0);
 }
 
+/// Duplicate column names are refused, as they are on every other surface.
+///
+/// The projected sample hides the collision from the analyzer's own validation
+/// when only one of the duplicates is text, and the sampled type then landed on
+/// the wrong column: `x: Int64, x: Utf8` holding dates reported
+/// `[("x", Date), ("x", String)]` — the integer column typed as a date, the
+/// date column left at its fallback. `profile()` and `infer_schema()` on a CSV
+/// with a duplicated header both reject the file, so this one now does too.
+#[test]
+fn duplicate_column_names_are_refused_like_every_other_surface() {
+    let ints: ArrayRef = Arc::new(Int64Array::from(vec![1_i64, 2, 3]));
+    let dates: ArrayRef = Arc::new(StringArray::from(vec![
+        "2026-01-02".to_string(),
+        "2026-01-03".to_string(),
+        "2026-01-04".to_string(),
+    ]));
+    let file = write_parquet(vec![("x", ints), ("x", dates)]);
+
+    let error = infer_schema(file.path()).expect_err("duplicate names must be refused");
+    assert_eq!(error.category(), "duplicate_column_name");
+    assert!(
+        error.to_string().contains("'x'"),
+        "the message must name the duplicate: {error}"
+    );
+
+    // The same file through the other two surfaces, so the three cannot drift.
+    assert_eq!(
+        analyze_structure(file.path(), None)
+            .expect_err("duplicate names must be refused")
+            .category(),
+        "duplicate_column_name"
+    );
+    assert!(Profiler::new().analyze_file(file.path()).is_err());
+}
+
+/// Provenance names the source that governs a column's type, not how many rows
+/// happened to be read for it.
+///
+/// A text column is typed by its values whether or not the caller's row budget
+/// let them be read — with a zero-row cap nothing decided it and `String` is a
+/// fallback, which is the opposite of a metadata answer. The CSV path draws the
+/// same line: it labels every column `"sample"` at `max_rows(0)` too.
+#[test]
+fn provenance_follows_the_schema_decision_not_the_read() {
+    let parquet = parquet_fixture();
+
+    let capped = analyze_structure(parquet.path(), Some(0)).unwrap();
+    assert_eq!(capped.rows_sampled, 0);
+    assert!(capped.truncated);
+    let provenance: Vec<(String, String)> = capped
+        .columns
+        .into_iter()
+        .map(|column| (column.name, column.provenance))
+        .collect();
+    assert_eq!(
+        provenance,
+        vec![
+            ("when".to_string(), "sample".to_string()),
+            ("ident".to_string(), "sample".to_string()),
+            ("numish".to_string(), "sample".to_string()),
+            ("boolish".to_string(), "sample".to_string()),
+            ("real_int".to_string(), "metadata".to_string()),
+        ]
+    );
+
+    // An empty file reads no rows either, and its text column is still the one
+    // the metadata could not type.
+    let empty = write_parquet(vec![
+        (
+            "id",
+            Arc::new(Int64Array::from(Vec::<i64>::new())) as ArrayRef,
+        ),
+        (
+            "label",
+            Arc::new(StringArray::from(Vec::<String>::new())) as ArrayRef,
+        ),
+    ]);
+    let report = analyze_structure(empty.path(), None).unwrap();
+    assert_eq!(
+        report
+            .columns
+            .into_iter()
+            .map(|column| (column.name, column.provenance))
+            .collect::<Vec<_>>(),
+        vec![
+            ("id".to_string(), "metadata".to_string()),
+            ("label".to_string(), "sample".to_string()),
+        ]
+    );
+}
+
 /// A zero-row sample of a file that does have text columns is not a settled
 /// schema, and must not claim to be. The CSV and JSON paths report the same
 /// clause for the same reason.


### PR DESCRIPTION
## What changed

Four findings from the Copilot review of #699, which posted twelve seconds
after that PR merged and so never got a pass. All four reproduce on `a433622`;
they are recorded with their reproductions in
https://github.com/AndreaBozzo/dataprof/issues/700#issuecomment-5571136040.

### 1. Duplicate column names typed the wrong columns (regression from #699)

The value sample is projected, so with `x: Int64` and `x: Utf8` the projection
hides the collision from the analyzer's own duplicate-name validation, and the
sampled type then lands on whichever `x` the name lookup finds first:

```
infer_schema: [("x", Date), ("x", String)]   # integer column typed as a date
profile:      Err("Duplicate column name: 'x' ... rename or drop")
```

`infer_schema()` on a **CSV** with a duplicated header already raises the same
error `profile()` does, so Parquet was the only surface answering at all for a
file nothing else will read. It validates the whole Arrow schema before
projecting now. That fixes the mis-assignment at its root and makes the
post-scan name lookup unambiguous by construction, rather than papering over it
with an index lookup that would still answer for a rejected file.

### 2. Provenance named the read instead of the source

```
analyze_structure(path, Some(0))
before: [("when", "metadata"), ..., ("real_int", "metadata")]  truncated=true
after:  [("when", "sample"),   ..., ("real_int", "metadata")]  truncated=true
```

Labelling a text column `"metadata"` claims the metadata as the source of a
type the metadata never decided -- `String` was a fallback -- in the same
report that says the pass was truncated. Provenance is the schema decision now:
a column the metadata cannot type is `"sample"` whether or not the caller's row
budget let a row be read for it, and `rows_sampled`/`truncated` report the read.
The CSV path already draws that line, labelling every column `"sample"` at
`max_rows(0)`. The same correction covers an empty file, whose text columns
were labelled `"metadata"` too.

This is the semantics half of #700, settled here because #700's counters
decision rests on it.

### 3 and 4. Two doc contracts that were narrower than the code

- `schema_stable` was documented as "the scan reached the end of the source".
  It is also true after reading zero rows when the metadata typed every column
  -- the fast path this surface is built on.
- `data_type_from_arrow_type`'s `None` was documented as "only the values can
  say". It means "no native arm", which covers three cases that behave
  differently: text is re-inferred from its values, binary is refused
  re-inference outright (#645), and a container is re-inferred from a bracketed
  serialisation that is not the data (#637). That is why the schema path
  carried a private predicate of its own -- one question answered in two
  places, the drift shape #661 removed from the profiler.
  `sampling_can_decide_type` answers it once now, exported next to the map.

**Related issues:** refs #693, #700

## How it was verified

Each behavior half reverted separately.

Validation removed, sampling and provenance left in place:

```console
$ cargo test --test partial_schema_parity
test duplicate_column_names_are_refused_like_every_other_surface ... FAILED
panicked at tests\partial_schema_parity.rs:248: duplicate names must be refused
test result: FAILED. 7 passed; 1 failed
```

Provenance reverted to reporting what the read produced, validation left in:

```console
$ cargo test --test partial_schema_parity
test provenance_follows_the_schema_decision_not_the_read ... FAILED
assertion `left == right` failed
  left: [("when", "metadata"), ("ident", "metadata"), ("numish", "metadata"), ("boolish", "metadata"), ("real_int", "metadata")]
 right: [("when", "sample"), ("ident", "sample"), ("numish", "sample"), ("boolish", "sample"), ("real_int", "metadata")]
test result: FAILED. 7 passed; 1 failed
```

Both in place:

```console
$ cargo test --test partial_schema_parity
test result: ok. 8 passed; 0 failed

$ cargo test -p dataprof-partial --features parquet
test result: ok. 37 passed; 0 failed

$ cargo test -p dataprof-parquet --features parquet
test result: ok. 37 passed; 0 failed
test result: ok. 6 passed; 0 failed

$ cargo test              # root package, default features
(all binaries green)

$ cargo fmt --all
$ cargo clippy --all --all-targets -- -D warnings
    Finished `dev` profile

$ RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py
MSRV gate passed: 6 feature graphs compile on 1.96

$ uv run maturin develop && uv run pytest python/tests -q
1277 passed, 9 skipped in 58.79s

$ uv run ruff format python/ .github/scripts/ .claude/skills/dataprof/scripts/
58 files left unchanged
$ uv run ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
All checks passed!
$ uv run ty check python/
All checks passed!
```

## Anything reviewers should know

- **Behavior change:** `infer_schema()` and `analyze_structure()` now raise
  `duplicate_column_name` for a Parquet file with duplicate column names, where
  before #699 they returned a schema and after #699 they returned a wrong one.
  This aligns the three surfaces -- CSV `infer_schema()`, Parquet
  `infer_schema()` and `profile()` all refuse the same file with the same error
  category. The test asserts that alignment rather than just the new error.
- **Provenance values are unchanged in kind.** What moved is which columns
  carry `"sample"` in the degenerate cases (zero-row cap, empty file). No
  serialized shape changed.
- **`sampling_can_decide_type` is new public API** on `dataprof-parquet`, an
  implementation-detail crate the facade does not re-export. It replaces a
  private predicate in `dataprof-partial`.
- #700 keeps the counters question; this PR only settles the provenance
  semantics that question depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
