### PR TITLE
feat(partial): report whole-file counters in a Parquet structural report

### DIFF
--- a/.claude/skills/dataprof/reference/api.md
+++ b/.claude/skills/dataprof/reference/api.md
@@ -157,6 +157,15 @@ Each entry in `columns` is a `StructureColumnSummary`: `name`, `data_type`,
 `total_count`, `null_count`, `null_ratio`, `unique_count`, `uniqueness_ratio`,
 `distinct_count_approximate`, `provenance`.
 
+A counter is present only when it describes the whole file. For CSV/JSON/JSONL
+that is the structural sample, so check `truncated` before reporting one as a
+dataset value. For Parquet the counts come from the file footer and cover every
+row -- they hold even when `truncated` is true, which there refers to the rows
+read to infer types. Parquet reports no distinct counts (`unique_count` and
+`distinct_count_approximate` are `None`): the footer carries none, and a
+sampled one would not describe the file. `provenance` names the source of the
+column's **type**, not of its counters.
+
 ## Capabilities fields
 
 `version`, `local_csv`, `local_json`, `local_jsonl`, `local_parquet`,

--- a/.claude/skills/dataprof/scripts/dp_context.py
+++ b/.claude/skills/dataprof/scripts/dp_context.py
@@ -240,11 +240,20 @@ def main(argv: list[str] | None = None) -> int:
             print(f"source: {structure.source}")
             print(f"format: {structure.format}  rows: {count}")
             # The row count comes from a full scan while the per-column numbers
-            # come from a bounded head sample. Printing them adjacently without
-            # saying so invites reading a sample's distinct count as the
+            # may come from a bounded head sample. Printing them adjacently
+            # without saying so invites reading a sample's distinct count as the
             # dataset's — off by 5x on the first file this was tried on.
-            sampled = structure.truncated or structure.source_exhausted is False
-            if sampled:
+            #
+            # Which numbers are sampled is per format, so the caveat is derived
+            # rather than assumed: a Parquet report's counts come from the file
+            # footer and describe every row, while only its types come from a
+            # sample. Telling a reader those counts are estimates would be as
+            # wrong as the omission this note exists to prevent.
+            truncated = structure.truncated or structure.source_exhausted is False
+            counted_from_sample = any(
+                column.unique_count is not None for column in structure.columns
+            )
+            if truncated and counted_from_sample:
                 print(
                     f"  NOTE: per-column numbers below describe the first "
                     f"{structure.rows_sampled} rows, not all {rows.count}. "
@@ -254,6 +263,15 @@ def main(argv: list[str] | None = None) -> int:
                     f"remaining rows are read. Do not report any of these as "
                     f"dataset values; run a full profile before you do."
                 )
+            elif truncated:
+                print(
+                    f"  NOTE: the types below were inferred from the first "
+                    f"{structure.rows_sampled} rows, not all {rows.count}: a "
+                    f"column typed numeric here can turn out to be text once the "
+                    f"remaining rows are read. The counts are the file's own and "
+                    f"cover every row; a column showing nulls=? could not be "
+                    f"counted for the whole file, so nothing is claimed for it."
+                )
             for column in structure.columns:
                 # null_ratio is 0..1, not a percentage. Scaling it here rather
                 # than labelling a ratio with a % sign, which is wrong by 100x.
@@ -261,7 +279,7 @@ def main(argv: list[str] | None = None) -> int:
                 # "~" marks a distinct count the profiler itself calls approximate,
                 # which is a different caveat from the sampling one above.
                 approx = "~" if column.distinct_count_approximate else ""
-                scope = " (of sample)" if sampled else ""
+                scope = " (of sample)" if truncated and counted_from_sample else ""
                 print(
                     f"  {column.name}: {column.data_type} "
                     f"nulls={nulls} unique={approx}{column.unique_count}{scope}"

--- a/crates/dataprof-core/src/partial.rs
+++ b/crates/dataprof-core/src/partial.rs
@@ -56,6 +56,15 @@ pub struct StructureReport {
 }
 
 /// Sample-derived or metadata-derived structural summary for one column.
+///
+/// The counters and the type answer to different sources, and `provenance`
+/// names the one that decided the *type*. A counter is present only when it
+/// describes the whole source: for CSV/JSON/JSONL that is the bounded
+/// structural sample, disclosed by `rows_sampled` and `truncated`; for Parquet
+/// the counts come from the file footer and cover every row, so they hold even
+/// when the type sample was truncated. `None` keeps its usual meaning — not
+/// analyzed — and is what a counter reports rather than a partial number
+/// (#700).
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StructureColumnSummary {
     pub name: String,

--- a/crates/dataprof-partial/src/lib.rs
+++ b/crates/dataprof-partial/src/lib.rs
@@ -234,24 +234,46 @@ fn infer_schema_parquet(
     start: Instant,
     sample_rows: usize,
 ) -> Result<SchemaResult, DataProfilerError> {
-    parquet_schema(path, start, sample_rows).map(|(schema, _)| schema)
+    parquet_scan(path, start, sample_rows, false).map(|scan| scan.schema)
 }
 
-/// [`infer_schema_parquet`], plus the names of the columns whose type the
-/// metadata could not decide. `analyze_structure()` reports that split as
-/// per-column provenance.
-///
-/// The split is the schema decision, not a report of what the read produced: a
-/// text column is governed by its values whether or not the caller's row budget
-/// let them be read. `rows_sampled` and `truncated` say what was read, and the
-/// CSV path draws the same line — it labels every column `"sample"` at
-/// `max_rows(0)`.
+/// What one bounded pass over a Parquet file's metadata (and, where it must,
+/// its values) can say about the file.
 #[cfg(feature = "parquet")]
-fn parquet_schema(
+struct ParquetScan {
+    schema: SchemaResult,
+    /// Names of the columns whose type the metadata could not decide.
+    value_typed: Vec<String>,
+    /// Exact whole-file null counts, by column name. A column is absent when
+    /// no count could be established for the whole file — never a partial one.
+    null_counts: std::collections::HashMap<String, usize>,
+    /// Rows in the file, from the footer. Exact.
+    total_rows: usize,
+}
+
+/// One pass for both partial surfaces.
+///
+/// `value_typed` is the schema decision, not a report of what the read
+/// produced: a text column is governed by its values whether or not the
+/// caller's row budget let them be read. `rows_sampled` and `truncated` say
+/// what was read, and the CSV path draws the same line — it labels every column
+/// `"sample"` at `max_rows(0)`.
+///
+/// `counters` asks for the per-column null counts `analyze_structure()`
+/// reports and `infer_schema()` has no use for. They come from the footer,
+/// which carries an exact per-column-chunk null count for the whole file at no
+/// read cost — except for floats, where the footer counts absent values and the
+/// profiler also counts NaN, so the footer number is a lower bound rather than
+/// an answer (#700). Those columns are counted from the values instead, and
+/// only when the scan covered the file: every counter in the report describes
+/// the whole file, or is absent.
+#[cfg(feature = "parquet")]
+fn parquet_scan(
     path: &Path,
     start: Instant,
     sample_rows: usize,
-) -> Result<(SchemaResult, Vec<String>), DataProfilerError> {
+    counters: bool,
+) -> Result<ParquetScan, DataProfilerError> {
     let file = fs::File::open(path).map_err(|_| DataProfilerError::FileNotFound {
         path: path.display().to_string(),
     })?;
@@ -282,9 +304,16 @@ fn parquet_schema(
 
     let mut columns: Vec<ColumnSchema> = Vec::with_capacity(arrow_schema.fields().len());
     let mut text_columns: Vec<usize> = Vec::new();
+    // Columns whose null count the footer cannot answer, so they are counted
+    // from the values with the text sample. Empty unless counters were asked
+    // for.
+    let mut nan_capable_columns: Vec<usize> = Vec::new();
 
     for (index, field) in arrow_schema.fields().iter().enumerate() {
         let logical = logical_arrow_type(field.data_type());
+        if counters && counts_nan_as_null(&logical) {
+            nan_capable_columns.push(index);
+        }
         let data_type = match data_type_from_arrow_type(&logical) {
             // The Arrow type decides this column on its own, and the profiler
             // reads the same list.
@@ -310,10 +339,30 @@ fn parquet_schema(
 
     let total_rows = builder.metadata().file_metadata().num_rows().max(0) as usize;
 
-    if text_columns.is_empty() || sample_rows == 0 {
+    // The footer's counts, for the columns whose definition of null it shares.
+    // Read before the builder is consumed by the projection below.
+    let mut null_counts = if counters {
+        footer_null_counts(&builder, &columns, &nan_capable_columns)
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    // Which columns the scan has to open the data for. Text columns need it to
+    // be typed at all, even from a prefix. NaN-capable columns need it only for
+    // their null count, which is reported only when it covers the file — so
+    // when the budget cannot cover the file, reading them would buy a number
+    // that gets thrown away, and they are left out.
+    let mut projected: Vec<usize> = text_columns.clone();
+    if total_rows <= sample_rows {
+        projected.extend(nan_capable_columns.iter().copied());
+    }
+    projected.sort_unstable();
+    projected.dedup();
+
+    if projected.is_empty() || sample_rows == 0 {
         let value_typed = value_typed_names(&columns, &text_columns);
-        return Ok((
-            SchemaResult {
+        return Ok(ParquetScan {
+            schema: SchemaResult {
                 columns,
                 rows_sampled: 0,
                 inference_time_ms: start.elapsed().as_millis(),
@@ -325,10 +374,15 @@ fn parquet_schema(
                 schema_stable: text_columns.is_empty() || total_rows == 0,
             },
             value_typed,
-        ));
+            null_counts,
+            total_rows,
+        });
     }
 
-    let projection = ProjectionMask::roots(builder.parquet_schema(), text_columns.iter().copied());
+    let projection = ProjectionMask::roots(builder.parquet_schema(), projected.iter().copied());
+    // `RecordBatchReader::schema()` needs the trait in scope; the projected
+    // schema is what the analyzer must be seeded with, not the file's.
+    use arrow::record_batch::RecordBatchReader as _;
     let reader = builder
         .with_projection(projection)
         .with_batch_size(sample_rows.min(PARQUET_SAMPLE_BATCH_ROWS))
@@ -345,6 +399,14 @@ fn parquet_schema(
     // exactly as it does for CSV and JSON in `schema_from_profiles`. Statistics
     // and patterns are skipped: only the type is read.
     let mut analyzer = RecordBatchAnalyzer::new();
+    // Seed from the projected schema: a zero-row file yields no batch, and
+    // without this its columns would have no profile to read a type or a count
+    // off — the same reason the Parquet profiler seeds itself.
+    analyzer
+        .initialize_schema(reader.schema().as_ref())
+        .map_err(|e| {
+            DataProfilerError::parquet_error(&format!("Failed to read Parquet schema: {}", e))
+        })?;
     let mut rows_sampled = 0usize;
     for batch in reader {
         let batch = batch.map_err(|e| {
@@ -359,8 +421,21 @@ fn parquet_schema(
         })?;
     }
 
+    // A count from a truncated scan describes a prefix, and its neighbours in
+    // the report describe the whole file. Rather than mix the two scopes in one
+    // row, a column the scan could not cover keeps no count at all.
+    let scan_covered_file = rows_sampled >= total_rows;
+    let text_names = value_typed_names(&columns, &text_columns);
+
     // Names are unique — validated above — so this lookup names one column.
     for profile in analyzer.to_profiles(true, true, None) {
+        let types_from_values = text_names.contains(&profile.name);
+        if counters && scan_covered_file {
+            null_counts.insert(profile.name.clone(), profile.null_count);
+        }
+        if !types_from_values {
+            continue;
+        }
         if let Some(column) = columns
             .iter_mut()
             .find(|column| column.name == profile.name)
@@ -369,20 +444,102 @@ fn parquet_schema(
         }
     }
 
-    let value_typed = value_typed_names(&columns, &text_columns);
-
-    Ok((
-        SchemaResult {
+    Ok(ParquetScan {
+        schema: SchemaResult {
             columns,
             rows_sampled,
             inference_time_ms: start.elapsed().as_millis(),
             // Every row of the sampled columns was read, so no further row can
             // change a type. A truncated sample can: the same clause the CSV
             // and JSON paths report.
-            schema_stable: rows_sampled >= total_rows,
+            schema_stable: scan_covered_file,
         },
-        value_typed,
-    ))
+        value_typed: text_names,
+        null_counts,
+        total_rows,
+    })
+}
+
+/// Whether the profiler counts values in this column as null that the Parquet
+/// footer does not.
+///
+/// The footer counts absent values — definition levels. The profiler counts NaN
+/// as null too, so for a float column holding `[1.0, NaN, null, 4.0]` the
+/// footer says 1 and a full profile says 2. Taking the footer number there
+/// would put a different number in the fast path than in the profile, which is
+/// the defect #693 fixed for types; these columns are counted from their values
+/// instead (#700).
+///
+/// Only floats: no other type has a NaN. Decimals are exact.
+#[cfg(feature = "parquet")]
+fn counts_nan_as_null(logical: &arrow::datatypes::DataType) -> bool {
+    matches!(
+        logical,
+        arrow::datatypes::DataType::Float16
+            | arrow::datatypes::DataType::Float32
+            | arrow::datatypes::DataType::Float64
+    )
+}
+
+/// Exact whole-file null counts from the footer's column-chunk statistics.
+///
+/// Free: the footer is already read for the schema and the row count. A column
+/// is left out — rather than guessed at — when any row group omits the
+/// statistic, when the column is nested (its leaves have multi-part paths and
+/// their null counts describe levels, not the column), or when the profiler
+/// would count values the footer does not (`counts_nan_as_null`).
+#[cfg(feature = "parquet")]
+fn footer_null_counts(
+    builder: &ParquetRecordBatchReaderBuilder<fs::File>,
+    columns: &[ColumnSchema],
+    counted_from_values: &[usize],
+) -> std::collections::HashMap<String, usize> {
+    let metadata = builder.metadata();
+    let descriptor = builder.parquet_schema();
+
+    // Top-level primitives only: a nested column's leaves carry multi-part
+    // paths, so they never match a field name and the column is left out.
+    let mut leaf_of_column: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for leaf in 0..descriptor.num_columns() {
+        let path = descriptor.column(leaf).path().parts().to_vec();
+        if let [only] = path.as_slice() {
+            leaf_of_column.insert(only.clone(), leaf);
+        }
+    }
+
+    let mut counts = std::collections::HashMap::new();
+    for (index, column) in columns.iter().enumerate() {
+        if counted_from_values.contains(&index) {
+            continue;
+        }
+        let Some(leaf) = leaf_of_column.get(column.name.as_str()).copied() else {
+            continue;
+        };
+
+        let mut total = 0usize;
+        let mut every_group_reported = true;
+        for group in 0..metadata.num_row_groups() {
+            match metadata
+                .row_group(group)
+                .column(leaf)
+                .statistics()
+                .and_then(|statistics| statistics.null_count_opt())
+            {
+                Some(nulls) => total += nulls as usize,
+                None => {
+                    every_group_reported = false;
+                    break;
+                }
+            }
+        }
+
+        if every_group_reported {
+            counts.insert(column.name.clone(), total);
+        }
+    }
+
+    counts
 }
 
 /// The names of the columns whose type the metadata could not decide.
@@ -1044,17 +1201,25 @@ fn analyze_structure_parquet(
 ) -> Result<StructureReport, DataProfilerError> {
     #[cfg(feature = "parquet")]
     {
-        let (schema, value_typed) = parquet_schema(path, Instant::now(), max_rows)?;
+        let scan = parquet_scan(path, Instant::now(), max_rows, true)?;
         let row_count = quick_row_count_with_format(path, FileFormat::Parquet)?;
-        // Provenance is per column, because a Parquet file is now typed from
-        // both sources: the encoding answers for an already-typed column, a
-        // bounded value sample for a text one. Labelling a sampled column
-        // "metadata" would claim a stability the sample does not have.
+        let ParquetScan {
+            schema,
+            value_typed,
+            null_counts,
+            total_rows,
+        } = scan;
+
+        // Provenance is per column, because a Parquet file is typed from both
+        // sources: the encoding answers for an already-typed column, a bounded
+        // value sample for a text one. Labelling a sampled column "metadata"
+        // would claim a stability the sample does not have.
         //
-        // The counters stay `None` even for the sampled columns: the rows read
-        // here type the column and are not counted. Whether a Parquet
-        // structural report should carry counters, and over which row set, is
-        // #700.
+        // The counters are a separate question from the type, and their answer
+        // is narrower: `total_count` and `null_count` describe the whole file
+        // or are absent, never a prefix (#700). Distinct counts have no
+        // whole-file source at all — the footer does not carry one — so they
+        // stay `None`, which is this repo's "not analyzed".
         let columns = schema
             .columns
             .into_iter()
@@ -1064,12 +1229,13 @@ fn analyze_structure_parquet(
                 } else {
                     "metadata"
                 };
+                let null_count = null_counts.get(&column.name).copied();
                 StructureColumnSummary {
                     name: column.name,
                     data_type: column.data_type,
-                    total_count: None,
-                    null_count: None,
-                    null_ratio: None,
+                    total_count: Some(total_rows),
+                    null_count,
+                    null_ratio: null_count.and_then(|nulls| ratio(nulls, total_rows)),
                     unique_count: None,
                     uniqueness_ratio: None,
                     distinct_count_approximate: None,
@@ -2086,7 +2252,18 @@ mod tests {
             .map(|col| (col.name.as_str(), col.provenance.as_str()))
             .collect();
         assert_eq!(provenance, vec![("id", "metadata"), ("label", "sample")]);
-        assert!(report.columns.iter().all(|col| col.total_count.is_none()));
+
+        // The counters describe the whole file even though the type sample was
+        // truncated to one row: they come from the footer, which counts every
+        // row group (#700).
+        for column in &report.columns {
+            assert_eq!(column.total_count, Some(2), "{}", column.name);
+            assert_eq!(column.null_count, Some(0), "{}", column.name);
+            assert_eq!(column.null_ratio, Some(0.0), "{}", column.name);
+            // No whole-file source for a distinct count, so none is claimed.
+            assert_eq!(column.unique_count, None, "{}", column.name);
+            assert_eq!(column.distinct_count_approximate, None, "{}", column.name);
+        }
     }
 
     /// A file whose columns are all typed by their encoding keeps the

--- a/crates/dataprof-python/src/partial.rs
+++ b/crates/dataprof-python/src/partial.rs
@@ -347,6 +347,13 @@ pub fn quick_row_count(path: &str) -> PyResult<PyRowCountEstimate> {
 }
 
 /// Analyze a file's structure with a bounded, lightweight pass.
+///
+/// `max_rows` bounds the rows read to infer types. For Parquet the per-column
+/// counts do not come from those rows: they come from the file footer and
+/// describe every row, so they stand even when the type sample was truncated.
+/// A count that could not be established for the whole file is absent rather
+/// than partial, and distinct counts are absent entirely — the footer carries
+/// none (#700).
 #[pyfunction(signature = (path, max_rows=None))]
 pub fn analyze_structure(path: &str, max_rows: Option<usize>) -> PyResult<PyStructureReport> {
     let result = dataprof::analyze_structure(Path::new(path), max_rows)

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -772,6 +772,20 @@ either because the scan reached the end of the file or because the Parquet
 metadata typed every column and no scan was needed. Once inference stops at the
 cap, a later row can still move it.
 
+### `analyze_structure()`
+
+```python
+structure = dp.analyze_structure("data.parquet")
+for column in structure.columns:
+    print(f"{column.name}: {column.data_type} nulls={column.null_count} ({column.provenance})")
+```
+
+Every counter it reports describes the whole file or is absent -- it never
+returns a partial count. For CSV and JSON that means checking `truncated`; for
+Parquet the counts come from the file footer, so they cover every row even when
+the type sample stopped at `max_rows`. Distinct counts are absent for Parquet,
+which has no whole-file source for one.
+
 ### `quick_row_count()`
 
 ```python

--- a/python/tests/test_python_api.py
+++ b/python/tests/test_python_api.py
@@ -1699,10 +1699,46 @@ class TestPartialAnalysis:
         # every row of it was read.
         assert structure.rows_sampled == 3
         assert structure.source_exhausted is True
-        # The sampled rows type the column; they are not counted. #700 decides
-        # whether a Parquet structural report should carry counters at all.
-        assert all(column.null_count is None for column in structure.columns)
+        # The counts come from the footer, not from the rows read to type the
+        # text column: they describe every row of the file (#700).
+        assert [(c.name, c.total_count, c.null_count) for c in structure.columns] == [
+            ("id", 3, 0),
+            ("label", 3, 0),
+        ]
+        # No whole-file source for a distinct count, so none is claimed.
+        assert all(column.unique_count is None for column in structure.columns)
         assert dataprof.infer_schema(path).schema_stable is True
+
+    def test_parquet_structure_counts_describe_the_whole_file(self, tmp_path):
+        """Counts come from the footer, so a truncated type sample does not
+        narrow them -- and a float column, whose nulls the footer undercounts,
+        is counted from its values instead (#700)."""
+        pa = pytest.importorskip("pyarrow")
+        pq = pytest.importorskip("pyarrow.parquet")
+
+        path = tmp_path / "counts.parquet"
+        pq.write_table(
+            pa.table(
+                {
+                    "id": [1, None, 3, 4],
+                    "label": ["a", "b", None, None],
+                    "score": [1.0, float("nan"), None, 4.0],
+                }
+            ),
+            path,
+        )
+
+        structure = dataprof.analyze_structure(path)
+        profile = dataprof.profile(path)
+
+        for column in structure.columns:
+            assert column.total_count == profile.rows, column.name
+            assert column.null_count == profile[column.name].null_count, column.name
+
+        # The float column's NaN counts as null, as it does in a full profile;
+        # the footer alone would have said 1.
+        counts = {column.name: column.null_count for column in structure.columns}
+        assert counts == {"id": 1, "label": 2, "score": 2}
 
     def test_fully_typed_parquet_still_reads_no_rows(self, tmp_path):
         """The metadata fast path survives where the metadata is the answer."""

--- a/tests/partial_schema_parity.rs
+++ b/tests/partial_schema_parity.rs
@@ -12,7 +12,9 @@
 use std::io::Write;
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, DictionaryArray, Int64Array, StringArray, Time32MillisecondArray};
+use arrow::array::{
+    ArrayRef, DictionaryArray, Float64Array, Int64Array, StringArray, Time32MillisecondArray,
+};
 use arrow::datatypes::{Field, Int8Type, Schema};
 use arrow::record_batch::RecordBatch;
 use dataprof::{DataType, Profiler, analyze_structure, infer_schema};
@@ -225,6 +227,116 @@ fn infer_schema_agrees_with_profile_on_a_time_column() {
     assert_eq!(schema_types(&file), expected);
     assert_eq!(structure_types(&file), expected);
     assert_eq!(infer_schema(file.path()).unwrap().rows_sampled, 0);
+}
+
+/// A Parquet structural report's counters describe the whole file, and agree
+/// with a full profile of it (#700).
+///
+/// The footer carries an exact per-column null count for every row group, so
+/// this costs no read for the columns whose definition of null it shares.
+#[test]
+fn structure_counters_match_a_full_profile() {
+    let ints: ArrayRef = Arc::new(Int64Array::from(vec![Some(1), None, Some(3), Some(4)]));
+    let text: ArrayRef = Arc::new(StringArray::from(vec![
+        Some("2026-01-02"),
+        Some("2026-01-03"),
+        None,
+        None,
+    ]));
+    let file = write_parquet(vec![("id", ints), ("when", text)]);
+
+    let report = analyze_structure(file.path(), None).unwrap();
+    let profile = Profiler::new().analyze_file(file.path()).unwrap();
+
+    for column in &report.columns {
+        let profiled = profile
+            .column_profiles
+            .iter()
+            .find(|candidate| candidate.name == column.name)
+            .expect("every structural column is profiled");
+        assert_eq!(
+            (column.total_count, column.null_count),
+            (Some(profiled.total_count), Some(profiled.null_count)),
+            "{} disagrees with its profile",
+            column.name
+        );
+    }
+
+    // Not a sampled approximation of them: these are the file's own numbers.
+    assert_eq!(report.columns[0].null_count, Some(1));
+    assert_eq!(report.columns[1].null_count, Some(2));
+}
+
+/// The float exception, which is why the footer is not simply trusted.
+///
+/// The footer counts absent values; the profiler counts NaN as null as well. A
+/// float column is therefore counted from its values, so the two surfaces agree
+/// on a column where the footer alone would have reported one null instead of
+/// two.
+#[test]
+fn float_null_counts_include_nan_like_the_profiler() {
+    let floats: ArrayRef = Arc::new(Float64Array::from(vec![
+        Some(1.0),
+        Some(f64::NAN),
+        None,
+        Some(4.0),
+    ]));
+    let file = write_parquet(vec![("v", floats)]);
+
+    let report = analyze_structure(file.path(), None).unwrap();
+    let profile = Profiler::new().analyze_file(file.path()).unwrap();
+
+    assert_eq!(report.columns[0].null_count, Some(2), "NaN counts as null");
+    assert_eq!(
+        report.columns[0].null_count,
+        Some(profile.column_profiles[0].null_count)
+    );
+}
+
+/// A count that cannot cover the file is not reported at all.
+///
+/// The float column needs a value read, and the row budget here cannot reach
+/// the end of the file. A prefix count would sit in the same report as its
+/// neighbours' whole-file counts with nothing to tell them apart, so the column
+/// reports no count — and no row is read for it either, since the number would
+/// have been discarded.
+#[test]
+fn a_count_that_cannot_cover_the_file_is_absent() {
+    let rows = 40;
+    let floats: ArrayRef = Arc::new(Float64Array::from(
+        (0..rows)
+            .map(|row| if row % 4 == 0 { None } else { Some(row as f64) })
+            .collect::<Vec<Option<f64>>>(),
+    ));
+    let ints: ArrayRef = Arc::new(Int64Array::from(
+        (0..rows).map(|row| row as i64).collect::<Vec<i64>>(),
+    ));
+    let file = write_parquet(vec![("v", floats), ("id", ints)]);
+
+    let capped = analyze_structure(file.path(), Some(10)).unwrap();
+    let float_column = &capped.columns[0];
+    let int_column = &capped.columns[1];
+
+    assert_eq!(
+        float_column.null_count, None,
+        "a prefix count is not a count"
+    );
+    assert_eq!(float_column.null_ratio, None);
+    // Its neighbour is still exact: the footer answered it for free.
+    assert_eq!(int_column.null_count, Some(0));
+    // total_count is the file's row count for both, never the sample's.
+    assert_eq!(float_column.total_count, Some(rows));
+    assert_eq!(int_column.total_count, Some(rows));
+
+    // Given the whole file, the float column is counted and agrees with a
+    // profile of it.
+    let whole = analyze_structure(file.path(), Some(rows)).unwrap();
+    let profile = Profiler::new().analyze_file(file.path()).unwrap();
+    assert_eq!(whole.columns[0].null_count, Some(10));
+    assert_eq!(
+        whole.columns[0].null_count,
+        Some(profile.column_profiles[0].null_count)
+    );
 }
 
 /// Duplicate column names are refused, as they are on every other surface.


### PR DESCRIPTION
## What changed

`analyze_structure()` reported `total_count`, `null_count` and `null_ratio` as
`None` for every Parquet column, while the same call on the identical data as
CSV filled them from its sample. The structural surface answered a different
question depending on the format the file arrived in.

The footer answers it exactly and for free -- column-chunk statistics carry a
null count per row group, so the counts describe **the whole file** at no read
cost, which is better than the sampled numbers CSV reports rather than worse.
`total_count` is the exact row count the metadata already carried.

```
before:  id  integer  metadata  total=None  nulls=None
after:   id  integer  metadata  total=4     nulls=1     (footer, exact, 0 rows read)
```

### The float exception, and why the footer is not simply trusted

The issue proposed this route on the premise that footer counts are "exact and
free". They are not, for floats: the footer counts absent values, and the
profiler counts NaN as null as well.

```
column [1.0, NaN, null, 4.0]
profile: null=2
footer:  null=1
```

Taking the footer number there would have put a different number on the cheap
path than in the profile -- the defect #693 fixed for types, reintroduced for
counts. Float columns are counted from their values instead, in the scan that
already runs for text columns. Measured and recorded on the issue before
building anything:
https://github.com/AndreaBozzo/dataprof/issues/700#issuecomment-5571302757

### The rule the report now keeps

**Every counter describes the whole file, or is absent.**

- A float column whose scan cannot reach the end of the file reports no count,
  rather than a prefix count sitting beside its neighbours' whole-file numbers
  with nothing to tell them apart. It is not read at all in that case, since
  the number would have been discarded.
- Distinct counts stay `None` throughout: the footer carries none, and a
  sampled one would not describe the file. `None` keeps meaning "not analyzed".
- Nested columns fall out on their own -- their leaves carry multi-part paths,
  so no top-level lookup matches and no count is claimed.

`provenance` continues to name the source of the column's **type**, which #701
settled; the counters answer to their own source, and the docs say so on both
surfaces.

The skill script's sampling caveat is derived rather than assumed now: for a
Parquet report it says the *types* came from a sample and the counts are the
file's own. Telling a reader that footer counts are sample estimates would be as
wrong as the omission that caveat exists to prevent.

**Related issue:** Closes #700

## How it was verified

The three parts reverted separately.

Counters removed entirely:

```console
$ cargo test --test partial_schema_parity
test structure_counters_match_a_full_profile ... FAILED
  left: (None, None)
 right: (Some(4), Some(1))
test float_null_counts_include_nan_like_the_profiler ... FAILED
  left: None
 right: Some(2)
test a_count_that_cannot_cover_the_file_is_absent ... FAILED
test result: FAILED. 8 passed; 3 failed
```

Float exception removed (footer trusted for floats too), everything else in
place -- the NaN divergence, exactly:

```console
test float_null_counts_include_nan_like_the_profiler ... FAILED
  left: Some(1)
 right: Some(2)
test result: FAILED. 9 passed; 2 failed
```

Whole-file gate removed (a prefix count reported as if it described the file):

```console
test a_count_that_cannot_cover_the_file_is_absent ... FAILED
  left: Some(3)        # nulls in the first 10 of 40 rows
 right: None
test result: FAILED. 10 passed; 1 failed
```

All three in place:

```console
$ cargo test --test partial_schema_parity
test result: ok. 11 passed; 0 failed

$ cargo test -p dataprof-partial --features parquet
test result: ok. 37 passed; 0 failed

$ cargo test                     # root package, default features
(all binaries green)

$ cargo fmt --all
$ cargo clippy --all --all-targets -- -D warnings
    Finished `dev` profile

$ RUSTUP_TOOLCHAIN=1.96 python .github/scripts/msrv_check.py
MSRV gate passed: 6 feature graphs compile on 1.96

$ uv run maturin develop && uv run pytest python/tests -q
1278 passed, 9 skipped in 63.34s

$ uv run pytest python/tests/test_skill_script.py -q
16 passed

$ uv run ruff format / ruff check / ty check
All checks passed!
```

## Anything reviewers should know

- **Builds on #701**, now merged; this branch was rebased onto it, so the diff
  here is only this change.
- **Behavior change:** a Parquet `StructureReport` now carries `total_count`,
  `null_count` and `null_ratio`. Callers that treated `None` as "Parquet never
  reports counters" will start seeing numbers -- numbers that match a full
  profile of the same file, asserted against `Profiler::analyze_file` rather
  than against expected constants.
- **New read, narrowly:** `analyze_structure()` on a file with float columns
  now reads those columns (bounded by `max_rows`, and skipped entirely when the
  budget cannot cover the file). `infer_schema()` is unaffected -- it asks for
  no counters and reads nothing it did not read before.
- **The NaN-as-null convention is load-bearing here** and is not documented on
  the report surface. It is what makes "read it from the footer" wrong. Worth
  its own line in the field docs; I have not added it in this PR because it
  describes `profile()`, not this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
