### PR TITLE
feat(python): accept Arrow C Stream inputs

### DIFF
--- a/.github/scripts/check_decode_audit.py
+++ b/.github/scripts/check_decode_audit.py
@@ -30,6 +30,7 @@ AUDITED_PATHS = [
     "crates/dataprof-csv/src",
     "crates/dataprof-engines/src/streaming",
     "crates/dataprof-python/src/arrow_export.rs",
+    "crates/dataprof-python/src/arrow_stream.rs",
     "crates/dataprof-metrics/src/stats",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "arrow",
  "bytes",
  "dataprof",
+ "dataprof-core",
  "dataprof-parquet",
  "dataprof-runtime",
  "pyo3",

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ For the leanest Rust build, use `default-features = false` or `cargo --no-defaul
 | Database query | Async | PostgreSQL, MySQL, SQLite via connection string |
 | pandas / polars DataFrame | Columnar | Python API only |
 | Arrow RecordBatch | Columnar | Via PyCapsule (zero-copy) or Rust API |
+| Arrow C Stream producer | Columnar | Python `RecordBatchReader`, DuckDB relation, or `__arrow_c_stream__` object; consumed batch by batch |
 | dict / list of dicts | Columnar | Python API only; no dependencies |
 | bytes / BytesIO | Columnar | Python API only; requires `format=`. CSV, JSON, JSONL, and Parquet need no Python dependencies |
 | Async byte stream | Incremental | Any `AsyncRead` source (HTTP, WebSocket, etc.) |

--- a/crates/dataprof-python/Cargo.toml
+++ b/crates/dataprof-python/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = { workspace = true }
 arrow = { workspace = true }
 bytes = { workspace = true, optional = true }
 dataprof = { workspace = true, default-features = true }
+dataprof-core = { workspace = true }
 dataprof-parquet = { workspace = true, features = ["arrow"] }
 dataprof-runtime = { workspace = true }
 pyo3 = { workspace = true }

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -341,10 +341,11 @@ pub fn analyze_parquet_to_arrow(path: &str) -> PyResult<PyRecordBatch> {
     Ok(PyRecordBatch::new(batch))
 }
 
-/// Profile a pandas or polars DataFrame directly.
+/// Profile a pandas/polars DataFrame or Arrow C Array / C Stream producer.
 ///
 /// This function accepts any object implementing the Arrow PyCapsule protocol,
-/// including pandas DataFrames (with pyarrow) and polars DataFrames.
+/// including pandas DataFrames (with pyarrow), polars DataFrames, and one-shot
+/// Arrow C Stream producers.
 ///
 /// # Arguments
 /// * `df` - A pandas DataFrame, polars DataFrame, or any Arrow-compatible object

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -362,6 +362,9 @@ pub fn profile_dataframe(
     max_rows: Option<usize>,
     config: Option<&PyProfilerConfig>,
 ) -> PyResult<super::types::PyProfileReport> {
+    if is_stream_source(df.bind(py))? {
+        return super::arrow_stream::profile_stream(py, df.bind(py), name, max_rows, config);
+    }
     let start = std::time::Instant::now();
 
     // decode-audit: no-data — an omitted optional config intentionally uses
@@ -475,13 +478,13 @@ pub fn profile_dataframe(
     Ok(super::types::PyProfileReport::new(report))
 }
 
-/// Profile a PyArrow Table or RecordBatch directly.
+/// Profile a PyArrow Table, RecordBatch, or Arrow C Stream producer directly.
 ///
 /// This function is optimized for PyArrow objects and avoids the library
 /// detection overhead of `profile_dataframe()`.
 ///
 /// # Arguments
-/// * `table` - A pyarrow.Table or pyarrow.RecordBatch
+/// * `table` - A pyarrow.Table, pyarrow.RecordBatch, or `__arrow_c_stream__` producer
 /// * `name` - Optional name for identification in reports (default: "arrow_table")
 /// * `max_rows` - Optional maximum number of rows to analyze (None = all rows)
 ///
@@ -496,6 +499,9 @@ pub fn profile_arrow(
     max_rows: Option<usize>,
     config: Option<&PyProfilerConfig>,
 ) -> PyResult<super::types::PyProfileReport> {
+    if is_stream_source(table.bind(py))? {
+        return super::arrow_stream::profile_stream(py, table.bind(py), name, max_rows, config);
+    }
     let start = std::time::Instant::now();
 
     // decode-audit: no-data — an omitted optional config intentionally uses
@@ -611,6 +617,16 @@ pub fn profile_arrow(
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+/// Preserve the established DataFrame/Table/C Array adapters. A producer with
+/// only the stream protocol needs no library-specific adapter or materialization.
+fn is_stream_source(obj: &Bound<'_, PyAny>) -> PyResult<bool> {
+    let library = detect_dataframe_library(obj.py(), &obj.clone().unbind())?;
+    Ok(obj.hasattr("__arrow_c_stream__")?
+        && !obj.hasattr("__arrow_c_array__")?
+        && !matches!(library, DataFrameLibrary::Pandas | DataFrameLibrary::Polars)
+        && !(matches!(library, DataFrameLibrary::PyArrow) && obj.get_type().name()? == "Table"))
+}
 
 /// Convert column profiles to Arrow RecordBatch for export.
 fn profiles_to_record_batch(profiles: &[ColumnProfile]) -> anyhow::Result<RecordBatch> {

--- a/crates/dataprof-python/src/arrow_stream.rs
+++ b/crates/dataprof-python/src/arrow_stream.rs
@@ -1,0 +1,304 @@
+//! Incremental, owning import of one-shot Arrow C Stream producers.
+//!
+//! Drive the callbacks directly: arrow-rs 59's ArrowArrayStreamReader discards
+//! schema error text and unwraps missing batch error text. Both are valid error
+//! cases that must remain catchable, with the available producer cause intact.
+#![allow(unsafe_code)]
+
+use std::ffi::CStr;
+use std::sync::Arc;
+
+use arrow::array::{Array, RecordBatch, StructArray};
+use arrow::datatypes::{DataType, Schema, SchemaRef};
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
+use arrow::ffi_stream::FFI_ArrowArrayStream;
+use arrow::record_batch::RecordBatchOptions;
+use dataprof::{DataSource, EngineType, ExecutionMetadata, MetricPack, TruncationReason};
+use dataprof_core::StreamSourceSystem;
+use dataprof_parquet::record_batch_analyzer::RecordBatchAnalyzer;
+use dataprof_runtime::ReportAssembler;
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
+
+use crate::config::PyProfilerConfig;
+use crate::errors::{analysis_error_to_py, analyzer_error_to_py};
+use crate::types::PyProfileReport;
+
+/// Own the moved C struct, releasing it on every success/error path. Calls stay
+/// attached to Python because producer callbacks may execute Python code.
+struct ImportedStream {
+    stream: FFI_ArrowArrayStream,
+    schema: SchemaRef,
+}
+
+impl ImportedStream {
+    fn new(source: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let capsule = source.call_method0("__arrow_c_stream__")?;
+        let capsule = capsule.cast::<PyCapsule>()?;
+        let pointer = capsule
+            .pointer_checked(Some(c"arrow_array_stream"))
+            .map_err(|_| PyTypeError::new_err("Expected PyCapsule named 'arrow_array_stream'"))?;
+        // SAFETY: the named capsule contains an ArrowArrayStream. from_raw
+        // moves it and clears the original release callback, so the capsule
+        // destructor cannot release our stream a second time.
+        let mut stream = unsafe { FFI_ArrowArrayStream::from_raw(pointer.as_ptr().cast()) };
+        if stream.release.is_none() {
+            return Err(PyValueError::new_err(
+                "Arrow stream was already consumed or released",
+            ));
+        }
+        let get_schema = stream.get_schema.ok_or_else(|| {
+            PyTypeError::new_err("Arrow stream is missing its get_schema callback")
+        })?;
+        if stream.get_next.is_none() {
+            return Err(PyTypeError::new_err(
+                "Arrow stream is missing its get_next callback",
+            ));
+        }
+        let mut schema = FFI_ArrowSchema::empty();
+        // SAFETY: stream is owned and the output is an initialized empty FFI struct.
+        let status = unsafe { get_schema(&mut stream, &mut schema) };
+        if status != 0 {
+            return Err(stream_error(source.py(), &mut stream, "schema", status));
+        }
+        let schema = Schema::try_from(&schema).map_err(|error| {
+            PyTypeError::new_err(format!(
+                "Arrow stream must expose a record-batch schema: {error}"
+            ))
+        })?;
+        Ok(Self {
+            stream,
+            schema: Arc::new(schema),
+        })
+    }
+
+    fn next(&mut self, py: Python<'_>, remaining: Option<usize>) -> PyResult<Option<RecordBatch>> {
+        let mut array = FFI_ArrowArray::empty();
+        let get_next = self.stream.get_next.expect("validated stream callback");
+        // SAFETY: the stream owns its callbacks and array is a valid output slot.
+        let status = unsafe { get_next(&mut self.stream, &mut array) };
+        if status != 0 {
+            return Err(stream_error(py, &mut self.stream, "batch", status));
+        }
+        if array.is_released() {
+            return Ok(None);
+        }
+        // SAFETY: the producer supplied a C Data Interface array described by
+        // the stream schema. Ownership moves into ArrayData, which releases it
+        // even if conversion/validation fails. Validate before typed access.
+        let data = unsafe {
+            arrow::ffi::from_ffi_and_data_type(
+                array,
+                DataType::Struct(self.schema.fields().clone()),
+            )
+        }
+        .map_err(|error| {
+            PyValueError::new_err(format!("Arrow stream batch import failed: {error}"))
+        })?;
+        // Check structural bounds before slicing unchecked imported children.
+        data.validate().map_err(|error| {
+            PyValueError::new_err(format!(
+                "Arrow stream batch violates the Arrow columnar spec: {error}"
+            ))
+        })?;
+        let data = match remaining {
+            Some(limit) => data.slice(0, limit.min(data.len())),
+            None => data,
+        };
+        // Value validation is O(n), so only validate the requested row slice.
+        data.validate_full().map_err(|error| {
+            PyValueError::new_err(format!(
+                "Arrow stream batch violates the Arrow columnar spec: {error}"
+            ))
+        })?;
+        let array = StructArray::from(data);
+        if array.null_count() != 0 {
+            return Err(PyValueError::new_err(
+                "Arrow stream record batches cannot have null rows",
+            ));
+        }
+        RecordBatch::try_new_with_options(
+            self.schema.clone(),
+            array.columns().to_vec(),
+            &RecordBatchOptions::new().with_row_count(Some(array.len())),
+        )
+        .map(Some)
+        .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+}
+
+/// The C interface carries error text, not a Python exception object. Copy it
+/// before releasing the stream, retaining it as the explicit Python cause.
+fn stream_error(
+    py: Python<'_>,
+    stream: &mut FFI_ArrowArrayStream,
+    stage: &str,
+    status: i32,
+) -> PyErr {
+    let message = stream.get_last_error.and_then(|callback| {
+        // SAFETY: callback belongs to the live stream; the returned string is
+        // borrowed only until the next callback, and is copied here immediately.
+        let pointer = unsafe { callback(stream) };
+        if pointer.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { CStr::from_ptr(pointer) }
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        }
+    });
+    let error =
+        PyRuntimeError::new_err(format!("Arrow stream {stage} failed (error code {status})"));
+    if let Some(message) = message {
+        error.set_cause(py, Some(PyRuntimeError::new_err(message)));
+    }
+    error
+}
+
+fn reject_nested(data_type: &DataType, name: &str) -> PyResult<()> {
+    match data_type {
+        DataType::Dictionary(_, values) => reject_nested(values, name),
+        DataType::RunEndEncoded(_, values) => reject_nested(values.data_type(), name),
+        value if value.is_nested() => Err(PyTypeError::new_err(format!(
+            "Arrow stream column '{name}' has unsupported nested type {value}; select flat columns before exporting the stream"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+pub(crate) fn profile_stream(
+    py: Python<'_>,
+    source: &Bound<'_, PyAny>,
+    name: String,
+    max_rows: Option<usize>,
+    config: Option<&PyProfilerConfig>,
+) -> PyResult<PyProfileReport> {
+    let start = std::time::Instant::now();
+    if let Some(config) = config
+        && (!matches!(config.engine, EngineType::Auto | EngineType::Columnar)
+            || config.chunk_size.is_some()
+            || config.memory_limit_mb.is_some()
+            || config.format_override.is_some()
+            || config.csv_delimiter.is_some()
+            || config.csv_flexible.is_some()
+            || config.sampling.is_some()
+            || config.stop_condition.is_some()
+            || config.on_progress.is_some()
+            || config.progress_interval_ms.is_some()
+            || config.json_error_policy != dataprof::JsonErrorPolicy::Skip)
+    {
+        return Err(PyValueError::new_err(
+            "Arrow streams cannot apply file/transport controls; use max_rows for a row cap",
+        ));
+    }
+    // decode-audit: no-data — absent configuration selects the default metric packs.
+    let options = config
+        .map(PyProfilerConfig::analysis_options)
+        .unwrap_or_default();
+    let packs = options.effective_metric_packs();
+    let include_quality = MetricPack::include_quality(packs.as_deref());
+    let hints = options.semantic_hints();
+    hints
+        .validate_quality_usage(include_quality)
+        .map_err(|error| analysis_error_to_py(&error))?;
+    let max_rows =
+        max_rows.or_else(|| config.and_then(|config| config.max_rows.map(|n| n as usize)));
+    let mut stream = ImportedStream::new(source)?;
+    let names: Vec<_> = stream
+        .schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+    dataprof::validate_unique_column_names(&names, "Arrow stream schema")
+        .map_err(|error| analysis_error_to_py(&error))?;
+    let indices = options
+        .column_indices(&names)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    let schema = match &indices {
+        Some(indices) => stream
+            .schema
+            .project(indices)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?,
+        None => stream.schema.as_ref().clone(),
+    };
+    for field in schema.fields() {
+        reject_nested(field.data_type(), field.name())?;
+    }
+    hints
+        .validate_names(
+            &schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+        )
+        .map_err(|error| analysis_error_to_py(&error))?;
+    let mut analyzer = RecordBatchAnalyzer::new().with_semantic_hints(hints);
+    analyzer
+        .initialize_schema(&schema)
+        .map_err(analyzer_error_to_py)?;
+    let mut rows = 0usize;
+    let mut capped = false;
+    loop {
+        if max_rows.is_some_and(|limit| rows >= limit) {
+            capped = true;
+            break;
+        }
+        let Some(mut batch) = stream.next(py, max_rows.map(|limit| limit - rows))? else {
+            break;
+        };
+        if let Some(indices) = &indices {
+            batch = batch
+                .project(indices)
+                .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        }
+        rows += batch.num_rows();
+        analyzer
+            .process_batch(&batch)
+            .map_err(analyzer_error_to_py)?;
+        py.check_signals()?;
+    }
+    let mut execution =
+        ExecutionMetadata::new(rows, schema.fields().len(), start.elapsed().as_millis())
+            .with_engine("columnar");
+    if capped {
+        execution = execution.with_truncation(TruncationReason::MaxRows(
+            max_rows.expect("cap was reached") as u64,
+        ));
+    }
+    let columns = analyzer.to_profiles_with_hints(
+        !MetricPack::include_statistics(packs.as_deref()),
+        !MetricPack::include_patterns(packs.as_deref()),
+        options.locale(),
+        hints,
+    );
+    let mut assembler = ReportAssembler::new(
+        DataSource::Stream {
+            topic: name,
+            batch_id: "0".to_string(),
+            partition: None,
+            consumer_group: None,
+            source_system: StreamSourceSystem::Custom("arrow_c_stream".to_string()),
+            session_id: None,
+            first_record_at: None,
+            last_record_at: None,
+        },
+        execution,
+    )
+    .columns(columns)
+    .with_row_duplicates(analyzer.row_duplicate_summary())
+    .with_row_completeness(analyzer.row_completeness_summary())
+    .with_analysis_options(&options);
+    if include_quality {
+        assembler = assembler
+            .with_quality_data(analyzer.create_sample_columns())
+            .with_exact_value_hint_bindings(analyzer.semantic_hint_bindings());
+    }
+    let report = assembler.build();
+    crate::errors::validate_report_hints(&report, hints, include_quality)?;
+    Ok(PyProfileReport::new(report))
+}

--- a/crates/dataprof-python/src/lib.rs
+++ b/crates/dataprof-python/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod analysis;
 pub mod arrow_export;
+mod arrow_stream;
 pub mod columns;
 pub mod config;
 pub mod errors;

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -126,6 +126,7 @@ emitted, and `auto` reports the engine it selected.
 | pandas `DataFrame` | In-memory DataFrame |
 | polars `DataFrame` | In-memory Polars DataFrame |
 | PyArrow `Table` or `RecordBatch` | Zero-copy via PyCapsule interface |
+| Arrow `RecordBatchReader` / `__arrow_c_stream__` producer | One-shot, incremental batch profiling; includes DuckDB relations |
 | `dict[str, list]` | Columns of cells; profiled natively, no dependencies |
 | `list[dict]` | Row-oriented notebook data; rows may omit keys, which read as nulls |
 | `bytes` or `io.BytesIO` | In-memory file contents; requires `format="csv"`, `"json"`, `"jsonl"`, or `"parquet"` |
@@ -918,6 +919,48 @@ asyncio.run(main())
 unique; duplicate aliases are rejected before values can be merged.
 
 ## Arrow Interop
+
+`profile()` also accepts one-shot producers implementing the
+[Arrow C Stream capsule protocol](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html#arrowstream-export):
+
+```python
+import pyarrow as pa
+import dataprof
+
+batches = [pa.record_batch({"id": [1, 2]}), pa.record_batch({"id": [3, 4]})]
+reader = pa.RecordBatchReader.from_batches(batches[0].schema, iter(batches))
+report = dataprof.profile(reader, max_rows=3)
+assert report.rows == 3
+assert report.source_type == "stream"
+
+# With DuckDB installed, pass a relation directly:
+# report = dataprof.profile(duckdb.sql("select * from my_table"), max_rows=1000)
+```
+
+dataprof consumes and releases each batch before fetching another; it does not
+call `to_arrow_table()` or collect the stream. Producer batch buffers and the
+bounded profiling accumulators determine memory use. A producer may itself
+materialize data when exporting; dataprof cannot control that allocation.
+PyArrow and DuckDB remain optional producer dependencies.
+
+`max_rows` stops at the requested row boundary, including zero, without asking
+for a subsequent batch. Reaching the cap sets `truncation_reason` even if that
+row happened to be the stream's last: end-of-stream was not checked. An uncapped
+or shorter stream is complete only after its producer signals the end. The
+report uses engine `columnar`, source type `stream`, and source system
+`arrow_c_stream`; the name identifies one profiling operation (`batch_id="0"`).
+The stream is one-shot: use a fresh reader for another profile.
+
+Metric packs, quality dimensions, locale, semantic hints, and column selection
+work as on Arrow tables. Unsupported file/transport controls raise `ValueError`
+before capsule export. Duplicate names are rejected before any batch is read,
+even with column selection. Selected nested types (structs, lists, maps, unions)
+raise `TypeError`; select flat columns before exporting, or with `columns=`.
+An empty stream with a schema retains its columns and unassessed quality.
+Batch/schema failures abort the call; no partial report is returned. The C
+interface carries producer error text, which is retained as `__cause__`, rather
+than the original Python exception object. Existing Table, C Array, pandas, and
+polars adapters retain their behavior.
 
 The `RecordBatch` class supports zero-copy exchange via the [Arrow PyCapsule interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html):
 

--- a/python/dataprof/_api.py
+++ b/python/dataprof/_api.py
@@ -236,7 +236,7 @@ def profile(
     """Profile a data source and return a report.
 
     Accepts file paths (str/Path), pandas DataFrames, polars DataFrames,
-    Arrow PyCapsule-compatible objects, dict/list-of-dicts, and bytes-like
+    Arrow C Array / C Stream producers, dict/list-of-dicts, and bytes-like
     file contents when ``format=`` is provided. Synchronous bytes use the
     in-memory columnar path and reject streaming-only controls such as
     ``chunk_size``, ``memory_limit_mb``, ``stop_condition``, and progress
@@ -555,6 +555,23 @@ def profile(
     if source_module.startswith("polars"):
         _warn_if_config_ignored()
         return _profile_python_dataframe(source, "dataframe")
+
+    # One-shot streams must reject ignored controls before exporting a capsule.
+    # Existing Table, DataFrame and C Array adapters retain their behavior.
+    if hasattr(source, "__arrow_c_stream__") and not (
+        hasattr(source, "__arrow_c_array__")
+        or (source_module.startswith("pyarrow") and type(source).__name__ == "Table")
+    ):
+        unsupported = [k for k, v in _file_only_kwargs.items() if v and k != "engine"]
+        if engine not in ("auto", "columnar"):
+            unsupported.append("engine")
+        if jsonl_on_error != "skip":
+            unsupported.append("jsonl_on_error")
+        if unsupported:
+            raise ValueError(
+                f"Arrow streams cannot apply: {', '.join(unsupported)}. Use max_rows for a row cap."
+            )
+        return ProfileReport(_profile_arrow(source, name or "arrow_stream", max_rows, _df_config()))
 
     # PyArrow objects (Table, RecordBatch) or any Arrow PyCapsule-compatible object
     if source_module.startswith("pyarrow") or hasattr(source, "__arrow_c_array__"):

--- a/python/dataprof/_api.py
+++ b/python/dataprof/_api.py
@@ -563,7 +563,7 @@ def profile(
         or (source_module.startswith("pyarrow") and type(source).__name__ == "Table")
     ):
         unsupported = [k for k, v in _file_only_kwargs.items() if v and k != "engine"]
-        if engine not in ("auto", "columnar"):
+        if engine.lower() not in ("auto", "columnar", "arrow"):
             unsupported.append("engine")
         if jsonl_on_error != "skip":
             unsupported.append("jsonl_on_error")

--- a/python/dataprof/interop.pyi
+++ b/python/dataprof/interop.pyi
@@ -32,7 +32,7 @@ def profile_arrow(
     name: str = "arrow_table",
     max_rows: int | None = None,
 ) -> ProfileReport:
-    """Profile a PyArrow Table or RecordBatch directly."""
+    """Profile a PyArrow Table, RecordBatch, or one-shot Arrow C Stream producer."""
     ...
 
 def analyze_csv_to_arrow(path: str | PathLike[str]) -> RecordBatch:

--- a/python/dataprof/interop.pyi
+++ b/python/dataprof/interop.pyi
@@ -24,7 +24,7 @@ def profile_dataframe(
     name: str = "dataframe",
     max_rows: int | None = None,
 ) -> ProfileReport:
-    """Profile a pandas/polars DataFrame via Arrow PyCapsule protocol."""
+    """Profile a pandas/polars DataFrame or Arrow C Array / C Stream producer."""
     ...
 
 def profile_arrow(

--- a/python/tests/test_arrow_c_stream.py
+++ b/python/tests/test_arrow_c_stream.py
@@ -1,0 +1,337 @@
+"""One-shot Arrow streams are consumed incrementally through their capsule."""
+
+import dataprof
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+
+
+def _quality_values(report):
+    return {key: value for key, value in report.quality_summary().items() if key != "source"}
+
+
+class StreamProducer:
+    def __init__(self, schema, batches):
+        self.reader = pa.RecordBatchReader.from_batches(schema, batches)
+        self.exports = 0
+
+    def __arrow_c_stream__(self, requested_schema=None):
+        self.exports += 1
+        return self.reader.__arrow_c_stream__(requested_schema)
+
+    def to_arrow_table(self):
+        raise AssertionError("must not materialize the stream")
+
+    def to_batches(self):
+        raise AssertionError("must not collect the stream")
+
+
+def _batches():
+    return [
+        pa.record_batch({"z": [2**60, None], "a": ["Roma", None]}),
+        pa.record_batch({"z": [2**60 + 1, 4], "a": ["東京", "Roma"]}),
+    ]
+
+
+@pytest.mark.parametrize("custom", [False, True])
+def test_stream_matches_table(custom):
+    batches = _batches()
+    source = (
+        StreamProducer(batches[0].schema, iter(batches))
+        if custom
+        else pa.RecordBatchReader.from_batches(batches[0].schema, batches)
+    )
+    report = dataprof.profile(source)
+    reference = dataprof.profile(pa.Table.from_batches(batches))
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+    assert report.rows == 4
+    assert report.source_type == "stream"
+    assert report.engine == "columnar"
+    assert report.truncation_reason is None
+
+
+@pytest.mark.parametrize("limit, reads", [(0, 0), (1, 1), (2, 1), (3, 2), (4, 2)])
+def test_row_cap_does_not_fetch_remaining_batches(limit, reads):
+    batches = _batches()
+    seen = []
+
+    def produce():
+        for batch in batches:
+            seen.append(1)
+            yield batch
+        raise AssertionError("read past the requested row cap")
+
+    report = dataprof.profile(StreamProducer(batches[0].schema, produce()), max_rows=limit)
+    assert report.rows == limit
+    assert len(seen) == reads
+    assert report.truncation_reason is not None
+
+
+def test_empty_stream_preserves_schema_and_absence():
+    schema = _batches()[0].schema
+    report = dataprof.profile(StreamProducer(schema, []))
+    reference = dataprof.profile(pa.Table.from_batches([], schema=schema))
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+    assert report.rows == 0
+    assert report.quality_score is None
+
+
+def test_duplicate_schema_fails_before_reading_even_with_projection():
+    schema = pa.schema([("x", pa.int64()), ("x", pa.int64())])
+
+    def produce():
+        raise AssertionError("schema must be checked before reading")
+        yield
+
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        dataprof.profile(StreamProducer(schema, produce()), columns=[])
+
+
+@pytest.mark.parametrize(
+    "nested",
+    [
+        pa.struct([("x", pa.int64())]),
+        pa.list_(pa.int64()),
+        pa.list_(pa.float32(), 3),
+        pa.map_(pa.string(), pa.int64()),
+    ],
+)
+def test_nested_stream_types_are_rejected(nested):
+    with pytest.raises(TypeError, match="nested.*column|column.*nested"):
+        dataprof.profile(StreamProducer(pa.schema([("nested", nested)]), []))
+
+
+def test_producer_failure_does_not_return_partial_report():
+    batches = _batches()
+
+    def produce():
+        yield batches[0]
+        raise ValueError("producer broke after first batch")
+
+    with pytest.raises(RuntimeError, match="Arrow stream") as caught:
+        dataprof.profile(StreamProducer(batches[0].schema, produce()))
+    assert caught.value.__cause__ is not None
+    assert "producer broke after first batch" in str(caught.value.__cause__)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"engine": "streaming"}, {"chunk_size": 10}, {"metrics": ["bogus"]}, {"locale": "bogus"}],
+)
+def test_invalid_controls_fail_before_export(kwargs):
+    source = StreamProducer(_batches()[0].schema, [])
+    with pytest.raises(ValueError):
+        dataprof.profile(source, **kwargs)
+    assert source.exports == 0
+
+
+def test_stream_option_parity():
+    batches = _batches()
+
+    def profile(source):
+        return dataprof.profile(
+            source,
+            columns=["a", "z"],
+            metrics=["schema", "quality"],
+            quality_dimensions=["completeness"],
+            locale="IT",
+        )
+
+    report = profile(StreamProducer(batches[0].schema, batches))
+    reference = profile(pa.Table.from_batches(batches))
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+    assert report.quality_score == reference.quality_score
+
+
+def test_duckdb_relation():
+    duckdb = pytest.importorskip("duckdb")
+    relation = duckdb.sql("select * from (values (1, 'Rome'), (2, NULL)) t(id, city)")
+    report = dataprof.profile(relation)
+    reference = dataprof.profile(relation.to_arrow_table())
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+
+
+def test_batches_are_released_during_consumption():
+    schema = pa.schema([("n", pa.int64())])
+    before = pa.total_allocated_bytes()
+    observations = []
+
+    def produce():
+        for _ in range(12):
+            batch = pa.record_batch([pa.array(range(4096), type=pa.int64())], schema=schema)
+            observations.append(pa.total_allocated_bytes() - before)
+            yield batch
+
+    assert dataprof.profile(StreamProducer(schema, produce())).rows == 12 * 4096
+    # Allow the generator and C exporter to hold the previous/current batch.
+    # Retaining all twelve imported batches exceeds this bound by a wide margin.
+    assert max(observations) <= 3 * 4096 * 8
+
+
+def test_export_exception_keeps_original_cause():
+    class Broken:
+        def __arrow_c_stream__(self, requested_schema=None):
+            raise ValueError("export failed") from OSError("producer unavailable")
+
+    with pytest.raises(ValueError, match="export failed") as caught:
+        dataprof.profile(Broken())
+    assert isinstance(caught.value.__cause__, OSError)
+
+
+def test_capsule_is_consumed_only_once():
+    reader = pa.RecordBatchReader.from_batches(_batches()[0].schema, _batches())
+
+    class ReusedCapsule:
+        capsule = reader.__arrow_c_stream__()
+
+        def __arrow_c_stream__(self, requested_schema=None):
+            return self.capsule
+
+    source = ReusedCapsule()
+    assert dataprof.profile(source).rows == 4
+    with pytest.raises(ValueError, match="consumed or released"):
+        dataprof.profile(source)
+
+
+def test_wrong_capsule_type_is_rejected():
+    class WrongCapsule:
+        def __arrow_c_stream__(self, requested_schema=None):
+            return pa.schema([]).__arrow_c_schema__()
+
+    with pytest.raises(TypeError, match="arrow_array_stream"):
+        dataprof.profile(WrongCapsule())
+
+
+@pytest.mark.parametrize("columns", [[], ["a"]])
+def test_projection_preserves_rows_and_withholds_whole_row_metrics(columns):
+    batches = _batches()
+    report = dataprof.profile(StreamProducer(batches[0].schema, batches), columns=columns)
+    reference = dataprof.profile(pa.Table.from_batches(batches), columns=columns)
+    assert report.rows == reference.rows == 4
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+    assert _quality_values(report) == _quality_values(reference)
+
+
+def test_semantic_hints_match_table():
+    batches = [pa.record_batch({"id": [101, 102], "amount": [-1, 2]})]
+
+    def profile(source):
+        return dataprof.profile(source, identifier_columns=["id"], positive_columns=["amount"])
+
+    report = profile(StreamProducer(batches[0].schema, batches))
+    reference = profile(pa.Table.from_batches(batches))
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+    assert _quality_values(report) == _quality_values(reference)
+
+
+def test_validation_respects_row_cap_and_nonzero_offsets():
+    column = pa.DictionaryArray.from_arrays(
+        pa.array([1, 0, 99], type=pa.int8()), pa.array(["a", "b"]), safe=False
+    )
+    batch = pa.record_batch({"c": column}).slice(1)
+    report = dataprof.profile(StreamProducer(batch.schema, [batch]), max_rows=1)
+    reference = dataprof.profile(batch, max_rows=1)
+    assert report.to_dict()["columns"] == reference.to_dict()["columns"]
+    with pytest.raises(ValueError, match="Arrow columnar spec"):
+        dataprof.profile(StreamProducer(batch.schema, [batch]))
+
+
+@pytest.mark.parametrize("entrypoint", ["profile_arrow", "profile_dataframe"])
+def test_direct_interop_stream_entrypoints(entrypoint):
+    from dataprof import interop
+
+    source = StreamProducer(_batches()[0].schema, _batches())
+    report = getattr(interop, entrypoint)(source, max_rows=3)
+    assert report.rows_processed == 3
+    assert report.source_type == "stream"
+
+
+def test_stream_provenance_and_cap_survive_serialization():
+    import json
+    from pathlib import Path
+
+    from jsonschema import Draft202012Validator
+
+    source = StreamProducer(_batches()[0].schema, _batches())
+    report = dataprof.profile(source, name="events", max_rows=3)
+    document = report.to_dict()
+    schema_path = Path(__file__).resolve().parents[2] / "docs/schema/profile-report.v1.schema.json"
+    Draft202012Validator(json.loads(schema_path.read_text(encoding="utf-8"))).validate(document)
+    restored = dataprof.ProfileReport.from_json(report.to_json())
+    assert restored.to_dict() == document
+    assert restored.source_type == "stream"
+    assert restored.truncation_reason == report.truncation_reason
+
+
+@pytest.mark.parametrize("stage", ["schema", "batch", "end", "cap"])
+@pytest.mark.parametrize("error_text", [None, b"producer diagnostic"])
+def test_c_callbacks_release_once_and_allow_missing_error_text(stage, error_text):
+    """A minimal C producer checks ownership and C errors independently of PyArrow's reader."""
+    import ctypes as ct
+
+    class CStream(ct.Structure):
+        _fields_ = [
+            (name, ct.c_void_p)
+            for name in ("get_schema", "get_next", "get_last_error", "release", "private_data")
+        ]
+
+    fetch = ct.CFUNCTYPE(ct.c_int, ct.c_void_p, ct.c_void_p)
+    release_callback = ct.CFUNCTYPE(None, ct.c_void_p)
+    last_error_callback = ct.CFUNCTYPE(ct.c_void_p, ct.c_void_p)
+    released = []
+    fetched = []
+    message = ct.create_string_buffer(error_text) if error_text is not None else None
+
+    @fetch
+    def get_schema(_stream, out):
+        if stage == "schema":
+            return 5
+        pa.schema([("x", pa.int64())])._export_to_c(out)
+        return 0
+
+    @fetch
+    def get_next(_stream, _out):
+        fetched.append(1)
+        # The initialized output remains released, signalling end-of-stream.
+        return 5 if stage == "batch" else 0
+
+    @last_error_callback
+    def get_last_error(_stream):
+        return ct.addressof(message) if message is not None else None
+
+    @release_callback
+    def release(stream):
+        released.append(1)
+        ct.cast(stream, ct.POINTER(CStream)).contents.release = None
+
+    stream = CStream(
+        *[
+            ct.cast(callback, ct.c_void_p).value
+            for callback in (get_schema, get_next, get_last_error, release)
+        ],
+        None,
+    )
+    # Also cover a producer that omits get_last_error entirely.
+    if error_text is None:
+        stream.get_last_error = None
+    new_capsule = ct.pythonapi.PyCapsule_New
+    new_capsule.argtypes = [ct.c_void_p, ct.c_char_p, ct.c_void_p]
+    new_capsule.restype = ct.py_object
+
+    class Producer:
+        def __arrow_c_stream__(self, requested_schema=None):
+            return new_capsule(ct.addressof(stream), b"arrow_array_stream", None)
+
+    if stage in ("schema", "batch"):
+        with pytest.raises(RuntimeError, match=f"Arrow stream {stage} failed") as caught:
+            dataprof.profile(Producer())
+        if error_text is not None:
+            assert str(caught.value.__cause__) == error_text.decode()
+        else:
+            assert caught.value.__cause__ is None
+    else:
+        report = dataprof.profile(Producer(), max_rows=0 if stage == "cap" else None)
+        assert report.rows == 0
+    assert fetched == ([1] if stage in ("batch", "end") else [])
+    assert released == [1]
+    assert stream.release is None  # ownership moved out of the capsule

--- a/python/tests/test_arrow_c_stream.py
+++ b/python/tests/test_arrow_c_stream.py
@@ -125,6 +125,24 @@ def test_invalid_controls_fail_before_export(kwargs):
     assert source.exports == 0
 
 
+@pytest.mark.parametrize("engine", ["auto", "AUTO", "columnar", "COLUMNAR", "arrow", "ArRoW"])
+def test_stream_accepts_documented_engine_spellings(engine):
+    source = StreamProducer(_batches()[0].schema, _batches())
+    report = dataprof.profile(source, engine=engine)
+    assert report.rows == 4
+    assert report.engine == "columnar"
+
+
+@pytest.mark.parametrize(
+    "engine", ["incremental", "INCREMENTAL", "streaming", "STREAMING", "bogus"]
+)
+def test_stream_rejects_unsupported_engines_before_export(engine):
+    source = StreamProducer(_batches()[0].schema, _batches())
+    with pytest.raises(ValueError, match="engine"):
+        dataprof.profile(source, engine=engine)
+    assert source.exports == 0
+
+
 def test_stream_option_parity():
     batches = _batches()
 


### PR DESCRIPTION
## What changed

`dataprof.profile()` now accepts one-shot Arrow C Stream producers, including PyArrow `RecordBatchReader` objects and DuckDB relations, without collecting a full table. Batches are processed and released incrementally, with schema and value validation, supported analysis controls, and producer errors retained as Python exception causes.

**Related issue:** Closes #505

## How it was verified

On Windows with Rust 1.98.1 and Python 3.12.13:

- `uv run --no-sync maturin develop` — built and installed the extension.
- `uv run --no-sync pytest python/tests/test_arrow_c_stream.py python/tests/test_arrow_pycapsule_import.py python/tests/test_dataframe_chunk_parity.py python/tests/test_zero_row_sources.py python/tests/test_python_api.py python/tests/test_report_exports.py -q --tb=short --no-showlocals` — **200 passed**, including DuckDB 1.5.5.
- `cargo clippy --all --all-targets -- -D warnings` — passed.
- `cargo fmt --all --check` — passed.
- `uv run --no-sync ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/` — passed.
- `uv run --no-sync ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/` — passed.
- `uv run --no-sync ty check python/` — passed.
- `uv run --no-sync python .github/scripts/check_decode_audit.py` — passed; the new importer is included in the audit.
- `git diff --check` — passed.

The initial regression run reproduced missing stream support before implementation. Coverage includes capsule ownership/release on success and failure, absent C error text, bounded Arrow buffer retention, row caps without fetching the next batch, large integers/nulls, empty schemas, duplicate names, unsupported nested columns, projection, semantic hints, and serialized provenance.

## Anything reviewers should know

- Reaching `max_rows` reports truncation even at an exact stream boundary: the next batch is deliberately not fetched to establish whether the stream ended.
- Reports reuse the existing `stream` source variant with source system `arrow_c_stream`; the published schema validates the output without modification.
- PyArrow and DuckDB remain optional producer dependencies. Existing Table, C Array, pandas, and polars adapters retain their behavior; removing DataFrame adapters suggested in the issue comments is outside this change.
- The importer drives C callbacks directly because arrow-rs 59's stream reader discards schema error text and unwraps missing batch error text. Dedicated C callback tests cover these failure paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for profiling one-shot Arrow C Stream producers, including Python `RecordBatchReader`, DuckDB relations, and other `__arrow_c_stream__` sources.
  * Streams are processed batch by batch with row limits, validation, truncation metadata, and clear producer error reporting.

* **Documentation**
  * Documented supported Arrow C Stream inputs, interoperability behavior, memory handling, and unsupported options.

* **Bug Fixes**
  * Unsupported configuration options now produce clear validation errors for stream sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->