### PR TITLE
fix(metrics): scope and enforce the cross-engine numeric equality contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,15 @@ change; run what matches the change and list the commands in the PR body.
   into a plausible number is the worst bug class for a profiler.
 - **Semantics**: `None`/absent means "not analyzed"; empty means "analyzed,
   nothing found". Preserve this distinction in reports and bindings.
-- **Output contract**: profile numbers must be identical regardless of which
-  engine or input path produced them. If you touch an engine or parser, check
-  the other paths for parity.
+- **Output contract**: the serialized, rounded metric values must be identical
+  across engines and input paths for the same logical data, analysis options,
+  and analyzed population. Rust Serde output and Python `to_dict()`/`to_json()`
+  govern this contract; source/execution provenance is compared separately.
+  Native raw floats retain full precision and may differ with accumulation
+  order. Parity tests compare serialized values exactly; raw diagnostics use
+  explicit tolerances (relative `1e-9`, absolute `1e-12`). Preserve absence as
+  well as numbers. See [the numeric contract](docs/schema/README.md#numeric-equality-contract).
+  If you touch an engine or parser, check the other paths for parity.
 
 ## Project board rules
 

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -160,7 +160,18 @@ fn analyze_column_with_options(
                     ColumnStats::None
                 }
             }
-            DataType::String | DataType::Identifier => calculate_text_stats(data),
+            DataType::String | DataType::Identifier => {
+                // Null-like tokens are counted as nulls above; they are not
+                // text values, so they must not enter the length statistics.
+                // The streaming engines feed a null-excluding accumulator here
+                // and this path has to agree with them (#547).
+                let values: Vec<String> = data
+                    .iter()
+                    .filter(|s| !is_null_like_token(s.trim()))
+                    .cloned()
+                    .collect();
+                calculate_text_stats(&values)
+            }
         }
     };
 
@@ -434,5 +445,27 @@ mod tests {
 
         assert_eq!(profile.null_count, 2); // 2 whitespace-only
         assert_eq!(profile.unique_count, Some(2)); // "value1" and "value2"
+    }
+
+    #[test]
+    fn text_lengths_exclude_null_like_tokens() {
+        // This path feeds the database connectors; the streaming engines use a
+        // null-excluding length accumulator. A token counted as a null must not
+        // also be counted as a four-character string (#547).
+        let data = vec![
+            "NULL".to_string(),
+            "a".to_string(),
+            "nan".to_string(),
+            "b".to_string(),
+        ];
+        let profile = analyze_column("test_col", &data);
+
+        assert_eq!(profile.null_count, 2);
+        let ColumnStats::Text(stats) = profile.stats else {
+            panic!("expected text stats");
+        };
+        assert_eq!(stats.min_length, 1);
+        assert_eq!(stats.max_length, 1);
+        assert_eq!(stats.avg_length, 1.0);
     }
 }

--- a/crates/dataprof-metrics/src/analysis/column.rs
+++ b/crates/dataprof-metrics/src/analysis/column.rs
@@ -7,7 +7,7 @@ use crate::analysis::inference::{
 };
 use crate::analysis::patterns::detect_patterns;
 use crate::stats::numeric::compute_numeric_stats_with_parsed_count;
-use crate::stats::{calculate_datetime_stats, calculate_text_stats};
+use crate::stats::{calculate_datetime_stats, calculate_text_stats_from_refs};
 
 /// Which parts of a column analysis to perform.
 ///
@@ -165,12 +165,11 @@ fn analyze_column_with_options(
                 // text values, so they must not enter the length statistics.
                 // The streaming engines feed a null-excluding accumulator here
                 // and this path has to agree with them (#547).
-                let values: Vec<String> = data
+                let values: Vec<&String> = data
                     .iter()
                     .filter(|s| !is_null_like_token(s.trim()))
-                    .cloned()
                     .collect();
-                calculate_text_stats(&values)
+                calculate_text_stats_from_refs(&values)
             }
         }
     };

--- a/crates/dataprof-metrics/src/stats/mod.rs
+++ b/crates/dataprof-metrics/src/stats/mod.rs
@@ -8,4 +8,4 @@ pub use accumulator::NumericAccumulator;
 pub use cardinality::{CardinalityEstimator, EXACT_CARDINALITY_THRESHOLD, HyperLogLog};
 pub use datetime::calculate_datetime_stats;
 pub use numeric::calculate_numeric_stats;
-pub use text::calculate_text_stats;
+pub use text::{calculate_text_stats, calculate_text_stats_from_refs};

--- a/crates/dataprof-metrics/src/stats/text.rs
+++ b/crates/dataprof-metrics/src/stats/text.rs
@@ -9,9 +9,27 @@ pub fn calculate_text_stats(data: &[String]) -> ColumnStats {
     ColumnStats::Text(compute_text_stats(data))
 }
 
+/// Borrowing variant for callers that must filter the column first.
+///
+/// Filtering through references keeps the caller from duplicating every string
+/// in the column just to drop a few of them.
+pub fn calculate_text_stats_from_refs(data: &[&String]) -> ColumnStats {
+    ColumnStats::Text(compute_text_stats_from_refs(data))
+}
+
 /// Compute text stats and return the inner struct directly.
 pub fn compute_text_stats(data: &[String]) -> TextStats {
-    let non_empty: Vec<&String> = data.iter().filter(|s| !s.trim().is_empty()).collect();
+    let borrowed: Vec<&String> = data.iter().collect();
+    compute_text_stats_from_refs(&borrowed)
+}
+
+/// Compute text stats over already-borrowed values.
+pub fn compute_text_stats_from_refs(data: &[&String]) -> TextStats {
+    let non_empty: Vec<&String> = data
+        .iter()
+        .copied()
+        .filter(|s| !s.trim().is_empty())
+        .collect();
 
     if non_empty.is_empty() {
         return TextStats::empty();

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -335,7 +335,14 @@ The Rust and Python layers implement the same convention and are held to shared
 fixtures (`tests/fixtures/rounding_parity.json` and
 `report_rounding_parity.json`), so the same data profiled through either gives
 the same numbers. Raw property access on `ColumnProfile` returns unrounded Rust
-values; use the export methods for rounded output.
+values; use the export methods for rounded output. Cross-engine numeric
+equality is defined on those serialized metrics, with no extra tolerance.
+Native attributes may differ in their final digits with accumulation order;
+loading a report retains the precision that was saved. Compare the same data,
+schema semantics, analysis options and analyzed population, and exclude source
+and execution provenance such as timing and memory from equality checks. See
+the [numeric contract](../schema/README.md#numeric-equality-contract) for scope,
+sampling and absence semantics.
 
 **Round-trip fidelity:** a report reloaded with `from_dict`, `from_json`, or
 `load` reports the same values as the report it was saved from, at the precision

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -107,16 +107,22 @@ data and analysis options; execution provenance such as timing and memory can
 differ. Loading preserves the saved precision. The contract itself changes no
 rounding rule and no schema version (#547).
 
-Enforcing it did surface one real violation. Text length statistics
-(`min_length`, `max_length`, `avg_length`) reported by the database connectors
-counted null-like tokens (`NULL`, `NaN`, in any case) as text values, while
-every file and in-memory engine excluded them. Database profiles of string columns
-containing those tokens now report the same lengths as every other path. This
-is the only reported-value change here.
+Enforcing it did surface one real violation. Text statistics reported by the
+database connectors counted null-like tokens (`NULL`, `NaN`, in any case) as
+text values, while every file and in-memory engine excluded them. Database
+profiles of string columns containing those tokens now report the same
+`min_length`, `max_length` and `avg_length` as every other path. The same
+filtering applies to the `most_frequent` and `least_frequent` entries those
+profiles carry: a null-like token no longer appears as a value, and the
+remaining percentages are shares of the non-null values. Those are the only
+reported-value changes here.
 
-Agent-facing thresholds continue to use serialized precision, while `all-null`
-remains an exact count-based claim (#526). See the
-[numeric contract](schema/README.md#numeric-equality-contract) for the full scope.
+Agent-facing thresholds should read serialized precision, and `all-null` remains
+an exact count-based claim (#526). One consumer does not yet follow that rule —
+`_dominant_pattern` thresholds on the native pattern confidence — so a value
+just under the boundary can survive a round trip differently. See the
+[numeric contract](schema/README.md#numeric-equality-contract) for the full
+scope and the open defects (#709).
 
 ## Planned for 0.12: explicit Python interpreter support
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -97,6 +97,27 @@ Shipping with these, tracked for 0.12:
 
 <!-- release-body:end -->
 
+## Planned for 0.12: numeric equality surface
+
+The cross-engine identical-numbers contract applies to serialized, rounded
+metrics: Rust Serde reports and Python `to_dict()`/`to_json()`/JSON `save()`
+exports. Native float attributes retain full precision and can differ in their
+last digits with accumulation order. Compare serialized metrics for the same
+data and analysis options; execution provenance such as timing and memory can
+differ. Loading preserves the saved precision. The contract itself changes no
+rounding rule and no schema version (#547).
+
+Enforcing it did surface one real violation. Text length statistics
+(`min_length`, `max_length`, `avg_length`) reported by the database connectors
+counted null-like tokens (`NULL`, `NaN`, in any case) as text values, while
+every file and in-memory engine excluded them. Database profiles of string columns
+containing those tokens now report the same lengths as every other path. This
+is the only reported-value change here.
+
+Agent-facing thresholds continue to use serialized precision, while `all-null`
+remains an exact count-based claim (#526). See the
+[numeric contract](schema/README.md#numeric-equality-contract) for the full scope.
+
 ## Planned for 0.12: explicit Python interpreter support
 
 Release wheels will support standard, GIL-enabled CPython 3.10–3.14 on the

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -22,6 +22,56 @@ reader policy and lets compatible fields be added without invalidating stored
 reports. Required fields, schema version, known enum values, and primitive
 types remain enforced.
 
+## Numeric equality contract
+
+The cross-engine identical-numbers contract governs **serialized, rounded
+metric values** (#547): Rust's Serde report and Python's `to_dict()`,
+`to_json()`, and JSON `save()` output. Compare corresponding metrics across
+the two dialects; their document layouts differ.
+
+For the same logical values, schema semantics, analysis options and analyzed
+population, serialized metrics must compare exactly, with no additional
+tolerance or rounding by the consumer. Counts, types and absence must also
+agree: `None`/missing means not analyzed, while empty means analyzed with
+nothing found. Source names, engine identifiers, timestamps, elapsed time,
+throughput, memory and input-byte measurements describe execution and are not
+cross-path equality targets. Whole report documents need not be identical.
+
+| Metric kind | Serialized precision |
+| --- | --- |
+| 0–100 percentages, including coefficient of variation | 2 decimal places |
+| Statistics and data values, including mean, standard deviation and extrema | 4 decimal places |
+| 0–1 ratios and average text length | 4 decimal places |
+| Quartiles | 2 decimal places |
+
+Rounding uses the stored binary float, with ties away from zero. The Rust
+`serde_helpers` and Python `_rounding` modules implement the same convention.
+Native Rust fields and Python `ColumnProfile` attributes retain full precision;
+their final digits may depend on accumulation order. Raw values are not
+required to be bit-identical across engines, or to equal the rounded values
+restored from JSON. Parity tests supplement exact serialized comparisons with
+raw diagnostics using relative tolerance `1e-9` and absolute tolerance `1e-12`;
+those tolerances do not weaken the serialized contract.
+
+This is a contract decision, not a change to reported values or the schema.
+Rounding alone cannot mathematically guarantee equality for every possible
+floating-point input, especially near rounding boundaries or at large
+magnitudes. A difference that survives serialization remains a parity defect
+to investigate, rather than an allowed raw-precision difference. The known
+nested JSON/Arrow representation mismatch (#637) is one such defect.
+
+Sampling and approximate statistics must retain their provenance. Different
+row selections or retained samples are different analyzed populations; compare
+like with like rather than treating sampling differences as numeric drift.
+Producer-side conversions also matter: pandas widening nullable integers to
+floats changes the schema before dataprof sees it.
+
+Derived threshold decisions use serialized precision so saving and loading
+cannot change the verdict, as established for `to_llm_context()` in #526.
+Structural claims remain exact: `all-null` is based on null and total counts,
+not a percentage rounded to 100. This decision does not define historical
+metric-unit compatibility, tracked separately in #675.
+
 ## Regenerate and verify
 
 Run from the repository root:

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -53,12 +53,15 @@ restored from JSON. Parity tests supplement exact serialized comparisons with
 raw diagnostics using relative tolerance `1e-9` and absolute tolerance `1e-12`;
 those tolerances do not weaken the serialized contract.
 
-This is a contract decision, not a change to reported values or the schema.
+This decision changes no rounding rule and no schema version.
 Rounding alone cannot mathematically guarantee equality for every possible
 floating-point input, especially near rounding boundaries or at large
 magnitudes. A difference that survives serialization remains a parity defect
 to investigate, rather than an allowed raw-precision difference. The known
-nested JSON/Arrow representation mismatch (#637) is one such defect.
+nested JSON/Arrow representation mismatch (#637) is one such defect, as is the
+text frequency divergence in #709: `most_frequent` and `least_frequent`
+serialize as absent from the streaming builders and present from
+`analyze_column`, which the database connectors use.
 
 Sampling and approximate statistics must retain their provenance. Different
 row selections or retained samples are different analyzed populations; compare
@@ -66,8 +69,12 @@ like with like rather than treating sampling differences as numeric drift.
 Producer-side conversions also matter: pandas widening nullable integers to
 floats changes the schema before dataprof sees it.
 
-Derived threshold decisions use serialized precision so saving and loading
-cannot change the verdict, as established for `to_llm_context()` in #526.
+Derived threshold decisions should use serialized precision so that saving and
+loading cannot change the verdict, as established for `to_llm_context()` in
+#526. That is not yet true of every consumer: `_dominant_pattern` compares the
+native `confidence` against its 0.5 threshold while serialization rounds that
+value to four decimals, so a confidence just under the boundary can be
+suppressed natively and emitted after a round trip.
 Structural claims remain exact: `all-null` is based on null and total counts,
 not a percentage rounded to 100. This decision does not define historical
 metric-unit compatibility, tracked separately in #675.

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -149,7 +149,13 @@ class Pattern:
     confidence: float
 
 class ColumnProfile:
-    """Column-level profiling statistics."""
+    """Column-level profiling statistics.
+
+    Native float attributes retain full precision and may differ across engines
+    with accumulation order. Cross-engine equality applies to the rounded
+    metrics in ProfileReport.to_dict()/to_json(); loaded reports retain that
+    serialized precision.
+    """
 
     name: str
     data_type: str

--- a/python/dataprof/_dataprof.pyi
+++ b/python/dataprof/_dataprof.pyi
@@ -153,7 +153,9 @@ class ColumnProfile:
 
     Native float attributes retain full precision and may differ across engines
     with accumulation order. Cross-engine equality applies to the rounded
-    metrics in ProfileReport.to_dict()/to_json(); loaded reports retain that
+    metrics in ProfileReport.to_dict()/to_json(), for the same logical data,
+    analysis options and analyzed population -- a sampled or truncated run is a
+    different population, not a numeric difference. Loaded reports retain that
     serialized precision.
     """
 

--- a/python/dataprof/_report.py
+++ b/python/dataprof/_report.py
@@ -41,10 +41,11 @@ class ProfileReport:
         len(report)                    # number of columns
 
     Cross-engine numeric equality applies to the rounded metrics exported by
-    ``to_dict()`` and ``to_json()`` for the same data and analysis options.
-    Native column float attributes retain full precision and may differ in
-    their final digits with accumulation order. Loading a report preserves
-    its serialized precision.
+    ``to_dict()`` and ``to_json()``, for the same logical data, analysis options
+    and analyzed population -- a sampled or truncated run is a different
+    population, not a numeric difference. Native column float attributes retain
+    full precision and may differ in their final digits with accumulation order.
+    Loading a report preserves its serialized precision.
     """
 
     _MAX_REPR_COLUMNS = 15

--- a/python/dataprof/_report.py
+++ b/python/dataprof/_report.py
@@ -39,6 +39,12 @@ class ProfileReport:
         "column_name" in report        # -> bool
         for name in report: ...        # iterate column names
         len(report)                    # number of columns
+
+    Cross-engine numeric equality applies to the rounded metrics exported by
+    ``to_dict()`` and ``to_json()`` for the same data and analysis options.
+    Native column float attributes retain full precision and may differ in
+    their final digits with accumulation order. Loading a report preserves
+    its serialized precision.
     """
 
     _MAX_REPR_COLUMNS = 15

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -1,8 +1,9 @@
 """Cross-engine parity suite (issue #363).
 
 One canonical fixture, materialised into every input format dataprof supports,
-profiled through every input path, asserting the resulting column profiles are
-identical. Each engine is tested against its own hand-written expectations
+profiled through every input path, asserting the serialized column profiles are
+identical (#547). Raw floats retain full precision and are additionally checked
+with explicit relative/absolute tolerances. Each engine has hand-written expectations
 elsewhere; this suite exists because an engine can be confidently, consistently
 wrong on its own — the 0.9.0 nullable-Parquet and database-decoding bugs both
 survived a full test suite and were only found by cross-engine disagreement.
@@ -14,6 +15,7 @@ expected exception with a comment, never by weakening the assertion.
 from __future__ import annotations
 
 import csv
+import io
 import json
 from typing import Any
 
@@ -50,8 +52,11 @@ COLUMNS: dict[str, list[Any]] = {
 }
 N_ROWS = 5
 
-# The full observable numeric/type surface of a ColumnProfile. Assert on all of
-# it — a sampled field is how an engine stays consistently wrong.
+# Raw-access diagnostics supplement exact comparisons of every serialized field.
+# These tolerances accommodate floating-point accumulation order; they do not
+# apply to the serialized equality contract.
+RAW_REL_TOL = 1e-9
+RAW_ABS_TOL = 1e-12
 FIELDS = ("data_type", "null_count", "unique_count", "min", "max", "mean", "std_dev")
 
 # Explicit, justified exceptions: (engine, column, field) -> expected value.
@@ -66,11 +71,16 @@ EXPECTED_EXCEPTIONS: dict[tuple[str, str, str], Any] = {
 
 ENGINES = (
     "csv",
+    "csv.incremental",
+    "csv.columnar",
+    "csv.bytes",
+    "csv.buffer",
     "json",
     "jsonl",
     "dict",
     "rows",
     "parquet",
+    "parquet.bytes",
     "arrow",
     "pandas",
     "polars",
@@ -98,14 +108,19 @@ def build_report(engine: str, tmp_path):
     if engine == "rows":
         return dataprof.profile(fixture_rows())
 
-    if engine == "csv":
+    if engine == "csv" or engine.startswith("csv."):
         path = tmp_path / "fixture.csv"
         with open(path, "w", newline="", encoding="utf-8") as handle:
             writer = csv.writer(handle)
             writer.writerow(COLUMNS.keys())
             for row in fixture_rows():
                 writer.writerow([_csv_cell(row[name]) for name in COLUMNS])
-        return dataprof.profile(str(path))
+        if engine == "csv.bytes":
+            return dataprof.profile(path.read_bytes(), format="csv")
+        if engine == "csv.buffer":
+            return dataprof.profile(io.BytesIO(path.read_bytes()), format="csv")
+        selected = engine.partition(".")[2] or "auto"
+        return dataprof.profile(str(path), engine=selected)
 
     if engine == "json":
         path = tmp_path / "fixture.json"
@@ -117,11 +132,13 @@ def build_report(engine: str, tmp_path):
         path.write_text("\n".join(json.dumps(row) for row in fixture_rows()), encoding="utf-8")
         return dataprof.profile(str(path))
 
-    if engine == "parquet":
+    if engine in ("parquet", "parquet.bytes"):
         pa = pytest.importorskip("pyarrow")
         pq = pytest.importorskip("pyarrow.parquet")
         path = tmp_path / "fixture.parquet"
         pq.write_table(pa.table(COLUMNS), path)
+        if engine == "parquet.bytes":
+            return dataprof.profile(path.read_bytes(), format="parquet")
         return dataprof.profile(str(path))
 
     if engine == "arrow":
@@ -144,8 +161,19 @@ def field_value(report, column: str, field: str) -> Any:
 
 
 def assert_profiles_match(engine: str, report, reference, exceptions) -> None:
+    """Compare complete serialized columns exactly, then diagnose raw floats."""
     __tracebackhide__ = True
     assert report.rows == N_ROWS, f"{engine}: expected {N_ROWS} rows, got {report.rows}"
+    expected_columns = reference.to_dict()["columns"]
+    for column in expected_columns:
+        for (exception_engine, name, field), value in exceptions.items():
+            if exception_engine == engine and name == column["name"]:
+                assert field in column, f"exception names an unknown serialized field: {field}"
+                column[field] = value
+    # No approximation or post-export re-rounding here: consumers see these
+    # exact numbers, including every optional statistic and absence marker.
+    assert report.to_dict()["columns"] == expected_columns, engine
+    assert json.loads(report.to_json())["columns"] == expected_columns, engine
     mismatches = []
     for column in COLUMNS:
         for field in FIELDS:
@@ -154,7 +182,7 @@ def assert_profiles_match(engine: str, report, reference, exceptions) -> None:
                 (engine, column, field), field_value(reference, column, field)
             )
             if isinstance(expected, float) and isinstance(actual, float):
-                matches = actual == pytest.approx(expected, rel=1e-9)
+                matches = actual == pytest.approx(expected, rel=RAW_REL_TOL, abs=RAW_ABS_TOL)
             else:
                 matches = actual == expected
             if not matches:
@@ -175,6 +203,27 @@ def reference():
 def test_engine_parity(engine, reference, tmp_path):
     report = build_report(engine, tmp_path)
     assert_profiles_match(engine, report, reference, EXPECTED_EXCEPTIONS)
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+def test_serialized_parity_preserves_full_precision_accessors(engine, tmp_path):
+    """Serialization defines equality without rounding native attribute access."""
+    path = tmp_path / "fractional.csv"
+    path.write_text("amount,label\n0,a\n0,東京\n1,café\n", encoding="utf-8")
+    report = dataprof.profile(path, engine=engine)
+    reference = dataprof.profile(path, engine="incremental")
+    document = report.to_dict()
+    assert document["columns"] == reference.to_dict()["columns"]
+    assert document["quality"] == reference.to_dict()["quality"]
+    assert document["columns"][0]["stats"]["mean"] == 0.3333
+    assert report["amount"].mean == pytest.approx(1 / 3, rel=RAW_REL_TOL, abs=RAW_ABS_TOL)
+    assert report["amount"].mean != document["columns"][0]["stats"]["mean"]
+    # Loading retains the serialized precision rather than reconstructing the
+    # producer's full-precision float. Derived agent output must still agree.
+    restored = dataprof.ProfileReport.from_dict(document)
+    assert restored["amount"].mean == 0.3333
+    assert restored.to_dict() == document
+    assert restored.to_llm_context() == report.to_llm_context()
 
 
 # ── Column order (issue #465) ──
@@ -309,8 +358,6 @@ def test_sqlite_parity(tmp_path):
         return await analyze_database_async(str(db_path), "SELECT * FROM fixture")
 
     report = asyncio.run(_run())
-    # The raw report exposes column_profiles as a list, not a mapping.
-    profiles = {profile.name: profile for profile in report.column_profiles}
 
     # SQLite has no boolean type: sqlite3 stores True/False as INTEGER 1/0, so
     # the database really contains integers. The reference for this arm is the
@@ -319,21 +366,7 @@ def test_sqlite_parity(tmp_path):
     sqlite_visible["flag"] = [int(value) for value in COLUMNS["flag"]]
     reference = dataprof.profile(sqlite_visible)
 
-    assert report.rows_processed == N_ROWS
-    mismatches = []
-    for column in COLUMNS:
-        for field in FIELDS:
-            actual = getattr(profiles[column], field)
-            expected = getattr(reference[column], field)
-            if isinstance(expected, float) and isinstance(actual, float):
-                matches = actual == pytest.approx(expected, rel=1e-9)
-            else:
-                matches = actual == expected
-            if not matches:
-                mismatches.append(f"  {column}.{field}: sqlite={actual!r} expected={expected!r}")
-    assert not mismatches, "sqlite disagrees with the reference profile on:\n" + "\n".join(
-        mismatches
-    )
+    assert_profiles_match("sqlite", dataprof.ProfileReport(report), reference, {})
 
 
 # ── Duplicate-row detection with nulls (issue #417) ──

--- a/python/tests/test_engine_parity.py
+++ b/python/tests/test_engine_parity.py
@@ -69,6 +69,15 @@ EXPECTED_EXCEPTIONS: dict[tuple[str, str, str], Any] = {
     ("pandas", "n", "data_type"): "float",
 }
 
+# Same mechanism for the quality block: (engine, dimension, field) -> value.
+QUALITY_EXCEPTIONS: dict[tuple[str, str, str], Any] = {
+    # Downstream of the `n` widening above: four more values are numeric once
+    # pandas has made them floats, so they enter the precision check. The
+    # consistency percentage is unaffected, which is the point of pinning the
+    # count rather than skipping the dimension.
+    ("pandas", "precision", "numeric_values_checked"): 12,
+}
+
 ENGINES = (
     "csv",
     "csv.incremental",
@@ -174,6 +183,16 @@ def assert_profiles_match(engine: str, report, reference, exceptions) -> None:
     # exact numbers, including every optional statistic and absence marker.
     assert report.to_dict()["columns"] == expected_columns, engine
     assert json.loads(report.to_json())["columns"] == expected_columns, engine
+    # Quality scores are rounded metrics, not execution provenance, so they are
+    # on the contract surface too. Left out, an engine could agree on every
+    # column and still report a different overall score.
+    expected_quality = reference.to_dict()["quality"]
+    for (exception_engine, dimension, field), value in QUALITY_EXCEPTIONS.items():
+        if exception_engine == engine:
+            assert dimension in expected_quality, f"unknown quality dimension: {dimension}"
+            assert field in expected_quality[dimension], f"unknown quality field: {field}"
+            expected_quality[dimension][field] = value
+    assert report.to_dict()["quality"] == expected_quality, engine
     mismatches = []
     for column in COLUMNS:
         for field in FIELDS:
@@ -207,7 +226,15 @@ def test_engine_parity(engine, reference, tmp_path):
 
 @pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
 def test_serialized_parity_preserves_full_precision_accessors(engine, tmp_path):
-    """Serialization defines equality without rounding native attribute access."""
+    """Characterize the contract: serialized equality, native precision intact.
+
+    This pins the two-surface behaviour the contract names; it is not a
+    regression guard, and it passes on the code before #547 because nothing
+    here was broken -- what was missing was the statement of which surface
+    equality is defined on. The `to_llm_context()` assertion covers only the
+    derived output this fixture reaches; `_dominant_pattern` still thresholds
+    on native confidence and is tracked separately.
+    """
     path = tmp_path / "fractional.csv"
     path.write_text("amount,label\n0,a\n0,東京\n1,café\n", encoding="utf-8")
     report = dataprof.profile(path, engine=engine)

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -555,6 +555,14 @@ fn test_standard_vs_arrow_csv_numeric_stats() {
         "serialized column profiles must match across CSV engines"
     );
 
+    // Quality scores are rounded metrics on the same contract surface, and are
+    // compared apart from the execution provenance that surrounds them.
+    assert_eq!(
+        serde_json::to_value(&std_report.quality).unwrap(),
+        serde_json::to_value(&arrow_report.quality).unwrap(),
+        "serialized quality must match across CSV engines"
+    );
+
     // Raw attributes retain full precision. These diagnostics allow only
     // accumulation-order differences, independently of serialized equality.
     for (standard, arrow) in std_report

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -1,7 +1,8 @@
 //! Cross-engine consistency test.
 //!
 //! Profiles the same CSV through the standard CSV engine and Arrow CSV engine,
-//! then asserts that numeric stats match within tolerance.
+//! then asserts exact equality of serialized metrics (#547). Raw numeric
+//! diagnostics allow relative tolerance 1e-9 or absolute tolerance 1e-12.
 
 use std::io::Write;
 use std::path::Path;
@@ -422,27 +423,24 @@ fn test_base_numeric_stats_exact_beyond_sample_capacity() {
         assert_eq!(id.invalid_count, Some(0), "[{engine}] invalid_count");
     }
 
-    // And the two engines must agree with each other exactly on base stats.
-    for name in ["id", "value"] {
-        let get = |r: &dataprof::ProfileReport| {
-            let col = r.column_profiles.iter().find(|c| c.name == name).unwrap();
-            match &col.stats {
-                ColumnStats::Numeric(n) => (n.min, n.max, n.mean, n.std_dev),
-                other => panic!("'{name}' should be numeric, got {other:?}"),
-            }
-        };
-        let (min1, max1, mean1, std1) = get(&std_report);
-        let (min2, max2, mean2, std2) = get(&arrow_report);
-        assert_eq!(min1, min2, "'{name}' min must match across engines");
-        assert_eq!(max1, max2, "'{name}' max must match across engines");
-        assert!(
-            (mean1 - mean2).abs() < 1e-9,
-            "'{name}' mean: {mean1} vs {mean2}"
-        );
-        assert!(
-            (std1 - std2).abs() < 1e-6 * std1.abs().max(1.0),
-            "'{name}' std_dev: {std1} vs {std2}"
-        );
+    // The contract applies at serialized precision. Sample-derived order
+    // statistics can differ because each engine retains a different sample;
+    // these base statistics consume the same complete population (#547).
+    let standard = serde_json::to_value(&std_report.column_profiles).unwrap();
+    let arrow = serde_json::to_value(&arrow_report.column_profiles).unwrap();
+    assert_eq!(
+        std_report.column_profiles.len(),
+        arrow_report.column_profiles.len()
+    );
+    for index in 0..std_report.column_profiles.len() {
+        for field in ["min", "max", "mean", "std_dev", "variance"] {
+            assert!(standard[index]["stats"]["Numeric"][field].is_number());
+            assert!(arrow[index]["stats"]["Numeric"][field].is_number());
+            assert_eq!(
+                standard[index]["stats"]["Numeric"][field], arrow[index]["stats"]["Numeric"][field],
+                "column {index}, serialized {field}"
+            );
+        }
     }
 }
 
@@ -549,113 +547,37 @@ fn test_standard_vs_arrow_csv_numeric_stats() {
         .analyze_file(path)
         .expect("Arrow CSV analysis should succeed");
 
-    // Same number of columns
+    // No tolerance on the contract surface, including optional fields: an
+    // absent statistic must not silently compare equal to a measured one.
     assert_eq!(
-        std_report.column_profiles.len(),
-        arrow_report.column_profiles.len(),
-        "Both engines should detect the same number of columns"
+        serde_json::to_value(&std_report.column_profiles).unwrap(),
+        serde_json::to_value(&arrow_report.column_profiles).unwrap(),
+        "serialized column profiles must match across CSV engines"
     );
 
-    for std_col in &std_report.column_profiles {
-        let arrow_col = arrow_report
-            .column_profiles
-            .iter()
-            .find(|c| c.name == std_col.name)
-            .unwrap_or_else(|| panic!("Column '{}' missing from Arrow report", std_col.name));
-
-        // Data type should match
-        assert_eq!(
-            std_col.data_type, arrow_col.data_type,
-            "Type mismatch for column '{}'",
-            std_col.name
-        );
-
-        // Row counts should match
-        assert_eq!(
-            std_col.total_count, arrow_col.total_count,
-            "total_count mismatch for '{}'",
-            std_col.name
-        );
-        assert_eq!(
-            std_col.null_count, arrow_col.null_count,
-            "null_count mismatch for '{}'",
-            std_col.name
-        );
-
-        // Compare numeric stats within tolerance
-        if let (ColumnStats::Numeric(n1), ColumnStats::Numeric(n2)) =
-            (&std_col.stats, &arrow_col.stats)
+    // Raw attributes retain full precision. These diagnostics allow only
+    // accumulation-order differences, independently of serialized equality.
+    for (standard, arrow) in std_report
+        .column_profiles
+        .iter()
+        .zip(&arrow_report.column_profiles)
+    {
+        if let (ColumnStats::Numeric(a), ColumnStats::Numeric(b)) = (&standard.stats, &arrow.stats)
         {
-            let tol = 0.01;
-            assert!(
-                (n1.min - n2.min).abs() < tol,
-                "'{}' min: {} vs {}",
-                std_col.name,
-                n1.min,
-                n2.min
-            );
-            assert!(
-                (n1.max - n2.max).abs() < tol,
-                "'{}' max: {} vs {}",
-                std_col.name,
-                n1.max,
-                n2.max
-            );
-            assert!(
-                (n1.mean - n2.mean).abs() < tol,
-                "'{}' mean: {} vs {}",
-                std_col.name,
-                n1.mean,
-                n2.mean
-            );
-            assert!(
-                (n1.std_dev - n2.std_dev).abs() < tol,
-                "'{}' std_dev: {} vs {}",
-                std_col.name,
-                n1.std_dev,
-                n2.std_dev
-            );
-            assert!(
-                (n1.variance - n2.variance).abs() < 0.1,
-                "'{}' variance: {} vs {}",
-                std_col.name,
-                n1.variance,
-                n2.variance
-            );
-
-            // Optional stats: only compare when both are Some
-            if let (Some(m1), Some(m2)) = (n1.median, n2.median) {
+            for (field, left, right) in [
+                ("min", a.min, b.min),
+                ("max", a.max, b.max),
+                ("mean", a.mean, b.mean),
+                ("std_dev", a.std_dev, b.std_dev),
+                ("variance", a.variance, b.variance),
+            ] {
+                let tolerance = (1e-9 * left.abs().max(right.abs())).max(1e-12);
                 assert!(
-                    (m1 - m2).abs() < 0.1,
-                    "'{}' median: {} vs {}",
-                    std_col.name,
-                    m1,
-                    m2
+                    (left - right).abs() <= tolerance,
+                    "{} raw {field}: {left} vs {right}",
+                    standard.name
                 );
             }
-            if let (Some(s1), Some(s2)) = (n1.skewness, n2.skewness) {
-                assert!(
-                    (s1 - s2).abs() < 0.1,
-                    "'{}' skewness: {} vs {}",
-                    std_col.name,
-                    s1,
-                    s2
-                );
-            }
-            if let (Some(k1), Some(k2)) = (n1.kurtosis, n2.kurtosis) {
-                assert!(
-                    (k1 - k2).abs() < 0.1,
-                    "'{}' kurtosis: {} vs {}",
-                    std_col.name,
-                    k1,
-                    k2
-                );
-            }
-        } else if matches!(std_col.data_type, DataType::Integer | DataType::Float) {
-            panic!(
-                "Column '{}' is {:?} but one engine produced non-Numeric stats: std={:?}, arrow={:?}",
-                std_col.name, std_col.data_type, std_col.stats, arrow_col.stats
-            );
         }
     }
 }


### PR DESCRIPTION
Closes #547.

## What this settles

The "profile numbers must be identical regardless of engine" rule was never
scoped, so it was read two ways: as a claim about raw `f64` values (which no
engine can guarantee, since accumulation order differs) or about what consumers
actually see. This scopes it to the second: **serialized, rounded metrics** —
Rust Serde output and Python `to_dict()` / `to_json()` / JSON `save()`.

- Native Rust fields and Python `ColumnProfile` attributes keep full precision
  and may differ in their final digits.
- Source and execution provenance (engine id, timings, memory, input bytes) is
  not an equality target.
- Absence is part of the contract: `None` means not analyzed, empty means
  analyzed and nothing found.
- A difference that survives serialization stays a parity defect, not an
  allowed raw-precision difference.

Documented in [the numeric contract](docs/schema/README.md#numeric-equality-contract),
with AGENTS.md, the Python guide and the docstrings pointing at it.

## Tests now enforce it

`test_engine_parity.py` and `tests/cross_engine_consistency.rs` compared a
hand-picked list of fields within a tolerance as loose as `0.01`. They now
compare the **complete serialized column documents** for exact equality, which
also covers optional statistics and absence markers — an absent statistic can
no longer silently compare equal to a measured one. Raw floats keep a separate
diagnostic check at rel `1e-9` / abs `1e-12`.

Coverage added: `csv.incremental`, `csv.columnar`, `csv.bytes`, `csv.buffer`,
`parquet.bytes`, and the sqlite arm folded onto the same assertion instead of
its own weaker loop.

## One real defect this found

Tightening the sqlite arm surfaced a genuine cross-path disagreement.
`analyze_column` fed raw values into the text statistics, so a `NULL` / `NaN`
token already counted as a null was *also* counted as a 4- or 3-character
string. The streaming engines feed a null-excluding length accumulator, so the
database connectors — the only other caller — disagreed with every file and
in-memory path:

| `null_str` = `["NULL","a","b","c","d"]` | min | max | avg |
| --- | --- | --- | --- |
| every file / in-memory engine | 1 | 1 | 1.0 |
| database connectors (before) | 1 | 4 | 1.6 |

Database profiles of string columns containing those tokens now report the same
lengths as every other path. This is the only reported-value change here; the
contract itself changes no rounding rule and no schema version.

## Verification

- `cargo test --workspace` — passes.
- `cargo fmt --all`, `cargo clippy --all --all-targets -- -D warnings` — clean
  on 1.98.1, matching the CI pin.
- `uv run pytest python/tests` — 1394 passed, 9 skipped (db-only).
- `uv run maturin develop --features "python,python-async,sqlite"` +
  `pytest python/tests/test_engine_parity.py` — 58 passed. The sqlite arm
  **fails on master's code** and passes with the fix; verified in both
  directions, and the new `text_lengths_exclude_null_like_tokens` unit test was
  confirmed to fail with the fix reverted alone.
- `uv run ruff format`, `ruff check`, `ty check` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text length statistics now exclude null-like values such as `NULL` and `NaN`, ensuring consistent results across data sources.

* **Documentation**
  * Clarified numeric equality across engines and input formats for serialized reports.
  * Documented rounding, precision retention, sampling, missing values, and comparison behavior.
  * Added guidance for interpreting native floating-point values and loaded reports.

* **Tests**
  * Expanded cross-engine coverage and exact serialized-profile comparisons.
  * Added validation for precision preservation and consistent handling of text statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review pass

Six findings from CodeRabbit and Copilot; five applied, one filed.

**Applied**

- *Cloning the column* (Copilot). The null-like filter built a second full
  `Vec<String>`, duplicating every string to drop a few. Added a borrowing
  variant of the text-stats entry point and collect `Vec<&String>` instead.
- *Frequency fields also change* (Copilot). Correct — the filtered slice also
  feeds `most_frequent`/`least_frequent`, so a null-like token no longer appears
  as a value and the remaining percentages are shares of the non-null values.
  The release note now says so.
- *"Not a change to reported values" is inaccurate* (Copilot). It is a change,
  for the database text statistics. The schema doc now claims only that no
  rounding rule and no schema version changed.
- *The threshold claim is too broad* (Copilot). Verified: `_dominant_pattern`
  compares native `confidence` against 0.5 while serialization rounds to 4dp, so
  a confidence just under the boundary is suppressed natively and emitted after
  a round trip. Narrowed the claim to the intent plus the known exception rather
  than changing threshold behaviour in this PR.
- *Quality is on the contract surface* (CodeRabbit). Added exact serialized
  quality assertions to both suites. It holds for every engine except pandas,
  which needs one bounded exception downstream of the int-to-float widening it
  already declares — pinned as a value rather than skipping the dimension, so
  nothing else can drift behind it.
- *State the analyzed-population condition* (CodeRabbit). Added to both Python
  docstrings.
- *The new round-trip test does not regress #547* (Copilot). Correct — it passes
  on the prior code, because nothing here was broken; what was missing was the
  statement of which surface equality is defined on. Reframed its docstring as a
  characterization rather than a regression guard. Did not add the suggested
  boundary assertion, because at the boundary the behaviour is the open defect
  above and the assertion would fail.

**Filed, not folded in: #709**

Copilot noticed that aligning the length statistics leaves `most_frequent` and
`least_frequent` still diverging. Confirmed on the same five values:

```
CSV engine:      {"Text":{"min_length":4,"max_length":5,"avg_length":4.6}}
analyze_column:  {"Text":{...,"most_frequent":[...],"least_frequent":[...]}}
```

`TextStats::from_lengths` hardcodes both to `None` and they are
`skip_serializing_if`, so the streaming builders serialize them absent while the
database path serializes them present. That is a live violation of the contract
this PR defines, and no test catches it: Python's `column_to_dict` drops both
fields, and the Rust suite compares two engines that share the `from_lengths`
builder. Resolving it means either dropping data Rust database consumers can
read today or computing top-N on a sample, so it is a behaviour decision rather
than something to fold in here. Recorded as a known defect in the schema doc
next to #637.

Gates re-run after these changes: `cargo test --workspace`, clippy on 1.98.1,
`pytest python/tests` (1394 passed), the sqlite arm (58 passed), ruff and ty.