### PR TITLE
fix: align empty-source quality across input paths

### DIFF
--- a/.claude/skills/dataprof/scripts/dp_context.py
+++ b/.claude/skills/dataprof/scripts/dp_context.py
@@ -85,7 +85,7 @@ def _caveats(report: Any) -> list[str]:
 # and a reader told only that it was "not analyzed" would report a clean skip.
 _QUALITY_ABSENCE = {
     "not_requested": "quality: not analyzed (not requested for this run)",
-    "no_data": "quality: not analyzed (the source held nothing to measure)",
+    "no_data": "quality: not analyzed (no quality sample was supplied)",
     "withheld_by_projection": (
         "quality: not analyzed (withheld: the requested dimensions measure whole "
         "rows and only some columns were profiled)"

--- a/crates/dataprof-csv/src/lib.rs
+++ b/crates/dataprof-csv/src/lib.rs
@@ -372,17 +372,6 @@ pub fn analyze_csv_file_with_dimensions_and_hints(
         parquet_metadata: None,
     };
 
-    // Every header name is pre-registered above, so no profiles means no header
-    // declared a column: the source is empty, not merely rowless.
-    if column_profiles.is_empty() && rows_read == 0 {
-        return Ok(ReportAssembler::new(
-            file_source,
-            ExecutionMetadata::new(0, 0, start.elapsed().as_millis()).with_engine("csv"),
-        )
-        .skip_quality_no_data()
-        .build());
-    }
-
     let sample_columns = profile_builder::quality_check_samples(&column_stats);
     let scan_time_ms = start.elapsed().as_millis();
     let num_columns = column_profiles.len();
@@ -599,10 +588,12 @@ mod tests {
         assert!(report.column_profiles.is_empty());
         assert_eq!(report.execution.rows_processed, 0);
         assert_eq!(report.execution.columns_detected, 0);
-        // Records this path's behaviour, not a settled contract: the engines
-        // answer the same empty file with a quality block scoring 0.0/Exact
-        // over nothing at all. See #573.
-        assert!(report.quality.is_none());
+        assert_eq!(
+            report.quality_status,
+            dataprof_runtime::QualityAnalysisStatus::Computed
+        );
+        assert!(report.quality.is_some());
+        assert!(report.quality_score().is_none());
     }
 
     #[test]

--- a/crates/dataprof-db/src/lib.rs
+++ b/crates/dataprof-db/src/lib.rs
@@ -275,7 +275,7 @@ pub async fn analyze_database_with_options(
                 .with_sampling(info.sampling_ratio)
                 .with_source_exhausted(false);
         }
-        let assembler = ReportAssembler::new(
+        return Ok(ReportAssembler::new(
             DataSource::Query {
                 engine: query_engine.clone(),
                 statement: query.to_string(),
@@ -283,17 +283,10 @@ pub async fn analyze_database_with_options(
                 execution_id: None,
             },
             exec,
-        );
-        // Not asking for quality outranks having nothing to measure, the same
-        // precedence the streaming and columnar engines apply to their own
-        // empty sources. Reading it off the options directly, rather than
-        // through `with_analysis_options`, keeps a column projection from
-        // answering an empty result set with `WithheldByProjection`.
-        return Ok(if options.include_quality() {
-            assembler.skip_quality_no_data().build()
-        } else {
-            assembler.skip_quality().build()
-        });
+        )
+        .with_quality_data(columns.into_map())
+        .with_analysis_options(options)
+        .build());
     }
 
     // decode-audit: no-data — the empty-columns case returned early above, so

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -393,9 +393,6 @@ impl AsyncStreamingProfiler {
         let json_error_policy = self.json_error_policy;
         let csv_flexible = self.csv_flexible;
         let csv_delimiter = self.csv_delimiter;
-        // JSON records with no fields are rows against an empty schema; a CSV
-        // stream with no header line has nothing to profile.
-        let allow_empty_schema = matches!(format, FileFormat::Json | FileFormat::Jsonl);
         let reader_handle = tokio::task::spawn_blocking(move || match format {
             FileFormat::Csv => Self::reader_task(
                 sync_reader,
@@ -415,9 +412,7 @@ impl AsyncStreamingProfiler {
         });
 
         // Process chunks on the current task
-        let process_result = self
-            .process_chunks(rx, source_info.size_hint, allow_empty_schema)
-            .await;
+        let process_result = self.process_chunks(rx, source_info.size_hint).await;
 
         // If processing failed, prefer the reader's error when it also failed:
         // a strict-mode malformed record aborts the reader before any data
@@ -1088,7 +1083,6 @@ impl AsyncStreamingProfiler {
         &self,
         mut rx: mpsc::Receiver<ParsedChunk>,
         size_hint: Option<u64>,
-        allow_empty_schema: bool,
     ) -> Result<
         (
             Vec<String>,
@@ -1138,24 +1132,15 @@ impl AsyncStreamingProfiler {
             });
         }
 
-        // decode-audit: impossible — `records` was checked non-empty above, and
-        // an empty header row is rejected right below.
+        // decode-audit: impossible — `records` was checked non-empty above.
         let headers: Vec<String> = header_chunk
             .records
             .into_iter()
             .next()
             .expect("non-empty header chunk has a first record");
 
-        // A JSON source may legitimately have no columns: records with no fields
-        // are rows against an empty schema. A CSV stream cannot — its first line
-        // is the schema, so an empty one means there is nothing to profile.
-        if headers.is_empty() && !allow_empty_schema {
-            return Err(DataProfilerError::StreamingError {
-                message: "No column headers found in stream".to_string(),
-                suggestion: "Provide a header row in the first chunk of the stream".to_string(),
-            });
-        }
-
+        // Both parsers explicitly send an empty schema for an empty source.
+        // It is analyzed with no columns, just like the synchronous paths (#723).
         // Headers are the declared schema even when the stream contains no
         // records. Pre-register them so the public async path preserves the
         // same header-only CSV invariant as the file-based engines.

--- a/crates/dataprof-engines/src/streaming/async_reader.rs
+++ b/crates/dataprof-engines/src/streaming/async_reader.rs
@@ -1309,7 +1309,7 @@ impl Default for AsyncStreamingProfiler {
 mod tests {
     use super::*;
     use dataprof_core::DataType;
-    use dataprof_runtime::{AsyncSourceInfo, BytesSource};
+    use dataprof_runtime::{AsyncSourceInfo, BytesSource, QualityAnalysisStatus};
 
     fn csv_source(data: &'static [u8]) -> BytesSource {
         BytesSource::new(
@@ -1362,11 +1362,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_empty_input() {
+    async fn test_empty_input_has_an_empty_quality_assessment() {
         let source = csv_source(b"");
         let profiler = AsyncStreamingProfiler::new();
-        let result = profiler.analyze_stream(source).await;
-        assert!(result.is_err());
+        let report = profiler.analyze_stream(source).await.unwrap();
+
+        assert!(report.column_profiles.is_empty());
+        assert_eq!(report.execution.rows_processed, 0);
+        assert_eq!(report.execution.columns_detected, 0);
+        assert!(report.execution.source_exhausted);
+        assert_eq!(report.quality_status, QualityAnalysisStatus::Computed);
+        assert!(report.quality_score().is_none());
+        let quality = report.quality.expect("empty input was analyzed");
+        assert!(quality.metrics.assessed_dimensions().is_empty());
     }
 
     #[tokio::test]

--- a/crates/dataprof-engines/src/streaming/incremental.rs
+++ b/crates/dataprof-engines/src/streaming/incremental.rs
@@ -443,7 +443,6 @@ impl IncrementalProfiler {
             execution = execution.with_source_exhausted(false);
         }
 
-        let empty_source = column_profiles.is_empty() && analyzed_rows == 0;
         let mut assembler = ReportAssembler::new(
             DataSource::File {
                 path: file_path.display().to_string(),
@@ -458,8 +457,6 @@ impl IncrementalProfiler {
 
         if !MetricPack::include_quality(packs) {
             assembler = assembler.skip_quality();
-        } else if empty_source {
-            assembler = assembler.skip_quality_no_data();
         } else {
             assembler = assembler
                 .with_quality_data(sample_columns)

--- a/crates/dataprof-parquet/src/arrow_profiler.rs
+++ b/crates/dataprof-parquet/src/arrow_profiler.rs
@@ -343,7 +343,6 @@ impl ArrowProfiler {
             execution = execution.with_truncation(TruncationReason::MaxRows(max as u64));
         }
 
-        let empty_source = column_profiles.is_empty() && total_rows == 0;
         let mut assembler = ReportAssembler::new(
             DataSource::File {
                 path: file_path.display().to_string(),
@@ -360,8 +359,6 @@ impl ArrowProfiler {
 
         if !MetricPack::include_quality(packs) {
             assembler = assembler.skip_quality();
-        } else if empty_source {
-            assembler = assembler.skip_quality_no_data();
         } else {
             assembler = assembler
                 .with_quality_data(sample_columns)

--- a/crates/dataprof-python/src/arrow_export.rs
+++ b/crates/dataprof-python/src/arrow_export.rs
@@ -1180,8 +1180,14 @@ fn import_via_pycapsule(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<Reco
             .collect::<Vec<_>>(),
     ));
 
-    RecordBatch::try_new(schema, struct_array.columns().to_vec())
-        .map_err(|e| PyRuntimeError::new_err(format!("RecordBatch creation failed: {}", e)))
+    // A zero-column batch cannot infer its row count from a child array.
+    // Preserve the count carried by the imported struct, including zero (#723).
+    RecordBatch::try_new_with_options(
+        schema,
+        struct_array.columns().to_vec(),
+        &arrow::record_batch::RecordBatchOptions::new().with_row_count(Some(struct_array.len())),
+    )
+    .map_err(|e| PyRuntimeError::new_err(format!("RecordBatch creation failed: {}", e)))
 }
 
 /// Validate an FFI-imported batch, then fold it into the analyzer.

--- a/crates/dataprof-runtime/src/profile_report.rs
+++ b/crates/dataprof-runtime/src/profile_report.rs
@@ -36,8 +36,8 @@ pub enum QualityAnalysisStatus {
     Computed,
     /// Not requested for this run — the quality pack was deselected.
     NotRequested,
-    /// Requested, but the run had nothing to compute from: an empty source,
-    /// or an input path that retained no sample.
+    /// Requested, but no quality sample was supplied to the assembler.
+    /// An empty sample is analyzed and reports `Computed`, even without columns.
     NoData,
     /// Requested, but every requested dimension measures whole rows and the
     /// run profiled a subset of columns. Completeness and uniqueness mean

--- a/crates/dataprof-runtime/src/report_assembler.rs
+++ b/crates/dataprof-runtime/src/report_assembler.rs
@@ -92,21 +92,22 @@ impl ReportAssembler {
     /// ask for it.
     ///
     /// Use [`skip_quality_no_data`](Self::skip_quality_no_data) when quality
-    /// was wanted but the source held nothing to measure. The report states
-    /// which of the two happened, so they must not be conflated here.
+    /// was wanted but no sample is available. An analyzed empty source supplies
+    /// an empty sample through [`with_quality_data`](Self::with_quality_data).
     pub fn skip_quality(mut self) -> Self {
         self.skip = Some(QualityAnalysisStatus::NotRequested);
         self
     }
 
-    /// Skip quality metric calculation because there was nothing to compute
-    /// from: an empty source, or a path that retained no sample.
+    /// Skip quality metric calculation because no sample is available.
+    /// An analyzed empty source must instead supply an empty quality sample;
+    /// that produces an assessment with no assessable dimensions (#723).
     ///
     /// A caller that already deselected quality keeps that answer, and only
     /// that one. Not asking is the more specific reason and does not stop being
-    /// true when the source also turns out to be empty. Every other reason is
+    /// true when the sample is also unavailable. Every other reason is
     /// replaced: a projection withholds dimensions that *could* have been
-    /// measured, which says nothing once there was nothing to measure at all.
+    /// measured, which says nothing once no sample is available at all.
     pub fn skip_quality_no_data(mut self) -> Self {
         if !matches!(self.skip, Some(QualityAnalysisStatus::NotRequested)) {
             self.skip = Some(QualityAnalysisStatus::NoData);
@@ -453,10 +454,28 @@ mod tests {
         assert_eq!(implicit.quality_status, QualityAnalysisStatus::NoData);
     }
 
-    /// Not asking is the more specific reason, and an empty source does not
+    #[test]
+    fn empty_quality_data_is_analyzed() {
+        let report = ReportAssembler::new(test_source(), ExecutionMetadata::new(0, 0, 1))
+            .with_quality_data(HashMap::new())
+            .build();
+
+        assert_eq!(report.quality_status, QualityAnalysisStatus::Computed);
+        assert!(report.quality_score().is_none());
+        assert!(
+            report
+                .quality
+                .unwrap()
+                .metrics
+                .assessed_dimensions()
+                .is_empty()
+        );
+    }
+
+    /// Not asking is the more specific reason, and an unavailable sample does not
     /// make it untrue. Builder order must not change the answer either way.
     #[test]
-    fn deselected_quality_survives_an_empty_source() {
+    fn deselected_quality_survives_an_unavailable_sample() {
         let deselected =
             AnalysisOptions::default().with_metric_packs(Some(vec![MetricPack::Schema]));
         let options_first = ReportAssembler::new(test_source(), ExecutionMetadata::new(0, 0, 1))
@@ -478,11 +497,11 @@ mod tests {
         );
     }
 
-    /// Deselection is the only reason that outranks an empty source. A
+    /// Deselection is the only reason that outranks an unavailable sample. A
     /// projection withholds dimensions that could have been measured, which
-    /// says nothing once there was nothing to measure at all.
+    /// says nothing once no sample is available at all.
     #[test]
-    fn an_empty_source_outranks_projection_withholding() {
+    fn an_unavailable_sample_outranks_projection_withholding() {
         let projected = AnalysisOptions::default()
             .with_quality_dimensions(Some(vec![
                 QualityDimension::Completeness,

--- a/docs/python/README.md
+++ b/docs/python/README.md
@@ -309,10 +309,14 @@ the other five states are the reasons it does not:
 |---|---|
 | `computed` | quality was computed; `quality` holds the assessment |
 | `not_requested` | the quality pack was deselected (`metrics=["schema"]`) |
-| `no_data` | requested, but the source held nothing to measure |
+| `no_data` | requested, but no quality sample was supplied to the assembler |
 | `withheld_by_projection` | requested, but every requested dimension measures whole rows and `columns=` selected a subset |
 | `failed` | requested and attempted; the computation failed, and `quality_error` says how |
 | `unrecorded` | loaded from a report saved before 0.12 that carried no assessment |
+
+An analyzed empty source reports `computed` with an empty assessment and
+`quality_score=None`, whether or not it declares columns. This is distinct from
+an unavailable quality sample (`no_data`).
 
 A gate deciding on a report should branch on this before reading
 `quality_score`: a failed computation and a run that never asked for quality

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 # Pending 0.12.0 changes
 
+- Empty inputs now consistently carry an empty quality assessment with
+  `quality_status: computed`, no score and no assessed dimensions (#723).
+  Empty CSV files previously withheld quality while buffers and other formats
+  emitted the assessment. Header-only sources follow the same rule; deselecting
+  quality still reports `not_requested`. Regenerate stored empty-input baselines
+  to compare across transports. The report schema remains v1.
+  Async empty CSV and zero-column Arrow RecordBatch inputs now produce reports
+  instead of errors.
+
 - Capped Parquet profiling (`max_rows`) now selects up to 32 contiguous ranges
   spread across the file instead of its prefix (#639). Files, byte buffers and
   HTTP reads use the same selection; HTTP reads now honor the cap. Re-baseline

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -322,7 +322,7 @@ only, an `error` message:
 | --- | --- |
 | `computed` | quality was computed; `quality` holds the assessment |
 | `not_requested` | the quality pack was deselected for this run |
-| `no_data` | requested, but the source held nothing to measure |
+| `no_data` | requested, but no quality sample was supplied to the assembler |
 | `withheld_by_projection` | requested, but every requested dimension measures whole rows and the run profiled a subset of columns |
 | `failed` | requested and attempted; the computation failed, and `error` says how |
 | `unrecorded` | read back from a document written before this field existed |
@@ -340,14 +340,31 @@ and nothing else about an older document is knowable.
 `quality_status` is provenance, not a metric, so it is outside the numeric
 equality contract above. It is assigned in one place, `ReportAssembler`, which
 every input path builds through, and agrees across engines and paths for a
-source that holds data.
+source with the same analysis options, including an empty source.
 
-It does **not** yet agree for an empty source, and the field is what made that
-visible. An empty CSV file reports `no_data`, while the same bytes through a
-buffer — and JSON, JSONL and the Arrow paths — report `computed` with an
-assessment in which nothing was assessable. Only three sites check for an empty
-source; every other path hands the assembler an empty sample. Which of the two
-answers is right is tracked in
-[#723](https://github.com/AndreaBozzo/dataprof/issues/723); until it is settled,
-do not compare `quality_status` across transports for a source that may be
-empty.
+### 0.12 empty-source quality parity (#723)
+
+A successfully analyzed zero-row source is **analyzed, nothing found**, whether
+it declares columns or has no columns at all. With quality enabled, CSV, JSON,
+JSONL, Parquet, queries and Arrow/dataframe inputs report `computed` and carry
+an assessment with no assessable dimensions. Python serializes
+`overall_score: null`, `assessed_dimensions: []` and null dimension scores;
+Rust serializes the corresponding empty quality metrics. File, byte-buffer,
+async and HTTP transports follow the same rule. Header-only CSV and zero-row
+Arrow/Parquet schemas retain their columns.
+Empty CSV streams and zero-column Arrow RecordBatches, which previously raised
+errors, now produce reports too.
+
+Previously, empty CSV files on the direct parser, incremental and columnar
+paths withheld quality and reported `no_data`, while CSV buffers and most
+other inputs emitted an empty assessment. Those CSV file paths, and the
+database assembler's no-column branch, now emit the assessment too. This is a
+behavior correction within schema v1: both shapes were already valid. Stored
+reports keep their original status and quality presence when loaded; consumers
+comparing empty extracts should regenerate older baselines for parity.
+
+Deselecting quality still yields absent `quality` and `not_requested`, and
+projection withholding still applies to the requested dimensions. `no_data`
+remains available for an assembler that receives no quality sample, distinct
+from an explicitly supplied empty sample. It no longer denotes a successfully
+analyzed empty source.

--- a/docs/schema/profile-report.v1.schema.json
+++ b/docs/schema/profile-report.v1.schema.json
@@ -1857,7 +1857,7 @@
           "type": "object"
         },
         {
-          "description": "Requested, but the run had nothing to compute from: an empty source,\nor an input path that retained no sample.",
+          "description": "Requested, but no quality sample was supplied to the assembler.\nAn empty sample is analyzed and reports `Computed`, even without columns.",
           "properties": {
             "state": {
               "const": "no_data",

--- a/python/dataprof/_report.py
+++ b/python/dataprof/_report.py
@@ -146,7 +146,8 @@ class ProfileReport:
         ``not_requested``
             The quality pack was deselected for this run.
         ``no_data``
-            Requested, but the source held nothing to measure.
+            Requested, but no quality sample was supplied to the assembler.
+            An empty sample is analyzed and reports ``computed``.
         ``withheld_by_projection``
             Requested, but every requested dimension measures whole rows and
             the run profiled a subset of columns.

--- a/python/examples/etl_quality_gate.py
+++ b/python/examples/etl_quality_gate.py
@@ -52,7 +52,7 @@ def _no_assessment(report: dp.ProfileReport) -> str:
         return f"quality computation failed: {report.quality_error}"
     return {
         "not_requested": "quality metrics were not requested for this run",
-        "no_data": "quality was requested but the extract held nothing to measure",
+        "no_data": "quality was requested but no quality sample was supplied",
         "withheld_by_projection": (
             "quality was withheld: the requested dimensions measure whole rows "
             "and only some columns were profiled"

--- a/python/tests/test_async_url_api.py
+++ b/python/tests/test_async_url_api.py
@@ -62,13 +62,34 @@ class _ThreadingTcpServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
 
 @pytest.fixture()
-def url_server():
+def url_server(tmp_path):
     incidents_csv = INCIDENTS_CSV.read_bytes()
     checkout_jsonl = CHECKOUT_JSONL.read_bytes()
     parquet_bytes = PARQUET_FILE.read_bytes()
     bom_json = codecs.BOM_UTF8 + b'[{"id":1,"score":2.5},{"id":2,"score":3.5}]'
     bom_jsonl = codecs.BOM_UTF8 + b'{"id":1,"score":2.5}\n{"id":2,"score":3.5}\n'
     fieldless_json = b"[{},{}]"
+    empty_payloads = {
+        "empty.csv": b"",
+        "header.csv": b"a,b\n",
+        "empty.json": b"[]",
+        "empty.jsonl": b"",
+    }
+
+    def empty_payload(name):
+        if name not in empty_payloads:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+
+            table = (
+                pa.table({"a": pa.array([], type=pa.int64())})
+                if name == "header.parquet"
+                else pa.table({})
+            )
+            path = tmp_path / name
+            pq.write_table(table, path)
+            empty_payloads[name] = path.read_bytes()
+        return empty_payloads[name]
 
     class Handler(http.server.BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
@@ -111,6 +132,8 @@ def url_server():
             return
 
         def _payload(self):
+            if self.path.removeprefix("/") in [*empty_payloads, "empty.parquet", "header.parquet"]:
+                return empty_payload(self.path.removeprefix("/"))
             if self.path == "/incidents.csv":
                 return incidents_csv
             if self.path == "/checkout_events.jsonl":
@@ -132,6 +155,8 @@ def url_server():
     try:
         port = server.server_address[1]
         yield {
+            "base": f"http://127.0.0.1:{port}",
+            "empty_payload": empty_payload,
             "csv": f"http://127.0.0.1:{port}/incidents.csv",
             "jsonl": f"http://127.0.0.1:{port}/checkout_events.jsonl",
             "parquet": f"http://127.0.0.1:{port}/data.parquet",
@@ -147,6 +172,40 @@ def url_server():
 
 
 class TestAsyncUrlProfiling:
+    @pytest.mark.parametrize(
+        "name",
+        ["empty.csv", "header.csv", "empty.json", "empty.jsonl", "empty.parquet", "header.parquet"],
+    )
+    @pytest.mark.parametrize("quality", [True, False])
+    def test_empty_quality_matches_files_bytes_and_http(self, url_server, tmp_path, name, quality):
+        import dataprof
+
+        if name.endswith("parquet"):
+            pytest.importorskip("pyarrow")
+            if not dataprof.capabilities().remote_parquet:
+                pytest.skip("Remote Parquet profiling requires the parquet-async feature")
+        payload = url_server["empty_payload"](name)
+        path = tmp_path / name
+        path.write_bytes(payload)
+        fmt = path.suffix.lstrip(".")
+        metrics = None if quality else ["schema"]
+        csv = b"a,b\n" if name.startswith("header") else b""
+        baseline = dataprof.profile(csv, format="csv", metrics=metrics).to_dict()["quality"]
+        reports = [
+            dataprof.profile(path, metrics=metrics),
+            _run(profile_file, path, metrics=metrics),
+            _run(profile_bytes, payload, format=fmt, metrics=metrics),
+            _run(profile_url, f"{url_server['base']}/{name}", metrics=metrics),
+        ]
+        for report in reports:
+            assert report.rows == 0
+            assert report.quality_status == ("computed" if quality else "not_requested")
+            assert report.to_dict()["quality"] == baseline
+            if quality:
+                assert report.quality is not None
+                assert report.to_dict()["quality"]["overall_score"] is None
+                assert report.to_dict()["quality"]["assessed_dimensions"] == []
+
     def test_profile_file_with_dogfood_csv(self):
         report = _run(profile_file, INCIDENTS_CSV)
 

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -125,6 +125,28 @@ def sqlite_db(tmp_path):
     return db_path
 
 
+def test_empty_query_quality_matches_empty_csv(sqlite_db, tmp_path):
+    path = tmp_path / "empty.csv"
+    path.write_bytes(b"id,cap,amount\n")
+    expected = dp.profile(path).to_dict()["quality"]
+    report = dp.ProfileReport(
+        _run(
+            analyze_database_async,
+            str(sqlite_db),
+            "SELECT * FROM parity WHERE 0",
+            10000,
+            None,
+            None,
+        )
+    )
+    assert report.rows == 0
+    assert report.quality_status == "computed"
+    assert report.quality is not None
+    assert report.to_dict()["quality"]["overall_score"] is None
+    assert report.to_dict()["quality"]["assessed_dimensions"] == []
+    assert report.to_dict()["quality"] == expected
+
+
 @pytest.fixture()
 def csv_file(tmp_path):
     """The same records on disk, for cross-source comparison."""

--- a/python/tests/test_database_option_parity.py
+++ b/python/tests/test_database_option_parity.py
@@ -147,6 +147,39 @@ def test_empty_query_quality_matches_empty_csv(sqlite_db, tmp_path):
     assert report.to_dict()["quality"] == expected
 
 
+@pytest.mark.parametrize("columns", [[], ["id"]])
+@pytest.mark.parametrize("metrics", [None, ["schema"]])
+def test_empty_projected_query_preserves_quality_selection(sqlite_db, tmp_path, columns, metrics):
+    """Projection withholding applies to empty queries and files alike."""
+    path = tmp_path / "empty.csv"
+    path.write_bytes(b"id,cap,amount\n")
+    dimensions = ["completeness", "uniqueness"]
+    query = dp.ProfileReport(
+        _run(
+            analyze_database_async,
+            str(sqlite_db),
+            "SELECT * FROM parity WHERE 0",
+            10000,
+            None,
+            ProfilerConfig(columns=columns, quality_dimensions=dimensions, metrics=metrics),
+        )
+    )
+    reports = [query]
+    for engine in ["incremental", "columnar"]:
+        reports.append(
+            dp.profile(
+                path, engine=engine, columns=columns, quality_dimensions=dimensions, metrics=metrics
+            )
+        )
+    for report in reports:
+        assert report.rows == 0
+        assert report.columns == len(columns)
+        assert report.quality is None
+        expected = "not_requested" if metrics else "withheld_by_projection"
+        assert report.quality_status == expected
+        assert report.to_dict()["quality_status"] == {"state": expected}
+
+
 @pytest.fixture()
 def csv_file(tmp_path):
     """The same records on disk, for cross-source comparison."""

--- a/python/tests/test_quality_status.py
+++ b/python/tests/test_quality_status.py
@@ -54,14 +54,15 @@ class TestStates:
         assert report.quality_status == "not_requested"
         assert report.quality_error is None
 
-    def test_empty_source_reads_as_no_data(self, tmp_path):
+    def test_empty_source_is_analyzed_with_nothing_assessable(self, tmp_path):
         path = tmp_path / "empty.csv"
         path.write_text("")
 
         report = dataprof.profile(str(path))
 
-        assert report.quality is None
-        assert report.quality_status == "no_data"
+        assert report.quality is not None
+        assert report.quality_status == "computed"
+        assert report.quality_score is None
 
     def test_projection_withholding_every_dimension_is_not_a_skip(self, csv_path):
         # Completeness and uniqueness both measure whole rows, so projecting a
@@ -87,19 +88,18 @@ class TestStates:
         assert report.quality_score is None
 
 
-def _every_reachable_state(csv_path, tmp_path):
+def _every_reachable_state(csv_path):
     """One report per state a Python caller can actually produce.
 
     `failed` is absent because no input path can make the metrics calculator
     return `Err`; it is forced in the Rust assembler tests. `unrecorded` only
     comes from loading an older document, which `TestSerialization` covers.
+    `no_data` requires an assembler with no supplied quality sample; empty
+    sources supply an empty sample and therefore report `computed` (#723).
     """
-    empty = tmp_path / "empty.csv"
-    empty.write_bytes(b"")
     return {
         "computed": dataprof.profile(csv_path),
         "not_requested": dataprof.profile(csv_path, metrics=["schema"]),
-        "no_data": dataprof.profile(str(empty)),
         "withheld_by_projection": dataprof.profile(
             csv_path,
             columns=["amount"],
@@ -109,13 +109,25 @@ def _every_reachable_state(csv_path, tmp_path):
 
 
 class TestSerialization:
+    def test_stored_empty_source_status_is_preserved(self, tmp_path):
+        path = tmp_path / "empty.csv"
+        path.write_bytes(b"")
+        document = dataprof.profile(path).to_dict()
+        document["quality"] = None
+        document["quality_status"] = {"state": "no_data"}
+
+        restored = dataprof.ProfileReport.from_dict(document)
+        assert restored.quality is None
+        assert restored.quality_status == "no_data"
+        assert restored.to_dict() == document
+
     def test_both_dialects_agree(self, csv_path, tmp_path):
         """The binding spells these strings by hand next to serde's rename_all.
 
         Nothing but this comparison stops the two from drifting apart, so it
         covers every state a Python caller can reach rather than a sample.
         """
-        for expected, report in _every_reachable_state(csv_path, tmp_path).items():
+        for expected, report in _every_reachable_state(csv_path).items():
             native = _native_status(report)
             assert native == {"state": expected}, expected
             assert report.to_dict()["quality_status"] == native, expected
@@ -130,7 +142,7 @@ class TestSerialization:
         assert json.loads(report.to_json())["quality_status"] == {"state": "not_requested"}
 
     def test_round_trip(self, csv_path, tmp_path):
-        for expected, report in _every_reachable_state(csv_path, tmp_path).items():
+        for expected, report in _every_reachable_state(csv_path).items():
             reloaded = dataprof.ProfileReport.from_dict(report.to_dict())
 
             assert reloaded.quality_status == expected

--- a/python/tests/test_skill_script.py
+++ b/python/tests/test_skill_script.py
@@ -106,19 +106,17 @@ def test_structure_mode_scales_null_ratio_to_a_percentage() -> None:
     assert "RowCountEstimate" not in result.stdout
 
 
-def test_absent_quality_is_reported_with_its_reason(tmp_path: Path) -> None:
-    """ "quality: not analyzed" alone would read as a clean skip.
-
-    The agent reading this output has to be able to tell a run that was never
-    asked for quality from one whose computation broke (#715).
-    """
+def test_empty_input_reports_quality_as_unassessed(tmp_path: Path) -> None:
+    """An empty source was analyzed, but no quality dimension was assessable (#723)."""
     source = tmp_path / "empty.csv"
     source.write_bytes(b"")
 
     result = run(str(source))
 
     assert result.returncode == 0, result.stderr
-    assert "quality: not analyzed (the source held nothing to measure)" in result.stdout
+    assert "rows: 0 | columns: 0 | quality: n/a" in result.stdout
+    assert "quality score: not assessed" in result.stdout
+    assert "quality: not analyzed" not in result.stdout
 
 
 def test_compare_mode_emits_deltas() -> None:
@@ -235,6 +233,13 @@ class _FailedReport:
 
     def __init__(self, error: str) -> None:
         self.quality_error = error
+
+
+def test_unavailable_quality_sample_is_distinct_from_analyzed_empty_input() -> None:
+    from types import SimpleNamespace
+
+    report = SimpleNamespace(quality=None, quality_status="no_data")
+    assert _quality_block(report) == ["quality: not analyzed (no quality sample was supplied)"]
 
 
 def test_failed_quality_computation_is_not_rendered_as_a_skip() -> None:

--- a/python/tests/test_zero_row_sources.py
+++ b/python/tests/test_zero_row_sources.py
@@ -26,6 +26,87 @@ import pytest
 pa = pytest.importorskip("pyarrow", reason="pyarrow is required for Arrow import tests")
 
 
+def _assert_empty_quality(report, expected):
+    assert report.rows == 0
+    assert report.quality_status == "computed"
+    assert report.quality is not None
+    document = report.to_dict()
+    assert document["quality_status"] == {"state": "computed"}
+    assert document["quality"]["overall_score"] is None
+    assert document["quality"]["assessed_dimensions"] == []
+    assert document["quality"] == expected
+    restored = dataprof.ProfileReport.from_json(report.to_json())
+    assert restored.quality_status == "computed"
+    assert restored.to_dict()["quality"] == expected
+
+
+@pytest.mark.parametrize("engine", ["auto", "incremental", "columnar"])
+@pytest.mark.parametrize(
+    ("fmt", "payload"), [("csv", b""), ("csv", b"a,b\n"), ("json", b"[]"), ("jsonl", b"")]
+)
+def test_empty_quality_matches_across_files_and_buffers(tmp_path, engine, fmt, payload):
+    """Same empty population, same serialized quality across paths (#723)."""
+    import io
+
+    path = tmp_path / f"empty.{fmt}"
+    path.write_bytes(payload)
+    table = _empty_pyarrow_table() if payload == b"a,b\n" else pa.table({})
+    expected = dataprof.profile(table).to_dict()["quality"]
+    for source in [path, payload, io.BytesIO(payload)]:
+        # Synchronous buffers use the columnar path; engine selection is only
+        # supported on file inputs.
+        selected_engine = engine if source is path else "auto"
+        report = dataprof.profile(source, format=fmt, engine=selected_engine)
+        _assert_empty_quality(report, expected)
+        if isinstance(source, io.BytesIO):
+            source.seek(0)
+        skipped = dataprof.profile(source, format=fmt, engine=selected_engine, metrics=["schema"])
+        assert skipped.quality is None
+        assert skipped.quality_status == "not_requested"
+
+
+@pytest.mark.parametrize("with_schema", [False, True])
+def test_empty_parquet_and_dataframe_quality_matches_csv(tmp_path, with_schema):
+    import pyarrow.parquet as pq
+
+    table = _empty_pyarrow_table() if with_schema else pa.table({})
+    path = tmp_path / "empty.parquet"
+    pq.write_table(table, path)
+    expected = dataprof.profile(b"a,b\n" if with_schema else b"", format="csv").to_dict()["quality"]
+    batch = pa.RecordBatch.from_arrays(
+        [pa.array([], type=field.type) for field in table.schema], schema=table.schema
+    )
+    for source in [path, path.read_bytes(), table, batch]:
+        fmt = "parquet" if isinstance(source, bytes) else None
+        _assert_empty_quality(dataprof.profile(source, format=fmt), expected)
+        skipped = dataprof.profile(source, format=fmt, metrics=["schema"])
+        assert skipped.quality is None
+        assert skipped.quality_status == "not_requested"
+
+
+@pytest.mark.parametrize("producer", ["pandas", "polars"])
+@pytest.mark.parametrize("with_schema", [False, True])
+def test_empty_dataframe_quality_matches_csv(producer, with_schema):
+    library = pytest.importorskip(producer)
+    frame = library.DataFrame({"a": [], "b": []} if with_schema else {})
+    expected = dataprof.profile(b"a,b\n" if with_schema else b"", format="csv").to_dict()["quality"]
+    _assert_empty_quality(dataprof.profile(frame), expected)
+    skipped = dataprof.profile(frame, metrics=["schema"])
+    assert skipped.quality is None
+    assert skipped.quality_status == "not_requested"
+
+
+@pytest.mark.parametrize("rows", [0, 2])
+def test_zero_column_record_batch_preserves_its_row_count(rows):
+    batch = pa.record_batch({"a": list(range(rows))}).select([])
+    assert batch.num_rows == rows
+    report = dataprof.profile(batch)
+    assert report.rows == rows
+    assert report.columns == 0
+    assert report.quality_status == "computed"
+    assert report.quality_score is None
+
+
 def _report(source, name):
     return dataprof.profile(source, name=name).to_dict()
 

--- a/tests/analysis_option_parity.rs
+++ b/tests/analysis_option_parity.rs
@@ -247,27 +247,82 @@ fn both_csv_engines_report_the_same_quality_status() {
     }
 }
 
-/// An empty CSV is not a run that skipped quality: nothing was asked to be
-/// skipped, there was simply nothing to measure.
+/// Zero rows is "analyzed, nothing found", with or without a schema (#723).
+/// Transports and dataframe producers are covered in the Python parity suite.
 #[test]
-fn an_empty_source_reports_no_data_rather_than_a_skip() {
-    let file = tempfile::NamedTempFile::with_suffix(".csv").unwrap();
-    for engine in [
-        EngineType::Auto,
-        EngineType::Incremental,
-        EngineType::Columnar,
+fn empty_sources_have_the_same_quality_on_every_format_and_engine() {
+    let mut sources = Vec::new();
+    for (suffix, content) in [
+        (".csv", ""),
+        (".csv", "a,b\n"),
+        (".json", "[]"),
+        (".jsonl", ""),
     ] {
-        let report = Profiler::new()
-            .engine(engine)
-            .analyze_file(file.path())
-            .unwrap_or_else(|e| panic!("[{engine:?}] profiling failed: {e}"));
+        let mut file = NamedTempFile::with_suffix(suffix).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        sources.push(file);
+    }
+    #[cfg(feature = "parquet")]
+    for fields in [
+        vec![],
+        vec![arrow::datatypes::Field::new(
+            "a",
+            arrow::datatypes::DataType::Int64,
+            true,
+        )],
+    ] {
+        let file = NamedTempFile::with_suffix(".parquet").unwrap();
+        parquet::arrow::ArrowWriter::try_new(
+            file.reopen().unwrap(),
+            std::sync::Arc::new(arrow::datatypes::Schema::new(fields)),
+            None,
+        )
+        .unwrap()
+        .close()
+        .unwrap();
+        sources.push(file);
+    }
 
-        assert!(report.quality.is_none());
-        assert_eq!(
-            report.quality_status,
-            QualityAnalysisStatus::NoData,
-            "[{engine:?}] empty source"
-        );
+    let mut baselines = [None, None];
+    for file in sources {
+        for engine in [
+            EngineType::Auto,
+            EngineType::Incremental,
+            EngineType::Columnar,
+        ] {
+            let label = format!("[{:?}, {engine:?}]", file.path());
+            let report = Profiler::new()
+                .engine(engine)
+                .analyze_file(file.path())
+                .unwrap_or_else(|e| panic!("{label} profiling failed: {e}"));
+            assert_eq!(report.execution.rows_processed, 0, "{label}");
+            assert_eq!(
+                report.quality_status,
+                QualityAnalysisStatus::Computed,
+                "{label}"
+            );
+            assert!(report.quality_score().is_none(), "{label}");
+            // The existing low-sample warning depends on whether there are
+            // columns. Compare whole metrics only between matching shapes.
+            let baseline = &mut baselines[usize::from(!report.column_profiles.is_empty())];
+            let quality = report.quality.unwrap();
+            assert!(quality.metrics.assessed_dimensions().is_empty(), "{label}");
+            let metrics = serde_json::to_value(&quality.metrics).unwrap();
+            assert_eq!(baseline.get_or_insert(metrics.clone()), &metrics, "{label}");
+
+            let deselected = Profiler::new()
+                .engine(engine)
+                .metric_packs(vec![MetricPack::Schema])
+                .analyze_file(file.path())
+                .unwrap();
+            assert!(deselected.quality.is_none(), "{label}");
+            assert_eq!(
+                deselected.quality_status,
+                QualityAnalysisStatus::NotRequested,
+                "{label}"
+            );
+        }
     }
 }
 

--- a/tests/cross_engine_consistency.rs
+++ b/tests/cross_engine_consistency.rs
@@ -242,10 +242,27 @@ fn test_empty_csv_quality_presence_matches_across_engines_and_serialization() {
     for (engine, report) in reports {
         assert!(report.column_profiles.is_empty(), "{engine}");
         assert_eq!(report.execution.rows_processed, 0, "{engine}");
-        assert!(report.quality.is_none(), "{engine} must not assess no data");
+        assert_eq!(
+            report.quality_status,
+            dataprof::QualityAnalysisStatus::Computed,
+            "{engine}"
+        );
+        assert!(report.quality_score().is_none(), "{engine}");
+        let quality = report.quality.as_ref().expect("empty input was analyzed");
+        assert!(quality.metrics.assessed_dimensions().is_empty(), "{engine}");
 
         let serialized = serde_json::to_value(&report).expect("report should serialize");
-        assert!(serialized["quality"].is_null(), "{engine}");
+        assert!(serialized["quality"].is_object(), "{engine}");
+        assert_eq!(
+            serialized["quality_status"],
+            json!({"state": "computed"}),
+            "{engine}"
+        );
+        assert_eq!(
+            serialized["quality"]["confidence"],
+            json!("NotAssessed"),
+            "{engine}"
+        );
     }
 }
 

--- a/tests/database_option_parity.rs
+++ b/tests/database_option_parity.rs
@@ -128,15 +128,15 @@ async fn schema_pack_omits_statistics_patterns_and_quality() {
     assert_eq!(report.column_profiles.len(), 3);
 }
 
-/// The database path has to say *why* a report carries no quality, and give the
-/// same answers the file paths give (#715).
+/// Queries follow the file paths' quality-status contract for both analyzed
+/// empty results and explicitly deselected quality (#715, #723).
 ///
 /// A zero-row query still describes its columns, so it is "analyzed, nothing
 /// found" — the same answer both empty and header-only CSV sources get (#723).
 /// The no-columns branch in `analyze_database_with_options` is not reachable
 /// from SQL and so is not asserted here.
 #[tokio::test]
-async fn query_reports_why_quality_is_absent() {
+async fn query_quality_status_distinguishes_empty_results_from_deselection() {
     let (_dir, db_path) = sqlite_fixture().await;
     const NO_ROWS: &str = "SELECT * FROM parity WHERE 0";
 

--- a/tests/database_option_parity.rs
+++ b/tests/database_option_parity.rs
@@ -132,7 +132,7 @@ async fn schema_pack_omits_statistics_patterns_and_quality() {
 /// same answers the file paths give (#715).
 ///
 /// A zero-row query still describes its columns, so it is "analyzed, nothing
-/// found" rather than an empty source — the same answer a header-only CSV gets.
+/// found" — the same answer both empty and header-only CSV sources get (#723).
 /// The no-columns branch in `analyze_database_with_options` is not reachable
 /// from SQL and so is not asserted here.
 #[tokio::test]


### PR DESCRIPTION
## What changed

Empty CSV files withheld quality while the same bytes through a buffer produced an empty assessment. All supported empty input paths now follow the same rule: with quality enabled, an analyzed zero-row source reports `quality_status: computed`, no quality score, and no assessed dimensions, whether or not it declares columns. Deselecting quality still reports `not_requested`.

This also lets empty async CSV streams and zero-column Arrow RecordBatches produce reports instead of errors. Parity tests cover both CSV engines, JSON/JSONL, Parquet files/buffers/HTTP, async transports, SQLite, Arrow, pandas and polars.

**Related issue:** Closes #723

## How it was verified

Rust unit and integration suites passed, including all 43 engine tests with every feature enabled and 28 cross-engine consistency tests. The full Python suite passed: 1,509 tests, with four expected skips (three Windows symlink privilege cases and the no-database stub case in the SQLite-enabled build). Async, remote Parquet and SQLite were enabled.

```bash
cargo test --locked -p dataprof-engines --all-features --lib
cargo test --locked --test cross_engine_consistency
cargo test --locked -p dataprof-csv -p dataprof-runtime
cargo test --locked --test analysis_option_parity --test profile_report_schema
cargo test --locked --test database_option_parity --features sqlite
cargo test --locked --test async_streaming --features async-streaming
cargo run --locked --example generate_profile_schema

uv run --no-sync maturin develop --features 'python,python-async,async-streaming,parquet-async,sqlite'
uv run --no-sync pytest python/tests -q --tb=short --no-showlocals
uv run --no-sync python python/examples/etl_quality_gate.py

cargo +1.98 clippy --locked --workspace --all-targets --features 'dataprof-python/python,dataprof-python/python-async,dataprof-python/parquet-async,dataprof-python/sqlite' -- -D warnings
cargo fmt --all --check
uv run --no-sync ruff format --check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run --no-sync ruff check python/ .github/scripts/ .claude/skills/dataprof/scripts/
uv run --no-sync ty check python/
uv run --no-sync python .github/scripts/check_decode_audit.py
git diff --check
```

## Anything reviewers should know

- Previously absent quality on empty CSV files is now present as an empty assessment. Regenerate older empty-input baselines when comparing across transports. Loading a stored report preserves its original status and quality presence.
- Schema v1 remains unchanged structurally; the regenerated artifact updates the description of `no_data`, which now describes an unavailable quality sample rather than an analyzed empty source.
- Existing low-sample warnings for declared columns and projection withholding remain in effect. Full serialized quality comparisons use corresponding source shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Empty and header-only inputs now produce reports with `quality_status: computed`, no score, and no assessed dimensions.
  - Empty CSV streams and zero-column Arrow batches now process successfully instead of returning errors.
  - Zero-row records preserve their row counts across supported input methods.
  - Quality output is consistent across files, bytes, buffers, HTTP sources, databases, and dataframes.

- **Documentation**
  - Clarified the distinction between unavailable quality samples (`no_data`) and analyzed empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
